### PR TITLE
#8083: Add an empty renderer for geometry types

### DIFF
--- a/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
+++ b/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
@@ -46,4 +46,12 @@ describe('Tests for the formatter functions', () => {
         expect(formatter({value: undefined})).toBe(null);
         expect(formatter({value: 0}).props.value).toBe(0);
     });
+    it('test getFormatter for geometry', () => {
+        const formatter = getFormatter({localType: "Geometry"});
+        expect(typeof formatter).toBe("function");
+        expect(formatter()).toBe(null);
+        expect(formatter({value: {properties: {}, geometry: {type: "Point", coordinates: [1, 2]}}})).toBe(null);
+        expect(formatter({value: null})).toBe(null);
+        expect(formatter({value: undefined})).toBe(null);
+    });
 });

--- a/web/client/components/data/featuregrid/formatters/index.js
+++ b/web/client/components/data/featuregrid/formatters/index.js
@@ -16,6 +16,8 @@ export const getFormatter = (desc) => {
         return ({value} = {}) => !isNil(value) ? <span>{value.toString()}</span> : null;
     } else if (['int', 'number'].includes(desc.localType)) {
         return ({value} = {}) => !isNil(value) ? <NumberFormat value={value} numberParams={{maximumFractionDigits: 17}}/> : null;
+    } else if (desc.localType === 'Geometry') {
+        return () => null;
     }
     return null;
 };


### PR DESCRIPTION
## Description
Adding an empty renderer for attributes of type "Geometry" avoids the error as for #8083 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8083

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
