### PR TITLE
#1945 Make FeatureGrid attributes visibility selector counted when user exports grid data

### DIFF
--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -20,6 +20,7 @@ import Message from '../../I18N/Message';
 import EmptyView from '../../misc/EmptyView';
 import DownloadOptions from './DownloadOptions';
 import Button from '../../misc/Button';
+import {getAttributesList} from "../../../utils/FeatureGridUtils";
 
 class DownloadDialog extends React.Component {
     static propTypes = {
@@ -43,7 +44,9 @@ class DownloadDialog extends React.Component {
         defaultSrs: PropTypes.string,
         layer: PropTypes.object,
         formatsLoading: PropTypes.bool,
-        virtualScroll: PropTypes.bool
+        virtualScroll: PropTypes.bool,
+        customAttributeSettings: PropTypes.object,
+        attributes: PropTypes.array
     };
 
     static defaultProps = {
@@ -127,7 +130,10 @@ class DownloadDialog extends React.Component {
                             wpsAdvancedOptionsVisible={!this.props.layer.search?.url}
                             downloadFilteredVisible={!!this.props.layer.search?.url}
                             layer={this.props.layer}
-                            virtualScroll={this.props.virtualScroll}/>}
+                            virtualScroll={this.props.virtualScroll}
+                            customAttributesSettings={this.props.customAttributeSettings}
+                            attributes={this.props.attributes}
+                        />}
             </div>
             {!this.props.checkingWPSAvailability && <div role="footer">
                 <Button
@@ -141,9 +147,10 @@ class DownloadDialog extends React.Component {
         </Dialog></Portal>) : null;
     }
     handleExport = () => {
-        const {url, filterObj, downloadOptions, defaultSrs, srsList, onExport, layer} = this.props;
+        const {url, filterObj, downloadOptions, defaultSrs, srsList, onExport, layer, attributes, customAttributeSettings} = this.props;
         const selectedSrs = downloadOptions && downloadOptions.selectedSrs || defaultSrs || (srsList[0] || {}).name;
-        onExport(url || layer.url, filterObj, assign({}, downloadOptions, {selectedSrs}));
+        const propertyName = getAttributesList(attributes, customAttributeSettings);
+        onExport(url || layer.url, filterObj, assign({}, downloadOptions, {selectedSrs}, {propertyName}));
     }
 }
 

--- a/web/client/components/data/download/FeatureEditorButton.jsx
+++ b/web/client/components/data/download/FeatureEditorButton.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import Button from '../featuregrid/toolbars/TButton';
+import withHint from "../featuregrid/enhancers/withHint";
+import TButtonComp from "../featuregrid/toolbars/TButton";
+const TButton = withHint(TButtonComp);
 
-
-export default ({disabled, results = [], mode, isDownloadOpen, onClick = () => {}}) => <Button
+export default ({disabled, results = [], mode, isDownloadOpen, onClick = () => {}}) => <TButton
     id="download-grid"
     keyProp="download-grid"
     tooltipId="featuregrid.toolbar.downloadGridData"

--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -106,7 +106,7 @@ const hasOutputFormat = (data) => {
 };
 
 const getWFSFeature = ({ url, filterObj = {}, layerFilter, downloadOptions = {}, options } = {}) => {
-    const { sortOptions, propertyName: pn } = options;
+    const { sortOptions, pn } = options;
 
     const data = mergeFiltersToOGC({ ogcVersion: '1.0.0', addXmlnsToRoot: true, xmlnsToAdd: ['xmlns:ogc="http://www.opengis.net/ogc"', 'xmlns:gml="http://www.opengis.net/gml"'] }, layerFilter, filterObj);
 
@@ -131,6 +131,7 @@ const getDefaultSortOptions = (attribute) => {
 const getFirstAttribute = (state)=> {
     return state.query && state.query.featureTypes && state.query.featureTypes[state.query.typeName] && state.query.featureTypes[state.query.typeName].attributes && state.query.featureTypes[state.query.typeName].attributes[0] && state.query.featureTypes[state.query.typeName].attributes[0].attribute || null;
 };
+
 const wpsExecuteErrorToMessage = e => {
     switch (e.code) {
     case 'ProcessFailed': {
@@ -246,7 +247,8 @@ export const startFeatureExportDownload = (action$, store) =>
             filterObj: action.filterObj,
             layerFilter,
             options: {
-                pagination: !virtualScroll && get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null
+                pagination: !virtualScroll && get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null,
+                pn: action.downloadOptions.propertyName
             }
         })
             .do(({ data, headers }) => {
@@ -265,7 +267,8 @@ export const startFeatureExportDownload = (action$, store) =>
                     layerFilter,
                     options: {
                         pagination: !virtualScroll && get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null,
-                        sortOptions: getDefaultSortOptions(getFirstAttribute(store.getState()))
+                        sortOptions: getDefaultSortOptions(getFirstAttribute(store.getState())),
+                        pn: action.downloadOptions.propertyName
                     }
                 }).do(({ data, headers }) => {
                     if (headers["content-type"] === "application/xml") { // TODO add expected mimetypes in the case you want application/dxf

--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -108,12 +108,12 @@ const hasOutputFormat = (data) => {
 };
 
 const getWFSFeature = ({ url, filterObj = {}, layerFilter, downloadOptions = {}, options } = {}) => {
-    const { sortOptions, pn } = options;
+    const { sortOptions, propertyNames } = options;
 
     const data = mergeFiltersToOGC({ ogcVersion: '1.0.0', addXmlnsToRoot: true, xmlnsToAdd: ['xmlns:ogc="http://www.opengis.net/ogc"', 'xmlns:gml="http://www.opengis.net/gml"'] }, layerFilter, filterObj);
 
     return getXMLFeature(url, getFilterFeature(query(
-        filterObj.featureTypeName, [...(sortOptions ? [sortBy(sortOptions.sortBy, sortOptions.sortOrder)] : []), ...(pn ? [propertyName(pn)] : []), ...(data ? castArray(data) : [])],
+        filterObj.featureTypeName, [...(sortOptions ? [sortBy(sortOptions.sortBy, sortOptions.sortOrder)] : []), ...(propertyNames ? [propertyName(propertyNames)] : []), ...(data ? castArray(data) : [])],
         { srsName: downloadOptions.selectedSrs })
     ), options, downloadOptions.selectedFormat);
 
@@ -254,7 +254,7 @@ export const startFeatureExportDownload = (action$, store) =>
             layerFilter,
             options: {
                 pagination: !virtualScroll && get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null,
-                pn: propertyNames
+                propertyNames
             }
         })
             .do(({ data, headers }) => {
@@ -274,7 +274,7 @@ export const startFeatureExportDownload = (action$, store) =>
                     options: {
                         pagination: !virtualScroll && get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null,
                         sortOptions: getDefaultSortOptions(getFirstAttribute(store.getState())),
-                        pn: action.downloadOptions.propertyName ? [...action.downloadOptions.propertyName,
+                        propertyNames: action.downloadOptions.propertyName ? [...action.downloadOptions.propertyName,
                             extractGeometryAttributeName(layerDescribeSelector(state, layer.name))] : null
                     }
                 }).do(({ data, headers }) => {

--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -56,6 +56,7 @@ import { queryPanelSelector, wfsDownloadSelector } from '../selectors/controls';
 import { getSelectedLayer } from '../selectors/layers';
 import { currentLocaleSelector } from '../selectors/locale';
 import { mapBboxSelector } from '../selectors/map';
+import { layerDescribeSelector } from "../selectors/query";
 import {
     isLoggedIn,
     userSelector
@@ -72,6 +73,7 @@ import { getLayerTitle } from '../utils/LayersUtils';
 import { bboxToFeatureGeometry } from '../utils/CoordinatesUtils';
 import { interceptOGCError } from '../utils/ObservableUtils';
 import requestBuilder from '../utils/ogc/WFS/RequestBuilder';
+import {extractGeometryAttributeName} from "../utils/WFSLayerUtils";
 
 const DOWNLOAD_FORMATS_LOOKUP = {
     "gml3": "GML3.1",
@@ -248,7 +250,8 @@ export const startFeatureExportDownload = (action$, store) =>
             layerFilter,
             options: {
                 pagination: !virtualScroll && get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null,
-                pn: action.downloadOptions.propertyName
+                pn: action.downloadOptions.propertyName ? [...action.downloadOptions.propertyName,
+                    extractGeometryAttributeName(layerDescribeSelector(state, layer.name))] : null
             }
         })
             .do(({ data, headers }) => {
@@ -268,7 +271,8 @@ export const startFeatureExportDownload = (action$, store) =>
                     options: {
                         pagination: !virtualScroll && get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null,
                         sortOptions: getDefaultSortOptions(getFirstAttribute(store.getState())),
-                        pn: action.downloadOptions.propertyName
+                        pn: action.downloadOptions.propertyName ? [...action.downloadOptions.propertyName,
+                            extractGeometryAttributeName(layerDescribeSelector(state, layer.name))] : null
                     }
                 }).do(({ data, headers }) => {
                     if (headers["content-type"] === "application/xml") { // TODO add expected mimetypes in the case you want application/dxf

--- a/web/client/observables/wps/download.js
+++ b/web/client/observables/wps/download.js
@@ -201,9 +201,9 @@ export const downloadWithAttributesFilter = (url, downloadOptions, executeOption
             ...omit(downloadOptions, 'notifyDownloadEstimatorSuccess', 'attribute', 'asynchronous', 'outputFormat'),
             asynchronous: false,
             outputAsReference: false,
-            resultOutput: 'application/json',
-            outputFormat: 'application/json'
-        }), executeOptions, {headers: {'Content-Type': 'application/xml', 'Accept': `application/xml, application/json`}});
+            resultOutput: 'application/wfs-collection-1.0',
+            outputFormat: 'application/wfs-collection-1.0'
+        }), executeOptions, {headers: {'Content-Type': 'application/xml', 'Accept': `application/xml, application/wfs-collection-1.0`}});
 
         return downloadEstimator$
             .catch(() => {
@@ -223,11 +223,11 @@ export const downloadWithAttributesFilter = (url, downloadOptions, executeOption
                 if (result === 'DownloadEstimatorSuccess') {
                     return Observable.of('DownloadEstimatorSuccess');
                 }
-                if (result?.type === 'FeatureCollection') {
+                if (result) {
                     return executeProcess(url, queryXML({
                         ...omit(downloadOptions, 'notifyDownloadEstimatorSuccess'),
-                        features: JSON.stringify(result),
-                        inputFormat: 'application/json',
+                        features: result,
+                        inputFormat: 'application/wfs-collection-1.0',
                         filter: null,
                         outputAsReference: downloadOptions.asynchronous ? downloadOptions.outputAsReference : false,
                         resultOutput

--- a/web/client/plugins/LayerDownload.jsx
+++ b/web/client/plugins/LayerDownload.jsx
@@ -35,17 +35,18 @@ import {
     infoBubbleMessageSelector,
     checkingExportDataEntriesSelector
 } from '../selectors/layerdownload';
-import { wfsURL } from '../selectors/query';
+import {attributesSelector, wfsURL} from '../selectors/query';
 import { getSelectedLayer } from '../selectors/layers';
 import { currentLocaleSelector } from '../selectors/locale';
+import { getCustomAttributesSettings } from "../selectors/featuregrid";
 
 import DownloadDialog from '../components/data/download/DownloadDialog';
 import ExportDataResultsComponent from '../components/data/download/ExportDataResultsComponent';
+
 import FeatureEditorButton from '../components/data/download/FeatureEditorButton';
-
 import * as epics from '../epics/layerdownload';
-import layerdownload from '../reducers/layerdownload';
 
+import layerdownload from '../reducers/layerdownload';
 import { createPlugin } from '../utils/PluginsUtils';
 
 /**
@@ -110,7 +111,9 @@ const LayerDownloadPlugin = createPlugin('LayerDownload', {
         layer: getSelectedLayer,
         service: serviceSelector,
         checkingWPSAvailability: checkingWPSAvailabilitySelector,
-        virtualScroll: state => state && state.featuregrid && state.featuregrid.virtualScroll
+        virtualScroll: state => state && state.featuregrid && state.featuregrid.virtualScroll,
+        customAttributeSettings: getCustomAttributesSettings,
+        attributes: attributesSelector
     }), {
         onExport: downloadFeatures,
         onDownloadOptionChange,

--- a/web/client/plugins/LayerDownload.jsx
+++ b/web/client/plugins/LayerDownload.jsx
@@ -38,7 +38,7 @@ import {
 import {attributesSelector, wfsURL} from '../selectors/query';
 import { getSelectedLayer } from '../selectors/layers';
 import { currentLocaleSelector } from '../selectors/locale';
-import { getCustomAttributesSettings } from "../selectors/featuregrid";
+import { customAttributesSettingsSelector } from "../selectors/featuregrid";
 
 import DownloadDialog from '../components/data/download/DownloadDialog';
 import ExportDataResultsComponent from '../components/data/download/ExportDataResultsComponent';
@@ -112,7 +112,7 @@ const LayerDownloadPlugin = createPlugin('LayerDownload', {
         service: serviceSelector,
         checkingWPSAvailability: checkingWPSAvailabilitySelector,
         virtualScroll: state => state && state.featuregrid && state.featuregrid.virtualScroll,
-        customAttributeSettings: getCustomAttributesSettings,
+        customAttributeSettings: customAttributesSettingsSelector,
         attributes: attributesSelector
     }), {
         onExport: downloadFeatures,

--- a/web/client/plugins/widgetbuilder/FeatureEditorButton.jsx
+++ b/web/client/plugins/widgetbuilder/FeatureEditorButton.jsx
@@ -2,14 +2,16 @@ import React from 'react';
 import {connect} from 'react-redux';
 import { createChart } from '../../actions/widgets';
 
-import Button from '../../components/data/featuregrid/toolbars/TButton';
+import withHint from "../../components/data/featuregrid/enhancers/withHint";
+import TButtonComp from "../../components/data/featuregrid/toolbars/TButton";
+const TButton = withHint(TButtonComp);
 const FeatureEditorButton = connect(
     () => ({}),
     {
         onClick: () => createChart()
     }
 )(({disabled, mode, onClick = () => {}}) => {
-    return (<Button
+    return (<TButton
         id="grid-map-chart"
         keyProp="grid-map-chart"
         tooltipId="featuregrid.toolbar.createNewChart"

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -23,7 +23,7 @@ export const getLayerById = getLayerFromId;
 export const getTitle = (layer = {}) => layer.title || layer.name;
 export const selectedLayerIdSelector = state => get(state, "featuregrid.selectedLayer");
 export const getCustomAttributeSettings = (state, att) => get(state, `featuregrid.attributes[${att.name || att.attribute}]`);
-export const getCustomAttributesSettings = (state) => get(state, `featuregrid.attributes`);
+export const customAttributesSettingsSelector = (state) => get(state, `featuregrid.attributes`);
 export const selectedFeaturesSelector = state => state && state.featuregrid && state.featuregrid.select;
 export const changesSelector = state => state && state.featuregrid && state.featuregrid.changes;
 export const newFeaturesSelector = state => state && state.featuregrid && state.featuregrid.newFeatures;

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -23,6 +23,7 @@ export const getLayerById = getLayerFromId;
 export const getTitle = (layer = {}) => layer.title || layer.name;
 export const selectedLayerIdSelector = state => get(state, "featuregrid.selectedLayer");
 export const getCustomAttributeSettings = (state, att) => get(state, `featuregrid.attributes[${att.name || att.attribute}]`);
+export const getCustomAttributesSettings = (state) => get(state, `featuregrid.attributes`);
 export const selectedFeaturesSelector = state => state && state.featuregrid && state.featuregrid.select;
 export const changesSelector = state => state && state.featuregrid && state.featuregrid.changes;
 export const newFeaturesSelector = state => state && state.featuregrid && state.featuregrid.newFeatures;

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -325,6 +325,9 @@ export const getAttributesList = (attributes, customAttributesSettings) => {
             const hide = customAttributesSettings[element.attribute]?.hide ?? false;
             return !hide;
         }).map((element) => element.attribute);
+        if (result.length === attributes.length) {
+            result = undefined;
+        }
     }
     return result;
 };

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -308,3 +308,23 @@ export const updatePages = (result, { endPage, startPage } = {}, { pages, featur
     }
     return { pages: oldPages.concat(pagesLoaded), features: oldFeatures.concat(fts) };
 };
+
+/**
+ * Process custom attributes settings of feature grid and returns array of feature attributes to be used in a query
+ * to limit results of WFS "getFeature" request
+ * undefined - all attributes to be fetched
+ * array - listed attributes to be fetched
+ * @param {array} attributes complete list of attributes available for export, see attributesSelector
+ * @param {object} customAttributesSettings object containing information about deactivated attributes, see getCustomAttributesSettings
+ * @returns undefined|array
+ */
+export const getAttributesList = (attributes, customAttributesSettings) => {
+    let result = undefined;
+    if (customAttributesSettings && attributes) {
+        result = attributes.filter((element) => {
+            const hide = customAttributesSettings[element.attribute]?.hide ?? false;
+            return !hide;
+        }).map((element) => element.attribute);
+    }
+    return result;
+};

--- a/web/client/utils/__tests__/FeatureGridUtils-test.js
+++ b/web/client/utils/__tests__/FeatureGridUtils-test.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
 */
 import expect from 'expect';
-import {updatePages, gridUpdateToQueryUpdate} from '../FeatureGridUtils';
+import {updatePages, gridUpdateToQueryUpdate, getAttributesList} from '../FeatureGridUtils';
 
 
 describe('FeatureGridUtils', () => {
@@ -156,5 +156,63 @@ describe('FeatureGridUtils', () => {
         expect(queryUpdateFilter.filterFields[3].operator).toBe("=");
         expect(queryUpdateFilter.filterFields[4].value).toBe(10);
         expect(queryUpdateFilter.filterFields[4].operator).toBe("<");
+    });
+    it('getAttributesList', () => {
+        const attributes = [
+            {
+                "label": "ATTR1",
+                "attribute": "ATTR1",
+                "type": "number",
+                "valueId": "id",
+                "valueLabel": "name",
+                "values": []
+            },
+            {
+                "label": "ATTR2",
+                "attribute": "ATTR2",
+                "type": "string",
+                "valueId": "id",
+                "valueLabel": "name",
+                "values": []
+            },
+            {
+                "label": "ATTR3",
+                "attribute": "ATTR3",
+                "type": "number",
+                "valueId": "id",
+                "valueLabel": "name",
+                "values": []
+            },
+            {
+                "label": "ATTR4",
+                "attribute": "ATTR4",
+                "type": "number",
+                "valueId": "id",
+                "valueLabel": "name",
+                "values": []
+            }
+        ];
+        const customAttributesSettings = {
+            ATTR2: {
+                hide: true
+            },
+            ATTR3: {
+                hide: false
+            },
+            ATTR4: {
+                hide: true
+            }
+        };
+
+        const customSettings = getAttributesList(attributes, customAttributesSettings);
+        const noSettings = getAttributesList(attributes, {});
+        const allDeselected = getAttributesList(attributes, attributes.reduce((prev, attr) => {
+            prev[attr.attribute] = {hide: true};
+            return prev;
+        }, {}));
+
+        expect(customSettings).toEqual(['ATTR1', 'ATTR3']);
+        expect(noSettings).toBe(undefined);
+        expect(allDeselected).toEqual([]);
     });
 });


### PR DESCRIPTION
## Description
This PR suggests changes needed to make FeatureGrid attributes visibility selector counted when user exports grid data.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#1945 

**What is the new behavior?**
WFS export will properly use list of hidden attributes to load data only for visible columns.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
