### PR TITLE
Backport 2022.01.xx - #7810 forcing the usage of JAVA_HOME in the binary scripts (#8096)

### DIFF
--- a/release/bin/mapstore2-startup.bat
+++ b/release/bin/mapstore2-startup.bat
@@ -17,6 +17,10 @@ set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
 
 :nativeJava
   set "JAVA_HOME=%CURRENT_DIR%\jre\win"
+  rem forcing to use jdk otherwise in case JRE_HOME defined in the system is not compatible
+  rem see https://github.com/geosolutions-it/MapStore2/issues/7810
+  rem so next setup is being disabled for this reason
+  set "JRE_HOME=%JAVA_HOME%"
 
 rem if you want to customize java version used, override JAVA_HOME variable here
 

--- a/release/bin/mapstore2-startup.sh
+++ b/release/bin/mapstore2-startup.sh
@@ -12,7 +12,7 @@ chmod +x bin/*.sh
 PRGDIR=`pwd`
 
 export JAVA_HOME="$PRGDIR/jre/linux"
-export JRE_HOME="$PRGDIR/jre/linux"
+export JRE_HOME="$JAVA_HOME"
 chmod +x jre/linux/bin/*
 
 echo "Welcome to MapStore2!"


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
 Backport 2022.01.xx - #7810 forcing the usage of JAVA_HOME in the binary scripts (#8096)