### PR TITLE
#7810 forcing the usage of JAVA_HOME in the binary scripts

### DIFF
--- a/release/bin/mapstore2-startup.bat
+++ b/release/bin/mapstore2-startup.bat
@@ -17,6 +17,10 @@ set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
 
 :nativeJava
   set "JAVA_HOME=%CURRENT_DIR%\jre\win"
+  rem forcing to use jdk otherwise in case JRE_HOME defined in the system is not compatible
+  rem see https://github.com/geosolutions-it/MapStore2/issues/7810
+  rem so next setup is being disabled for this reason
+  set "JRE_HOME=%JAVA_HOME%"
 
 rem if you want to customize java version used, override JAVA_HOME variable here
 

--- a/release/bin/mapstore2-startup.sh
+++ b/release/bin/mapstore2-startup.sh
@@ -12,7 +12,7 @@ chmod +x bin/*.sh
 PRGDIR=`pwd`
 
 export JAVA_HOME="$PRGDIR/jre/linux"
-export JRE_HOME="$PRGDIR/jre/linux"
+export JRE_HOME="$JAVA_HOME"
 chmod +x jre/linux/bin/*
 
 echo "Welcome to MapStore2!"

--- a/release/tomcat/bin/setclasspath.bat
+++ b/release/tomcat/bin/setclasspath.bat
@@ -26,7 +26,12 @@ rem In debug mode we need a real JDK (JAVA_HOME)
 if ""%1"" == ""debug"" goto needJavaHome
 
 rem Otherwise either JRE or JDK are fine
-if not "%JRE_HOME%" == "" goto gotJreHome
+
+rem forcing to use jdk otherwise in case JRE_HOME defined in the system is not compatible
+rem see https://github.com/geosolutions-it/MapStore2/issues/7810
+rem so next setup is being disabled for this reason
+rem if not "%JRE_HOME%" == "" goto gotJreHome
+
 if not "%JAVA_HOME%" == "" goto gotJavaHome
 echo Neither the JAVA_HOME nor the JRE_HOME environment variable is defined
 echo At least one of these environment variable is needed to run this program

--- a/release/tomcat/bin/setclasspath.bat
+++ b/release/tomcat/bin/setclasspath.bat
@@ -27,11 +27,7 @@ if ""%1"" == ""debug"" goto needJavaHome
 
 rem Otherwise either JRE or JDK are fine
 
-rem forcing to use jdk otherwise in case JRE_HOME defined in the system is not compatible
-rem see https://github.com/geosolutions-it/MapStore2/issues/7810
-rem so next setup is being disabled for this reason
-rem if not "%JRE_HOME%" == "" goto gotJreHome
-
+if not "%JRE_HOME%" == "" goto gotJreHome
 if not "%JAVA_HOME%" == "" goto gotJavaHome
 echo Neither the JAVA_HOME nor the JRE_HOME environment variable is defined
 echo At least one of these environment variable is needed to run this program

--- a/release/tomcat/bin/setclasspath.bat
+++ b/release/tomcat/bin/setclasspath.bat
@@ -26,7 +26,6 @@ rem In debug mode we need a real JDK (JAVA_HOME)
 if ""%1"" == ""debug"" goto needJavaHome
 
 rem Otherwise either JRE or JDK are fine
-
 if not "%JRE_HOME%" == "" goto gotJreHome
 if not "%JAVA_HOME%" == "" goto gotJavaHome
 echo Neither the JAVA_HOME nor the JRE_HOME environment variable is defined


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7810

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
new binaries will ignore JRE_HOME configured at system level, but it will force JRE_HOME = JAVA_HOME

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
