### PR TITLE
#7948: Update map config with leaflet resolution

### DIFF
--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -55,7 +55,8 @@ class LeafletMap extends React.Component {
         resolutions: PropTypes.array,
         hookRegister: PropTypes.object,
         onCreationError: PropTypes.func,
-        onMouseOut: PropTypes.func
+        onMouseOut: PropTypes.func,
+        onResolutionsChange: PropTypes.func
     };
 
     static defaultProps = {
@@ -83,7 +84,8 @@ class LeafletMap extends React.Component {
         style: {},
         interactive: true,
         resolutions: getGoogleMercatorResolutions(0, 23),
-        onMouseOut: () => {}
+        onMouseOut: () => {},
+        onResolutionsChange: () => {}
     };
 
     state = { };
@@ -188,7 +190,7 @@ class LeafletMap extends React.Component {
         this.setMousePointer(this.props.mousePointer);
         // NOTE: this re-call render function after div creation to have the map initialized.
         this.forceUpdate();
-
+        this.props.onResolutionsChange(this.getResolutions());
         this.map.on('layeradd', (event) => {
             // we want to run init code only the first time a layer is added to the map
             if (event.layer._ms2Added) {
@@ -292,6 +294,7 @@ class LeafletMap extends React.Component {
             if (limits.minZoom !== (oldLimits && oldLimits.minZoom)) {
                 this.map.setMinZoom(limits.minZoom);
             }
+            this.props.onResolutionsChange(this.getResolutions());
         }
         return false;
     }

--- a/web/client/components/map/leaflet/__tests__/Map-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Map-test.jsx
@@ -786,4 +786,39 @@ describe('LeafletMap', () => {
         const attributions = document.body.getElementsByClassName('leaflet-control-attribution');
         expect(attributions.length).toBe(2);
     });
+    it('test map onResolutionsChange', () => {
+        const actions = {
+            onResolutionsChange: () => {}
+        };
+        const spyOnResolutionsChange = expect.spyOn(actions, 'onResolutionsChange');
+        let map = ReactDOM.render(
+            <LeafletMap center={{y: 43.9, x: 10.3}} zoom={11} onResolutionsChange={actions.onResolutionsChange}/>,
+            document.getElementById("container"));
+
+        expect(map).toExist();
+        let event = {
+            layer: {
+                layerId: 2,
+                on: () => {},
+                _ms2LoadingTileCount: 1
+            }
+        };
+        map.addLayerObservable(event, true);
+        event.layer.layerLoadingStream$.next();
+        event.layer.layerErrorStream$.next({ target: { layerId: 2 }});
+        event.layer.layerLoadStream$.next();
+        expect(spyOnResolutionsChange).toHaveBeenCalled();
+    });
+    it('test map on limit change call onResolutionsChange', () => {
+        const actions = {
+            onResolutionsChange: () => {}
+        };
+        const spyOnResolutionsChange = expect.spyOn(actions, 'onResolutionsChange');
+        let map = ReactDOM.render(<LeafletMap id="mymap" center={{y: 43.9, x: 10.3}} zoom={11} mapOptions={{zoomAnimation: false}} onResolutionsChange={actions.onResolutionsChange}/>, document.getElementById("container"));
+        map = ReactDOM.render(<LeafletMap id="mymap" center={{y: 44, x: 10}} zoom={5} limits={{test: "test"}} onResolutionsChange={actions.onResolutionsChange}/>, document.getElementById("container"));
+        expect(map).toExist();
+
+        expect(spyOnResolutionsChange).toHaveBeenCalled();
+        expect(spyOnResolutionsChange.calls.length).toBe(2);
+    });
 });


### PR DESCRIPTION
## Description
This PR updates the leaflet map to update map config with resolutions. Which in turn allows the print plugin to filterLayers based `isInsideResolutionsLimits`. This ultimately fixes the leaflet map from not displayed in print preview section

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#7948 

**What is the new behavior?**
The leaflet map is displayed in the print preview section

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
