### PR TITLE
updated redux-dev-tools to new method's names

### DIFF
--- a/web/client/components/development/Debug.jsx
+++ b/web/client/components/development/Debug.jsx
@@ -17,7 +17,7 @@ const urlQuery = url.parse(window.location.href, true).query;
 
 class Debug extends React.Component {
     render() {
-        if (urlQuery && urlQuery.debug && __DEVTOOLS__ && !window.devToolsExtension) {
+        if (urlQuery && urlQuery.debug && __DEVTOOLS__ && !window.__REDUX_DEVTOOLS_EXTENSION__) {
             const DevTools = require('./DevTools').default;
             return (
                 <DevTools/>

--- a/web/client/utils/StateUtils.js
+++ b/web/client/utils/StateUtils.js
@@ -164,9 +164,9 @@ export const createStore = ({
     const epic = rootEpic || combineEpics(...wrapEpics(epics));
     const allMiddlewares = epic ? [persistMiddleware(createEpicMiddleware(epic)), ...middlewares] : middlewares;
     const middleware = applyMiddleware.apply(null, getMiddlewares(allMiddlewares, debug));
-    const finalCreateStore = (window.devToolsExtension && debug ? compose(
+    const finalCreateStore = (window.__REDUX_DEVTOOLS_EXTENSION__ && debug ? compose(
         middleware,
-        window.devToolsExtension()
+        window.__REDUX_DEVTOOLS_EXTENSION__()
     ) : middleware)(createReduxStore);
     return setStore(finalCreateStore(reducer, state, enhancer));
 };


### PR DESCRIPTION
## Description
The latest version of Redux-Dev-Tools doesn't longer work with MapStore2, showing always the store as empty.
Based on the documentation, the method's name have changed and need to be updated accordingly. 

Taken from: https://github.com/reduxjs/redux-devtools/tree/main/extension#usage

> Note that starting from v2.7, window.devToolsExtension was renamed to window.__REDUX_DEVTOOLS_EXTENSION__ / window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue

**What is the current behavior?**
Redux-Dev-Tools state inspector is always shown as empty and cannot connect to the store successfully. 


**What is the new behavior?**
Redux-Dev-Tools can connect normally to the store and display all it's attributes/states:

![image](https://user-images.githubusercontent.com/1714616/152967394-5e55f916-9804-4f8c-82ac-0b0a44fbc2a8.png)


## Breaking change
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information

https://github.com/reduxjs/redux-devtools/
