### PR TITLE
Issue #8029 - Save button disappear on map Import

### DIFF
--- a/web/client/components/import/dragZone/enhancers/__tests__/useFiles-test.js
+++ b/web/client/components/import/dragZone/enhancers/__tests__/useFiles-test.js
@@ -24,7 +24,6 @@ describe('useFiles enhancer', () => {
         setTimeout(done);
     });
     it('useFiles rendering with map', (done) => {
-
         const actions = {
             loadMap: (conf, mapId, zoomToExtent ) => {
                 expect(conf).toExist();
@@ -53,6 +52,45 @@ describe('useFiles enhancer', () => {
         const EnhancedSink = useFiles(sink);
         ReactDOM.render(<EnhancedSink maps={[ {map: {zoom: 4, center: { x: 1, y: 1 }, bbox: { x: 1, y: 1 }, maxExtent: "TEST"}} ]}
             loadAnnotations={actions.loadAnnotations} setLayers={actions.setLayers} loadMap={actions.loadMap} onClose={actions.onClose} currentMap={{zoom: 4, center: { x: 1, y: 1 }}} />, document.getElementById("container"));
+        expect(spyOnClose).toHaveBeenCalled();
+        expect(spyLoadAnnotations).toNotHaveBeenCalled();
+        expect(spySetLayers).toNotHaveBeenCalled();
+    });
+    it('useFiles rendering with map with pre-existing mapId', (done) => {
+        const actions = {
+            loadMap: (conf, mapId, zoomToExtent ) => {
+                expect(conf).toExist();
+                expect(conf.map).toExist();
+                expect(conf.map.bbox).toExist();
+                expect(conf.map.center).toExist();
+                expect(conf.map.zoom).toExist();
+                expect(mapId).toExist();
+                expect(zoomToExtent).toBe(false);
+                done();
+            },
+            loadMapInfo: (mapId, info) => {
+                expect(mapId).toBe("10");
+                expect(info).toExist();
+            },
+            onClose: () => {},
+            loadAnnotations: () => {},
+            setLayers: () => {}
+        };
+        const spyOnClose = expect.spyOn(actions, 'onClose');
+        const spyLoadMapInfo = expect.spyOn(actions, 'loadMapInfo');
+        const spyLoadAnnotations = expect.spyOn(actions, 'loadAnnotations');
+        const spySetLayers = expect.spyOn(actions, 'setLayers');
+
+        const sink = createSink( props => {
+            expect(props).toExist();
+            expect(props.maps).toExist();
+            expect(props.useFiles).toExist();
+            props.useFiles({maps: props.maps});
+        });
+        const EnhancedSink = useFiles(sink);
+        ReactDOM.render(<EnhancedSink maps={[ {map: {zoom: 4, center: { x: 1, y: 1 }, bbox: { x: 1, y: 1 }, maxExtent: "TEST"}} ]}
+            loadAnnotations={actions.loadAnnotations} setLayers={actions.setLayers} loadMap={actions.loadMap} loadMapInfo={actions.loadMapInfo} onClose={actions.onClose} currentMap={{zoom: 4, center: { x: 1, y: 1 }, mapId: "10"}} />, document.getElementById("container"));
+        expect(spyLoadMapInfo).toHaveBeenCalled();
         expect(spyOnClose).toHaveBeenCalled();
         expect(spyLoadAnnotations).toNotHaveBeenCalled();
         expect(spySetLayers).toNotHaveBeenCalled();

--- a/web/client/components/import/dragZone/enhancers/processFiles.jsx
+++ b/web/client/components/import/dragZone/enhancers/processFiles.jsx
@@ -115,7 +115,9 @@ const readFile = (onWarnings) => (file) => {
         });
     }
     if (type === 'application/vnd.wmc') {
-        return readWMC(file).then(config => [config]);
+        return readWMC(file).then((config) => {
+            return [{...config, "fileName": file.name}];
+        });
     }
     return null;
 };

--- a/web/client/components/import/dragZone/enhancers/useFiles.js
+++ b/web/client/components/import/dragZone/enhancers/useFiles.js
@@ -9,13 +9,14 @@ import { checkIfLayerFitsExtentForProjection } from '../../../../utils/Coordinat
  */
 export default compose(
     withHandlers({
-        useFiles: ({ currentMap, loadMap = () => { }, onClose = () => { }, setLayers = () => { },
+        useFiles: ({ currentMap, loadMap = () => { }, loadMapInfo = () => { }, onClose = () => { }, setLayers = () => { },
             annotationsLayer, loadAnnotations = () => {}, warning = () => {}}) =>
             ({ layers = [], maps = [] }, warnings) => {
                 const map = maps[0]; // only 1 map is allowed
                 if (map) {
                     // also handles maps without zoom or center
-                    const { zoom, center } = currentMap;
+                    const { zoom, center, mapId } = currentMap;
+                    const { fileName } = map;
                     loadMap({
                         ...map,
                         map: {
@@ -23,7 +24,11 @@ export default compose(
                             zoom: map.map.zoom || zoom,
                             center: map.map.center || center
                         }
-                    }, null, !map.map.zoom && (map.map.bbox || {bounds: map.map.maxExtent}));
+                    }, mapId ? mapId : null, !map.map.zoom && (map.map.bbox || {bounds: map.map.maxExtent}));
+                    // keeps mapinfo of pre-existing map if present (to keep save map overwrite)
+                    if (mapId && fileName) {
+                        loadMapInfo(mapId);
+                    }
                     onClose(); // close if loaded the map
                 }
                 if (layers.length > 0) {

--- a/web/client/plugins/import/Import.jsx
+++ b/web/client/plugins/import/Import.jsx
@@ -12,7 +12,7 @@ import { createStructuredSelector } from 'reselect';
 import DragZone from '../../components/import/ImportDragZone';
 import { connect } from 'react-redux';
 import StyleDialog from './StyleDialog';
-import { configureMap } from '../../actions/config';
+import { configureMap, loadMapInfo } from '../../actions/config';
 import { mapSelector } from '../../selectors/map';
 
 export default compose(
@@ -36,7 +36,8 @@ export default compose(
             connect(createStructuredSelector({
                 currentMap: mapSelector
             }), {
-                loadMap: configureMap
+                loadMap: configureMap,
+                loadMapInfo
             }),
             renderComponent(DragZone)
         )

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -69,7 +69,9 @@ function mapConfig(state = null, action) {
             }),
             mapConfigRawData: { ...action.config }
         };
-        newMapState.map = assign({}, newMapState.map, {mapId: action.mapId, size, version: hasVersion ? action.config.version : 1});
+        // if map is loaded from an already saved map keep the same id
+        const mapId = action.config?.fileName && state.map.present.mapId ? state.map.present.mapId : action.mapId;
+        newMapState.map = assign({}, newMapState.map, {mapId, size, version: hasVersion ? action.config.version : 1});
         // we store the map initial state for future usage
         return assign({}, newMapState, {mapInitialConfig: {...newMapState.map, mapId: action.mapId}});
     case MAP_CONFIG_LOAD_ERROR:


### PR DESCRIPTION
Fixes the bug including `fileName` and `mapId` when loading
the json and wmc file, moreover triggers the mapInfo action
to record mapSave conditionals variables to make the save button appear

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?**
Loading a map configuration either in `json` or `wmc` from an already saved map (not a new one) when the loaded map finished loading, overwriting the pre-saved one the button `Save` disappears from the burger menu plugin. As a consequence it is not possible to overwrite a pre-saved map with a new configuration.
#8029 

**What is the new behavior?**
Loading a map configuration either in `json` or `wmc` from an already saved map (not a new one) when the loaded map finished loading, overwriting the pre-saved one the button `Save` is in the burger menu plugin. It is now possible to overwrite a pre-saved map with a new configuration.

![recording_1](https://user-images.githubusercontent.com/14953970/160652112-dc68ee31-3567-4d8e-863c-2ec2f6e7781f.gif)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
