### PR TITLE
set params endpoint

### DIFF
--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -109,3 +109,24 @@ Data of resulting layer can be additionally filtered by passing "CQL_FILTER" int
 ```
 Number of objects passed to the options can be different to the number of layers, in this case options will be applied to the first X layers, where X is the length of options array.
 
+#### Passing Parameters with POST Request
+
+Sometimes the request parameters can be too big to be passed in the URL, for instance when dealing with a entire map, or complex data. To overcome this kind of situations an adhoc `POST` service available at `mapstore/rest/config/setParams` allows to pass the parameters in the request payload as either `application/json` or `application/x-www-form-urlencoded`. 
+The parameters will be then made available in the `sessionStorage` with key `queryParams`. Optionally a `page` value can be passed together with the params to specify to which url be redirect. If no page attribute is specified by default redirection happens to `mapstore/#viewer/openlayers/config`.
+
+Example `application/json` request payload:
+```
+{
+ "map":{....},
+ "center":{...},
+ "bbox":{...},
+ "featureinfo":{...},
+ "actions":{...},
+ "page":"#/viewer/openlayers/config"
+}
+```
+
+Example `application/x-www-form-urlencoded` request payload:
+```
+"map"={....}&"center"={...}&"bbox"={...}&"featureinfo"={...}&"actions"={...}&"page"="#/viewer/openlayers/config"
+```

--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -111,7 +111,7 @@ Number of objects passed to the options can be different to the number of layers
 
 #### Passing Parameters with POST Request
 
-Sometimes the request parameters can be too big to be passed in the URL, for instance when dealing with a entire map, or complex data. To overcome this kind of situations an adhoc `POST` service available at `mapstore/rest/config/setParams` allows to pass the parameters in the request payload as either `application/json` or `application/x-www-form-urlencoded`. 
+Sometimes the request parameters can be too big to be passed in the URL, for instance when dealing with an entire map, or complex data. To overcome this kind of situations, an adhoc `POST` service available at `mapstore/rest/config/setParams` allows to pass the parameters in the request payload as either `application/json` or `application/x-www-form-urlencoded`. 
 The parameters will be then made available in the `sessionStorage` with key `queryParams`. Optionally a `page` value can be passed together with the params to specify to which url be redirect. If no page attribute is specified by default redirection happens to `mapstore/#viewer/openlayers/config`.
 
 Example `application/json` request payload:

--- a/java/services/src/main/java/it/geosolutions/mapstore/controllers/rest/config/SetParamsController.java
+++ b/java/services/src/main/java/it/geosolutions/mapstore/controllers/rest/config/SetParamsController.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package it.geosolutions.mapstore.controllers.rest.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
+import com.google.common.base.Charsets;
+import it.geosolutions.mapstore.controllers.BaseConfigController;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * This controller exposes a service to read a JSON body holding parameters and a redirect page,
+ * making it available in an HTML page for javascript manipulation.
+ */
+@Controller
+public class SetParamsController extends BaseConfigController {
+
+
+    private static final String PAGE_PARAM="page";
+    private static final String QUERY_PARAMS="queryParams";
+
+
+
+    /**
+     * Write an HTML output with a script to redirect to the page url
+     * and set the JSON request payload in the sessionStorage.
+     * @param request the HttpServletRequest.
+     * @param response the HttpServletResponse.
+     * @throws IOException
+     */
+    @RequestMapping(value="/setParams", method = RequestMethod.POST, consumes = {MediaType.APPLICATION_JSON_VALUE})
+    public void setParams(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String strJSON=IOUtils.toString(request.getInputStream(), Charsets.UTF_8.name());
+        ObjectMapper mapper=new ObjectMapper();
+        JsonNode node;
+        try {
+            node = mapper.readTree(strJSON);
+        } catch (JsonProcessingException e){
+            String message="Error while parsing the JSON request payload.";
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,message);
+            throw new IOException(message,e);
+        }
+        if (!(node instanceof ObjectNode)){
+            throw new UnsupportedOperationException("The request payload is not a JSON Object.");
+        }
+        if (!node.has(PAGE_PARAM)){
+            String message="No attribute "+PAGE_PARAM+" holding the redirect value was found";
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,message);
+        }
+        JsonNode pageNode=node.get(PAGE_PARAM);
+        if (!(pageNode instanceof ValueNode)){
+            String message="The page JSON attribute should be a string value.";
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,message);
+        }
+        String jsString= StringEscapeUtils.escapeJavaScript(node.toString());
+        response.setContentType("text/html");
+        java.io.PrintWriter out = response.getWriter();
+        out.write("<html><head><script>");
+        out.write("let params=".concat("'").concat(jsString).concat("'; "));
+        out.write("sessionStorage.setItem(\"".concat(QUERY_PARAMS).concat("\",params); "));
+        out.write("location.href=\"".concat(pageNode.asText()).concat("\"; "));
+        out.write("</script></head><body></body></html>");
+    }
+
+
+
+}

