### PR TITLE
#7861 Activate contexts tab on home page by default

### DIFF
--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -828,7 +828,7 @@
               "name": "ContextCreator",
               "cfg": {
                   "documentationBaseURL": "https://mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins",
-                  "backToPageDestRoute": "/context-manager",
+                  "backToPageDestRoute": "/",
                   "backToPageConfirmationMessage": "contextCreator.undo"
               }
           },
@@ -840,7 +840,6 @@
             }
           }
         ],
-        "manager": ["Header", "Redirect", "Manager", "Home", "UserManager", "GroupManager", "Footer"],
-        "context-manager": ["Header", "Redirect", "Home", "ContextManager", "Footer"]
+        "manager": ["Header", "Redirect", "Manager", "Home", "UserManager", "GroupManager", "Footer"]
     }
 }

--- a/web/client/plugins/CreateNewMap.jsx
+++ b/web/client/plugins/CreateNewMap.jsx
@@ -39,6 +39,7 @@ class CreateNewMap extends React.Component {
         mapType: PropTypes.string,
         showNewDashboard: PropTypes.bool,
         showNewGeostory: PropTypes.bool,
+        showNewContext: PropTypes.bool,
         colProps: PropTypes.object,
         isLoggedIn: PropTypes.bool,
         allowedRoles: PropTypes.array,
@@ -60,6 +61,7 @@ class CreateNewMap extends React.Component {
         mapType: "leaflet",
         showNewDashboard: true,
         showNewGeostory: true,
+        showNewContext: true,
         isLoggedIn: false,
         allowedRoles: ["ADMIN", "USER"],
         colProps: {
@@ -115,6 +117,11 @@ class CreateNewMap extends React.Component {
                             {this.props.showNewGeostory ?
                                 <Button tooltipId="resources.geostories.newGeostory" className="square-button" bsStyle="primary" onClick={() => { this.context.router.history.push("/geostory/newgeostory/"); }}>
                                     <Glyphicon glyph="add-geostory" />
+                                </Button>
+                                : null}
+                            {this.props.showNewContext ?
+                                <Button tooltipId="resources.contexts.newContext" className="square-button" bsStyle="primary" onClick={() => { this.context.router.history.push("/context-creator/new/"); }}>
+                                    <Glyphicon glyph="map-context" />
                                 </Button>
                                 : null}
                         </ButtonToolbar>

--- a/web/client/plugins/__tests__/Contexts-test.jsx
+++ b/web/client/plugins/__tests__/Contexts-test.jsx
@@ -29,7 +29,6 @@ describe('Contexts Plugin', () => {
         const { Plugin } = getPluginForTest(ContextsPlugin, {});
         ReactDOM.render(<Plugin />, document.getElementById("container"));
         // eslint-disable-next-line no-console
-        console.log(document.getElementById("container").innerHTML);
         const emptyStateImage = document.getElementsByClassName('empty-state-image');
         const emptyStateMainView = document.getElementsByClassName('empty-state-main-view');
         expect(emptyStateImage.length).toBe(1);

--- a/web/client/plugins/__tests__/CreateNewMap-test.jsx
+++ b/web/client/plugins/__tests__/CreateNewMap-test.jsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import CreateNewMapPlugin from '../CreateNewMap';
+import { getPluginForTest } from './pluginsTestUtils';
+import security from "../../reducers/security";
+
+describe('Contexts Plugin', () => {
+
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates CreateNewMap plugin with default configuration for anonymous visitor', () => {
+        const initialState = {
+            security: {
+                user: null
+            }
+        };
+        const { Plugin } = getPluginForTest({...CreateNewMapPlugin, reducers: {
+            ...CreateNewMapPlugin.reducers,
+            security
+        }}, initialState );
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        const wrapper = document.getElementsByClassName("create-new-map-container")[0];
+        const container = wrapper.getElementsByClassName("container")[0];
+        const buttons = wrapper.getElementsByClassName("btn");
+        expect(container.style.display).toBe('none');
+        expect(buttons.length).toBe(4);
+    });
+    it('creates CreateNewMap plugin with default configuration for logged-in used', () => {
+        const initialState = {
+            security: {
+                user: {
+                    role: "USER",
+                    name: "user",
+                    enabled: true
+                }
+            }
+        };
+        const { Plugin } = getPluginForTest({...CreateNewMapPlugin, reducers: {
+            ...CreateNewMapPlugin.reducers,
+            security
+        }}, initialState );
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        const wrapper = document.getElementsByClassName("create-new-map-container")[0];
+        const container = wrapper.getElementsByClassName("container")[0];
+        const buttons = wrapper.getElementsByClassName("btn");
+        expect(container.style.display).toNotBe('none');
+        expect(buttons.length).toBe(4);
+    });
+});

--- a/web/client/plugins/__tests__/CreateNewMap-test.jsx
+++ b/web/client/plugins/__tests__/CreateNewMap-test.jsx
@@ -13,7 +13,7 @@ import CreateNewMapPlugin from '../CreateNewMap';
 import { getPluginForTest } from './pluginsTestUtils';
 import security from "../../reducers/security";
 
-describe('Contexts Plugin', () => {
+describe('CreateNewMap Plugin', () => {
 
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';

--- a/web/client/product/appConfig.js
+++ b/web/client/product/appConfig.js
@@ -48,10 +48,6 @@ export default {
         path: "/manager/:tool",
         component: require('./pages/Manager').default
     }, {
-        name: "context-manager",
-        path: "/context-manager",
-        component: require('./pages/ContextManager').default
-    }, {
         name: "dashboard",
         path: "/dashboard",
         component: require('./pages/Dashboard').default

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -437,6 +437,7 @@
                 "errorLoadingGeostories": "Beim Laden von GeoStories ist ein Fehler aufgetreten"
             },
             "contexts": {
+              "newContext": "Neuer Kontext",
               "title": "Kontexte ({count})",
               "titleNoCount": "Kontexte",
               "noContextAvailable": "Kein Kontext verfügbar"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -399,6 +399,7 @@
                 "errorLoadingGeostories": "There was an error loading GeoStories"
             },
             "contexts": {
+              "newContext": "New context",
               "title": "Contexts ({count})",
               "titleNoCount": "Contexts",
               "noContextAvailable": "No context available"

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -399,6 +399,7 @@
                 "errorLoadingGeostories": "Hubo un error al cargar GeoStories"
             },
             "contexts": {
+              "newContext": "Nuevo contexto",
               "title": "Contextos ({count})",
               "titleNoCount": "Contextos",
               "noContextAvailable": "Sin contexto disponible"

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -399,6 +399,7 @@
                 "errorLoadingGeostories": "Une erreur s'est produite lors du chargement de GeoStories"
             },
             "contexts": {
+              "newContext": "Nouveau contexte",
               "title": "Contextes ({count})",
               "titleNoCount": "Contextes",
               "noContextAvailable": "Aucun contexte disponible"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -399,6 +399,7 @@
                 "errorLoadingGeostories": "Si è verificato un errore durante il caricamento di GeoStories"
             },
             "contexts": {
+              "newContext": "Nuovo contesto",
               "title": "Contesti ({count})",
               "titleNoCount": "Contesti",
               "noContextAvailable": "Nessun contesto disponibile"


### PR DESCRIPTION
## Description
This PR suggests changes needed to have contexts tab active on home page by default.
Additionally it adds support of having "New" context button at toolbar on the home page.
Context-manager page is removed from app configuration and localConfig.json 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other: Default configuration update; Minor changes to the feature.

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7861 

**What is the new behavior?**
- Contexts tab is available on home page by default
- "New context" button is available on the home page.
- Couple basic tests are added to perform very basic checks of map/context/dashboard/geostory creation toolbar.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
