### PR TITLE
backport 2022.01.xx - #8000: fixes regression in Print plugin with the flag useFixedScales (#8001)

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -551,7 +551,10 @@ export default {
                     print = () => {
                         this.props.setPage(0);
                         this.props.onBeforePrint();
-                        this.props.printingService.print(this.getMapConfiguration()?.layers)
+                        this.props.printingService.print({
+                            layers: this.getMapConfiguration()?.layers,
+                            scales: this.props.useFixedScales ? getPrintScales(this.props.capabilities) : undefined
+                        })
                             .then((spec) =>
                                 this.props.onPrint(this.props.capabilities.createURL, { ...spec, ...this.props.overrideOptions })
                             )

--- a/web/client/plugins/__tests__/Print-test.jsx
+++ b/web/client/plugins/__tests__/Print-test.jsx
@@ -55,7 +55,7 @@ const initialState = {
                 }
             }],
             dpis: [],
-            scales: []
+            scales: [1_000_000, 500_000, 100_000]
         }
     }
 };
@@ -158,6 +158,39 @@ describe('Print Plugin', () => {
                 ReactDOM.render(<Plugin />, document.getElementById("container"));
                 expect(document.getElementById("mapstore-print-preview-panel")).toExist();
                 done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+
+    it('default configuration with useFixedScales', (done) => {
+        let submittedSpec;
+        const printingService = {
+            print(spec) {
+                submittedSpec = spec;
+            },
+            getMapConfiguration() {
+                return {
+                    layers: []
+                };
+            },
+            validate() { return {};}
+        };
+        getPrintPlugin({}).then(({ Plugin }) => {
+            try {
+                ReactDOM.render(<Plugin printingService={printingService}
+                    useFixedScales mapPreviewOptions={{
+                        onLoadingMapPlugins: (loading) => {
+                            if (!loading) {
+                                const submit = document.getElementsByClassName("print-submit").item(0);
+                                expect(submit).toExist();
+                                submit.click();
+                                expect(submittedSpec.scales.length).toBe(3);
+                                done();
+                            }
+                        }
+                    }}/>, document.getElementById("container"));
             } catch (ex) {
                 done(ex);
             }

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -236,9 +236,9 @@ export const getMapfishPrintSpecification = (rawSpec, state) => {
     const spec = {...baseSpec, ...params};
     const mapProjection = mapProjectionSelector(state);
     const projectedCenter = reproject(spec.center, 'EPSG:4326', spec.projection);
-    const projectedZoom = reprojectZoom(spec.scaleZoom, mapProjection, spec.projection);
-    const scales = getScales(spec.projection);
-    const reprojectedScale = scales[projectedZoom] || defaultScales[Math.round(projectedZoom)];
+    const projectedZoom = Math.round(reprojectZoom(spec.scaleZoom, mapProjection, spec.projection));
+    const scales = spec.scales || getScales(spec.projection);
+    const reprojectedScale = scales[projectedZoom] || defaultScales[projectedZoom];
 
     const projectedSpec = {
         ...spec,
@@ -442,12 +442,12 @@ export function addValidator(id, name, validator) {
  */
 export const getDefaultPrintingService = () => {
     return {
-        print: (layers) => {
+        print: (extra) => {
             const state = getStore().getState();
             const printSpec = printSpecificationSelector(state);
-            const intialSpec = layers ? {
+            const intialSpec = extra ? {
                 ...printSpec,
-                layers
+                ...extra
             } : printSpec;
             return getSpecTransformerChain().map(t => t.transformer).reduce((previous, f) => {
                 return previous.then(spec=> f(state, spec));

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -32,6 +32,7 @@ import { KVP1, REST1 } from '../../test-resources/layers/wmts';
 import { poi as TMS110_1 } from '../../test-resources/layers/tms';
 import { BasemapAT, NASAGIBS, NLS_CUSTOM_URL } from '../../test-resources/layers/tileprovider';
 import { setStore } from '../StateUtils';
+import { getGoogleMercatorScales } from '../MapUtils';
 
 const layer = {
     url: "http://mygeoserver",
@@ -495,6 +496,23 @@ describe('PrintUtils', () => {
         const printSpec = getMapfishPrintSpecification({...testSpec, params: {custom: "customvalue"}});
         expect(printSpec).toExist();
         expect(printSpec.custom).toBe("customvalue");
+    });
+    it('getMapfishPrintSpecification with fixed scales', () => {
+        const printSpec = getMapfishPrintSpecification({
+            ...testSpec,
+            scaleZoom: 3,
+            scales: [2000000, 1000000, 500000, 100000, 50000]
+        });
+        expect(printSpec).toExist();
+        expect(printSpec.pages[0].scale).toBe(100000);
+    });
+    it('getMapfishPrintSpecification with standard scales', () => {
+        const printSpec = getMapfishPrintSpecification({
+            ...testSpec,
+            scaleZoom: 3
+        });
+        expect(printSpec).toExist();
+        expect(printSpec.pages[0].scale).toBe(getGoogleMercatorScales(0, 21)[3]);
     });
     it('from rgba to rgb', () => {
         const rgb = rgbaTorgb("rgba(255, 255, 255, 0.1)");


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport 2022.01.xx - #8000: fixes regression in Print plugin with the flag useFixedScales (#8001)