### PR TITLE
#7969 - Allow to change home icon

### DIFF
--- a/web/client/components/home/Home.jsx
+++ b/web/client/components/home/Home.jsx
@@ -21,7 +21,7 @@ export const getPath = () => {
 };
 class Home extends React.Component {
     static propTypes = {
-        icon: PropTypes.node,
+        icon: PropTypes.string,
         onCheckMapChanges: PropTypes.func,
         onCloseUnsavedDialog: PropTypes.func,
         displayUnsavedDialog: PropTypes.bool,
@@ -35,7 +35,7 @@ class Home extends React.Component {
     };
 
     static defaultProps = {
-        icon: <Glyphicon glyph="home"/>,
+        icon: "home",
         onCheckMapChanges: () => {},
         onCloseUnsavedDialog: () => {},
         renderUnsavedMapChangesDialog: true,
@@ -55,7 +55,7 @@ class Home extends React.Component {
                         onClick={this.checkUnsavedChanges}
                         tooltip={tooltip}
                         {...pick(restProps, ['disabled', 'active', 'block', 'componentClass', 'href', 'children', 'icon', 'bsStyle', 'className'])}
-                    >{this.props.icon}</Button>
+                    ><Glyphicon glyph={this.props.icon}/></Button>
                 </OverlayTrigger>
                 <ConfirmModal
                     ref="unsavedMapModal"


### PR DESCRIPTION
_Same PR https://github.com/geosolutions-it/MapStore2/pull/7970 with correct branch @tdipisa_

## Description
This PR allow to change the default Top Toolbar Home icon from Home plugin config (@MaelREBOUX).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7969 


**What is the new behavior?**
The Home plugin allow to change the glyph icon name.

In localConfig.json : 

```
{
    "override": {},
    "name": "Home",
    "cfg": {
        "icon": "plus"
    }
},
```
Return : 

![image](https://user-images.githubusercontent.com/16317988/158438121-429dba70-ab60-4f6a-b0ed-e6721fbc154c.png)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

A futur need of the georchestra community.