### PR TITLE
[Backport 2022.01.xx] #7776 - fix for overflowing display tab

### DIFF
--- a/web/client/components/layout/BorderLayout.jsx
+++ b/web/client/components/layout/BorderLayout.jsx
@@ -34,7 +34,7 @@ export default ({id, children, header, footer, columns, height, style = {}, clas
             flex: 1,
             overflowY: "auto"
         }}>
-            <main className="ms2-border-layout-content" style={{flex: 1}}>
+            <main className="ms2-border-layout-content" style={{flex: 1, overflowX: 'hidden'}}>
                 {height ? <div style={{height}}>{children}</div> : children}
             </main>
             {height ? <div style={{height}}>{columns}</div> : columns}

--- a/web/client/components/misc/wizard/WizardContainer.jsx
+++ b/web/client/components/misc/wizard/WizardContainer.jsx
@@ -67,7 +67,7 @@ class WizardComponent extends React.Component {
        const children = this.props.children || [];
        const childrenLenght = children.length >= 0 ? children.length : 1;
        return (
-           <div key="wizard-pages" className="ms-wizard">
+           <div key="wizard-pages" className="ms-wizard map-options">
                {React.Children.map(children, (child, i) => {
                    if (i === this.props.step) {
                        return React.cloneElement(child, {

--- a/web/client/themes/default/less/toc.less
+++ b/web/client/themes/default/less/toc.less
@@ -1102,8 +1102,7 @@
 }
 
 .adjust-display {
-    position: absolute;
-    width: calc(100% - 5px);
+    width: auto;
 }
 
 // display form toc settings

--- a/web/client/themes/default/less/wizard.less
+++ b/web/client/themes/default/less/wizard.less
@@ -26,7 +26,7 @@
                 &.line {
                     display: none;
                 }
-            } 
+            }
             .custom-color {
                 padding-left: 10px;
             }
@@ -60,6 +60,9 @@
 }
 .ms-wizard > .row{
     margin: 15px;
+}
+.ms-wizard.map-options {
+    padding: 8px;
 }
 .mapstore-step-title {
     font-size: 20px;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7776 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The display tab does not overflow and horizontal scrolling is no more present


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
