### PR TITLE
[Backport 2022.01.xx] #7893: A wrong GML format is used for the WPS export spatial filter

### DIFF
--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -305,7 +305,7 @@ export const startFeatureExportDownload = (action$, store) =>
                     data: {
                         mimeType: 'text/xml; subtype=filter/1.1',
                         data: mergeFiltersToOGC({
-                            ogcVersion: '1.0.0',
+                            ogcVersion: '1.1.0',
                             addXmlnsToRoot: true,
                             xmlnsToAdd: ['xmlns:ogc="http://www.opengis.net/ogc"', 'xmlns:gml="http://www.opengis.net/gml"']
                         }, layer.layerFilter, action.filterObj)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This https://github.com/geosolutions-it/MapStore2/pull/7353 fixes an inconsistent ogc version inside wps layer download. The filter version was updated to 1.1 in this PR but the ogc version was not changed to match.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7893 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The correct gml formal is used in the request

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
