### PR TITLE
#8065: Fix layer identification in applying capabilities

### DIFF
--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -8,11 +8,11 @@
 
 import urlUtil from 'url';
 
-import { get, head, last, template, isNil } from 'lodash';
+import { get, head, last, template, isNil, castArray } from 'lodash';
 import assign from 'object-assign';
 
 import axios from '../libs/ajax';
-import {cleanDuplicatedQuestionMarks, getConfigProp} from '../utils/ConfigUtils';
+import { cleanDuplicatedQuestionMarks, getConfigProp } from '../utils/ConfigUtils';
 import { extractCrsFromURN, makeBboxFromOWS, makeNumericEPSG } from '../utils/CoordinatesUtils';
 import WMS from "../api/WMS";
 
@@ -82,26 +82,126 @@ export const constructXMLBody = (startPosition, maxRecords, searchText, {filter}
     return template(cswGetRecordsXml)({filterXml: !searchText ? staticFilter : dynamicFilter, startPosition, maxRecords});
 };
 
+// Extract the relevant information from the wms URL for (RNDT / INSPIRE)
+const extractWMSParamsFromURL = wms => {
+    console.log(new URLSearchParams(wms.value));
+    const lowerCaseParams = new Map(Array.from(new URLSearchParams(wms.value)).map(([key, value]) => [key.toLowerCase(), value]));
+    const layerName = lowerCaseParams.get('layers');
+    const wmsVersion = lowerCaseParams.get('version');
+    if (layerName) {
+        return {
+            ...wms,
+            protocol: 'OGC:WMS',
+            name: layerName,
+            value: `${wms.value.match( /[^\?]+[\?]+/g)}SERIVCE=WMS${wmsVersion && `&VERSION=${wmsVersion}`}`
+        };
+    }
+    return false;
+};
+
+const toReference = (layerType, data, options) => {
+    if (!data.name) {
+        return null;
+    }
+    switch (layerType) {
+    case 'wms':
+        const urlValue = !(data.value.indexOf("http") === 0)
+            ? (options && options.catalogURL || "") + "/" + data.value
+            : data.value;
+        return {
+            type: data.protocol || data.scheme,
+            url: urlValue,
+            SRS: [],
+            params: {
+                name: data.name
+            }
+        };
+    case 'arcgis':
+        return {
+            type: 'arcgis',
+            url: data.value,
+            SRS: [],
+            params: {
+                name: data.name
+            }
+        };
+    default:
+        return null;
+    }
+};
+
+const REGEX_WMS_EXPLICIT = [/^OGC:WMS-(.*)-http-get-map/g, /^OGC:WMS/g];
+const REGEX_WMS_EXTRACT = /serviceType\/ogc\/wms/g;
+const REGEX_WMS_ALL = REGEX_WMS_EXPLICIT.concat(REGEX_WMS_EXTRACT);
+
+export const getLayerReferenceFromDc = (dc, options, checkEsri = true) => {
+    const URI = dc?.URI && castArray(dc.URI);
+    // look in URI objects for wms and thumbnail
+    if (URI) {
+        const wms = head(URI.map( uri => {
+            if (uri.protocol) {
+                if (REGEX_WMS_EXPLICIT.some(regex => uri.protocol.match(regex))) {
+                    /** wms protocol params are explicitly defined as attributes (INSPIRE)*/
+                    return uri;
+                }
+                if (uri.protocol.match(REGEX_WMS_EXTRACT)) {
+                    /** wms protocol params must be extracted from the element text (RNDT / INSPIRE) */
+                    return extractWMSParamsFromURL(uri);
+                }
+            }
+            return false;
+        }).filter(item => item));
+        if (wms) {
+            return toReference('wms', wms, options);
+        }
+    }
+    // look in references objects
+    if (dc?.references?.length) {
+        const refs = castArray(dc.references);
+        const wms = head(refs.filter((ref) => { return ref.scheme && REGEX_WMS_EXPLICIT.some(regex => ref.scheme.match(regex)); }));
+        if (wms) {
+            let urlObj = urlUtil.parse(wms.value, true);
+            let layerName = urlObj.query && urlObj.query.layers || dc.alternative;
+            return toReference('wms', { ...wms, name: layerName }, options);
+        }
+        if (checkEsri) {
+            // checks for esri arcgis in geonode csw
+            const esri = head(refs.filter((ref) => {
+                return ref.scheme && ref.scheme === "WWW:DOWNLOAD-REST_MAP";
+            }));
+            if (esri) {
+                return toReference('arcgis', {...esri, name: dc.alternative}, options);
+            }
+        }
+    }
+    return null;
+};
+
 let capabilitiesCache = {};
 
 /**
- * Add capabilities data to CSW records
+ * Add capabilities data to CSW records if WMS url is found
  * Currently limited to only scale denominators (visibility limits)
- * @param {string} url wms url
+ * @param {object[]} _dcRef dc.reference or dc.URI
  * @param {object} result csw results object
  */
