### PR TITLE
Issue #7868: fix error that throws error when click in empty space of map in mobile view

### DIFF
--- a/web/client/epics/__tests__/measurement-test.jsx
+++ b/web/client/epics/__tests__/measurement-test.jsx
@@ -267,13 +267,6 @@ describe('measurement epics', () => {
                     enabled: true
                 }
             },
-            localConfig: {
-                plugins: {
-                    desktop: [{
-                        name: 'Measure'
-                    }]
-                }
-            },
             measurement: {
                 currentFeature: 0,
                 features: [{

--- a/web/client/epics/__tests__/measurement-test.jsx
+++ b/web/client/epics/__tests__/measurement-test.jsx
@@ -267,6 +267,13 @@ describe('measurement epics', () => {
                     enabled: true
                 }
             },
+            localConfig: {
+                plugins: {
+                    desktop: [{
+                        name: 'Measure'
+                    }]
+                }
+            },
             measurement: {
                 currentFeature: 0,
                 features: [{

--- a/web/client/epics/measurement.js
+++ b/web/client/epics/measurement.js
@@ -88,16 +88,8 @@ export const setMeasureStateFromAnnotationEpic = (action$, store) =>
 export const addCoordinatesEpic = (action$, {getState = () => {}}) =>
     action$.ofType(CLICK_ON_MAP)
         .filter(() => {
-            const localConfig = localConfigSelector(getState());
-            const platform = isBrowserMobile(getState()) ? 'mobile' : 'desktop';
-            const plugins = localConfig && localConfig.plugins && localConfig.plugins[platform];
-            const pluginName = 'Measure';
-            const pluginConfig = plugins && plugins.find(plugin => (plugin?.name === pluginName || plugin === pluginName));
-            if (pluginConfig) {
-                const {showCoordinateEditor, enabled} = getState().controls.measure;
-                return showCoordinateEditor && enabled;
-            }
-            return false;
+            const { showCoordinateEditor, enabled } = getState()?.controls?.measure || {};
+            return showCoordinateEditor && enabled;
         } )
         .switchMap(({point}) => {
             const { currentFeature: index, features = [], geomType } = getState()?.measurement || {};

--- a/web/client/epics/measurement.js
+++ b/web/client/epics/measurement.js
@@ -21,8 +21,6 @@ import {showCoordinateEditorSelector, measureSelector} from '../selectors/contro
 import {geomTypeSelector} from '../selectors/measurement';
 import { CLICK_ON_MAP } from '../actions/map';
 import {newAnnotation, setEditingFeature, cleanHighlight, toggleVisibilityAnnotation} from '../actions/annotations';
-import {localConfigSelector} from "../selectors/localConfig";
-import {isBrowserMobile} from "../selectors/dashboard";
 
 export const addAnnotationFromMeasureEpic = (action$) =>
     action$.ofType(ADD_MEASURE_AS_ANNOTATION)


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7868 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Error is not thrown when clicking on map in mobile view
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
