### PR TITLE
#7890: align applicationContext-print.xml to work with upgraded mapfish-print library

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -153,7 +153,7 @@ Downstream project should update following configurations:
 ### Upgrading the printing engine
 The mapfish-print based printing engine has been upgraded to align to the latest official 2.1.5 in term of functionalities.
 
-An update to the MapStore printing engine context file (applicationContext-print.xml) is needed for all projects built with the printing profile enabled. The following sections should be added to the file:
+An update to the MapStore printing engine context file (`applicationContext-print.xml`) is needed for all projects built with the printing profile enabled. The following sections should be added to the file:
 
 ```diff
 <bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -150,6 +150,29 @@ Downstream project should update following configurations:
 
 - This step is needed only for custom project with a specific `publicPath` different from the default one. In this case you may need to specify what folder deliver the  cesium build ( by default `dist/cesium`). To do that, you can add the  `cesiumBaseUrl` parameter in the webpack dev and prod configs to the correct location of the cesium static assets, widgets and workers folder.
 
+### Upgrading the printing engine
+The mapfish-print based printing engine has been upgraded to align to the latest official 2.1.5 in term of functionalities.
+
+An update to the MapStore printing engine context file (applicationContext-print.xml) is needed for all projects built with the printing profile enabled. The following sections should be added to the file:
+
+```diff
+<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
++<bean id="threadResources" class="org.mapfish.print.ThreadResources">
++    <property name="connectionTimeout" value="30000"/>
++    <property name="socketTimeout" value="30000" />
++    <property name="globalParallelFetches" value="200"/>
++    <property name="perHostParallelFetches" value="30" />
++</bean>
+
+<bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
++
++<bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" lazy-init="false"/>
++<bean id="healthCheckRegistry" class="com.codahale.metrics.health.HealthCheckRegistry" lazy-init="false"/>
++<bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator"  lazy-init="false"/>
++<bean id="jvmMetricsConfigurator" class="org.mapfish.print.metrics.JvmMetricsConfigurator" lazy-init="false"/>
++<bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
+```
+
 ## Migration from 2021.02.01 to 2021.02.02
 ### Style parsers dynamic import
 

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -173,6 +173,45 @@ An update to the MapStore printing engine context file (`applicationContext-prin
 +<bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
 ```
 
+Also, remember to update your project pom.xml with the updated dependency:
+
+ - locate the print-lib dependency in the pom.xml file
+ - replace the dependency with the following snippet 
+
+```xml
+<dependency>
+    <groupId>org.mapfish.print</groupId>
+    <artifactId>print-lib</artifactId>
+    <version>geosolutions-2.1-SNAPSHOT</version>
+    <exclusions>
+        <exclusion>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+```
+
 ## Migration from 2021.02.01 to 2021.02.02
 ### Style parsers dynamic import
 

--- a/java/printing/assembly/mapstore-printing.xml
+++ b/java/printing/assembly/mapstore-printing.xml
@@ -19,26 +19,43 @@
                 <include>**/bcmail-*.jar</include>
                 <include>**/bcprov-*.jar</include>
                 <include>**/commons-lang3-*.jar</include>
+                <include>**/commons-httpclient-*.jar</include>
+                <include>**/commons-io-*.jar</include>
+                <include>**/commons-text-*.jar</include>
+                <include>**/disruptor-*.jar</include>
                 <include>**/ejml-*.jar</include>
                 <include>**/fontbox-*.jar</include>
                 <include>**/fop-*.jar</include>
                 <include>**/GeographicLib-*.jar</include>
                 <include>**/gt-*.jar</include>
+                <include>**/guava-*.jar</include>
+                <include>**/httpclient-*.jar</include>
+                <include>**/httpcore-*.jar</include>
+                <include>**/imageio-*.jar</include>
                 <include>**/hsqldb-*.jar</include>
                 <include>**/itext-*.jar</include>
+                <include>**/itextpdf-*.jar</include>
                 <include>**/jai*.jar</include>
+                <include>**/jaxb-*.jar</include>
+                <include>**/jdom2-*.jar</include>
                 <include>**/jempbox-*.jar</include>
                 <include>**/jgridshift-*.jar</include>
-                <include>**/json-2008*.jar</include>
+                <include>**/json-2018*.jar</include>
                 <include>**/jts-core-*.jar</include>
+                <include>**/jt-*.jar</include>
                 <include>**/jyaml-*.jar</include>
+                <include>**/metrics-*.jar</include>
                 <include>**/pdfbox-*.jar</include>
                 <include>**/si-*.jar</include>
+                <include>**/slf4j-api-*.jar</include>
                 <include>**/systems-common-*.jar</include>
+                <include>**/txw2-*.jar</include>
                 <include>**/unit-*.jar</include>
                 <include>**/uom-*.jar</include>
-                <include>**/xml-apis-ext-*.jar</include>
+                <include>**/xml-apis-*.jar</include>
+                <include>**/xml-commons-resolver*.jar</include>
                 <include>**/xmlgraphics-commons-*.jar</include>
+                <include>**/xercesImpl-*.jar</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/java/printing/pom.xml
+++ b/java/printing/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>geosolutions-2.0-SNAPSHOT</version>
+        <version>geosolutions-2.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/printing/webapp/applicationContext-print.xml
+++ b/java/printing/webapp/applicationContext-print.xml
@@ -18,6 +18,12 @@
 
     <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
 	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
+    <bean id="threadResources" class="org.mapfish.print.ThreadResources">
+        <property name="connectionTimeout" value="30000"/>
+        <property name="socketTimeout" value="30000" />
+        <property name="globalParallelFetches" value="200"/>
+        <property name="perHostParallelFetches" value="30" />
+	</bean>
 
       <!-- Define MapReaderFactories -->
     <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
@@ -86,4 +92,10 @@
     <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
     <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
     <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
+
+    <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" lazy-init="false"/>
+    <bean id="healthCheckRegistry" class="com.codahale.metrics.health.HealthCheckRegistry" lazy-init="false"/>
+    <bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator"  lazy-init="false"/>
+    <bean id="jvmMetricsConfigurator" class="org.mapfish.print.metrics.JvmMetricsConfigurator" lazy-init="false"/>
+    <bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
 </beans>

--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -87,35 +87,12 @@
             <artifactId>maven-war-plugin</artifactId>
             <version>2.1.1</version>
             <configuration>
-                <packagingExcludes>
-                WEB-INF/lib/commons-beanutils-1.7.0.jar,
-                WEB-INF/lib/commons-codec-1.2.jar,
-                WEB-INF/lib/commons-collections-3.2.1.jar,
+                <packagingExcludes>WEB-INF/lib/commons-codec-1.2.jar,
                 WEB-INF/lib/commons-io-1.1.jar,
-                WEB-INF/lib/commons-io-2.1.jar,
-                WEB-INF/lib/commons-lang-2.3.jar,
                 WEB-INF/lib/commons-logging-1.0.4.jar,
-                WEB-INF/lib/commons-logging-1.1.1.jar,
                 WEB-INF/lib/commons-pool-1.3.jar,
-                WEB-INF/lib/guava-15.0.jar,
-                WEB-INF/lib/httpclient-4.2.5.jar,
-                WEB-INF/lib/httpcore-4.2.4.jar,
-                WEB-INF/lib/jackson-annotations-2.2.2.jar,
-                WEB-INF/lib/jackson-core-2.2.2.jar,
-                WEB-INF/lib/jackson-annotations-2.2.2.jar,
-                WEB-INF/lib/jackson-databind-2.2.2.jar,
-                WEB-INF/lib/javassist-3.8.0.GA.jar,
-                WEB-INF/lib/jaxb-api-2.1.jar,
-                WEB-INF/lib/jaxb-api-2.3.1.jar,
-                WEB-INF/lib/jaxb-runtime-2.3.1.jar,
                 WEB-INF/lib/slf4j-api-1.5*.jar,
-                WEB-INF/lib/slf4j-api-1.7.2.jar,
-                WEB-INF/lib/slf4j-api-1.7.21.jar,
-                WEB-INF/lib/slf4j-log4j12-1.5*.jar,
-                WEB-INF/lib/spring-tx-5.2.15*.jar,
-                WEB-INF/lib/txw2-2.3.1.jar,
-                WEB-INF/lib/xercesImpl-2.4.0.jar,
-                WEB-INF/lib/xml-apis-1.0.b2.jar
+                WEB-INF/lib/spring-tx-5.2.15*.jar
                 </packagingExcludes>
                 <overlays>
                     <overlay>

--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -92,6 +92,7 @@
                 WEB-INF/lib/commons-logging-1.0.4.jar,
                 WEB-INF/lib/commons-pool-1.3.jar,
                 WEB-INF/lib/slf4j-api-1.5*.jar,
+                WEB-INF/lib/slf4j-log4j12-1.5*.jar,
                 WEB-INF/lib/spring-tx-5.2.15*.jar
                 </packagingExcludes>
                 <overlays>

--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -87,13 +87,35 @@
             <artifactId>maven-war-plugin</artifactId>
             <version>2.1.1</version>
             <configuration>
-                <packagingExcludes>WEB-INF/lib/commons-codec-1.2.jar,
+                <packagingExcludes>
+                WEB-INF/lib/commons-beanutils-1.7.0.jar,
+                WEB-INF/lib/commons-codec-1.2.jar,
+                WEB-INF/lib/commons-collections-3.2.1.jar,
                 WEB-INF/lib/commons-io-1.1.jar,
+                WEB-INF/lib/commons-io-2.1.jar,
+                WEB-INF/lib/commons-lang-2.3.jar,
                 WEB-INF/lib/commons-logging-1.0.4.jar,
+                WEB-INF/lib/commons-logging-1.1.1.jar,
                 WEB-INF/lib/commons-pool-1.3.jar,
+                WEB-INF/lib/guava-15.0.jar,
+                WEB-INF/lib/httpclient-4.2.5.jar,
+                WEB-INF/lib/httpcore-4.2.4.jar,
+                WEB-INF/lib/jackson-annotations-2.2.2.jar,
+                WEB-INF/lib/jackson-core-2.2.2.jar,
+                WEB-INF/lib/jackson-annotations-2.2.2.jar,
+                WEB-INF/lib/jackson-databind-2.2.2.jar,
+                WEB-INF/lib/javassist-3.8.0.GA.jar,
+                WEB-INF/lib/jaxb-api-2.1.jar,
+                WEB-INF/lib/jaxb-api-2.3.1.jar,
+                WEB-INF/lib/jaxb-runtime-2.3.1.jar,
                 WEB-INF/lib/slf4j-api-1.5*.jar,
+                WEB-INF/lib/slf4j-api-1.7.2.jar,
+                WEB-INF/lib/slf4j-api-1.7.21.jar,
                 WEB-INF/lib/slf4j-log4j12-1.5*.jar,
-                WEB-INF/lib/spring-tx-5.2.15*.jar
+                WEB-INF/lib/spring-tx-5.2.15*.jar,
+                WEB-INF/lib/txw2-2.3.1.jar,
+                WEB-INF/lib/xercesImpl-2.4.0.jar,
+                WEB-INF/lib/xml-apis-1.0.b2.jar
                 </packagingExcludes>
                 <overlays>
                     <overlay>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -330,18 +330,6 @@
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
@@ -360,10 +348,6 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-context</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -323,7 +323,7 @@
         <dependency>
             <groupId>org.mapfish.print</groupId>
             <artifactId>print-lib</artifactId>
-            <version>geosolutions-2.0-SNAPSHOT</version>
+            <version>geosolutions-2.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -330,12 +330,40 @@
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-web</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-context</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -368,6 +368,7 @@
                 WEB-INF/lib/commons-logging-1.0.4.jar,
                 WEB-INF/lib/commons-pool-1.3.jar,
                 WEB-INF/lib/slf4j-api-1.5*.jar,
+                WEB-INF/lib/slf4j-log4j12-1.5*.jar,
                 WEB-INF/lib/spring-tx-5.2.15*.jar
                 </packagingExcludes>
                 <overlays>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -363,13 +363,35 @@
             <artifactId>maven-war-plugin</artifactId>
             <version>2.1.1</version>
             <configuration>
-                <packagingExcludes>WEB-INF/lib/commons-codec-1.2.jar,
+                <packagingExcludes>
+                WEB-INF/lib/commons-beanutils-1.7.0.jar,
+                WEB-INF/lib/commons-codec-1.2.jar,
+                WEB-INF/lib/commons-collections-3.2.1.jar,
                 WEB-INF/lib/commons-io-1.1.jar,
+                WEB-INF/lib/commons-io-2.1.jar,
+                WEB-INF/lib/commons-lang-2.3.jar,
                 WEB-INF/lib/commons-logging-1.0.4.jar,
+                WEB-INF/lib/commons-logging-1.1.1.jar,
                 WEB-INF/lib/commons-pool-1.3.jar,
+                WEB-INF/lib/guava-15.0.jar,
+                WEB-INF/lib/httpclient-4.2.5.jar,
+                WEB-INF/lib/httpcore-4.2.4.jar,
+                WEB-INF/lib/jackson-annotations-2.2.2.jar,
+                WEB-INF/lib/jackson-core-2.2.2.jar,
+                WEB-INF/lib/jackson-annotations-2.2.2.jar,
+                WEB-INF/lib/jackson-databind-2.2.2.jar,
+                WEB-INF/lib/javassist-3.8.0.GA.jar,
+                WEB-INF/lib/jaxb-api-2.1.jar,
+                WEB-INF/lib/jaxb-api-2.3.1.jar,
+                WEB-INF/lib/jaxb-runtime-2.3.1.jar,
                 WEB-INF/lib/slf4j-api-1.5*.jar,
+                WEB-INF/lib/slf4j-api-1.7.2.jar,
+                WEB-INF/lib/slf4j-api-1.7.21.jar,
                 WEB-INF/lib/slf4j-log4j12-1.5*.jar,
-                WEB-INF/lib/spring-tx-5.2.15*.jar
+                WEB-INF/lib/spring-tx-5.2.15*.jar,
+                WEB-INF/lib/txw2-2.3.1.jar,
+                WEB-INF/lib/xercesImpl-2.4.0.jar,
+                WEB-INF/lib/xml-apis-1.0.b2.jar
                 </packagingExcludes>
                 <overlays>
                     <overlay>
@@ -453,6 +475,48 @@
                     <groupId>org.mapfish.print</groupId>
                     <artifactId>print-lib</artifactId>
                     <version>geosolutions-2.1-SNAPSHOT</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>commons-codec</groupId>
+                            <artifactId>commons-codec</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.httpcomponents</groupId>
+                            <artifactId>httpclient</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.httpcomponents</groupId>
+                            <artifactId>httpcore</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.fasterxml.jackson.core</groupId>
+                            <artifactId>jackson-annotations</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.fasterxml.jackson.core</groupId>
+                            <artifactId>jackson-core</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>com.fasterxml.jackson.core</groupId>
+                            <artifactId>jackson-databind</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-web</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-context</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>xerces</groupId>
+                            <artifactId>xercesImpl</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
             </dependencies>
             </profile>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -452,7 +452,7 @@
                 <dependency>
                     <groupId>org.mapfish.print</groupId>
                     <artifactId>print-lib</artifactId>
-                    <version>geosolutions-2.0-SNAPSHOT</version>
+                    <version>geosolutions-2.1-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             </profile>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -363,35 +363,12 @@
             <artifactId>maven-war-plugin</artifactId>
             <version>2.1.1</version>
             <configuration>
-                <packagingExcludes>
-                WEB-INF/lib/commons-beanutils-1.7.0.jar,
-                WEB-INF/lib/commons-codec-1.2.jar,
-                WEB-INF/lib/commons-collections-3.2.1.jar,
+                <packagingExcludes>WEB-INF/lib/commons-codec-1.2.jar,
                 WEB-INF/lib/commons-io-1.1.jar,
-                WEB-INF/lib/commons-io-2.1.jar,
-                WEB-INF/lib/commons-lang-2.3.jar,
                 WEB-INF/lib/commons-logging-1.0.4.jar,
-                WEB-INF/lib/commons-logging-1.1.1.jar,
                 WEB-INF/lib/commons-pool-1.3.jar,
-                WEB-INF/lib/guava-15.0.jar,
-                WEB-INF/lib/httpclient-4.2.5.jar,
-                WEB-INF/lib/httpcore-4.2.4.jar,
-                WEB-INF/lib/jackson-annotations-2.2.2.jar,
-                WEB-INF/lib/jackson-core-2.2.2.jar,
-                WEB-INF/lib/jackson-annotations-2.2.2.jar,
-                WEB-INF/lib/jackson-databind-2.2.2.jar,
-                WEB-INF/lib/javassist-3.8.0.GA.jar,
-                WEB-INF/lib/jaxb-api-2.1.jar,
-                WEB-INF/lib/jaxb-api-2.3.1.jar,
-                WEB-INF/lib/jaxb-runtime-2.3.1.jar,
                 WEB-INF/lib/slf4j-api-1.5*.jar,
-                WEB-INF/lib/slf4j-api-1.7.2.jar,
-                WEB-INF/lib/slf4j-api-1.7.21.jar,
-                WEB-INF/lib/slf4j-log4j12-1.5*.jar,
-                WEB-INF/lib/spring-tx-5.2.15*.jar,
-                WEB-INF/lib/txw2-2.3.1.jar,
-                WEB-INF/lib/xercesImpl-2.4.0.jar,
-                WEB-INF/lib/xml-apis-1.0.b2.jar
+                WEB-INF/lib/spring-tx-5.2.15*.jar
                 </packagingExcludes>
                 <overlays>
                     <overlay>
@@ -481,18 +458,6 @@
                             <artifactId>commons-codec</artifactId>
                         </exclusion>
                         <exclusion>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.apache.httpcomponents</groupId>
-                            <artifactId>httpclient</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>org.apache.httpcomponents</groupId>
-                            <artifactId>httpcore</artifactId>
-                        </exclusion>
-                        <exclusion>
                             <groupId>com.fasterxml.jackson.core</groupId>
                             <artifactId>jackson-annotations</artifactId>
                         </exclusion>
@@ -511,10 +476,6 @@
                         <exclusion>
                             <groupId>org.springframework</groupId>
                             <artifactId>spring-context</artifactId>
-                        </exclusion>
-                        <exclusion>
-                            <groupId>xerces</groupId>
-                            <artifactId>xercesImpl</artifactId>
                         </exclusion>
                     </exclusions>
                 </dependency>

--- a/project/standard/templates/web/src/printing/applicationContext-print.xml
+++ b/project/standard/templates/web/src/printing/applicationContext-print.xml
@@ -18,6 +18,12 @@
 
     <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
 	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
+    <bean id="threadResources" class="org.mapfish.print.ThreadResources">
+        <property name="connectionTimeout" value="30000"/>
+        <property name="socketTimeout" value="30000" />
+        <property name="globalParallelFetches" value="200"/>
+        <property name="perHostParallelFetches" value="30" />
+	</bean>
 
       <!-- Define MapReaderFactories -->
     <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
@@ -86,4 +92,10 @@
     <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
     <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
     <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
+
+    <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" lazy-init="false"/>
+    <bean id="healthCheckRegistry" class="com.codahale.metrics.health.HealthCheckRegistry" lazy-init="false"/>
+    <bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator"  lazy-init="false"/>
+    <bean id="jvmMetricsConfigurator" class="org.mapfish.print.metrics.JvmMetricsConfigurator" lazy-init="false"/>
+    <bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
 </beans>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Upgrades print-lib to use geosolutions-2.1-SNAPSHOT.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: library upgrade

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#7890 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
MapStore won't start with the upgraded print-lib.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
MapStore starts correctly with the upgraded print-lib.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] Yes, and I documented them in migration notes
 - [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->
All projects built with the printing profile enabled will need to update the applicationContext-print.xml file as explained in the migration notes.

## Other useful information
