### PR TITLE
Issue #7895 Autocomplete drop down menu won't populate on first click

### DIFF
--- a/web/client/observables/autocomplete.js
+++ b/web/client/observables/autocomplete.js
@@ -39,10 +39,10 @@ export const singleAttributeFilter = ({searchText = "", queriableAttributes = []
  * @return {external:Observable} the stream used for fetching data for the autocomplete editor
 */
 export const createPagedUniqueAutompleteStream = (props$) => props$
-    .throttle(props => Rx.Observable.timer(props.delayDebounce || 0))
-    .merge(props$.debounce(props => Rx.Observable.timer(props.delayDebounce || 0)))
     .distinctUntilChanged( ({value, currentPage, attribute}, newProps = {}) =>
         !(newProps.value !== value || newProps.currentPage !== currentPage || newProps.attribute !== attribute))
+    .throttle(props => Rx.Observable.timer(props.delayDebounce || 0))
+    .merge(props$.debounce(props => Rx.Observable.timer(props.delayDebounce || 0))).distinctUntilChanged()
     .switchMap((p) => {
         if (p.performFetch) {
             const data = getWpsPayload({


### PR DESCRIPTION
## Description
This PR reintroduces a couple of lines in the autocomplete observable
to allow the population of the autocomplete drop down menu on first opening, this issue was introduced to solve another issue #7789 .
**WARNING**
This PR may in fact reintroduce the scroll blinking issue, please report any test issue.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
On the color class modal, the autocomplete fields won't display the correct results when users open the dropdown menu the first time.
#7895 

**What is the new behavior?**
On the color class modal, the autocomplete fields will now display the correct classification value even when users open the dropdown menu the first time.

## Other useful information
since #7789 won't show on every screen size, it will worthwhile (not to say mandatory) for testers to verify such issue is not reintroduced with this PR.
