### PR TITLE
#7007: Fix cesium css import

### DIFF
--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -171,7 +171,9 @@ module.exports = (...args) => mapArgumentsToObject(args, ({
         }),
         new NormalModuleReplacementPlugin(/leaflet$/, path.join(paths.framework, "libs", "leaflet")),
         new NormalModuleReplacementPlugin(/proj4$/, path.join(paths.framework, "libs", "proj4")),
-        new NormalModuleReplacementPlugin(/cesium\.widgets\.css/, path.join(paths.base, "node_modules", "cesium/Build/Cesium/Widgets/widgets.css")),
+        // it's not possible to load directly from the module name `cesium/Build/Cesium/Widgets/widgets.css`
+        // see https://github.com/CesiumGS/cesium/issues/9212
+        new NormalModuleReplacementPlugin(/^cesium\/index\.css$/, path.join(paths.base, "node_modules", "cesium/Build/Cesium/Widgets/widgets.css")),
         new NoEmitOnErrorsPlugin()]
         .concat(castArray(plugins))
         .concat(prod ? prodPlugins : devPlugins),

--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -171,6 +171,7 @@ module.exports = (...args) => mapArgumentsToObject(args, ({
         }),
         new NormalModuleReplacementPlugin(/leaflet$/, path.join(paths.framework, "libs", "leaflet")),
         new NormalModuleReplacementPlugin(/proj4$/, path.join(paths.framework, "libs", "proj4")),
+        new NormalModuleReplacementPlugin(/cesium\.widgets\.css/, path.join(paths.base, "node_modules", "cesium/Build/Cesium/Widgets/widgets.css")),
         new NoEmitOnErrorsPlugin()]
         .concat(castArray(plugins))
         .concat(prod ? prodPlugins : devPlugins),

--- a/build/karma.conf.continuous-test.js
+++ b/build/karma.conf.continuous-test.js
@@ -8,7 +8,7 @@ module.exports = function karmaConfig(config) {
             { pattern: './web/client/translations/**/*', included: false }
         ],
         browsers: ["Chrome"],
-        basePath: "..",
+        basePath: path.join(__dirname, ".."),
         path: path.join(__dirname, "..", "web", "client"),
         testFile: 'build/tests.webpack.js',
         singleRun: false

--- a/build/karma.conf.single-run.js
+++ b/build/karma.conf.single-run.js
@@ -11,7 +11,7 @@ module.exports = function karmaConfig(config) {
             { pattern: './web/client/translations/**/*', included: false }
         ],
         path: path.join(__dirname, "..", "web", "client"),
-        basePath: "..",
+        basePath: path.join(__dirname, ".."),
         testFile: 'build/tests-travis.webpack.js',
         singleRun: true
     });

--- a/build/testConfig.js
+++ b/build/testConfig.js
@@ -2,6 +2,7 @@ const assign = require('object-assign');
 const nodePath = require('path');
 const webpack = require('webpack');
 const ProvidePlugin = require("webpack/lib/ProvidePlugin");
+const NormalModuleReplacementPlugin = require("webpack/lib/NormalModuleReplacementPlugin");
 
 module.exports = ({browsers = [ 'ChromeHeadless' ], files, path, testFile, singleRun, basePath = ".", alias = {}}) => ({
     browsers,
@@ -147,7 +148,10 @@ module.exports = ({browsers = [ 'ChromeHeadless' ], files, path, testFile, singl
             new webpack.DefinePlugin({
                 // Define relative base path in cesium for loading assets
                 'CESIUM_BASE_URL': JSON.stringify(nodePath.join(basePath, 'node_modules', 'cesium', 'Source'))
-            })
+            }),
+            // it's not possible to load directly from the module name `cesium/Build/Cesium/Widgets/widgets.css`
+            // see https://github.com/CesiumGS/cesium/issues/9212
+            new NormalModuleReplacementPlugin(/^cesium\/index\.css$/, nodePath.join(basePath, 'node_modules', 'cesium/Build/Cesium/Widgets/widgets.css'))
         ]
     },
     webpackServer: {

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -8,7 +8,7 @@
 import * as Cesium from 'cesium';
 // it's not possible to load directly from the module name `cesium/Build/Cesium/Widgets/widgets.css`
 // see https://github.com/CesiumGS/cesium/issues/9212
-import 'cesium.widgets.css';
+import 'cesium/index.css';
 
 import '@znemz/cesium-navigation/dist/index.css';
 import viewerCesiumNavigationMixin from '@znemz/cesium-navigation';

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -8,7 +8,7 @@
 import * as Cesium from 'cesium';
 // it's not possible to load directly from the module name `cesium/Build/Cesium/Widgets/widgets.css`
 // see https://github.com/CesiumGS/cesium/issues/9212
-import '../../../../../node_modules/cesium/Build/Cesium/Widgets/widgets.css';
+import 'cesium.widgets.css';
 
 import '@znemz/cesium-navigation/dist/index.css';
 import viewerCesiumNavigationMixin from '@znemz/cesium-navigation';


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The widgets.css style of cesium is not exposed in the package.json of the module so it is not possible to import directly the css. The first solution was to include the css with an absolute import of the file retrieved from node_modules but it works only for the core. This PR introduces an alias so the css is included correctly also in mapstore project

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7007

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