-const addCapabilitiesToRecords = (url, result) => {
-    const cached = capabilitiesCache[url];
+const addCapabilitiesToRecords = (_dcRef, result) => {
+    const { value: _url } = _dcRef?.find(t =>
+        REGEX_WMS_ALL.some(regex=> t?.scheme?.match(regex) || t?.protocol?.match(regex))) || {}; // Get WMS URL from references
+    const [parsedUrl] = _url && _url.split('?') || [];
+    if (!parsedUrl) return {...result}; // Return record when no url found
+
+    const cached = capabilitiesCache[parsedUrl];
     const isCached = cached && new Date().getTime() < cached.timestamp + (getConfigProp('cacheExpire') || 60) * 1000;
     return Promise.resolve(
         isCached
             ? cached.data
-            : WMS.getCapabilities(url + '?version=')
+            : WMS.getCapabilities(parsedUrl + '?version=')
                 .then((caps)=> get(caps, 'capability.layer.layer', []))
                 .catch(()=> []))
         .then((layers) => {
             if (!isCached) {
-                capabilitiesCache[url] = {
+                capabilitiesCache[parsedUrl] = {
                     timestamp: new Date().getTime(),
                     data: layers
                 };
@@ -110,10 +210,11 @@ const addCapabilitiesToRecords = (url, result) => {
             return {
                 ...result,
                 records: result?.records?.map(record=> {
+                    const name = get(getLayerReferenceFromDc(record?.dc, null, false), 'params.name', '');
                     const {
                         minScaleDenominator: MinScaleDenominator,
                         maxScaleDenominator: MaxScaleDenominator
-                    } = layers.find(l=> l.name === record?.dc?.identifier) || {};
+                    } = layers.find(l=> l.name === name) || {};
                     return {
                         ...record,
                         ...((!isNil(MinScaleDenominator) || !isNil(MaxScaleDenominator))
@@ -299,9 +400,7 @@ const Api = {
                                     }
                                 }
                                 result.records = records;
-                                const { value: _url } = _dcRef?.find(t => t.scheme === 'OGC:WMS' || t.protocol === 'OGC:WMS') || {}; // Get WMS URL from references
-                                const [parsedUrl] = _url && _url.split('?') || [];
-                                return parsedUrl ? addCapabilitiesToRecords(parsedUrl, result) : {...result};
+                                return addCapabilitiesToRecords(_dcRef, result);
                             } else if (json && json.name && json.name.localPart === "ExceptionReport") {
                                 return {
                                     error: json.value.exception && json.value.exception.length && json.value.exception[0].exceptionText || 'GenericError'

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -11,7 +11,7 @@ import axios from '../../libs/ajax';
 import MockAdapter from 'axios-mock-adapter';
 import GRDCResponse from 'raw-loader!../../test-resources/csw/getRecordsResponseDC.xml';
 
-import API, { constructXMLBody } from '../CSW';
+import API, {constructXMLBody, getLayerReferenceFromDc} from '../CSW';
 
 describe('Test correctness of the CSW APIs', () => {
     it('getRecords ISO Metadata Profile', (done) => {
@@ -46,16 +46,16 @@ describe('Test correctness of the CSW APIs', () => {
                 const [rec0, rec1, rec2, rec3] = result.records;
 
                 expect(rec0.dc).toExist();
-                expect(rec0.dc.URI).toExist();
-                expect(rec0.dc.URI[0]);
                 expect(rec0.boundingBox).toExist();
                 expect(rec0.boundingBox.crs).toBe('EPSG:4326');
                 expect(rec0.boundingBox.extent).toEqual([45.542, 11.874, 46.026, 12.718]);
-                const uri = rec0.dc.URI[0];
+
+                expect(rec1.dc.URI).toExist();
+                expect(rec1.dc.URI[0]).toExist();
+                const uri = rec1.dc.URI[0];
                 expect(uri.name).toExist();
                 expect(uri.value).toExist();
                 expect(uri.description).toExist();
-
                 expect(rec1.boundingBox).toExist();
                 expect(rec1.boundingBox.crs).toBe('EPSG:4326');
                 expect(rec1.boundingBox.extent).toEqual([12.002717999999996, 45.760718, 12.429282000000002, 46.187282]);
@@ -126,6 +126,17 @@ describe('Test correctness of the CSW APIs', () => {
             try {
                 expect(result).toBeTruthy();
                 expect(result.records[0].capabilities).toBeTruthy();
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+    it("dc:uri do not add capabilities when layer name doesn't match", (done) => {
+        API.getRecords('base/web/client/test-resources/csw/getRecordsWithDcURI.xml', 1, 2).then((result) => {
+            try {
+                expect(result).toBeTruthy();
+                expect(result.records[1].capabilities).toBeFalsy();
                 done();
             } catch (ex) {
                 done(ex);
@@ -206,5 +217,43 @@ describe("constructXMLBody", () => {
         body = constructXMLBody(1, 5, null);
         expect(body.indexOf("dc:type")).toNotBe(-1); // Static filter
         expect(body.indexOf("text*")).toBe(-1); // Dynamic filter
+    });
+});
+
+describe("getLayerReferenceFromDc", () => {
+    it("test layer reference with dc.references of scheme OGC:WMS", () => {
+        const dc = {references: [{value: "http://wmsurl", scheme: 'OGC:WMS'}, {value: "wfsurl", scheme: 'OGC:WFS'}], alternative: "some_layer"};
+        const layerRef = getLayerReferenceFromDc(dc);
+        expect(layerRef.params.name).toBe('some_layer');
+        expect(layerRef.type).toBe('OGC:WMS');
+        expect(layerRef.url).toBe('http://wmsurl');
+    });
+    it("test layer reference with dc.references of scheme OGC:WMS-http-get-map", () => {
+        const dc = {references: [{value: "http://wmsurl", scheme: 'OGC:WMS-http-get-map'}, {value: "wfsurl", scheme: 'OGC:WFS'}], alternative: "some_layer"};
+        const layerRef = getLayerReferenceFromDc(dc);
+        expect(layerRef.params.name).toBe('some_layer');
+        expect(layerRef.type).toBe('OGC:WMS-http-get-map');
+        expect(layerRef.url).toBe('http://wmsurl');
+    });
+    it("test layer reference with dc.URI of scheme serviceType/ogc/wms and options", () => {
+        const dc = {URI: [{value: "wmsurl?service=wms&layers=some_layer&version=1.3.0", protocol: 'serviceType/ogc/wms'}, {value: "wfsurl", protocol: 'OGC:WFS'}]};
+        const layerRef = getLayerReferenceFromDc(dc, {catalogURL: "catalog_url"});
+        expect(layerRef.params.name).toBe('some_layer');
+        expect(layerRef.type).toBe('OGC:WMS');
+        expect(layerRef.url).toBe('catalog_url/wmsurl?SERIVCE=WMS&VERSION=1.3.0');
+    });
+    it("test layer reference with dc.URI of scheme OGC:WMS", () => {
+        const dc = {URI: [{value: "http://wmsurl", protocol: 'OGC:WMS', name: 'some_layer'}, {value: "wfsurl", protocol: 'OGC:WFS'}]};
+        const layerRef = getLayerReferenceFromDc(dc);
+        expect(layerRef.params.name).toBe('some_layer');
+        expect(layerRef.type).toBe('OGC:WMS');
+        expect(layerRef.url).toBe('http://wmsurl');
+    });
+    it("test layer reference with dc.references of scheme WWW:DOWNLOAD-REST_MAP", () => {
+        const dc = {references: [{value: "http://esri_url", scheme: 'WWW:DOWNLOAD-REST_MAP'}, {value: "wfsurl", protocol: 'OGC:WFS'}], alternative: "some_layer"};
+        const layerRef = getLayerReferenceFromDc(dc);
+        expect(layerRef.params.name).toBe('some_layer');
+        expect(layerRef.type).toBe('arcgis');
+        expect(layerRef.url).toBe('http://esri_url');
     });
 });

--- a/web/client/test-resources/csw/getRecordsResponseDC.xml
+++ b/web/client/test-resources/csw/getRecordsResponseDC.xml
@@ -2,7 +2,6 @@
   <csw:SearchStatus timestamp="2016-05-11T13:00:06" />
   <csw:SearchResults numberOfRecordsMatched="100" numberOfRecordsReturned="2" elementSet="full" nextRecord="3">
     <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
-      <dc:identifier>workspace:layer_name1</dc:identifier>
       <dc:title>c1020047_title</dc:title>
       <dc:type>dataset</dc:type>
       <dc:subject>sub1, sub2, sub3</dc:subject>
@@ -13,12 +12,11 @@
       <dc:source />
       <dc:format />
       <dct:references scheme="OGC:WMS">base/web/client/test-resources/csw/getCapability.xml</dct:references>
+      <dct:alternative>workspace:layer_name1</dct:alternative>
       <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
         <ows:LowerCorner>12.718 45.542</ows:LowerCorner>
         <ows:UpperCorner>11.874 46.026</ows:UpperCorner>
       </ows:BoundingBox>
-      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name1" description="desc1">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
-      <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187146&amp;fname=0171b07a-8cf1-4950-8a71-b01e6a6aee38_s.png&amp;access=public</dc:URI>
     </csw:Record>
     <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
       <dc:identifier>d698f693-6e7e-47a9-a138-918068d0b082</dc:identifier>

--- a/web/client/test-resources/csw/getRecordsWithDcURI.xml
+++ b/web/client/test-resources/csw/getRecordsWithDcURI.xml
@@ -10,7 +10,7 @@
         <ows:LowerCorner>12.718 45.542</ows:LowerCorner>
         <ows:UpperCorner>11.874 46.026</ows:UpperCorner>
       </ows:BoundingBox>
-      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name1" description="desc1">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name1" description="desc1">base/web/client/test-resources/csw/getCapability.xml</dc:URI>
       <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187146&amp;fname=0171b07a-8cf1-4950-8a71-b01e6a6aee38_s.png&amp;access=public</dc:URI>
     </csw:Record>
     <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
@@ -23,7 +23,7 @@
         <ows:LowerCorner>12.429282000000002 45.760718</ows:LowerCorner>
         <ows:UpperCorner>12.002717999999996 46.187282</ows:UpperCorner>
       </ows:BoundingBox>
-      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name1" description="desc1">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="OGC:WMS" name="workspace:layer_name10" description="desc1">base/web/client/test-resources/csw/getCapability.xml</dc:URI>
       <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187049&amp;fname=d698f693-6e7e-47a9-a138-918068d0b082_s.png&amp;access=public</dc:URI>
     </csw:Record>
     <csw:Record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dct="http://purl.org/dc/terms/">


### PR DESCRIPTION
## Description
This PR fixes the incorrect layer identification prop used in getting capabilities from the layer

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#8065 

**What is the new behavior?**
Correct layer is identified and capabilities info is applied when present to the csw records

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
**Testing**
Use this [map](https://dev-mapstore.geosolutionsgroup.com/mapstore/#/viewer/openlayers/35532)
This map has various CSW catalog services added
1. To test record with dc.references select `GeoSolutions GeoServer CSW` and search for `ny_poi`
2. To test record with dc.URI, select `GeoOrcherstra` and search for  `arbres d'ornement`

Add these layers to see if the capabilities info are added along. 
Note: Make sure `Set visibility limits` is enabled in each service entry
