### PR TITLE
Fix to jsdoc

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -484,10 +484,11 @@ export const getDefaultPrintingService = () => {
 export const DEFAULT_PRINT_RATIO = 96.0 / 72.0;
 
 /**
+ * Returns the correct multiplier to sync the screen resolution and the printed map resolution.
  * @param {number} printSize printed map size (in print points (1/72"))
  * @param {number} screenSize screen preview size (in pixels)
- * @param {number} [dpiRatio=DEFAULT_PRINT_RATIO] ratio screen_dpi / printed_dpi
- * @returns the resolution multiplier to apply to the screen preview. This multiplier allows to sync the screen resolution and the printed map resolution
+ * @param {number} dpiRatio ratio screen_dpi / printed_dpi
+ * @return {number} the resolution multiplier to apply to the screen preview
  * @memberof utils.PrintUtils
  */
 export function getResolutionMultiplier(printSize, screenSize, dpiRatio = DEFAULT_PRINT_RATIO) {

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -479,16 +479,16 @@ export const getDefaultPrintingService = () => {
 /**
  * Default screen DPI (96) to Print DPI (72). Used to calculate correct resolution for
  * screen preview and printed map.
+ * @memberof utils.PrintUtils
  */
 export const DEFAULT_PRINT_RATIO = 96.0 / 72.0;
 
 /**
- * Returns the correct multiplier to sync the screen resolution and the printed map resolution.
- *
  * @param {number} printSize printed map size (in print points (1/72"))
  * @param {number} screenSize screen preview size (in pixels)
- * @param {number} dpiRatio ratio screen_dpi / printed_dpi
- * @returns the resolution multiplier to apply to the screen preview
+ * @param {number} [dpiRatio=DEFAULT_PRINT_RATIO] ratio screen_dpi / printed_dpi
+ * @returns the resolution multiplier to apply to the screen preview. This multiplier allows to sync the screen resolution and the printed map resolution
+ * @memberof utils.PrintUtils
  */
 export function getResolutionMultiplier(printSize, screenSize, dpiRatio = DEFAULT_PRINT_RATIO) {
     return printSize / screenSize * dpiRatio;


### PR DESCRIPTION
## Description

Documentation broke in ad170b809fff9df7de6b8c6e46d53f102a176d33

This because of the wrong format of `@return `, that unfortunately doesn't make the build fail, but only creates a blank page.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Documentation not working
https://dev-mapstore.geosolutionsgroup.com/mapstore/docs/

**What is the new behavior?**

Documentation works again. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