--- a/java/services/src/main/java/it/geosolutions/mapstore/controllers/rest/config/SetParamsController.java
+++ b/java/services/src/main/java/it/geosolutions/mapstore/controllers/rest/config/SetParamsController.java
@@ -10,14 +10,21 @@ package it.geosolutions.mapstore.controllers.rest.config;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
-import com.google.common.base.Charsets;
 import it.geosolutions.mapstore.controllers.BaseConfigController;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringEscapeUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -25,6 +32,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
 
 /**
  * This controller exposes a service to read a JSON body holding parameters and a redirect page,
@@ -36,48 +47,109 @@ public class SetParamsController extends BaseConfigController {
 
     private static final String PAGE_PARAM="page";
     private static final String QUERY_PARAMS="queryParams";
+    private static final String DEF_PAGE="../../#viewer/openlayers/config";
 
 
 
     /**
      * Write an HTML output with a script to redirect to the page url
-     * and set the JSON request payload in the sessionStorage.
+     * and set request payload in the sessionStorage as a JSON.
      * @param request the HttpServletRequest.
      * @param response the HttpServletResponse.
      * @throws IOException
      */
-    @RequestMapping(value="/setParams", method = RequestMethod.POST, consumes = {MediaType.APPLICATION_JSON_VALUE})
-    public void setParams(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String strJSON=IOUtils.toString(request.getInputStream(), Charsets.UTF_8.name());
-        ObjectMapper mapper=new ObjectMapper();
+    @RequestMapping(value="/setParams", method = RequestMethod.POST, consumes = {MediaType.APPLICATION_JSON_VALUE,MediaType.APPLICATION_FORM_URLENCODED_VALUE})
+    public void setParams(HttpServletRequest request, HttpServletResponse response, @RequestHeader("Content-Type") String contentType) throws IOException {
         JsonNode node;
-        try {
-            node = mapper.readTree(strJSON);
-        } catch (JsonProcessingException e){
-            String message="Error while parsing the JSON request payload.";
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,message);
-            throw new IOException(message,e);
-        }
-        if (!(node instanceof ObjectNode)){
-            throw new UnsupportedOperationException("The request payload is not a JSON Object.");
-        }
-        if (!node.has(PAGE_PARAM)){
-            String message="No attribute "+PAGE_PARAM+" holding the redirect value was found";
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,message);
-        }
-        JsonNode pageNode=node.get(PAGE_PARAM);
-        if (!(pageNode instanceof ValueNode)){
-            String message="The page JSON attribute should be a string value.";
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,message);
-        }
+        if (contentType.equals(MediaType.APPLICATION_FORM_URLENCODED_VALUE))
+            node=formEncodedToJSON(new HttpServletRequestInput(request));
+        else node=toJSON(request);
         String jsString= StringEscapeUtils.escapeJavaScript(node.toString());
         response.setContentType("text/html");
         java.io.PrintWriter out = response.getWriter();
