### PR TITLE
#7890: align applicationContext-print.xml to work with upgraded mapfi…

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -153,7 +153,7 @@ Downstream project should update following configurations:
 ### Upgrading the printing engine
 The mapfish-print based printing engine has been upgraded to align to the latest official 2.1.5 in term of functionalities.
 
-An update to the MapStore printing engine context file (applicationContext-print.xml) is needed for all projects built with the printing profile enabled. The following sections should be added to the file:
+An update to the MapStore printing engine context file (`applicationContext-print.xml`) is needed for all projects built with the printing profile enabled. The following sections should be added to the file:
 
 ```diff
 <bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -150,6 +150,29 @@ Downstream project should update following configurations:
 
 - This step is needed only for custom project with a specific `publicPath` different from the default one. In this case you may need to specify what folder deliver the  cesium build ( by default `dist/cesium`). To do that, you can add the  `cesiumBaseUrl` parameter in the webpack dev and prod configs to the correct location of the cesium static assets, widgets and workers folder.
 
+### Upgrading the printing engine
+The mapfish-print based printing engine has been upgraded to align to the latest official 2.1.5 in term of functionalities.
+
+An update to the MapStore printing engine context file (applicationContext-print.xml) is needed for all projects built with the printing profile enabled. The following sections should be added to the file:
+
+```diff
+<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
++<bean id="threadResources" class="org.mapfish.print.ThreadResources">
++    <property name="connectionTimeout" value="30000"/>
++    <property name="socketTimeout" value="30000" />
++    <property name="globalParallelFetches" value="200"/>
++    <property name="perHostParallelFetches" value="30" />
++</bean>
+
+<bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
++
++<bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" lazy-init="false"/>
++<bean id="healthCheckRegistry" class="com.codahale.metrics.health.HealthCheckRegistry" lazy-init="false"/>
++<bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator"  lazy-init="false"/>
++<bean id="jvmMetricsConfigurator" class="org.mapfish.print.metrics.JvmMetricsConfigurator" lazy-init="false"/>
++<bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
+```
+
 ## Migration from 2021.02.01 to 2021.02.02
 ### Style parsers dynamic import
 

--- a/java/printing/pom.xml
+++ b/java/printing/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>geosolutions-2.0-SNAPSHOT</version>
+        <version>geosolutions-2.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/printing/webapp/applicationContext-print.xml
+++ b/java/printing/webapp/applicationContext-print.xml
@@ -18,6 +18,12 @@
 
     <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
 	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
+    <bean id="threadResources" class="org.mapfish.print.ThreadResources">
+        <property name="connectionTimeout" value="30000"/>
+        <property name="socketTimeout" value="30000" />
+        <property name="globalParallelFetches" value="200"/>
+        <property name="perHostParallelFetches" value="30" />
+	</bean>
 
       <!-- Define MapReaderFactories -->
     <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
@@ -86,4 +92,10 @@
     <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
     <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
     <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
+
+    <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" lazy-init="false"/>
+    <bean id="healthCheckRegistry" class="com.codahale.metrics.health.HealthCheckRegistry" lazy-init="false"/>
+    <bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator"  lazy-init="false"/>
+    <bean id="jvmMetricsConfigurator" class="org.mapfish.print.metrics.JvmMetricsConfigurator" lazy-init="false"/>
+    <bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
 </beans>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -323,7 +323,7 @@
         <dependency>
             <groupId>org.mapfish.print</groupId>
             <artifactId>print-lib</artifactId>
-            <version>geosolutions-2.0-SNAPSHOT</version>
+            <version>geosolutions-2.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -452,7 +452,7 @@
                 <dependency>
                     <groupId>org.mapfish.print</groupId>
                     <artifactId>print-lib</artifactId>
-                    <version>geosolutions-2.0-SNAPSHOT</version>
+                    <version>geosolutions-2.1-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             </profile>

--- a/project/standard/templates/web/src/printing/applicationContext-print.xml
+++ b/project/standard/templates/web/src/printing/applicationContext-print.xml
@@ -18,6 +18,12 @@
 
     <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
 	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
+    <bean id="threadResources" class="org.mapfish.print.ThreadResources">
+        <property name="connectionTimeout" value="30000"/>
+        <property name="socketTimeout" value="30000" />
+        <property name="globalParallelFetches" value="200"/>
+        <property name="perHostParallelFetches" value="30" />
+	</bean>
 
       <!-- Define MapReaderFactories -->
     <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
@@ -86,4 +92,10 @@
     <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
     <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
     <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
+
+    <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" lazy-init="false"/>
+    <bean id="healthCheckRegistry" class="com.codahale.metrics.health.HealthCheckRegistry" lazy-init="false"/>
+    <bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator"  lazy-init="false"/>
+    <bean id="jvmMetricsConfigurator" class="org.mapfish.print.metrics.JvmMetricsConfigurator" lazy-init="false"/>
+    <bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
 </beans>


### PR DESCRIPTION
…sh-print library

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
When https://github.com/geosolutions-it/mapfish-print/pull/49 will be merged on the mapfish-print project, this PR will allow MapStore to work properly with the new version.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: library upgrade

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#7890 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
MapStore won't start with the upgraded print-lib.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
MapStore starts correctly with the upgraded print-lib.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] Yes, and I documented them in migration notes
 - [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->
All projects built with the printing profile enabled will need to update the applicationContext-print.xml file as explained in the migration notes.

## Other useful information
