### PR TITLE
Issue #7983 - GeoStories - support of WMTS layers with tileMatrix configuration

### DIFF
--- a/web/client/plugins/geostory/MediaViewer.js
+++ b/web/client/plugins/geostory/MediaViewer.js
@@ -19,6 +19,7 @@ import connectMap, {withLocalMapState, withMapEditingAndLocalMapState} from '../
 import emptyState from '../../components/misc/enhancers/emptyState';
 import { resourcesSelector } from '../../selectors/geostory';
 import { SectionTypes } from '../../utils/GeoStoryUtils';
+import { extractTileMatrixFromSources } from '../../utils/LayersUtils';
 import withMediaVisibilityContainer from '../../components/geostory/common/enhancers/withMediaVisibilityContainer';
 import autoMapType from '../../components/map/enhancers/autoMapType';
 import withScalesDenominators from "../../components/map/enhancers/withScalesDenominators";
@@ -43,10 +44,26 @@ const image = branch(
     )
 )(withMediaVisibilityContainer(Image));
 
-const map = compose(
+const geostoryMap = compose(
     branch(
         ({ resourceId }) => resourceId,
         connectMap
+    ),
+    withProps(
+        ({ map = {}}) => {
+            return {
+                map: {
+                    ...map,
+                    layers: map.layers && map.layers.map(layer => {
+                        if (layer.tileMatrixSet && map.sources) {
+                            const tileMatrix = extractTileMatrixFromSources(map.sources, layer);
+                            return {...layer, ...tileMatrix};
+                        }
+                        return layer;
+                    })
+                }
+            };
+        }
     ),
     autoMapType,
     withScalesDenominators,
@@ -84,7 +101,7 @@ const video = branch(
 
 const mediaTypesMap = {
     image,
-    map,
+    map: geostoryMap,
     video
 };
 

--- a/web/client/selectors/__tests__/mediaEditor-test.js
+++ b/web/client/selectors/__tests__/mediaEditor-test.js
@@ -182,6 +182,71 @@ describe('mediaEditor selectors', () => {
             }
         })).toEqual({id: "id"});
     });
