### PR TITLE
Revert "#7890: align applicationContext-print.xml to work with upgraded mapfi…"

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -150,29 +150,6 @@ Downstream project should update following configurations:
 
 - This step is needed only for custom project with a specific `publicPath` different from the default one. In this case you may need to specify what folder deliver the  cesium build ( by default `dist/cesium`). To do that, you can add the  `cesiumBaseUrl` parameter in the webpack dev and prod configs to the correct location of the cesium static assets, widgets and workers folder.
 
-### Upgrading the printing engine
-The mapfish-print based printing engine has been upgraded to align to the latest official 2.1.5 in term of functionalities.
-
-An update to the MapStore printing engine context file (`applicationContext-print.xml`) is needed for all projects built with the printing profile enabled. The following sections should be added to the file:
-
-```diff
-<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
-+<bean id="threadResources" class="org.mapfish.print.ThreadResources">
-+    <property name="connectionTimeout" value="30000"/>
-+    <property name="socketTimeout" value="30000" />
-+    <property name="globalParallelFetches" value="200"/>
-+    <property name="perHostParallelFetches" value="30" />
-+</bean>
-
-<bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
-+
-+<bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" lazy-init="false"/>
-+<bean id="healthCheckRegistry" class="com.codahale.metrics.health.HealthCheckRegistry" lazy-init="false"/>
-+<bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator"  lazy-init="false"/>
-+<bean id="jvmMetricsConfigurator" class="org.mapfish.print.metrics.JvmMetricsConfigurator" lazy-init="false"/>
-+<bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
-```
-
 ## Migration from 2021.02.01 to 2021.02.02
 ### Style parsers dynamic import
 

--- a/java/printing/pom.xml
+++ b/java/printing/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>geosolutions-2.1-SNAPSHOT</version>
+        <version>geosolutions-2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/printing/webapp/applicationContext-print.xml
+++ b/java/printing/webapp/applicationContext-print.xml
@@ -18,12 +18,6 @@
 
     <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
 	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
-    <bean id="threadResources" class="org.mapfish.print.ThreadResources">
-        <property name="connectionTimeout" value="30000"/>
-        <property name="socketTimeout" value="30000" />
-        <property name="globalParallelFetches" value="200"/>
-        <property name="perHostParallelFetches" value="30" />
-	</bean>
 
       <!-- Define MapReaderFactories -->
     <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
@@ -92,10 +86,4 @@
     <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
     <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
     <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
-
-    <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" lazy-init="false"/>
-    <bean id="healthCheckRegistry" class="com.codahale.metrics.health.HealthCheckRegistry" lazy-init="false"/>
-    <bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator"  lazy-init="false"/>
-    <bean id="jvmMetricsConfigurator" class="org.mapfish.print.metrics.JvmMetricsConfigurator" lazy-init="false"/>
-    <bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
 </beans>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -323,7 +323,7 @@
         <dependency>
             <groupId>org.mapfish.print</groupId>
             <artifactId>print-lib</artifactId>
-            <version>geosolutions-2.1-SNAPSHOT</version>
+            <version>geosolutions-2.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -452,7 +452,7 @@
                 <dependency>
                     <groupId>org.mapfish.print</groupId>
                     <artifactId>print-lib</artifactId>
-                    <version>geosolutions-2.1-SNAPSHOT</version>
+                    <version>geosolutions-2.0-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             </profile>

--- a/project/standard/templates/web/src/printing/applicationContext-print.xml
+++ b/project/standard/templates/web/src/printing/applicationContext-print.xml
@@ -18,12 +18,6 @@
 
     <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
 	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
-    <bean id="threadResources" class="org.mapfish.print.ThreadResources">
-        <property name="connectionTimeout" value="30000"/>
-        <property name="socketTimeout" value="30000" />
-        <property name="globalParallelFetches" value="200"/>
-        <property name="perHostParallelFetches" value="30" />
-	</bean>
 
       <!-- Define MapReaderFactories -->
     <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
@@ -92,10 +86,4 @@
     <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
     <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
     <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
-
-    <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" lazy-init="false"/>
-    <bean id="healthCheckRegistry" class="com.codahale.metrics.health.HealthCheckRegistry" lazy-init="false"/>
-    <bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator"  lazy-init="false"/>
-    <bean id="jvmMetricsConfigurator" class="org.mapfish.print.metrics.JvmMetricsConfigurator" lazy-init="false"/>
-    <bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
 </beans>


### PR DESCRIPTION
Reverts geosolutions-it/MapStore2#7891

Because of this problem: https://github.com/geosolutions-it/MapStore2/pull/7891#issuecomment-1060455482

I don't have tested personally this issue to confirm that the PR caused the problem. It is only because dev was working before this merge, AFAIK
If @mbarto doesn't have a quick idea or solution, I'm going to revert to this PR to let you investigate more on the problem, while dev is open for other testings. 