### PR TITLE
#7938 Fix version of proxy to 1.1-SNAPSHOT

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -136,7 +136,7 @@ Downstream project should update following configurations:
 -            </resource>
 -        </resources>
 -    </configuration>
--</execution> 
+-</execution>
 ```
 
 - remove all the external script and css related to cesium and cesium-navigation now included as packages
@@ -453,7 +453,7 @@ Here the changes in `pom.xml` and `web/pom.xml to update:
     <groupId>proxy</groupId>
     <artifactId>http_proxy</artifactId>
 -      <version>1.1.0</version>
-+      <version>1.2-SNAPSHOT</version>
++      <version>1.1-SNAPSHOT</version>
     <type>war</type>
     <scope>runtime</scope>
     </dependency>

--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.3-SNAPSHOT</version>
+      <version>1.1-SNAPSHOT</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/project/custom/templates/web/pom.xml
+++ b/project/custom/templates/web/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.2-SNAPSHOT</version>
+      <version>1.1-SNAPSHOT</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.3-SNAPSHOT</version>
+      <version>1.1-SNAPSHOT</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
## Description
This PR restore 1.1-SNAPSHOT on master. 

A separate PR is done on stable for this, with 1.1.1 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7938

**What is the new behavior?**
http proxy has be restored to previous version.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
