### PR TITLE
Issue #7853 - fix regression that allowed heading, pitch, roll input numbers to exceed given range

### DIFF
--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -27,7 +27,7 @@ import {
 import Message from '../../components/I18N/Message';
 import { join, isNil, isEqual, inRange, isEmpty, pick, omit } from 'lodash';
 import { removeQueryFromUrl, getSharedGeostoryUrl, CENTERANDZOOM, BBOX, MARKERANDZOOM, SHARE_TABS } from '../../utils/ShareUtils';
-import { getLonLatFromPoint, convertRadianToDegrees, convertDegreesToRadian } from '../../utils/CoordinatesUtils';
+import { getLonLatFromPoint, convertRadianToDegrees, convertDegreesToRadian, setValueBoundaries } from '../../utils/CoordinatesUtils';
 import { getMessageById } from '../../utils/LocaleUtils';
 import SwitchPanel from '../misc/switch/SwitchPanel';
 import Editor from '../data/identify/coordinates/Editor';
@@ -151,6 +151,13 @@ class SharePanel extends React.Component {
             !isEqual(this.props.isVisible, newProps.isVisible) ||
             !isEqual(this.props?.viewerOptions?.orientation, newProps.viewerOptions?.orientation)) {
             this.initializeDefaults(newProps);
+        }
+        if (this.props?.viewerOptions?.orientation) {
+            this.setState({
+                heading: convertRadianToDegrees(newProps.viewerOptions?.orientation?.heading),
+                pitch: convertRadianToDegrees(newProps.viewerOptions?.orientation?.pitch),
+                roll: convertRadianToDegrees(newProps.viewerOptions?.orientation?.roll)
+            });
         }
     }
 
@@ -301,13 +308,6 @@ class SharePanel extends React.Component {
         this.props.updateMapView(updateMapProperties);
     }
 
-    setValueBoundaries = (value, min, max) => {
-        if (value.length < 1) { return 0;}
-        if (value < min) { return min;}
-        if (value > max) { return max;}
-        return  value;
-    }
-
     renderAdvancedSettings = () => {
         return (
             <SwitchPanel
@@ -419,7 +419,7 @@ class SharePanel extends React.Component {
                                             });
                                         }}
                                         onBlur={()=> {
-                                            const angle = this.setValueBoundaries(this.state.heading, 0, 360);
+                                            const angle = setValueBoundaries(this.state.heading, 0, 360);
                                             this.updateMapView('heading', angle);
                                         }}
                                     />
@@ -443,7 +443,7 @@ class SharePanel extends React.Component {
                                             });
                                         }}
                                         onBlur={()=> {
-                                            const angle = this.setValueBoundaries(this.state.roll, -90, 90);
+                                            const angle = setValueBoundaries(this.state.roll, -90, 90);
                                             this.updateMapView('roll', angle);
                                         }}
                                     />
@@ -467,7 +467,7 @@ class SharePanel extends React.Component {
                                             });
                                         }}
                                         onBlur={()=> {
-                                            const angle = this.setValueBoundaries(this.state.pitch, -90, 90);
+                                            const angle = setValueBoundaries(this.state.pitch, -90, 90);
                                             this.updateMapView('pitch', angle);
                                         }}
                                     />

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -34,6 +34,15 @@ function mapConfig(state = {eventListeners: {}}, action) {
     switch (action.type) {
     case CHANGE_MAP_VIEW:
         const {type, ...params} = action;
+        if (params?.viewerOptions) {
+            const heading = CoordinatesUtils.setValueBoundaries(params.viewerOptions.orientation.heading, CoordinatesUtils.convertDegreesToRadian(0), CoordinatesUtils.convertDegreesToRadian(360));
+            const pitch = CoordinatesUtils.setValueBoundaries(params.viewerOptions.orientation.pitch, CoordinatesUtils.convertDegreesToRadian(-90), CoordinatesUtils.convertDegreesToRadian(90));
+            const roll = CoordinatesUtils.setValueBoundaries(params.viewerOptions.orientation.roll, CoordinatesUtils.convertDegreesToRadian(-90), CoordinatesUtils.convertDegreesToRadian(90));
+            params.viewerOptions.orientation.heading = heading;
+            params.viewerOptions.orientation.pitch = pitch;
+            params.viewerOptions.orientation.roll = roll;
+        }
+        params.zoom = isNaN(params.zoom) ? 1 : params.zoom;
         return assign({}, state, params);
     case CHANGE_MOUSE_POINTER:
         return assign({}, state, {

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -1109,6 +1109,13 @@ export const convertDegreesToRadian = (deg) => {
     return isNumber(value) && ((value * Math.PI) / 180);
 };
 
+export const setValueBoundaries = (value, min, max ) => {
+    if (isNaN(value) && value.length < 1) { return 0;}
+    if (value < min) { return min;}
+    if (value > max) { return max;}
+    return  parseFloat(value);
+};
+
 CoordinatesUtils = {
     setCrsLabels,
     getUnits,
@@ -1167,6 +1174,7 @@ CoordinatesUtils = {
     getLonLatFromPoint,
     getExtentForProjection,
     convertRadianToDegrees,
-    convertDegreesToRadian
+    convertDegreesToRadian,
+    setValueBoundaries
 };
 export default CoordinatesUtils;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7853 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Heading, pitch and roll input do not allow numbers that exceed their given ranges
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
