### PR TITLE
Issue #7907 - Undefined colorCategories results

### DIFF
--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -99,16 +99,16 @@ const getRangeClassificationColors = (values, colorCategories, customColorEnable
  */
 const getClassification = (classificationType, values, autoColorOptions, customColorEnabled) => {
     // if chart is absolute-values/category classified
-    const colorCategories = classificationType === 'value' ? autoColorOptions?.classification :
+    const colorCategories = classificationType === 'value' ? autoColorOptions?.classification || [] :
     // if chart is range classified
-        classificationType === 'range' ? autoColorOptions?.rangeClassification :
+        classificationType === 'range' ? autoColorOptions?.rangeClassification || [] :
         // chart may not be classified or error
-            [] || [];
+            [];
 
     // if chart is absolute-values/category classified
-    const classificationColors = classificationType === 'value' ? getClassificationColors(values, colorCategories, customColorEnabled, autoColorOptions) || [] :
+    const classificationColors = classificationType === 'value' && colorCategories.length ? getClassificationColors(values, colorCategories, customColorEnabled, autoColorOptions) || [] :
         // if chart is range classified
-        classificationType === 'range' ? getRangeClassificationColors(values, colorCategories, customColorEnabled, autoColorOptions) || [] :
+        classificationType === 'range'  && colorCategories.length ? getRangeClassificationColors(values, colorCategories, customColorEnabled, autoColorOptions) || [] :
         // chart may not be classified or error
             [];
 

--- a/web/client/components/charts/__tests__/WidgetChart-test.js
+++ b/web/client/components/charts/__tests__/WidgetChart-test.js
@@ -190,11 +190,14 @@ describe('Widget Chart: data conversions ', () => {
             expect(layout.colorway).toEqual(defaultColorGenerator(data[0].values.length, autoColorOptions));
         });
     });
