### PR TITLE
#8087: 3D Tiles Styling with filter

### DIFF
--- a/web/client/components/data/query/GroupField.jsx
+++ b/web/client/components/data/query/GroupField.jsx
@@ -47,7 +47,7 @@ class GroupField extends React.Component {
         booleanOperators: PropTypes.array,
         defaultOperators: PropTypes.array,
         comboOptions: PropTypes.object,
-        format: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
+        textFieldTooltipMessageId: PropTypes.string
     };
 
     static contextTypes = {
@@ -88,7 +88,7 @@ class GroupField extends React.Component {
         arrayOperators: ["contains"],
         booleanOperators: ["="],
         defaultOperators: ["=", ">", "<", ">=", "<=", "<>", "><"],
-        format: false
+        textFieldTooltipMessageId: 'queryform.attributefilter.tooltipTextField'
     };
 
     getComboValues = (selected, attributes) => {
@@ -191,14 +191,14 @@ class GroupField extends React.Component {
                     operator={filterField.operator}
                     attType="number"/>
                 {
-                    // flag to swtich from AutocompleteField to TextField
+                    // flag to switch from AutocompleteField to TextField
                     this.props.autocompleteEnabled ?
                         (<AutocompleteField
                             dropUp={this.props.dropUp}
                             filterField={filterField}
                             attType="string"/>) :
                         (<TextField
-                            tooltipMessage={this.props.format === 'css' ? "queryform.attributefilter.tooltipTextFieldCSS" : "queryform.attributefilter.tooltipTextField"}
+                            tooltipMessage={this.props.textFieldTooltipMessageId}
                             operator={filterField.operator}
                             attType="string"/>)
                 }

--- a/web/client/components/styleeditor/FilterBuilder.jsx
+++ b/web/client/components/styleeditor/FilterBuilder.jsx
@@ -51,10 +51,14 @@ const FilterBuilder = ({
     onChange = () => {}
 }) => {
     const { groupFields, filterFields } = filterObj;
+    const textFieldTooltipMessageIds = {
+        'css': 'queryform.attributefilter.tooltipTextFieldCSS',
+        '3dtiles': 'queryform.attributefilter.tooltipTextField3DTiles'
+    };
     return (
         <div className="ms-style-rule-filter">
             <GroupField
-                format={format}
+                textFieldTooltipMessageId={textFieldTooltipMessageIds[format]}
                 attributes={attributes}
                 filterFields={filterFields}
                 groupFields={groupFields}

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1051,6 +1051,7 @@
                 "attribute_filter_header": "Attributfilter",
                 "tooltipTextField": "Verwenden <b>*</b> für ein beliebiges Zeichen</br>Verwenden . für ein einzelnes Zeichen</br>Verwenden <b>!</b> für Sonderzeichen (* und .)</br>",
                 "tooltipTextFieldCSS": "Verwenden <b>%</b> für ein beliebiges Zeichen</br>Verwenden <b>_</b> für ein einzelnes Zeichen</br>Verwenden <b>\\</b> für Sonderzeichen (% und _)</br>",
+                "tooltipTextField3DTiles": "Verwenden Sie einen Wert, der von der <strong>regExp</strong>-Funktion der 3D-Kachelstilspezifikation 1.0 unterstützt wird",
                 "groupField": {
                     "any": "einer",
                     "all": "aller",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1012,6 +1012,7 @@
                 "attribute_filter_header": "Attribute filter",
                 "tooltipTextField": "use <b>*</b> for any number of any char</br>use . for a single char</br>use <b>!</b> to escape the above two (* and .)</br>",
                 "tooltipTextFieldCSS": "use <b>%</b> for any number of any char</br>use <b>_</b> for a single char</br>use <b>\\</b> to escape the above two (% and _)</br>",
+                "tooltipTextField3DTiles": "use a value supported by the <strong>regExp</strong> function of the 3d tiles style specification 1.0",
                 "groupField": {
                     "any": "any",
                     "all": "all",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1012,6 +1012,7 @@
                 "attribute_filter_header": "Filtro por atributo",
                 "tooltipTextField": "utiliza <b>*</b> para cualquier carácter</br>utiliza . para un solo carácter</br>utiliza <b>!</b> para caracteres especiales (* y .)</br>",
                 "tooltipTextFieldCSS": "utiliza <b>%</b> para cualquier carácter</br>utiliza <b>_</b> para un solo carácter</br>utiliza <b>\\</b> para caracteres especiales (% y _)</br>",
+                "tooltipTextField3DTiles": "use un valor compatible con la función <strong>regExp</strong> de la especificación de estilo de 3D tiles 1.0",
                 "groupField": {
                     "any": "alguna",
                     "all": "todas",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1012,6 +1012,7 @@
                 "attribute_filter_header": "Attribut filtre",
                 "tooltipTextField": "utilise <b>*</b> pour tout caractère</br>utilise . pour un seul caractère</br>utilise <b>!</b> pour les caractères spéciaux (* et .)</br>",
                 "tooltipTextFieldCSS": "utilise <b>%</b> pour tout caractère</br>utilise <b>_</b> pour un seul caractère</br>utilise <b>\\</b> pour les caractères spéciaux (% et _)</br>",
+                "tooltipTextField3DTiles": "utilisez une valeur prise en charge par la fonction <strong>regExp</strong> de la spécification de style de tuiles 3d 1.0",
                 "groupField": {
                     "any": "certain",
                     "all": "tous",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1012,6 +1012,7 @@
                 "attribute_filter_header": "Filtro Attributi",
                 "tooltipTextField": "usa <b>*</b> per qualsiasi carattere</br>usa . un solo carattere</br>usa <b>!</b> per i caratteri speciali (* e .)</br>",
                 "tooltipTextFieldCSS": "usa <b>%</b> per qualsiasi carattere</br>usa <b>_</b> un solo carattere</br>usa <b>\\</b> per i caratteri speciali (% e _)</br>",
+                "tooltipTextField3DTiles": "usa un valore supportato dalla funzione <strong>regExp</strong> della specifica 1.0 dello stile dei 3d tiles",
                 "groupField": {
                     "any": "almeno una delle",
                     "all": "tutte le",

--- a/web/client/utils/styleparser/ThreeDTilesStyleParser.js
+++ b/web/client/utils/styleparser/ThreeDTilesStyleParser.js
@@ -13,8 +13,11 @@ import tinycolor from 'tinycolor2';
 const DEFAULT_POINT_SIZE = 1;
 
 function formatExpression(property, operator, value) {
-    const isValidProperty = `!(\${${property}} === undefined || \${${property}} === null || isNaN(\${${property}}))`;
-    return `(${isValidProperty} && \${${property}} ${operator} ${operator === '=~' ? `regExp('${value}')` : value})`;
+    const isValidProperty = `!(\${${property}} === undefined${value === null ? '' : ` || \${${property}} === null`})`;
+    if (operator === '=~') {
+        return `(${isValidProperty} && regExp('${value}').test(\${${property}}) === true)`;
+    }
+    return `(${isValidProperty} && \${${property}} ${operator} ${isString(value) ? `'${value}'` : value})`;
 }
 
 function filterToExpression(filter) {

--- a/web/client/utils/styleparser/__tests__/ThreeDTilesStyleParser-test.js
+++ b/web/client/utils/styleparser/__tests__/ThreeDTilesStyleParser-test.js
@@ -425,8 +425,8 @@ describe('ThreeDTilesStyleParser', () => {
                             color: {
                                 conditions: [
                                     [ true, 'color(\'#00ff00\', 1)' ],
-                                    [ '(!(${height} === undefined || ${height} === null || isNaN(${height})) && ${height} !== 10)', 'color(\'#0000ff\', 1)' ],
-                                    [ '(!(${height} === undefined || ${height} === null || isNaN(${height})) && ${height} === 10)', 'color(\'#ff0000\', 1)' ]
+                                    [ '(!(${height} === undefined || ${height} === null) && ${height} !== 10)', 'color(\'#0000ff\', 1)' ],
+                                    [ '(!(${height} === undefined || ${height} === null) && ${height} === 10)', 'color(\'#ff0000\', 1)' ]
                                 ]
                             }
                         });
@@ -468,12 +468,197 @@ describe('ThreeDTilesStyleParser', () => {
                 .then((parsed) => {
                     try {
                         expect(parsed).toEqual({
-                            show: '((!(${height} === undefined || ${height} === null || isNaN(${height})) && ${height} === 10) && (!(${category} === undefined || ${category} === null || isNaN(${category})) && ${category} === 2)) || ((!(${height} === undefined || ${height} === null || isNaN(${height})) && ${height} === 10) || (!(${category} === undefined || ${category} === null || isNaN(${category})) && ${category} === 1))',
+                            show: '((!(${height} === undefined || ${height} === null) && ${height} === 10) && (!(${category} === undefined || ${category} === null) && ${category} === 2)) || ((!(${height} === undefined || ${height} === null) && ${height} === 10) || (!(${category} === undefined || ${category} === null) && ${category} === 1))',
                             color: {
                                 conditions: [
-                                    [ '((!(${height} === undefined || ${height} === null || isNaN(${height})) && ${height} === 10) && (!(${category} === undefined || ${category} === null || isNaN(${category})) && ${category} === 2))', 'color(\'#0000ff\', 1)' ],
-                                    [ '((!(${height} === undefined || ${height} === null || isNaN(${height})) && ${height} === 10) || (!(${category} === undefined || ${category} === null || isNaN(${category})) && ${category} === 1))', 'color(\'#ff0000\', 1)' ],
+                                    [ '((!(${height} === undefined || ${height} === null) && ${height} === 10) && (!(${category} === undefined || ${category} === null) && ${category} === 2))', 'color(\'#0000ff\', 1)' ],
+                                    [ '((!(${height} === undefined || ${height} === null) && ${height} === 10) || (!(${category} === undefined || ${category} === null) && ${category} === 1))', 'color(\'#ff0000\', 1)' ],
                                     [ true, 'color(\'#ffffff\', 1)' ]
+                                ]
+                            }
+                        });
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                });
+        });
+
+        it('should create conditions for number value', (done) => {
+            const style = {
+                name: '',
+                rules: [
+                    {
+                        filter: ['==', 'height', 10],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#ff0000',
+                                fillOpacity: 1
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['>', 'height', 10],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#0000ff',
+                                fillOpacity: 1
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['<', 'height', 10],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#0000ff',
+                                fillOpacity: 1
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['>=', 'height', 10],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#0000ff',
+                                fillOpacity: 1
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['<=', 'height', 10],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#0000ff',
+                                fillOpacity: 1
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['!=', 'height', 10],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#0000ff',
+                                fillOpacity: 1
+                            }
+                        ]
+                    },
+                    {
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#00ff00',
+                                fillOpacity: 1
+                            }
+                        ]
+                    }
+                ]
+            };
+            parser.writeStyle(style)
+                .then((parsed) => {
+                    try {
+                        expect(parsed).toEqual({
+                            color: {
+                                conditions: [
+                                    [ true, 'color(\'#00ff00\', 1)' ],
+                                    [ '(!(${height} === undefined || ${height} === null) && ${height} !== 10)', 'color(\'#0000ff\', 1)' ],
+                                    [ '(!(${height} === undefined || ${height} === null) && ${height} <= 10)', 'color(\'#0000ff\', 1)' ],
+                                    [ '(!(${height} === undefined || ${height} === null) && ${height} >= 10)', 'color(\'#0000ff\', 1)' ],
+                                    [ '(!(${height} === undefined || ${height} === null) && ${height} < 10)', 'color(\'#0000ff\', 1)' ],
+                                    [ '(!(${height} === undefined || ${height} === null) && ${height} > 10)', 'color(\'#0000ff\', 1)' ],
+                                    [ '(!(${height} === undefined || ${height} === null) && ${height} === 10)', 'color(\'#ff0000\', 1)' ]
+                                ]
+                            }
+                        });
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                });
+        });
+        it('should create conditions for string value', (done) => {
+            const style = {
+                name: '',
+                rules: [
+                    {
+                        filter: ['==', 'name', 'mesh_1'],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#ff0000',
+                                fillOpacity: 1
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['!=', 'name', 'mesh_1'],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#0000ff',
+                                fillOpacity: 1
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['==', 'name', null],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#0000ff',
+                                fillOpacity: 1
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['*=', 'name', 'me'],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#0000ff',
+                                fillOpacity: 1
+                            }
+                        ]
+                    },
+                    {
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Fill',
+                                color: '#00ff00',
+                                fillOpacity: 1
+                            }
+                        ]
+                    }
+                ]
+            };
+            parser.writeStyle(style)
+                .then((parsed) => {
+                    try {
+                        expect(parsed).toEqual({
+                            color: {
+                                conditions: [
+                                    [ true, 'color(\'#00ff00\', 1)' ],
+                                    [ '(!(${name} === undefined || ${name} === null) && regExp(\'me\').test(${name}) === true)', 'color(\'#0000ff\', 1)' ],
+                                    [ '(!(${name} === undefined) && ${name} === null)', 'color(\'#0000ff\', 1)' ],
+                                    [ '(!(${name} === undefined || ${name} === null) && ${name} !== \'mesh_1\')', 'color(\'#0000ff\', 1)' ],
+                                    [ '(!(${name} === undefined || ${name} === null) && ${name} === \'mesh_1\')', 'color(\'#ff0000\', 1)' ]
                                 ]
                             }
                         });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes the wrong conversion of filters from the visual style editor of 3d stile when a property is a string

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8087

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
This PR fixes the wrong conversion of filters from the visual style editor of 3d stile when a property is a string

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
