### PR TITLE
7779 : Wrong tooltip in map viewer widgets

### DIFF
--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1798,7 +1798,7 @@
                     "addLayer": "Add a layer to the map",
                     "useTheSelectedLayer": "Use the selected layer",
                     "connectToAMap": "Connect to another widget",
-                    "connectToTheMap": "Connect to the other widget",
+                    "connectToTheMap": "Connect to the map",
                     "selectMapToConnect": "Select the widget to connect",
                     "clearConnection": "Clear connection",
                     "classAttributes": {

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -1432,7 +1432,7 @@
                     "addLayer": "Add a layer to the map",
                     "useTheSelectedLayer": "Use the selected layer",
                     "connectToAMap": "Connect to another widget",
-                    "connectToTheMap": "Connect to the other widget",
+                    "connectToTheMap": "Connect to the map",
                     "selectMapToConnect": "Select the widget to connect",
                     "clearConnection": "Clear connection"
                 },

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -1408,7 +1408,7 @@
                     "addLayer": "Add a layer to the map",
                     "useTheSelectedLayer": "Use the selected layer",
                     "connectToAMap": "Connect to another widget",
-                    "connectToTheMap": "Connect to the other widget",
+                    "connectToTheMap": "Connect to the map",
                     "selectMapToConnect": "Select the widget to connect",
                     "clearConnection": "Clear connection"
                 },


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
The tooltip should report: "Connect to the other widget"
#<issue>

**What is the new behavior?**
The tooltip should report: "Connect to the map"

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