+    it('selectedItemSelector - include tileMatrix in WMTS layers for "map" media resource', () => {
+        const selectedMapMedia = selectedItemSelector({
+            mediaEditor: {
+                selected: "id",
+                settings: {mediaType: "map", sourceId: "id"},
+                data: {
+                    map: {
+                        id: {
+                            resultData: {
+                                resources: [{
+                                    id: "id",
+                                    type: "map",
+                                    data: {
+                                        type: "map",
+                                        id: "mapId",
+                                        sources: {
+                                            "http://localhost/geoserver/gwc/service/wmts": {
+                                                tileMatrixSet: {
+                                                    'EPSG:4326': {
+                                                        tileMatrixSet: {
+                                                            "ows:Identifier": "EPSG:4326",
+                                                            "ows:SupportedCRS": "urn:ogc:def:crs:EPSG::4326"
+                                                        },
+                                                        TileMatrix: []
+                                                    },
+                                                    "EPSG:900913": {
+                                                        tileMatrixSet: {
+                                                            'ows:Identifier': 'EPSG:900913',
+                                                            'ows:SupportedCRS': 'urn:ogc:def:crs:EPSG::900913'
+                                                        },
+                                                        TileMatrix: []
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        layers: [{
+                                            id: "workspace:layer__1",
+                                            format: "image/png",
+                                            name: 'workspace:layer',
+                                            type: "wmts",
+                                            url: "http://localhost/geoserver/gwc/service/wmts",
+                                            allowedSRS: {
+                                                "EPSG:4326": true,
+                                                "EPSG:900913": true
+                                            },
+                                            matrixIds: [
+                                                "EPSG:4326",
+                                                "EPSG:900913"
+                                            ],
+                                            tileMatrixSet: true
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        expect(selectedMapMedia.id).toBe("id");
+        expect(selectedMapMedia.data.layers[0].tileMatrixSet).toExist();
+        expect(selectedMapMedia.data.layers[0].tileMatrixSet.length).toBe(2);
+        expect(selectedMapMedia.data.layers[0].tileMatrixSet[0].tileMatrixSet['ows:Identifier']).toBe("EPSG:4326");
+        expect(selectedMapMedia.data.layers[0].tileMatrixSet[1].tileMatrixSet['ows:Identifier']).toBe("EPSG:900913");
+    });
     it('getCurrentMediaResourcesParams', () => {
         const params = { page: 1 };
         expect(getCurrentMediaResourcesParams({

--- a/web/client/selectors/mediaEditor.js
+++ b/web/client/selectors/mediaEditor.js
@@ -8,6 +8,7 @@
 
 import { get, find } from "lodash";
 import { createSelector } from "reselect";
+import { splitMapAndLayers, extractTileMatrixFromSources } from '../utils/LayersUtils';
 
 /**
  * Selects the open/closed state of the mediaEditor
@@ -36,7 +37,25 @@ export const getLoadingMediaList = state => get(state, "mediaEditor.loadingList"
 export const selectedItemSelector = createSelector(
     currentResourcesSelector,
     selectedIdSelector,
-    (resources = [], id) => find(resources, {id})
+    (resources = [], id) => {
+        const item  = find(resources, {id});
+        if (item && item.type === 'map' && item.data.layers)  {
+            return {
+                ...item,
+                data: {
+                    ...item.data,
+                    layers: item.data.layers.map(layer => {
+                        if (layer.tileMatrixSet && item.data.sources) {
+                            const tileMatrix = extractTileMatrixFromSources(item.data.sources, layer);
+                            return {...layer, ...tileMatrix};
+                        }
+                        return layer;
+                    })
+                }
+            };
+        }
+        return item;
+    }
 );
 export const disabledMediaTypeSelector = state => get(state, "mediaEditor.disabledMediaType", []);
 

--- a/web/client/selectors/mediaEditor.js
+++ b/web/client/selectors/mediaEditor.js
@@ -8,7 +8,7 @@
 
 import { get, find } from "lodash";
 import { createSelector } from "reselect";
-import { splitMapAndLayers, extractTileMatrixFromSources } from '../utils/LayersUtils';
+import { extractTileMatrixFromSources } from '../utils/LayersUtils';
 
 /**
  * Selects the open/closed state of the mediaEditor


### PR DESCRIPTION
Implementation of map object parsing and tileMatrix key
inclusion for WMTS layer imported in geostories maps

## Description
This PR fixes a bug that made the map crash whenever a user saved a map containing at least one WMTS layer, may this be loaded as part of a saved `json` config file or as a newly created map/media resource in the MediaEditor component.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

#7983 

**What is the current behavior?**

**case 1.** Export a map from map Editor in json format and subsequently import the map in GeoStory within the media import, the import is successful, the application will crash upon geostory map confirmation.

**case 2.** create a new map from the map editor of GeoStory and add a WMTS layer (as a background or not), same result as case 1.

#7983 

**What is the new behavior?**

**case 1.** Export a map from map Editor in json format and subsequently import the map in GeoStory within the media import, the import is successful, the application will correctly translate `json` configuration in a map that will be displayed in the MediaPreview component.

![recording_1](https://user-images.githubusercontent.com/14953970/160136021-af209731-a5bb-46d9-a7c3-780587996e37.gif)

**case 2.** create a new map from the map editor of GeoStory and add a WMTS layer, once clicked on the `OK` button the MediaPreview component will display the loaded map resource.

![recording_1](https://user-images.githubusercontent.com/14953970/160137058-8902977f-94e5-4d4d-be4d-53582453e348.gif)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
1. Clarified in #7983 that `WMC` config files are currently not supported for WMTS layers configurations (only WMS is)
2. Once this is merged we may agree with the customer if this will be backported to previous releases or not.
