### PR TITLE
[Backport 2022.01.xx] #7868: fix error that throws error when click in empty space of map in mobile

### DIFF
--- a/web/client/epics/measurement.js
+++ b/web/client/epics/measurement.js
@@ -86,7 +86,7 @@ export const setMeasureStateFromAnnotationEpic = (action$, store) =>
 export const addCoordinatesEpic = (action$, {getState = () => {}}) =>
     action$.ofType(CLICK_ON_MAP)
         .filter(() => {
-            const {showCoordinateEditor, enabled} = getState().controls.measure;
+            const { showCoordinateEditor, enabled } = getState()?.controls?.measure || {};
             return showCoordinateEditor && enabled;
         } )
         .switchMap(({point}) => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7868 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Error is not thrown when clicking on map in mobile view
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
