### PR TITLE
[Backport 2022.01.xx] #8018: Implement get feature info for 3D Tiles (#8019)

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -196,6 +196,7 @@ class CesiumMap extends React.Component {
     onClick = (map, movement) => {
         if (this.props.onClick && movement.position !== null) {
             const cartesian = map.camera.pickEllipsoid(movement.position, map.scene.globe.ellipsoid);
+            const intersectedFeatures = this.getIntersectedFeatures(map, movement.position);
             let cartographic = ClickUtils.getMouseXYZ(map, movement) || cartesian && Cesium.Cartographic.fromCartesian(cartesian);
             if (cartographic) {
                 const latitude = cartographic.latitude * 180.0 / Math.PI;
@@ -214,7 +215,8 @@ class CesiumMap extends React.Component {
                         lat: latitude,
                         lng: longitude
                     },
-                    crs: "EPSG:4326"
+                    crs: "EPSG:4326",
+                    intersectedFeatures
                 });
             }
         }
@@ -276,6 +278,30 @@ class CesiumMap extends React.Component {
     getHeightFromZoom = (zoom) => {
         return this.props.zoomToHeight / Math.pow(2, zoom - 1);
     };
+
+    getIntersectedFeatures = (map, position) => {
+        const features = map.scene.drillPick(position);
+        if (features) {
+            const groupIntersectedFeatures = features.reduce((acc, feature) => {
+                if (feature instanceof Cesium.Cesium3DTileFeature && feature?.tileset?.msId) {
+                    const msId = feature.tileset.msId;
+                    // 3d tile feature does not contain a geometry in the Cesium3DTileFeature class
+                    // it has content but refers to the whole tile model
+                    const propertyNames = feature.getPropertyNames();
+                    const properties = Object.fromEntries(propertyNames.map(key => [key, feature.getProperty(key)]));
+                    return {
+                        ...acc,
+                        [msId]: acc[msId]
+                            ? [...acc[msId], { type: 'Feature', properties, geometry: null }]
+                            : [{ type: 'Feature', properties, geometry: null }]
+                    };
+                }
+                return acc;
+            }, []);
+            return Object.keys(groupIntersectedFeatures).map(id => ({ id, features: groupIntersectedFeatures[id] }));
+        }
+        return [];
+    }
 
     render() {
         const map = this.map;

--- a/web/client/components/map/cesium/__tests__/Map-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test.jsx
@@ -197,6 +197,28 @@ describe('CesiumMap', () => {
             done();
         }, 800);
     });
+    it('click on layer should return intersected features', (done) => {
+        const testHandlers = {
+            handler: () => {}
+        };
+        const spy = expect.spyOn(testHandlers, 'handler');
+
+        const map = ReactDOM.render(
+            <CesiumMap
+                center={{y: 43.9, x: 10.3}}
+                zoom={11}
+                onClick={testHandlers.handler}
+            />
+            , document.getElementById("container"));
+        expect(map.map).toExist();
+        map.onClick(map.map, {position: {x: 100, y: 100 }});
+        setTimeout(() => {
+            expect(spy.calls.length).toEqual(1);
+            expect(spy.calls[0].arguments.length).toEqual(1);
+            expect(spy.calls[0].arguments[0].intersectedFeatures).toEqual([]);
+            done();
+        }, 800);
+    });
     it('check if the map changes when receive new props', () => {
         let map = ReactDOM.render(
             <CesiumMap

--- a/web/client/components/map/cesium/plugins/ThreeDTilesLayer.js
+++ b/web/client/components/map/cesium/plugins/ThreeDTilesLayer.js
@@ -46,6 +46,9 @@ Layers.registerType('3dtiles', {
                 })
             }));
 