-    it('color mapping classification and classificationAttributeType are undefined - Pie Chart', () => {
+    it('color mapping classification is undefined - Pie Chart', () => {
         const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", name: 'global.colors.custom' };
         const { data, layout } = toPlotly({
             type: 'pie',
             autoColorOptions,
+            options: {
+                classificationAttributeType: 'string'
+            },
             ...DATASET_2
         });
         expect(data.length).toBe(1);
@@ -774,11 +777,14 @@ describe('Widget Chart: data conversions ', () => {
             expect(DATASET_WITH_DATES.type).toBe('line');
             expect(data[0].x[0] <= data[0].x[1]).toBeTruthy();
         });
-        it('color mapping classification and classificationAttributeType are undefined - Bar Chart', () => {
+        it('color mapping classification is undefined - Bar Chart', () => {
             const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "", name: 'global.colors.custom' };
             const { data, layout } = toPlotly({
                 type: 'bar',
                 autoColorOptions,
+                options: {
+                    classificationAttributeType: 'string'
+                },
                 ...DATASET_2
             });
             expect(data.length).toBe(1);

--- a/web/client/components/charts/__tests__/WidgetChart-test.js
+++ b/web/client/components/charts/__tests__/WidgetChart-test.js
@@ -190,6 +190,30 @@ describe('Widget Chart: data conversions ', () => {
             expect(layout.colorway).toEqual(defaultColorGenerator(data[0].values.length, autoColorOptions));
         });
     });
+    it('color mapping classification and classificationAttributeType are undefined - Pie Chart', () => {
+        const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", name: 'global.colors.custom' };
+        const { data, layout } = toPlotly({
+            type: 'pie',
+            autoColorOptions,
+            ...DATASET_2
+        });
+        expect(data.length).toBe(1);
+        expect(data[0].type).toBe('pie');
+        expect(data[0].textposition).toEqual('inside');
+        // data values mapped
+        data[0].values.map((v, i) => expect(v).toBe(DATASET_2.data[i][DATASET_2.series[0].dataKey]));
+        // data labels mapped
+        data[0].labels.map((v, i) => {
+            const classLabel = DATASET_2.data[i].name;
+            expect(v).toBe(classLabel);
+        });
+        // colors are those defined by the user
+        data[0].marker.colors.map((v) => {
+            expect(v).toBe(autoColorOptions.defaultCustomColor);
+        });
+        // LAYOUT
+        expect(layout.margin).toEqual({t: 5, b: 5, l: 2, r: 2, pad: 4}); // fixed margins
+    });
     describe('Pie chart - Color coded custom classifications with absolute values', () => {
         it('custom classified colors - using custom labels and colors only', () => {
             const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", classification: LABELLED_CLASSIFICATION, name: 'global.colors.custom' };
@@ -780,30 +804,6 @@ describe('Widget Chart: data conversions ', () => {
             // xaxis
             expect(layout.xaxis.automargin).toBeTruthy();
             expect(layout.xaxis.tickangle).toEqual('auto');
-        });
-        it('color mapping classification and classificationAttributeType are undefined - Pie Chart', () => {
-            const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", name: 'global.colors.custom' };
-            const { data, layout } = toPlotly({
-                type: 'pie',
-                autoColorOptions,
-                ...DATASET_2
-            });
-            expect(data.length).toBe(1);
-            expect(data[0].type).toBe('pie');
-            expect(data[0].textposition).toEqual('inside');
-            // data values mapped
-            data[0].values.map((v, i) => expect(v).toBe(DATASET_2.data[i][DATASET_2.series[0].dataKey]));
-            // data labels mapped
-            data[0].labels.map((v, i) => {
-                const classLabel = DATASET_2.data[i].name;
-                expect(v).toBe(classLabel);
-            });
-            // colors are those defined by the user
-            data[0].marker.colors.map((v) => {
-                expect(v).toBe(autoColorOptions.defaultCustomColor);
-            });
-            // LAYOUT
-            expect(layout.margin).toEqual({t: 5, b: 5, l: 2, r: 2, pad: 4}); // fixed margins
         });
     });
 });

--- a/web/client/components/charts/__tests__/WidgetChart-test.js
+++ b/web/client/components/charts/__tests__/WidgetChart-test.js
@@ -750,5 +750,60 @@ describe('Widget Chart: data conversions ', () => {
             expect(DATASET_WITH_DATES.type).toBe('line');
             expect(data[0].x[0] <= data[0].x[1]).toBeTruthy();
         });
+        it('color mapping classification and classificationAttributeType are undefined - Bar Chart', () => {
+            const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "", name: 'global.colors.custom' };
+            const { data, layout } = toPlotly({
+                type: 'bar',
+                autoColorOptions,
+                ...DATASET_2
+            });
+            expect(data.length).toBe(1);
+            // expect(data[0].type).toBe('line');
+
+            // data values mapped
+            data[0].y.map((v, i) => expect(v).toBe(DATASET_1.data[i][DATASET_1.series[0].dataKey]));
+            // data labels mapped
+            data[0].x.map((v, i) => expect(v).toBe(DATASET_1.data[i][DATASET_1.xAxis.dataKey]));
+            // LAYOUT
+
+            // minimal margins, bottom automatic
+            expect(layout.margin).toEqual({ t: 5, b: 30, l: 5, r: 5, pad: 4 });
+
+            // colors generated are the defaults, generated on series (1 color for series, so 1)
+            expect(layout.colorway).toEqual([autoColorOptions.defaultCustomColor]);
+
+            // yaxis
+            expect(layout.yaxis.automargin).toBeTruthy();
+            expect(layout.yaxis.showticklabels).toBeFalsy();
+            expect(layout.yaxis.showgrid).toBeFalsy();
+
+            // xaxis
+            expect(layout.xaxis.automargin).toBeTruthy();
+            expect(layout.xaxis.tickangle).toEqual('auto');
+        });
+        it('color mapping classification and classificationAttributeType are undefined - Pie Chart', () => {
+            const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", name: 'global.colors.custom' };
+            const { data, layout } = toPlotly({
+                type: 'pie',
+                autoColorOptions,
+                ...DATASET_2
+            });
+            expect(data.length).toBe(1);
+            expect(data[0].type).toBe('pie');
+            expect(data[0].textposition).toEqual('inside');
+            // data values mapped
+            data[0].values.map((v, i) => expect(v).toBe(DATASET_2.data[i][DATASET_2.series[0].dataKey]));
+            // data labels mapped
+            data[0].labels.map((v, i) => {
+                const classLabel = DATASET_2.data[i].name;
+                expect(v).toBe(classLabel);
+            });
+            // colors are those defined by the user
+            data[0].marker.colors.map((v) => {
+                expect(v).toBe(autoColorOptions.defaultCustomColor);
+            });
+            // LAYOUT
+            expect(layout.margin).toEqual({t: 5, b: 5, l: 2, r: 2, pad: 4}); // fixed margins
+        });
     });
 });


### PR DESCRIPTION
This commit contains code that falls back to empty array if
no entry `classification` or `rangeClassification` is found
in the autocolorOptions object, despite the chart being marked
as classified, the inconsistency may be there for charts created
before the dual (strings, numbers) classification was introduced

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7907 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
