### PR TITLE
#7106 Make map in GeoStory updated on the fly without need to save it…

### DIFF
--- a/web/client/components/geostory/common/enhancers/__tests__/map-test.jsx
+++ b/web/client/components/geostory/common/enhancers/__tests__/map-test.jsx
@@ -93,12 +93,10 @@ describe("geostory media map component enhancers", () => {
     it('withToolbar it correctly sets buttons', (done) => {
 
         const actions = {
-            toggleEditing: () => {},
             onReset: () => {},
             toggleAdvancedEditing: () => {}
         };
 
-        const SpyToggleEditing = expect.spyOn(actions, 'toggleEditing');
         const SpyOnReset = expect.spyOn(actions, 'onReset');
         const SpyToggleAdvancedEditing = expect.spyOn(actions, 'toggleAdvancedEditing');
 
@@ -108,7 +106,7 @@ describe("geostory media map component enhancers", () => {
 
         const buttons = document.querySelectorAll("button");
         expect(buttons).toExist();
-        expect(buttons.length).toBe(3);
+        expect(buttons.length).toBe(2);
         for (let btn of buttons) {
             ReactTestUtils.Simulate.click(btn);
         }
@@ -116,7 +114,6 @@ describe("geostory media map component enhancers", () => {
         expect(confirmButtons).toExist();
         expect(confirmButtons.length).toBe(3);
         ReactTestUtils.Simulate.click(confirmButtons[1]);
-        expect(SpyToggleEditing).toHaveBeenCalled();
         expect(SpyOnReset).toHaveBeenCalled();
         expect(SpyToggleAdvancedEditing).toHaveBeenCalled();
         done();

--- a/web/client/components/geostory/common/enhancers/map.jsx
+++ b/web/client/components/geostory/common/enhancers/map.jsx
@@ -87,9 +87,6 @@ export const handleToolbar = withHandlers({
         update(focusedContent.path + ".editMap", !editMap),
     onReset: ({update, focusedContent: {path = ""} = {}}) => () => {
         update(path + `.map`, undefined);
-    },
-    discardAndClose: ({update, focusedContent = {}}) => () => {
-        update(focusedContent.path + ".editMap", false);
     }
 });
 /**

--- a/web/client/components/geostory/common/enhancers/map.jsx
+++ b/web/client/components/geostory/common/enhancers/map.jsx
@@ -88,8 +88,7 @@ export const handleToolbar = withHandlers({
     onReset: ({update, focusedContent: {path = ""} = {}}) => () => {
         update(path + `.map`, undefined);
     },
-    discardAndClose: ({update, focusedContent = {}}) => (contentMap) => {
-        update(focusedContent.path + `.map`, contentMap);
+    discardAndClose: ({update, focusedContent = {}}) => () => {
         update(focusedContent.path + ".editMap", false);
     }
 });
@@ -107,13 +106,8 @@ const ResetButton = (props) => (<ConfirmButton
 />);
 
 export const withToolbar = compose(
-    withProps(({pendingChanges, toggleEditing, disableReset, onReset, toggleAdvancedEditing = () => {}}) => ({
+    withProps(({disableReset, onReset, toggleAdvancedEditing = () => {}}) => ({
         buttons: [{
-            glyph: "floppy-disk",
-            disabled: !pendingChanges,
-            tooltipId: "geostory.contentToolbar.saveChanges",
-            onClick: toggleEditing
-        }, {
             renderButton: <ResetButton disabled={disableReset} onClick={onReset}/>
         },
         {
@@ -163,18 +157,7 @@ export const withConfirmClose = compose(
     withProps(({toggleEditing})  => ({
         CloseBtn: (props) => (
             <ToolbarButton  onClick={toggleEditing} {...props} />)
-    })),
-    branch(
-        ({pendingChanges}) => pendingChanges,
-        withProps(({discardAndClose, contentMap}) => ({
-            CloseBtn: (props) => (
-                <ConfirmButton
-                    onClick={ () =>discardAndClose(contentMap)}
-                    confirmTitle={<Message msgId="geostory.contentToolbar.confirmCloseMapEditing" />}
-                    confirmContent={<Message msgId="geostory.contentToolbar.pendingChangesDiscardConfirm" />}
-                    {...props}/>)
-        }))
-    )
+    }))
 );
 
 /**

--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -10,6 +10,7 @@
 import React from "react";
 import Toolbar from '../../misc/toolbar/Toolbar';
 import {SizeButtonToolbar, AlignButtonToolbar, ThemeButtonToolbar, DeleteButtonToolbar} from "./ToolbarButtons";
+import uuid from "uuid";
 
 const BUTTON_CLASSES = 'square-button-md no-border';
 const toolButtons = {
@@ -56,7 +57,7 @@ const toolButtons = {
         renderButton: <DeleteButtonToolbar {...props}/>
 
     }),
-    editMap: ({editMap = false, update = () => {}}) => ({
+    editMap: ({editMap = false, map, update = () => {}, ...props}) => ({
         // using normal ToolbarButton because this has no options
         glyph: "map-edit",
         visible: true,
@@ -64,7 +65,9 @@ const toolButtons = {
         bsStyle: editMap ? "success" : "default",
         tooltipId: "geostory.contentToolbar.editMap",
         onClick: () => {
+            const { center, zoom, resolution } = map ?? props;
             update( 'editMap', !editMap);
+            !editMap && update("map", {center, zoom, mapStateSource: uuid(), resolution, resetPanAndZoom: false}, 'merge');
         }
     }),
     editURL: ({ editURL = false, path, editWebPage = () => {}}) => ({


### PR DESCRIPTION
## Description
Make map in GeoStory updated on the fly without need to save it by "Save" button explicitly.
- Removed save button from toolbar.
- Click on close glyph will not trigger discard modal. Instead of it all the changes will be kept as is.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other: small changes in feature configuration/workflow

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7106 

**What is the new behavior?**
Map configuration is updated with no need to use save button.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
