### PR TITLE
[Backport 2022.01.xx] #8008: Improve visibility of 3d tiles (#8011)

### DIFF
--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -197,6 +197,19 @@ export default class extends React.Component {
                     </Col>
                 </Row>
 
+                {this.props.element.type === "3dtiles" && <Row>
+                    <Col xs={12}>
+                        <FormGroup>
+                            <ControlLabel><Message msgId="layerProperties.heightOffset"/></ControlLabel>
+                            <IntlNumberFormControl
+                                type="number"
+                                name={"heightOffset"}
+                                value={this.props.element.heightOffset || 0}
+                                onChange={(val)=> this.props.onChange("heightOffset", parseFloat(val))}/>
+                        </FormGroup>
+                    </Col>
+                </Row>}
+
                 {this.props.element.type === "wms" &&
                 <Row>
                     <Col xs={12}>

--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -132,11 +132,15 @@ class CesiumLayer extends React.Component {
         const oldVisibility = this.getVisibilityOption(this.props);
         const newVisibility = this.getVisibilityOption(newProps);
         if (newVisibility !== oldVisibility) {
-            if (newVisibility) {
-                this.addLayer(newProps);
-                this.updateZIndex();
+            if (this.layer?.detached && this.layer?.setVisible) {
+                this.layer.setVisible(newVisibility);
             } else {
-                this.removeLayer();
+                if (newVisibility) {
+                    this.addLayer(newProps);
+                    this.updateZIndex();
+                } else {
+                    this.removeLayer();
+                }
             }
         }
     };

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -136,6 +136,16 @@ class CesiumMap extends React.Component {
         this.setMousePointer(this.props.mousePointer);
 
         this.map = map;
+        const scene = this.map.scene;
+
+        // configure the sky environment
+        scene.skyAtmosphere.show = this.props.mapOptions?.showSkyAtmosphere ?? true;
+        scene.fog.enabled = this.props.mapOptions?.enableFog ?? false;
+        scene.globe.showGroundAtmosphere = this.props.mapOptions?.showGroundAtmosphere ?? false;
+
+        // this is needed to display correctly intersection between terrain and primitives
+        scene.globe.depthTestAgainstTerrain = this.props.mapOptions?.depthTestAgainstTerrain ?? true;
+
         this.forceUpdate();
         if (this.props.mapOptions.navigationTools) {
             this.cesiumNavigation = window.CesiumNavigation;

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -1227,4 +1227,51 @@ describe('Cesium layer', () => {
         expect(cmp.layer).toBeTruthy();
         expect(cmp.layer.tileSet).toBeFalsy();
     });
+    it('should create a 3d tiles layer with and offset applied to the height', (done) => {
+        const options = {
+            type: '3dtiles',
+            url: 'base/web/client/test-resources/3dtiles/tileset.json',
+            title: 'Title',
+            visibility: true,
+            heightOffset: 100,
+            bbox: {
+                crs: 'EPSG:4326',
+                bounds: {
+                    minx: -180,
+                    miny: -90,
+                    maxx: 180,
+                    maxy: 90
+                }
+            }
+        };
+        // create layers
+        const cmp = ReactDOM.render(
+            <CesiumLayer
+                type="3dtiles"
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        expect(cmp).toBeTruthy();
+        expect(cmp.layer).toBeTruthy();
+        expect(cmp.layer.tileSet).toBeTruthy();
+        expect(Cesium.Matrix4.toArray(cmp.layer.tileSet.modelMatrix)).toEqual(
+            [
+                1, 0, 0, 0,
+                0, 1, 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1
+            ]
+        );
+        cmp.layer.tileSet.readyPromise.then(() => {
+            expect(Cesium.Matrix4.toArray(cmp.layer.tileSet.modelMatrix).map(Math.round)).toEqual(
+                [
+                    1, 0, 0, 0,
+                    0, 1, 0, 0,
+                    0, 0, 1, 0,
+                    19, -74, 64, 1
+                ]
+            );
+            done();
+        });
+    });
 });

--- a/web/client/test-resources/3dtiles/tileset.json
+++ b/web/client/test-resources/3dtiles/tileset.json
@@ -1,0 +1,47 @@
+{
+    "asset": {
+        "version": "1.0"
+    },
+    "geometricError": 100,
+    "root": {
+        "boundingVolume": {
+            "region": [
+                -1.3197004795898053,
+                0.6988582109,
+                -1.3196595204101946,
+                0.6988897891,
+                0,
+                20
+            ]
+        },
+        "geometricError": 10,
+        "refine": "REPLACE",
+        "content": {
+            "uri": "file.i3dm"
+        },
+        "children": [
+            {
+                "boundingVolume": {
+                    "region": [
+                        -1.3197004795898053,
+                        0.6988582109,
+                        -1.3196595204101946,
+                        0.6988897891,
+                        0,
+                        20
+                    ]
+                },
+                "geometricError": 0,
+                "content": {
+                    "uri": "tree.i3dm"
+                }
+            }
+        ]
+    },
+    "properties": {
+        "Height": {
+            "minimum": 20,
+            "maximum": 20
+        }
+    }
+}

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -107,6 +107,7 @@
             "templateFormatInfoAlertExample": "Die ID des Features lautet <span style='white-space:nowrap'>${ properties.daten }</span> oder <span style='white-space:nowrap'>${ properties['daten-wert'] }</span>",
             "templateError": "Beim Anwenden der Vorlage auf die vom Server zurückgegebenen Informationen ist ein Fehler aufgetreten. Bitte überprüfen Sie die Vorlage",
             "templatePreview": "Vorschau template",
+            "heightOffset": "Höhenversatz (m)",
             "visibilityLimits": {
                 "title": "Sichtbarkeitsgrenzen",
                 "serverValuesUpdateUndefined": "Der Server hat keine Skalierungssichtbarkeitsbeschränkungen für diese Ebene angegeben",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -107,6 +107,7 @@
             "templateFormatInfoAlertExample": "The id of the feature is <span style='white-space:nowrap'>${ properties.id }</span> or <span style='white-space:nowrap'>${ properties['data-value'] }</span>",
             "templateError": "There was an error applying the template to the information returned by the server, please check the template",
             "templatePreview": "Template preview",
+            "heightOffset": "Height offset (m)",
             "visibilityLimits": {
                 "title": "Visibility limits",
                 "serverValuesUpdateUndefined": "The server did not provided scale visibility limits for this layer",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -104,6 +104,7 @@
             "styleWarning": "El editor de estilo de capa para el tipo de geometría '{geometryType}' no es compatible.",
             "templateFormatInfoAlert1": "Haga clic en el botón Editar para agregar una nueva plantilla.",
             "templateFormatInfoAlert2": "Use ${ attribute } para ajustar las propiedades que necesita visualizar",
+            "heightOffset": "Desplazamiento de altura (m)",
             "visibilityLimits": {
                 "title": "Límites de visibilidad",
                 "serverValuesUpdateUndefined": "El servidor no proporcionó límites de visibilidad de escala para esta capa",

--- a/web/client/translations/data.fi-FI.json
+++ b/web/client/translations/data.fi-FI.json
@@ -92,6 +92,7 @@
       "templateFormatInfoAlert2": "Käytä ${ attribute } kääriäksesi näytettävät ominaisuudet",
       "templateFormatInfoAlertExample": "Kohteen ID on ${ properties }",
       "templatePreview": "Mallin esikatselu",
+      "heightOffset": "Height offset (m)",
       "tooltip": {
         "label": "Työkaluvinkkejä",
         "title": "Otsikko",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -107,6 +107,7 @@
             "templateFormatInfoAlertExample": "L'ID de la fonctionnalité est <span style='white-space:nowrap'>${ properties.ID }</span> ou <span style='white-space:nowrap'>${ properties['données-valeur'] }</span>",
             "templateError": "Une erreur s'est produite lors de l'application du modèle aux informations renvoyées par le serveur, veuillez vérifier le modèle",
             "templatePreview": "Aperçu du modèle",
+            "heightOffset": "Décalage en hauteur (m)",
             "visibilityLimits": {
                 "title": "Limites de visibilité",
                 "serverValuesUpdateUndefined": "Le serveur n'a pas fourni de limites de visibilité d'échelle pour cette couche",

--- a/web/client/translations/data.hr-HR.json
+++ b/web/client/translations/data.hr-HR.json
@@ -91,6 +91,7 @@
             "templateFormatInfoAlert2": "Koristi ${ attribute } za označavanje atributa za prikaz",
             "templateFormatInfoAlertExample": "Id objekta je ${ properties }",
             "templatePreview": "Pregled predloška",
+            "heightOffset": "Height offset (m)",
             "tooltip": {
                 "label": "Info oblačić",
                 "title": "Naslov",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -107,6 +107,7 @@
             "templateFormatInfoAlertExample": "id della feature è <span style='white-space:nowrap'>${ properties.id }</span> o <span style='white-space:nowrap'>${ properties['dato-valore'] }</span>",
             "templateError": "Si è verificato un errore durante l'applicazione del template alle informazioni restituite dal server, controllare il template.",
             "templatePreview": "Anteprima template",
+            "heightOffset": "Spostamento in altezza (m)",
             "visibilityLimits": {
                 "title": "Limiti di visibilità",
                 "serverValuesUpdateUndefined": "Il server non ha fornito limiti di visibilità di scala per questo livello",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -104,6 +104,7 @@
             "templateFormatInfoAlert2": "Gebruik ${ attribute } om de eigenschappen die je wenst te tonen aan te duiden.",
             "templateFormatInfoAlertExample": "Het id van het object is ${ properties }",
             "templatePreview": "Sjabloon voorbeeld",
+            "heightOffset": "Height offset (m)",
 	    "visibilityLimits": {
                 "title": "Zichtbaarheidslimieten",
                 "serverValuesUpdateUndefined": "De server heeft geen limieten voor de zichtbaarheid van de schaal voor deze laag opgegeven",

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -93,6 +93,7 @@
             "templateFormatInfoAlert2": "Use ${ attribute } para identificar as propriedades que necessita visualizar",
             "templateFormatInfoAlertExample": "O id do tema é ${ properties }",
             "templatePreview": "Preview do Template",
+            "heightOffset": "Height offset (m)",
             "tooltip": {
                 "label": "Tooltip",
                 "title": "Title",

--- a/web/client/translations/data.sk-SK.json
+++ b/web/client/translations/data.sk-SK.json
@@ -103,6 +103,7 @@
             "templateFormatInfoAlert2": "Použi ${ attribute } pre zoskupenie vlastností, ktoré potrebuješ na zobrazenie",
             "templateFormatInfoAlertExample": "ID tejto funkcie je ${ properties }",
             "templatePreview": "Náhľad šablóny",
+            "heightOffset": "Height offset (m)",
             "visibilityLimits": {
                 "title": "Limity viditeľnosti",
                 "serverValuesUpdateUndefined": "Server pre túto vrstvu neposkytol obmedzenia mierky viditeľnosti",

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -108,6 +108,7 @@
             "templateFormatInfoAlertExample": "Objektets id är <span style = 'white-space: nowrap'> $ {properties.id} </span> eller <span style = 'white-space: nowrap'> $ {properties [ 'data-value']} </span> ",
             "templateError": "Det uppstod ett fel när mallen skulle tillämpas på den information som servern returnerade. Kontrollera mallen",
             "templatePreview": "Förhandsvisning av mall",
+            "heightOffset": "Height offset (m)",
             "visibilityLimits": {
                 "title": "Synlighetsgränser",
                 "serverValuesUpdateUndefined": "Servern angav inga synlighetsgränser för detta lager",

--- a/web/client/translations/data.vi-VN.json
+++ b/web/client/translations/data.vi-VN.json
@@ -697,6 +697,7 @@
             "textFormatTitle": "VĂN BẢN",
             "title": "Tiêu đề",
             "titleTranslations": "Bản dịch tiêu đề",
+            "heightOffset": "Height offset (m)",
             "tooltip": {
                 "both": "Tiêu đề và mô tả",
                 "bottom": "Dưới cùng",

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -92,6 +92,7 @@
             "templateFormatInfoAlert2": "Use ${ attribute } to wrap the properties you need to display",
             "templateFormatInfoAlertExample": "The id of the feature is ${ properties }",
             "templatePreview": "Template preview",
+            "heightOffset": "Height offset (m)",
             "tooltip": {
                 "label": "Tooltip",
                 "title": "Title",

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -575,6 +575,7 @@ export const saveLayer = (layer) => {
         tileSize: layer.tileSize,
         version: layer.version
     },
+    layer.heightOffset ? { heightOffset: layer.heightOffset } : {},
     layer.params ? { params: layer.params } : {},
     layer.credits ? { credits: layer.credits } : {},
     layer.extendedParams ? { extendedParams: layer.extendedParams } : {},

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1081,6 +1081,15 @@ describe('LayersUtils', () => {
                     expect(l.tooltipOptions).toExist();
                     expect(l.tooltipPlacement).toExist();
                 }
+            ],
+            // save heightOffset for 3dtiles
+            [
+                {
+                    heightOffset: 10
+                },
+                l => {
+                    expect(l.heightOffset).toBe(10);
+                }
             ]
         ];
         layers.map(([layer, test]) => test(LayersUtils.saveLayer(layer)) );


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR includes following visibility fixes:

- fix min and max scale limits visibility
- remove fog and ground atmosphere by default
- allow to apply an offset to the height of the whole tileset

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8008

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
