### PR TITLE
[Backport 2022.01.xx] #7849: wrong getCapabilities request sent for csw

### DIFF
--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -286,8 +286,11 @@ var Api = {
                                                     dc[elName] = finalEl;
                                                 }
                                             }
+                                            const URIs = dc.references.length > 0 ? dc.references : dc.URI;
                                             if (!_dcRef) {
-                                                _dcRef = dc.references;
+                                                _dcRef = URIs;
+                                            } else {
+                                                _dcRef = _dcRef.concat(URIs);
                                             }
                                             obj.dc = dc;
                                         }
@@ -295,9 +298,9 @@ var Api = {
                                     }
                                 }
                                 result.records = records;
-                                const {value: _url} = _dcRef?.find(t=> t.scheme === 'OGC:WMS') || {}; // Get WMS URL from references
+                                const { value: _url } = _dcRef?.find(t => t.scheme === 'OGC:WMS' || t.protocol === 'OGC:WMS') || {}; // Get WMS URL from references
                                 const [parsedUrl] = _url && _url.split('?') || [];
-                                return addCapabilitiesToRecords(parsedUrl, result);
+                                return parsedUrl ? addCapabilitiesToRecords(parsedUrl, result) : {...result};
                             } else if (json && json.name && json.name.localPart === "ExceptionReport") {
                                 return {
                                     error: json.value.exception && json.value.exception.length && json.value.exception[0].exceptionText || 'GenericError'

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -108,6 +108,30 @@ describe('Test correctness of the CSW APIs', () => {
             }
         });
     });