+            // assign the original mapstore id of the layer
+            tileSet.msId = options.id;
+
             if (tileSet.ready) {
                 updateModelMatrix(tileSet, options);
             } else {

--- a/web/client/components/map/leaflet/__tests__/Map-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Map-test.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import LeafletMap from '../Map.jsx';
 import LeafLetLayer from '../Layer.jsx';
+import LeafLetFeature from '../Feature.jsx';
 import expect from 'expect';
 import {isNumber} from 'lodash';
 const {
@@ -292,6 +293,60 @@ describe('LeafletMap', () => {
         expect(spy.calls[0].arguments[0].modifiers.alt).toBe(false);
         expect(spy.calls[0].arguments[0].modifiers.ctrl).toBe(false);
         expect(spy.calls[0].arguments[0].modifiers.shift).toBe(false);
+    });
+
+    it('click on layer should return intersected features', () => {
+        const testHandlers = {
+            handler: () => { }
+        };
+        const spy = expect.spyOn(testHandlers, 'handler');
+        const feature = {
+            type: 'Feature',
+            geometry: {
+                type: 'Point',
+                coordinates: [43, 10]
+            },
+            properties: {}
+        };
+        const options = {
+            id: 'vector'
+        };
+        const map = ReactDOM.render(
+            <LeafletMap
+                center={{ y: 43, x: 10 }}
+                zoom={11}
+                onClick={testHandlers.handler}
+                mapOptions={{ zoomAnimation: false }}
+            >
+                <LeafLetLayer type="vector" options={options}>
+                    <LeafLetFeature {...feature}/>
+                </LeafLetLayer>
+            </LeafletMap>
+            , document.getElementById("container"));
+
+        const leafletMap = map.map;
+        leafletMap.fire('singleclick', {
+            containerPoint: {
+                x: 100,
+                y: 100
+            },
+            latlng: {
+                lat: 10,
+                lng: 43
+            },
+            originalEvent: {
+                altKey: false,
+                ctrlKey: false,
+                shiftKey: false
+            }
+        });
+        expect(spy.calls.length).toBe(1);
+        expect(spy.calls[0].arguments[0].intersectedFeatures).toEqual([
+            {
+                id: 'vector',
+                features: [ feature ]
+            }
+        ]);
     });
 
     it('check if the handler for "mousemove" event is called', () => {

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -371,9 +371,13 @@ describe('OpenlayersMap', () => {
                             getFirstCoordinate: () => [10.3, 43.9],
                             getType: () => {
                                 return 'Polygon';
-                            }
+                            },
+                            getCoordinates: () => []
                         };
-                    }
+                    },
+                    getGeometryName: () => '',
+                    getProperties: () => ({}),
+                    getId: () => ''
                 }, {
                     get: (key) => key === "handleClickOnLayer" ? false : "ID"
                 });
@@ -411,9 +415,13 @@ describe('OpenlayersMap', () => {
                             getFirstCoordinate: () => [10.3, 43.9], // this makes sense only for points, maybe centroid is more appropriate
                             getType: () => {
                                 return 'Polygon';
-                            }
+                            },
+                            getCoordinates: () => []
                         };
-                    }
+                    },
+                    getGeometryName: () => '',
+                    getProperties: () => ({}),
+                    getId: () => ''
                 }, {
                     get: (key) => key === "handleClickOnLayer" ? true : "ID"
                 });
@@ -452,9 +460,13 @@ describe('OpenlayersMap', () => {
                             getFirstCoordinate: () => [43.0, 10], // this makes sense only for points, maybe centroid is more appropriate
                             getType: () => {
                                 return 'Point';
-                            }
+                            },
+                            getCoordinates: () => []
                         };
-                    }
+                    },
+                    getGeometryName: () => '',
+                    getProperties: () => ({}),
+                    getId: () => ''
                 }, {
                     get: (key) => key === "handleClickOnLayer" ? true : "ID"
                 });
@@ -472,6 +484,62 @@ describe('OpenlayersMap', () => {
             // also layer id is passed (e.g. used as flag for hide GFI marker)
             expect(spy.calls[0].arguments[1]).toBe("ID");
 
+            done();
+        }, 500);
+    });
+
+    it('click on layer should return intersected features', (done) => {
+        const testHandlers = {
+            handler: () => { }
+        };
+        const spy = expect.spyOn(testHandlers, 'handler');
+        const comp = (<OpenlayersMap projection="EPSG:4326" center={{ y: 43.9, x: 10.3 }} zoom={11}
+            onClick={testHandlers.handler} />);
+        const map = ReactDOM.render(comp, document.getElementById("map"));
+        expect(map).toExist();
+        setTimeout(() => {
+            map.map.forEachFeatureAtPixel = (pixel, callback) => {
+                callback.call(null, {
+                    feature: new Feature({
+                        geometry: new Point([43.0, 10]),
+                        name: 'My Point'
+                    }),
+                    getGeometry: () => {
+                        return {
+                            getFirstCoordinate: () => [43.0, 10],
+                            getType: () => {
+                                return 'Point';
+                            },
+                            getCoordinates: () => [43.0, 10]
+                        };
+                    },
+                    getGeometryName: () => 'Point',
+                    getProperties: () => ({}),
+                    getId: () => ''
+                }, {
+                    get: (key) => key === "msId" ? "ID" : false
+                });
+            };
+            map.map.dispatchEvent({
+                type: 'singleclick',
+                coordinate: [43.3, 10.3],
+                pixel: map.map.getPixelFromCoordinate([0.5, 0.5]),
+                originalEvent: {}
+            });
+            expect(spy.calls.length).toEqual(1);
+            expect(spy.calls[0].arguments[0].intersectedFeatures).toEqual([
+                {
+                    id: 'ID',
+                    features: [
+                        {
+                            type: 'Feature',
+                            geometry: { type: 'Point', coordinates: [43.0, 10] },
+                            properties: null,
+                            id: ''
+                        }
+                    ]
+                }
+            ]);
             done();
         }, 500);
     });

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -18,6 +18,7 @@ import wfs from './mapinfo/wfs';
 import wms from './mapinfo/wms';
 import wmts from './mapinfo/wmts';
 import vector from './mapinfo/vector';
