### PR TITLE
#8063 Document strategy of merging the map object with the current map

### DIFF
--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -123,11 +123,6 @@ It also allows partial overriding of existing map configuration by passing only 
 Following example will override "catalogServices" and "mapInfoConfiguration":
 ```text
 #/viewer/openlayers/config?map={"mapInfoConfiguration":{"trigger":"click","infoFormat":"text/html"},"catalogServices":{"services": {"wms": {"url": "http://example.com/geoserver/wms","type": "wms","title": "WMS","autoload": true}},"selectedService": "wms"}}
-```
-Following example will update map "center" and "zoom" level, but also it will change trigger event for the display of information sheet to "Hover":
-```text
-#/viewer/openlayers/config?map={"mapInfoConfiguration":{"trigger":"hover","infoFormat":"text/html"},"map":{"zoom":8,"center":{"x":1250000,"y":5370000,"crs":"EPSG:900913"}}}
-```
 
 ### Center / Zoom
 

--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -110,11 +110,23 @@ GET: `#/viewer/openlayers/config?featureinfo={"lat": 43.077, "lng": 12.656, "fil
 
 ### Map
 
-Allows to pass the entire map JSON definition. (See the map configuration format of MapStore(
+Allows to pass the entire map JSON definition (see the map configuration format of MapStore). 
+
 GET:
 
 ```text
 #/viewer/openlayers/config?map={"version":2,"map":{"projection":"EPSG:900913","units":"m","center":{"x":1250000,"y":5370000,"crs":"EPSG:900913"},"zoom":5,"maxExtent":[-20037508.34,-20037508.34,20037508.34,20037508.34],"layers":[{"type":"osm","title":"Open Street Map","name":"mapnik","source":"osm","group":"background","visibility":true}]}}
+```
+
+It also allows partial overriding of existing map configuration by passing only specific properties of the root object and/or the internal "map" object.
+
+Following example will override "catalogServices" and "mapInfoConfiguration":
+```text
+#/viewer/openlayers/config?map={"mapInfoConfiguration":{"trigger":"click","infoFormat":"text/html"},"catalogServices":{"services": {"wms": {"url": "http://example.com/geoserver/wms","type": "wms","title": "WMS","autoload": true}},"selectedService": "wms"}}
+```
+Following example will update map "center" and "zoom" level, but also it will change trigger event for the display of information sheet to "Hover":
+```text
+#/viewer/openlayers/config?map={"mapInfoConfiguration":{"trigger":"hover","infoFormat":"text/html"},"map":{"zoom":8,"center":{"x":1250000,"y":5370000,"crs":"EPSG:900913"}}}
 ```
 
 ### Center / Zoom

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -35,7 +35,7 @@ const prepareMapConfiguration = (data, override, state) => {
     let mapConfig = merge({}, data, override);
     mapConfig = {
         ...mapConfig,
-        ...queryParamsMap,
+        ...(queryParamsMap ?? {}),
         map: {
             ...(mapConfig?.map ?? {}),
             ...(queryParamsMap?.map ?? {})

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -33,17 +33,15 @@ import {getRequestParameterValue} from "../utils/QueryParamsUtils";
 const prepareMapConfiguration = (data, override, state) => {
     const queryParamsMap = getRequestParameterValue('map', state);
     let mapConfig = merge({}, data, override);
-    if (queryParamsMap?.version && queryParamsMap?.map) {
-        mapConfig = {
-            ...mapConfig,
-            ...queryParamsMap,
-            map: {
-                ...(mapConfig?.map ?? {}),
-                ...(queryParamsMap?.map ?? {})
+    mapConfig = {
+        ...mapConfig,
+        ...queryParamsMap,
+        map: {
+            ...(mapConfig?.map ?? {}),
+            ...(queryParamsMap?.map ?? {})
 
-            }
-        };
-    }
+        }
+    };
     return mapConfig;
 };
 


### PR DESCRIPTION
## Description
- Documenting strategy of merging the map object with the current map
- Removing check that was forcing to have valid MapStore map passed in "map" parameter. It was not compliant with the fact that configuration might not have keys required for check and can override only specific properties, which is also valid.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8063 

**What is the new behavior?**
Documentation is updated;
Removed validation check that was the reason of partial overriding of the map configuration not working when "version" and "map" properties are not passed in the "map" parameter.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