-        out.write("<html><head><script>");
+        out.write("<html><head>");
+        out.write("<meta charset=\"UTF-8\">");
+        out.write("<script>");
         out.write("let params=".concat("'").concat(jsString).concat("'; "));
         out.write("sessionStorage.setItem(\"".concat(QUERY_PARAMS).concat("\",params); "));
-        out.write("location.href=\"".concat(pageNode.asText()).concat("\"; "));
+        out.write("location.href=\"".concat(getPage(node)).concat("\"; "));
         out.write("</script></head><body></body></html>");
+    }
+
+    private String getPage(JsonNode node){
+        String pageStr=null;
+        if (node.has(PAGE_PARAM)){
+            JsonNode pageNode=node.get(PAGE_PARAM);
+            if (pageNode!=null && !(pageNode instanceof NullNode) && !(pageNode instanceof ValueNode)){
+                String error="The page JSON attribute should be a string value.";
+                throw new UnsupportedOperationException(error);
+            }
+
+            if (pageNode instanceof TextNode){
+                pageStr=pageNode.asText();
+            }
+        }
+        if (pageStr==null) pageStr=DEF_PAGE;
+        return pageStr;
+    }
+
+    private JsonNode formEncodedToJSON(HttpInputMessage message) throws IOException {
+        FormHttpMessageConverter converter=new FormHttpMessageConverter();
+        MultiValueMap<String,String> result=converter.read(null,message);
+        Map<String,String> map=result.toSingleValueMap();
+        return mapToJSONObject(map);
+    }
+
+    private ObjectNode mapToJSONObject(Map<String,String> map){
+        ObjectMapper mapper=new ObjectMapper();
+        JsonNodeFactory factory=new JsonNodeFactory(false);
+        ObjectNode resultJSON=factory.objectNode();
+        for (String k:map.keySet()){
+            if (k.equals(PAGE_PARAM)) {
+                resultJSON.set(k, factory.textNode(map.get(k)));
+            } else {
+                String val=map.get(k);
+                try {
+                    JsonNode node=mapper.readTree(val);
+                    resultJSON.set(k,node);
+                }catch (JsonProcessingException e){
+                    resultJSON.set(k,factory.textNode(val));
+                }
+            }
+        }
+        return resultJSON;
+    }
+
+    private JsonNode toJSON(HttpServletRequest request) throws IOException {
+       String jsonStr=IOUtils.toString(request.getInputStream(),"UTF-8");
+        ObjectMapper mapper=new ObjectMapper();
+        return mapper.readTree(jsonStr);
+    }
+
+    // a simple HttpInputMessage wrapping an HttpServletRequest
+    private class HttpServletRequestInput implements HttpInputMessage{
+
+        private HttpServletRequest request;
+
+        HttpServletRequestInput(HttpServletRequest request){
+            this.request=request;
+        }
+
+        @Override
+        public InputStream getBody() throws IOException {
+            return request.getInputStream();
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            HttpHeaders headers=new HttpHeaders();
+            Enumeration<String> names= request.getHeaderNames();
+            while(names.hasMoreElements()){
+                String name=names.nextElement();
+                headers.put(name, Collections.list(request.getHeaders(name)));
+            }
+            return headers;
+        }
     }
 
 

--- a/java/services/src/test/java/it/geosolutions/mapstore/SetParamsControllerTest.java
+++ b/java/services/src/test/java/it/geosolutions/mapstore/SetParamsControllerTest.java
@@ -7,13 +7,20 @@
  */
 package it.geosolutions.mapstore;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import it.geosolutions.mapstore.controllers.rest.config.SetParamsController;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.MockHttpInputMessage;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import static org.junit.Assert.assertTrue;
 
