### PR TITLE
[Backport 2022.01.xx] #7007: fix cesium terrain layer and imagery positions (#7924)

### DIFF
--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -103,21 +103,28 @@ class CesiumLayer extends React.Component {
 
     updateZIndex = (position) => {
         const layerPos = position || this.props.position;
-        const actualPos = this.props.map.imageryLayers._layers.reduce((previous, current, index) => {
-            return this.provider === current ? index : previous;
-        }, -1);
-        let newPos = this.props.map.imageryLayers._layers.reduce((previous, current, index) => {
-            return previous === -1 && layerPos < current._position ? index : previous;
-        }, -1);
-        if (newPos === -1) {
-            newPos = actualPos;
-        }
-        const diff = newPos - actualPos;
-        if (diff !== 0) {
-            Array.apply(null, {length: Math.abs(diff)}).map(Number.call, Number)
-                .forEach(() => {
-                    this.props.map.imageryLayers[diff > 0 ? 'raise' : 'lower'](this.provider);
-                });
+        // in some cases the position index inside layer state
+        // does not match the one inside imagery layers of Cesium
+        // because a 3D environment could contain others entities that does not follow the imagery z index
+        // (eg: terrain or meshes)
+        if (this.provider) {
+            // take the current index of the image layer
+            const previousIndex = this.props.map.imageryLayers._layers.indexOf(this.provider);
+            // sort list of imagery layers by new positions
+            const nextImageryLayersOrder = [...this.props.map.imageryLayers._layers].sort((a, b) => {
+                const aPosition = a === this.provider ? layerPos : a._position;
+                const bPosition = b === this.provider ? layerPos : b._position;
+                return aPosition - bPosition;
+            });
+            // take the next index of the image layer
+            const nextIndex = nextImageryLayersOrder.indexOf(this.provider);
+            const diff = nextIndex - previousIndex;
+            if (diff !== 0) {
+                [...new Array(Math.abs(diff)).keys()]
+                    .forEach(() => {
+                        this.props.map.imageryLayers[diff > 0 ? 'raise' : 'lower'](this.provider);
+                    });
+            }
         }
     };
 
@@ -225,7 +232,7 @@ class CesiumLayer extends React.Component {
         }
         // detached layers are layers that do not work through a provider
         // for this reason they cannot be added or removed from the map imageryProviders
-        if (this.layer.detached && this.layer?.remove) {
+        if (this.layer?.detached && this.layer?.remove) {
             this.layer.remove();
         }
     };

--- a/web/client/components/map/cesium/__tests__/Map-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test.jsx
@@ -244,6 +244,46 @@ describe('CesiumMap', () => {
         // unregister hook
         registerHook(ZOOM_TO_EXTENT_HOOK);
     });
+    it('should reorder the layer correctly even if the position property of layer exceed the imageryLayers length', () => {
+
+        let map = ReactDOM.render(
+            <CesiumMap id="mymap" center={{ y: 43.9, x: 10.3 }} zoom={11}>
+                <CesiumLayer type="wms" position={1} options={{ url: '/wms', name: 'layer01' }} />
+                <CesiumLayer type="wms" position={3} options={{ url: '/wms', name: 'layer02' }} />
+                <CesiumLayer type="wms" position={6} options={{ url: '/wms', name: 'layer03' }} />
+            </CesiumMap>,
+            document.getElementById('container')
+        );
+
+        expect(map).toBeTruthy();
+        expect(ReactDOM.findDOMNode(map).id).toBe('mymap');
+        expect(map.map.imageryLayers._layers.map(({ _position }) => _position)).toEqual([1, 3, 6]);
+        expect(map.map.imageryLayers._layers.map(({ imageryProvider }) => imageryProvider.layers)).toEqual([ 'layer01', 'layer02', 'layer03' ]);
+
+        map = ReactDOM.render(
+            <CesiumMap id="mymap" center={{ y: 43.9, x: 10.3 }} zoom={11}>
+                <CesiumLayer type="wms" position={1} options={{ url: '/wms', name: 'layer01' }} />
+                <CesiumLayer type="wms" position={3} options={{ url: '/wms', name: 'layer02' }} />
+                <CesiumLayer type="wms" position={4} options={{ url: '/wms', name: 'layer03' }} />
+            </CesiumMap>,
+            document.getElementById('container')
+        );
+
+        expect(map.map.imageryLayers._layers.map(({ _position }) => _position)).toEqual([1, 3, 4]);
+        expect(map.map.imageryLayers._layers.map(({ imageryProvider }) => imageryProvider.layers)).toEqual([ 'layer01', 'layer02', 'layer03' ]);
+
+        map = ReactDOM.render(
+            <CesiumMap id="mymap" center={{ y: 43.9, x: 10.3 }} zoom={11}>
+                <CesiumLayer type="wms" position={1} options={{ url: '/wms', name: 'layer01' }} />
+                <CesiumLayer type="wms" position={3} options={{ url: '/wms', name: 'layer02' }} />
+                <CesiumLayer type="wms" position={2} options={{ url: '/wms', name: 'layer03' }} />
+            </CesiumMap>,
+            document.getElementById('container')
+        );
+
+        expect(map.map.imageryLayers._layers.map(({ _position }) => _position)).toEqual([1, 2, 3]);
+        expect(map.map.imageryLayers._layers.map(({ imageryProvider }) => imageryProvider.layers)).toEqual([ 'layer01', 'layer03', 'layer02' ]);
+    });
     describe("hookRegister", () => {
         it("default", () => {
             const map = ReactDOM.render(<CesiumMap id="mymap" center={{y: 43.9, x: 10.3}} zoom={11}/>, document.getElementById("container"));

--- a/web/client/utils/cesium/BILTerrainProvider.js
+++ b/web/client/utils/cesium/BILTerrainProvider.js
@@ -953,7 +953,13 @@ const createBilTerrainProvider = function(Cesium) {
 							var limitations={highest:resultat.highest,lowest:resultat.lowest,offset:resultat.offset};
                             var proxy = resultat.proxy || { getURL: v => v } ;
 							var hasChildren = terrainChildrenMask(x, y, level,provider);
-                            var promise = Cesium.throttleRequestByServer(proxy.getURL(url),Cesium.loadImage);
+                            var promise = Cesium.Resource.fetchImage({
+								url: proxy.getURL(url),
+								request: new Cesium.Request({
+									throttleByServer: true
+								})
+							});
+							
 							if (Cesium.defined(promise)) {
 								retour = Cesium.when(promise,function(image){
 											return GeoserverTerrainProvider.imageToHeightmapTerrainData(image,limitations,
@@ -984,7 +990,13 @@ const createBilTerrainProvider = function(Cesium) {
 							var limitations={highest:resultat.highest,lowest:resultat.lowest,offset:resultat.offset};
 							var hasChildren = terrainChildrenMask(x, y, level,provider);
                             var proxy = resultat.proxy || { getURL: v => v };
-                            var promise = Cesium.throttleRequestByServer(proxy.getURL(urlArray),Cesium.loadArrayBuffer);
+							
+                            var promise = Cesium.Resource.fetchArrayBuffer({
+								url: proxy.getURL(urlArray),
+								request: new Cesium.Request({
+									throttleByServer: true
+								})
+							});
 					        if (Cesium.defined(promise)) {
 								retour = Cesium.when(promise,
 													function(arrayBuffer) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Fixes related to the cesium upgrade https://github.com/geosolutions-it/MapStore2/pull/7863#issuecomment-1054145070:

- update terrain promise classes
- refactor z index management of imagery layer
- ensure layer exist before remove it

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7007

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
