### PR TITLE
Make sure we request XML metadata as application/xml (#7850)

### DIFF
--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -358,7 +358,7 @@ export default (API) => ({
                                 return Rx.Observable.empty();
                             });
 
-                        const metadataFlow = Rx.Observable.defer(() => axios.get(metadataUrl))
+                        const metadataFlow = Rx.Observable.defer(() => axios.get(metadataUrl, {headers: {'Accept': 'application/xml'}}))
                             .pluck('data')
                             .map(metadataXml => new DOMParser().parseFromString(metadataXml))
                             .map(metadataDoc => {


### PR DESCRIPTION
fixes browser OOM with GN API urls, as axios defaults to `application/json`
geonetwork returns json data and XML parsing blows.

## Description
cf #7850 - an improvement would be to make sure the returned content is proper XML or catch parser exceptions, instead of consuming all memory

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 
## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7850

**What is the new behavior?**

![image](https://user-images.githubusercontent.com/3421760/153018812-6f00f26c-8eda-4bcc-85f1-01f16cb4e629.png)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

Untested yet with other implementations, and no tests added.