### PR TITLE
[Backport 2022.01.xx] #7860: Custom tileprovider losing attribution on map save (#7901)

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -580,6 +580,7 @@ export const saveLayer = (layer) => {
     layer.credits ? { credits: layer.credits } : {},
     layer.extendedParams ? { extendedParams: layer.extendedParams } : {},
     layer.localizedLayerStyles ? { localizedLayerStyles: layer.localizedLayerStyles } : {},
+    layer.options ? { options: layer.options } : {},
     layer.credits ? { credits: layer.credits } : {});
 };
 /**

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1082,6 +1082,17 @@ describe('LayersUtils', () => {
                     expect(l.tooltipPlacement).toExist();
                 }
             ],
+            [
+                {
+                    options: {
+                        attribution: "right"
+                    }
+                },
+                l => {
+                    expect(l.options).toExist();
+                    expect(l.options.attribution).toExist();
+                }
+            ],
             // save heightOffset for 3dtiles
             [
                 {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixed bug where layer attribution options are not saved in a custom tile provider

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7860 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
When saving a map, layer set in a custom tile provider layer are saved.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