+import threeDTiles from './mapinfo/threeDTiles';
 
 let MapInfoUtils;
 /**
@@ -221,10 +222,11 @@ export const defaultQueryableFilter = (l) => {
     ;
 };
 export const services = {
-    wfs,
-    wms,
-    wmts,
-    vector
+    'wfs': wfs,
+    'wms': wms,
+    'wmts': wmts,
+    'vector': vector,
+    '3dtiles': threeDTiles
 };
 /**
  * To get the custom viewer with the given type

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -306,6 +306,23 @@ describe('MapInfoUtils', () => {
         expect(req1.request.lat).toBe(25);
     });
 
+    it('buildIdentifyRequest works for 3d tiles', () => {
+        const layer = {
+            type: "3dtiles"
+        };
+        const req = buildIdentifyRequest(layer, {});
+        expect(req).toEqual({
+            request: {
+                features: [],
+                outputFormat: 'application/json'
+            },
+            metadata: {
+                title: layer.title
+            },
+            url: 'client'
+        });
+    });
+
     it('getViewer and setViewer test', () => {
         let props = {
             map: {

--- a/web/client/utils/mapinfo/__tests__/threeDTiles-test.js
+++ b/web/client/utils/mapinfo/__tests__/threeDTiles-test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import threeDTiles from '../threeDTiles';
+
+describe('mapinfo 3D tiles utils', () => {
+    it('should create a request with empty features', () => {
+        const layer = {
+            title: 'Title'
+        };
+        const request = threeDTiles.buildRequest(layer);
+        expect(request).toEqual({
+            request: {
+                features: [],
+                outputFormat: 'application/json'
+            },
+            metadata: {
+                title: layer.title
+            },
+            url: 'client'
+        });
+    });
+    it('should create a request with features retrieved from the intersected ones', () => {
+        const layer = {
+            id: 'layer-id',
+            title: 'Title'
+        };
+        const point = {
+            intersectedFeatures: [{ id: 'layer-id', features: [{ type: 'Feature', properties: { key: 'value' }, geometry: null }] }]
+        };
+        const request = threeDTiles.buildRequest(layer, { point });
+        expect(request).toEqual({
+            request: {
+                features: [{ type: 'Feature', properties: { key: 'value' }, geometry: null }],
+                outputFormat: 'application/json'
+            },
+            metadata: {
+                title: layer.title
+            },
+            url: 'client'
+        });
+    });
+    it('should return the response object from getIdentifyFlow', (done) => {
+        threeDTiles.getIdentifyFlow(undefined, undefined, { features: [] })
+            .toPromise()
+            .then((response) => {
+                expect(response).toEqual({
+                    data: {
+                        features: []
+                    }
+                });
+                done();
+            });
+    });
+});

--- a/web/client/utils/mapinfo/threeDTiles.js
+++ b/web/client/utils/mapinfo/threeDTiles.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Observable } from 'rxjs';
+import isObject from 'lodash/isObject';
+
+export default {
+    buildRequest: (layer, { point, currentLocale } = {}) => {
+        const { features = [] } = point?.intersectedFeatures?.find(({ id }) => id === layer.id) || {};
+        return {
+            request: {
+                features: [...features],
+                outputFormat: 'application/json'
+            },
+            metadata: {
+                title: isObject(layer.title)
+                    ? layer.title[currentLocale] || layer.title.default
+                    : layer.title
+            },
+            url: 'client'
+        };
+    },
+    getIdentifyFlow: (layer, baseURL, { features = [] } = {}) => {
+        return Observable.of({
+            data: {
+                features
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces following updates:

- return intersected feature on click events for all types of map
- implement 3d tile support for map info services

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8018

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