+
+    it('does not include capabilities when no parsedUrl in getRecords', (done) => {
+        API.getRecords('base/web/client/test-resources/csw/getRecordsNoWMS.xml', 1, 1).then((result) => {
+            try {
+                expect(result).toBeTruthy();
+                expect(result.records[0].capabilities).toBeFalsy();
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+
+    it('obtains parsedUrl from dc:uri and gets capabilities', (done) => {
+        API.getRecords('base/web/client/test-resources/csw/getRecordsWithDcURI.xml', 1, 1).then((result) => {
+            try {
+                expect(result).toBeTruthy();
+                expect(result.records[0].capabilities).toBeTruthy();
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
 });
 
 describe('workspaceSearch', () => {

--- a/web/client/test-resources/csw/getRecordsNoWMS.xml
+++ b/web/client/test-resources/csw/getRecordsNoWMS.xml
@@ -1,0 +1,59 @@
+<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
+  <csw:SearchStatus timestamp="2016-05-11T13:00:06" />
+  <csw:SearchResults numberOfRecordsMatched="100" numberOfRecordsReturned="2" elementSet="full" nextRecord="3">
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>workspace:layer_name1</dc:identifier>
+      <dc:title>c1020047_title</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>sub1, sub2, sub3</dc:subject>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
+        <ows:LowerCorner>12.718 45.542</ows:LowerCorner>
+        <ows:UpperCorner>11.874 46.026</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="test service" name="workspace:layer_name4" description="desc2">http://ows.domain.it:80/geoserver/service?SERVICE=sample&amp;</dc:URI>
+      <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187146&amp;fname=0171b07a-8cf1-4950-8a71-b01e6a6aee38_s.png&amp;access=public</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>d698f693-6e7e-47a9-a138-918068d0b082</dc:identifier>
+      <dc:title>Title2</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>geoscientificInformation</dc:subject>
+      <dc:format />
+      <ows:BoundingBox crs="urn:ogc:def:crs:OGC:1.3:CRS84">
+        <ows:LowerCorner>12.429282000000002 45.760718</ows:LowerCorner>
+        <ows:UpperCorner>12.002717999999996 46.187282</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="test service" name="workspace:layer_name4" description="desc2">http://ows.domain.it:80/geoserver/service?SERVICE=sample&amp;</dc:URI>
+      <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187049&amp;fname=d698f693-6e7e-47a9-a138-918068d0b082_s.png&amp;access=public</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>urn:isogeo:metadata:uuid:01ca64b3-6d69-43b7-b953-7743e11daafe</dc:identifier>
+      <dc:title>Title3</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>infoMapAccessService</dc:subject>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::RGF93 / Lambert-93 (EPSG:2154)">
+        <ows:LowerCorner>-4.1149 47.93257</ows:LowerCorner>
+        <ows:UpperCorner>-4.14168 47.959353362144</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="test service" name="workspace:layer_name4" description="desc2">http://ows.domain.it:80/geoserver/service?SERVICE=sample&amp;</dc:URI>
+      <dc:URI protocol="image/png">http://geowww.agrocampus-ouest.fr/img/metadata/KBZ.png</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork">
+      <dc:identifier>9df78858-ade9-4591-badf-63934f1afffc</dc:identifier>
+      <dc:date>2020-10-06T11:52:43.9635506</dc:date>
+      <dc:title>Title 4</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>Air Transport Network</dc:subject>
+      <dc:format>PDF</dc:format>
+      <dc:format>PNG</dc:format>
+      <dc:format>JPEG</dc:format>
+      <dc:language>eng</dc:language>
+      <ows:BoundingBox crs="urn:ogc:def:crs:INSPIRE RS registry::http://www.opengis.net/def/crs/EPSG/0/3857">
+          <ows:LowerCorner>13.27 47.46</ows:LowerCorner>
+          <ows:UpperCorner>12.56 48.13</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="test service" name="workspace:layer_name4" description="desc2">http://ows.domain.it:80/geoserver/service?SERVICE=sample&amp;</dc:URI>
+      <dc:URI protocol="image/png">https://test-geoserver.at/img/metadata/KBZ.png</dc:URI>
+    </csw:Record>
+  </csw:SearchResults>
+</csw:GetRecordsResponse>

--- a/web/client/test-resources/csw/getRecordsWithDcURI.xml
+++ b/web/client/test-resources/csw/getRecordsWithDcURI.xml
@@ -1,0 +1,59 @@
+<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
+  <csw:SearchStatus timestamp="2016-05-11T13:00:06" />
+  <csw:SearchResults numberOfRecordsMatched="100" numberOfRecordsReturned="2" elementSet="full" nextRecord="3">
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>workspace:layer_name1</dc:identifier>
+      <dc:title>c1020047_title</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>sub1, sub2, sub3</dc:subject>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
+        <ows:LowerCorner>12.718 45.542</ows:LowerCorner>
+        <ows:UpperCorner>11.874 46.026</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name1" description="desc1">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187146&amp;fname=0171b07a-8cf1-4950-8a71-b01e6a6aee38_s.png&amp;access=public</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>d698f693-6e7e-47a9-a138-918068d0b082</dc:identifier>
+      <dc:title>Title2</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>geoscientificInformation</dc:subject>
+      <dc:format />
+      <ows:BoundingBox crs="urn:ogc:def:crs:OGC:1.3:CRS84">
+        <ows:LowerCorner>12.429282000000002 45.760718</ows:LowerCorner>
+        <ows:UpperCorner>12.002717999999996 46.187282</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name1" description="desc1">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187049&amp;fname=d698f693-6e7e-47a9-a138-918068d0b082_s.png&amp;access=public</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>urn:isogeo:metadata:uuid:01ca64b3-6d69-43b7-b953-7743e11daafe</dc:identifier>
+      <dc:title>Title3</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>infoMapAccessService</dc:subject>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::RGF93 / Lambert-93 (EPSG:2154)">
+        <ows:LowerCorner>-4.1149 47.93257</ows:LowerCorner>
+        <ows:UpperCorner>-4.14168 47.959353362144</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name1" description="desc1">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="image/png">http://geowww.agrocampus-ouest.fr/img/metadata/KBZ.png</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork">
+      <dc:identifier>9df78858-ade9-4591-badf-63934f1afffc</dc:identifier>
+      <dc:date>2020-10-06T11:52:43.9635506</dc:date>
+      <dc:title>Title 4</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>Air Transport Network</dc:subject>
+      <dc:format>PDF</dc:format>
+      <dc:format>PNG</dc:format>
+      <dc:format>JPEG</dc:format>
+      <dc:language>eng</dc:language>
+      <ows:BoundingBox crs="urn:ogc:def:crs:INSPIRE RS registry::http://www.opengis.net/def/crs/EPSG/0/3857">
+          <ows:LowerCorner>13.27 47.46</ows:LowerCorner>
+          <ows:UpperCorner>12.56 48.13</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS" name="workspace:layer_name1" description="desc1">base/web/client/test-resources/csw/getCapability.xml</dc:URI>
+      <dc:URI protocol="image/png">https://test-geoserver.at/img/metadata/KBZ.png</dc:URI>
+    </csw:Record>
+  </csw:SearchResults>
+</csw:GetRecordsResponse>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes wrong requests for some CWS GetCapabalities
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7849 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The correct base url is used in the GetCapabilities request. Also in cases of no WMS reference, no `getCapabilitiees` request is made 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
