### PR TITLE
#8030: Share panel orientation fix

### DIFF
--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -34,14 +34,6 @@ function mapConfig(state = {eventListeners: {}}, action) {
     switch (action.type) {
     case CHANGE_MAP_VIEW:
         const {type, ...params} = action;
-        if (params?.viewerOptions) {
-            const heading = CoordinatesUtils.setValueBoundaries(params.viewerOptions.orientation.heading, CoordinatesUtils.convertDegreesToRadian(0), CoordinatesUtils.convertDegreesToRadian(360));
-            const pitch = CoordinatesUtils.setValueBoundaries(params.viewerOptions.orientation.pitch, CoordinatesUtils.convertDegreesToRadian(-90), CoordinatesUtils.convertDegreesToRadian(90));
-            const roll = CoordinatesUtils.setValueBoundaries(params.viewerOptions.orientation.roll, CoordinatesUtils.convertDegreesToRadian(-90), CoordinatesUtils.convertDegreesToRadian(90));
-            params.viewerOptions.orientation.heading = heading;
-            params.viewerOptions.orientation.pitch = pitch;
-            params.viewerOptions.orientation.roll = roll;
-        }
         params.zoom = isNaN(params.zoom) ? 1 : params.zoom;
         return assign({}, state, params);
     case CHANGE_MOUSE_POINTER:

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1332,7 +1332,7 @@
             "coordTooltip": "Klicken Sie auf die Karte, um die Koordinaten zu ändern / festzulegen",
             "zoomToolTip": "Min: 1 und Max: 35",
             "headingToolTip": "Min: 0° und Max: 360°",
-            "rollToolTip": "Min: -90° und Max: 90°",
+            "rollToolTip": "Min: 0° und Max: 360°",
             "pitchToolTip": "Min: -90° und Max: 90°",
             "showSectionId": "Bildlaufposition einschließen",
             "showConnections": "Verbindungen anzeigen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1284,7 +1284,7 @@
             "coordTooltip": "Click on map to grab the coordinates",
             "zoomToolTip": "Min: 1 and Max: 35",
             "headingToolTip": "Min: 0° and Max: 360°",
-            "rollToolTip": "Min: -90° and Max: 90°",
+            "rollToolTip": "Min: 0° and Max: 360°",
             "pitchToolTip": "Min: -90° and Max: 90°",
             "wrongCenterAndZoomParamTitle": "Invalid center and zoom param",
             "wrongCenterAndZoomParamMessage": "Center and Zoom param must be center=lon,lat&zoom=value and (+|- 90° lat, +|-180° lon, <=+35 zoom)",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1293,7 +1293,7 @@
             "coordTooltip": "Haga clic en el mapa para tomar las coordenadas.",
             "zoomToolTip": "Min: 1 y Max: 35",
             "headingToolTip": "Min: 0° y Max: 360°",
-            "rollToolTip": "Min: -90° y Max: 90°",
+            "rollToolTip": "Min: 0° y Max: 360°",
             "pitchToolTip": "Min: -90° y Max: 90°",
             "showSectionId": "Incluir posición de desplazamiento",
             "showConnections": "Mostrar conexiones",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1291,7 +1291,7 @@
             "coordTooltip": "Cliquez sur la carte pour saisir les coordonnées",
             "zoomToolTip": "Min: 1 et Max: 35",
             "headingToolTip": "Min: 0° et Max: 360°",
-            "rollToolTip": "Min: -90° et Max: 90°",
+            "rollToolTip": "Min: 0° et Max: 360°",
             "pitchToolTip": "Min: -90° et Max: 90°",
             "addBboxParam": "Ajouter un paramètre de rectangle englobant au lien de partage",
             "wrongBboxParamTitle": "Paramètre de rectangle englobant invalide",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1293,7 +1293,7 @@
             "coordTooltip": "Clicca sulla mappa per ottenere le coordinate del centro",
             "zoomToolTip": "Min: 1 e Max: 35",
             "headingToolTip": "Min: 0° e Max: 360°",
-            "rollToolTip": "Min: -90° e Max: 90°",
+            "rollToolTip": "Min: 0° e Max: 360°",
             "pitchToolTip": "Min: -90° e Max: 90°",
             "showSectionId": "Includi posizione di scorrimento",
             "showConnections": "Mostra connessioni",

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -1109,13 +1109,6 @@ export const convertDegreesToRadian = (deg) => {
     return isNumber(value) && ((value * Math.PI) / 180);
 };
 
-export const setValueBoundaries = (value, min, max ) => {
-    if (isNaN(value) && value.length < 1) { return 0;}
-    if (value < min) { return min;}
-    if (value > max) { return max;}
-    return  parseFloat(value);
-};
-
 CoordinatesUtils = {
     setCrsLabels,
     getUnits,
@@ -1174,7 +1167,6 @@ CoordinatesUtils = {
     getLonLatFromPoint,
     getExtentForProjection,
     convertRadianToDegrees,
-    convertDegreesToRadian,
-    setValueBoundaries
+    convertDegreesToRadian
 };
 export default CoordinatesUtils;


### PR DESCRIPTION
## Description
This PR fixes the orientation of roll in 3d map with the share panel, as the roll data should be in range of 0 to 360 as we recieve from Cesium map

Test cases were not impacted as it was only matter of interpretation of roll limits and code refactored wherever possible

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#8030 

**What is the new behavior?**

- The orientation is interpreted correctly and converted to degress to be displayed in Share panel
- Orientation change invoked by the 3d map rotation handler, will display correct converted roll info

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