@@ -22,15 +29,37 @@ public class SetParamsControllerTest {
 
     @Test
     public void setParamsEndpointTest() throws IOException {
-        MockHttpServletRequest request=new MockHttpServletRequest();
-        request.setContent("{\"page\":\"../../../\",\"queryParam\":{\"param1\":\"l'object value1\",\"param2\":\"value\"}}".getBytes());
         MockHttpServletResponse response=new MockHttpServletResponse();
+        String payload="{\"page\":\"../../../\",\"queryParam\":{\"param1\":\"l'object value1\",\"param2\":\"value\"}}";
+        MockHttpServletRequest request=new MockHttpServletRequest();
+        request.setContent(payload.getBytes());
         SetParamsController paramsController=new SetParamsController();
-        paramsController.setParams(request,response);
+        paramsController.setParams(request,response,"application/json");
         String resp=response.getContentAsString();
         response.getContentType().equals("text/html");
         assertTrue(resp.contains("sessionStorage.setItem(\"queryParams\",params"));
         assertTrue(resp.contains("l\\\'object"));
         assertTrue(resp.contains("location.href=\"../../../\";"));
+    }
+
+    @Test
+    public void setParamsEndpointTestFormURLEncoded() throws IOException {
+        String payload="map={\"name\":\"value\",\"name2\":\"value2\"}&" +
+            "bbox=[0,1,2,3]&" +
+            "page=#/viewer/openlayers/config";
+        MockHttpServletRequest request=new MockHttpServletRequest();
+        request.setContent(payload.getBytes());
+        MockHttpServletResponse response=new MockHttpServletResponse();
+        SetParamsController paramsController=new SetParamsController();
+        paramsController.setParams(request,response, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        String result=response.getContentAsString();
+        response.getContentType().equals("text/html");
+        assertTrue(result.contains("sessionStorage.setItem(\"queryParams\",params"));
+        assertTrue(result.contains("location.href=\"#/viewer/openlayers/config\";"));
+        // extract the JSON
+        String json=result.substring(result.indexOf("'")+1,result.lastIndexOf("}")+1);;
+        //check it is valid
+        ObjectMapper mapper=new ObjectMapper();
+        assertTrue(mapper.readTree(StringEscapeUtils.unescapeJavaScript(json)).isObject());
     }
 }

--- a/java/services/src/test/java/it/geosolutions/mapstore/SetParamsControllerTest.java
+++ b/java/services/src/test/java/it/geosolutions/mapstore/SetParamsControllerTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package it.geosolutions.mapstore;
+
+import it.geosolutions.mapstore.controllers.rest.config.SetParamsController;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class SetParamsControllerTest {
+
+
+    @Test
+    public void setParamsEndpointTest() throws IOException {
+        MockHttpServletRequest request=new MockHttpServletRequest();
+        request.setContent("{\"page\":\"../../../\",\"queryParam\":{\"param1\":\"l'object value1\",\"param2\":\"value\"}}".getBytes());
+        MockHttpServletResponse response=new MockHttpServletResponse();
+        SetParamsController paramsController=new SetParamsController();
+        paramsController.setParams(request,response);
+        String resp=response.getContentAsString();
+        response.getContentType().equals("text/html");
+        assertTrue(resp.contains("sessionStorage.setItem(\"queryParams\",params"));
+        assertTrue(resp.contains("l\\\'object"));
+        assertTrue(resp.contains("location.href=\"../../../\";"));
+    }
+}


### PR DESCRIPTION
## Description
Add a setParams endpoint at **mapstore/rest/config/setParams**. The endpoint expect a JSON object like the following:

```
{
"map":{....},
"center":{...},
"bbox":{...},
"featureinfo":{...},
"actions":{...},
"page":"#/viewer/openlayers/config"
}
```
The overall JSON object will be made available in the sessionStorage with name `queryParams`.
The page attribute will be picked up and used for redirect after the JSON has been made available in the sessionStorage.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8034 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
