### PR TITLE
[Backport 2022.01.xx] #7866; updated UI enhancements in mobile maps

### DIFF
--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -39,7 +39,8 @@ class DefaultViewer extends React.Component {
         showEmptyMessageGFI: PropTypes.bool,
         renderValidOnly: PropTypes.bool,
         loaded: PropTypes.bool,
-        isMobile: PropTypes.bool
+        isMobile: PropTypes.bool,
+        disableInfoAlert: PropTypes.bool
     };
 
     static defaultProps = {
@@ -62,7 +63,8 @@ class DefaultViewer extends React.Component {
         onNext: () => {},
         onPrevious: () => {},
         setIndex: () => {},
-        isMobile: false
+        isMobile: false,
+        disableInfoAlert: false
     };
 
     shouldComponentUpdate(nextProps) {
@@ -109,7 +111,7 @@ class DefaultViewer extends React.Component {
                 const {layerMetadata} = res;
                 return layerMetadata.title;
             });
-            return this.props.showEmptyMessageGFI ? (
+            return this.props.showEmptyMessageGFI && !this.props.disableInfoAlert ? (
                 <Alert bsStyle={"info"}>
                     <Message msgId={"noInfoForLayers"} />
                     <b>{titles.join(', ')}</b>

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -69,7 +69,9 @@ export default props => {
         formatCoord,
         loaded,
         validator = () => null,
-        toggleHighlightFeature = () => {}
+        toggleHighlightFeature = () => {},
+        disableCoordinatesRow,
+        disableInfoAlert
     } = props;
     const latlng = point && point.latlng || null;
 
@@ -144,7 +146,8 @@ export default props => {
                             />
                         </div>
                     </Row>,
-                    <Row className="coordinates-edit-row">
+                    !disableCoordinatesRow &&
+                    (<Row className="coordinates-edit-row">
                         <span className="identify-icon glyphicon glyphicon-point"/>
                         <div style={showCoordinateEditor ? {zIndex: 1} : {}} className={"coordinate-editor"}>
                             <Coordinate
@@ -169,7 +172,7 @@ export default props => {
                                  * for this reason they ahve been disabled
                                 */
                             }/>
-                    </Row>
+                    </Row>)
                 ].filter(headRow => headRow)}>
                 <Viewer
                     index={index}
@@ -179,6 +182,7 @@ export default props => {
                     responses={responses}
                     requests={requests}
                     showEmptyMessageGFI={showEmptyMessageGFI}
+                    disableInfoAlert={disableInfoAlert}
                     {...viewerOptions}/>
             </DockablePanel>
             <Portal>

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -208,6 +208,8 @@
                 "cfg": {
                     "showFullscreen": true,
                     "position": "bottom",
+                    "disableInfoAlert": true,
+                    "disableCoordinatesRow": true,
                     "size": 0.5,
                     "fluid": true,
                     "viewerOptions": {

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -104,7 +104,7 @@ const selector = createStructuredSelector({
  */
 const identifyIndex = compose(
     connect(
-        createSelector(indexSelector, isLoadedResponseSelector, (state) => state.browser && state.browser.mobile, (index, loaded, isMobile) => ({ index, loaded, isMobile })),
+        createSelector(indexSelector, isLoadedResponseSelector, (state) => state.browser && state.browser.mobile,  (index, loaded, isMobile) => ({ index, loaded, isMobile })),
         {
             setIndex: changePage
         }

--- a/web/client/product/assets/css/mobile.css
+++ b/web/client/product/assets/css/mobile.css
@@ -9,6 +9,7 @@
 #navigationBar .mapToolbar {
     bottom: 25px;
     margin-bottom: 0;
+    box-shadow: none;
 }
 
 .background-plugin-position {
@@ -22,4 +23,8 @@
 
 .ol-attribution.ol-uncollapsible {
     background-color: transparent;
+}
+
+.ms-primary.ms-header {
+    box-shadow: none;
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7866 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
- Removed shadows from mobile view
- Decreased sizes of padding and margin on mobile
- Decreased the size of the header in mobile view
- Added the possibility to disable the info alert via config on mobile (and effectively disable it only for c040)
- Added the possibility to disable the coordinates row on mobile (and effectively disable it only for c040)
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
