### PR TITLE
[Backport 2022.01.xx] #7991; fix regression that caused maps with query params to crush

### DIFF
--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -19,6 +19,32 @@ import { SHOW_NOTIFICATION } from '../../actions/notifications';
 import { onLocationChanged } from 'connected-react-router';
 import {toggleControl} from "../../actions/controls";
 import {layerLoad} from "../../actions/layers";
+import {ActionsObservable} from "redux-observable";
+import Rx from "rxjs";
+
+const center = {
+    x: -74.2,
+    y: 40.7,
+    crs: "EPSG:4326"
+};
+const zoom = 16;
+const bbox = {
+    bounds: {
+        minx: -180,
+        miny: -90,
+        maxx: 180,
+        maxy: 90
+    },
+    crs: "EPSG:4326",
+    rotation: 0
+};
+const size = {
+    height: 8717,
+    width: 8717
+};
+
+const mapStateSource = 'map';
+const projection = "EPSG:900913";
 
 describe('queryparam epics', () => {
     it('test readQueryParamsOnMapEpic without params in url search', (done) => {
@@ -340,30 +366,6 @@ describe('queryparam epics', () => {
             }, state);
     });
     it('Test actions dispatched on Change View', (done)=>{
-
-        const center = {
-            x: -74.2,
-            y: 40.7,
-            crs: "EPSG:4326"
-        };
-        const zoom = 16;
-        const bbox = {
-            bounds: {
-                minx: -180,
-                miny: -90,
-                maxx: 180,
-                maxy: 90
-            },
-            crs: "EPSG:4326",
-            rotation: 0
-        };
-        const size = {
-            height: 8717,
-            width: 8717
-        };
-
-        const mapStateSource = 'map';
-        const projection = "EPSG:900913";
         const viewerOptions = {
             orientation: {
                 heading: 0.1,
@@ -372,6 +374,9 @@ describe('queryparam epics', () => {
             }
         };
         const state = {
+            maptype: {
+                mapType: 'cesium'
+            },
             router: {
                 location: {
                     search: "?center=-74.2,40.7&zoom=16.5&heading=0.1&pitch=-0.7&roll=6.2"
@@ -391,5 +396,59 @@ describe('queryparam epics', () => {
                 }
                 done();
             }, state);
+    });
+    //
+    it('changeMapView does not trigger orientateMap if map type is not cesium', (done)=>{
+        const viewerOptions = {
+            orientation: {
+                heading: 0.1,
+                pitch: -0.7,
+                roll: 6.2
+            }
+        };
+        const state = {
+            maptype: {
+                mapType: 'openlayer'
+            },
+            router: {
+                location: {
+                    search: "?center=-74.2,40.7&zoom=16.5&heading=0.1&pitch=-0.7&roll=6.2"
+                }
+            }
+        };
+        const action = changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions, '');
+        const checkActions = actions => {
+            expect(actions.length).toBe(0);
+            done();
+        };
+        checkMapOrientation(new ActionsObservable(Rx.Observable.of(action)), {getState: () => state})
+            .toArray()
+            .subscribe(checkActions);
+    });
+    it('changeMapView does not trigger orientateMap if any of the viewerOptions values is undefined', (done)=>{
+        const viewerOptions = {
+            orientation: {
+                pitch: -0.7,
+                roll: 6.2
+            }
+        };
+        const state = {
+            maptype: {
+                mapType: 'cesium'
+            },
+            router: {
+                location: {
+                    search: "?center=-74.2,40.7&zoom=16.5&pitch=-0.7&roll=6.2"
+                }
+            }
+        };
+        const action = changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions, '');
+        const checkActions = actions => {
+            expect(actions.length).toBe(0);
+            done();
+        };
+        checkMapOrientation(new ActionsObservable(Rx.Observable.of(action)), {getState: () => state})
+            .toArray()
+            .subscribe(checkActions);
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7991 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
- The map does not crash when using query params
- `orientateMap` action is dispatched only when using 3D maps
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
