### PR TITLE
#8010: Disable undo and redo editor functionality for new vector style

### DIFF
--- a/web/client/components/styleeditor/VisualStyleEditor.jsx
+++ b/web/client/components/styleeditor/VisualStyleEditor.jsx
@@ -292,11 +292,11 @@ function VisualStyleEditor({
                         {
                             glyph: 'undo',
                             tooltipId: 'styleeditor.undoStyle',
-                            disabled: styleHistory?.past?.length === 0,
+                            disabled: (styleHistory?.past?.length || 0) === 0,
                             onClick: () => dispatch({ type: UNDO_STYLE })
                         },
                         {
-                            disabled: styleHistory?.future?.length === 0,
+                            disabled: (styleHistory?.future?.length || 0) === 0,
                             tooltipId: 'styleeditor.redoStyle',
                             glyph: 'redo',
                             onClick: () => dispatch({ type: REDO_STYLE })

--- a/web/client/components/styleeditor/__tests__/VisualStyleEditor-test.js
+++ b/web/client/components/styleeditor/__tests__/VisualStyleEditor-test.js
@@ -273,4 +273,18 @@ describe('VisualStyleEditor', () => {
             />, document.getElementById('container'));
         });
     });
+    it('should disable undo and redo when history is empty', () => {
+        ReactDOM.render(<VisualStyleEditor
+            format="3dtiles"
+            code={{
+                color: 'color(\'#ff0000\')'
+            }}
+            defaultStyleJSON={null}
+        />, document.getElementById('container'));
+        const disabledButtons = document.querySelectorAll('.disabled');
+        expect([...disabledButtons].map(node => node.children[0].getAttribute('class'))).toEqual([
+            'glyphicon glyphicon-undo',
+            'glyphicon glyphicon-redo'
+        ]);
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Fix bug reported here https://github.com/geosolutions-it/MapStore2/pull/8047#issuecomment-1091732438

Undo and redo are disabled in the visual style editor when the vector style is new and the history is empty

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8010

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Undo and redo are disabled in the visual style editor when the vector style is new and the history is empty

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
