### PR TITLE
#7869 - Snapping tool, minor bugfixes

### DIFF
--- a/web/client/components/data/featuregrid/toolbars/TSplitButton.less
+++ b/web/client/components/data/featuregrid/toolbars/TSplitButton.less
@@ -9,6 +9,10 @@
             padding: 3px 10px;
             margin-bottom: 0;
         }
+
+        .Select {
+            margin: 0 15px;
+        }
     }
     .Select-menu-outer {
         .Select-menu {

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -486,9 +486,7 @@ export default class DrawSupport extends React.Component {
                         source,
                         style: new Style({
                             stroke: new Stroke({
-                                opacity: 0,
-                                fillOpacity: 0,
-                                strokeOpacity: 0
+                                color: 'rgba(255,255,0,0)'
                             })
                         })
                     });

--- a/web/client/selectors/draw.js
+++ b/web/client/selectors/draw.js
@@ -43,7 +43,7 @@ export const availableSnappingLayers = createShallowSelectorCreator(
     const id = selectedLayer?.id;
     const availableExtraLayers = additionalLayers.filter(l => (config?.additionalLayers ?? []).includes(l.id)).map(l => l.options);
     const layersList = availableExtraLayers.concat(layers);
-    const currentLayer = id ? [{value: id, label: selectedLayer.title ?? selectedLayer.name, active: id === snappingId}] : [];
+    const currentLayer = id ? [{value: id, label: getLayerTitle(selectedLayer, locale), active: id === snappingId}] : [];
 
     return currentLayer.concat(
         layersList.map((layer) =>


### PR DESCRIPTION
## Description
Minor bugfix to address two issues:
- App was crashing when selected layer has title translated into several languages;
- Layer stroke opacity was not set properly. It is set properly only when it's controlled by stroke color with rgba value that have 0 opacity.
- Corrected margin for layer selector in snapping options dropdown.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
[#](https://github.com/geosolutions-it/MapStore2/pull/8042#issuecomment-1084317217)

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
