### PR TITLE
Update github actions to test the build with all the profiles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,9 @@ jobs:
 
   test-back-end:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        profile: [none, ldap, printing, printingbundle]
     steps:
       - name: "checking out"
         uses: actions/checkout@v2
@@ -91,7 +94,9 @@ jobs:
       # JAVA CHECKS
       ##############
       - name: java
-        run: mvn --batch-mode --update-snapshots verify
+        env:
+          PROFILE: ${{ matrix.profile }}
+        run: mvn --batch-mode --update-snapshots verify -P$PROFILE
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        profile: [none, ldap, printing, printingbundle]
+        profile: [none, ldap, printing, printingbundle, release]
     steps:
       - name: "checking out"
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description
During the release I noticed that some profiles are used only in jenkins. We should do at least a smoke test for these profiles in order to undestand if they don't fail for some build reasons (missing or wrong dependencies, file or missing java files, test failures in sub-modules)

Producing a set of additional builds in parallel.
![image](https://user-images.githubusercontent.com/1279510/157233555-ee7fff48-8eea-4ce3-80e2-93f4b91a68dc.png)


This attempt improvement checks if mapstore builds with all the profiles passed. 
Doing to see if the github action are executed correctly. 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
