### PR TITLE
#8137: Optimization of the catalog service calls

### DIFF
--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -51,6 +51,7 @@ export const TOGGLE_ADVANCED_SETTINGS = 'CATALOG:TOGGLE_ADVANCED_SETTINGS';
 export const FORMAT_OPTIONS_FETCH = 'CATALOG:FORMAT_OPTIONS_FETCH';
 export const FORMAT_OPTIONS_LOADING = 'CATALOG:FORMAT_OPTIONS_LOADING';
 export const SET_FORMAT_OPTIONS = 'CATALOG:SET_FORMAT_OPTIONS';
+export const NEW_SERVICE_STATUS = 'CATALOG:NEW_SERVICE_STATUS';
 
 /**
  * Adds a list of layers from the given catalogs to the map
@@ -293,3 +294,9 @@ export function recordsNotFound(records = "") {
         values: {records}
     });
 }
+export const setNewServiceStatus = (status) => {
+    return {
+        type: NEW_SERVICE_STATUS,
+        status
+    };
+};

--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -82,7 +82,9 @@ class Catalog extends React.Component {
         formatOptions: PropTypes.array,
         infoFormatOptions: PropTypes.array,
         layerBaseConfig: PropTypes.object,
-        service: PropTypes.object
+        service: PropTypes.object,
+        isNewServiceAdded: PropTypes.bool,
+        setNewServiceStatus: PropTypes.func
     };
 
     static contextTypes = {
@@ -110,6 +112,7 @@ class Catalog extends React.Component {
         onReset: () => { },
         onSearch: () => { },
         changeLayerProperties: () => { },
+        setNewServiceStatus: () => { },
         pageSize: 4,
         records: [],
         loading: false,
@@ -196,7 +199,7 @@ class Catalog extends React.Component {
     }
 
     renderPagination = () => {
-        if (this.props.result) {
+        if (this.props.result && !this.props.isNewServiceAdded) {
             let total = this.props.result.numberOfRecordsMatched;
             let returned = this.props.result.numberOfRecordsReturned;
             let start = this.props.searchOptions.startPosition;
@@ -238,6 +241,11 @@ class Catalog extends React.Component {
                 hideThumbnail = selectedService.hideThumbnail;
             }
         }
+        const records = !this.props.isNewServiceAdded ? this.props.records.map(
+            (record) => showTemplate && metadataTemplate
+                ? { ...record, metadataTemplate }
+                : record
+        ) : [];
 
         return (<div className="catalog-results">
             <RecordGrid
@@ -245,10 +253,7 @@ class Catalog extends React.Component {
                 crs={this.props.crs}
                 key="records"
                 hideThumbnail={hideThumbnail}
-                records={this.props.records.map(
-                    (record) => showTemplate && metadataTemplate
-                        ? { ...record, metadataTemplate }
-                        : record)}
+                records={records}
                 clearModal={this.props.clearModal}
                 layers={this.props.layers}
                 modalParams={this.props.modalParams}
@@ -359,12 +364,14 @@ class Catalog extends React.Component {
 
     isValidServiceSelected = () => {
         return this.props.services[this.props.selectedService] !== undefined;
-
     };
     search = ({ services, selectedService, start = 1, searchText = "" } = {}) => {
         const url = buildServiceUrl(services[selectedService]);
         const type = services[selectedService].type;
-        this.props.onSearch({ format: type, url, startPosition: start, maxRecords: this.props.pageSize, text: searchText || "", options: { service: this.props.services[selectedService] } });
+        this.props.isNewServiceAdded && this.props.setNewServiceStatus(false);
+        if (!this.props.isNewServiceAdded || searchText !== "") {
+            this.props.onSearch({ format: type, url, startPosition: start, maxRecords: this.props.pageSize, text: searchText || "", options: { service: this.props.services[selectedService] } });
+        }
     };
 
     reset = () => {

--- a/web/client/components/catalog/__tests__/Catalog-test.jsx
+++ b/web/client/components/catalog/__tests__/Catalog-test.jsx
@@ -128,4 +128,58 @@ describe('Test Catalog panel', () => {
         expect(inputField.innerText).toBe("defaultMapBackgroundsServiceTitle");
         expect(item).toExist();
     });
+    it('test the search of records with new service added', () => {
+        const SERVICE = {
+            type: "csw",
+            url: "url",
+            title: "csw"
+        };
+        const actions = { setNewServiceStatus: () => {} };
+        const spyOnNewService = expect.spyOn(actions, 'setNewServiceStatus');
+        const item = ReactDOM.render(<Catalog
+            services={{ "csw": SERVICE}}
+            selectedService="csw"
+            isNewServiceAdded
+            setNewServiceStatus={actions.setNewServiceStatus}
+            result={{numberOfRecordsMatched: 4, numberOfRecordsReturned: 10}}
+        />, document.getElementById("container"));
+        expect(item).toExist();
+        const catalogPagination = document.getElementsByClassName('catalog-pagination');
+        const buttons = TestUtils.scryRenderedDOMComponentsWithTag(item, "button");
+        expect(buttons.length).toBe(1);
+        const searchButton = buttons[0];
+        TestUtils.Simulate.click(searchButton);
+        expect(spyOnNewService).toHaveBeenCalled();
+        expect(spyOnNewService.calls[0].arguments[0]).toBeFalsy();
+        expect(catalogPagination.length).toBe(0); // Pagination is hidden
+    });
+    it('test the search of records with no new service added', () => {
+        const SERVICE = {
+            type: "csw",
+            url: "url",
+            title: "csw"
+        };
+        const actions = { onSearch: () => {}, setNewServiceStatus: () => {} };
+        const spyOnNewService = expect.spyOn(actions, 'setNewServiceStatus');
+        const spyOnSearch = expect.spyOn(actions, 'onSearch');
+        const item = ReactDOM.render(<Catalog
+            services={{ "csw": SERVICE}}
+            selectedService="csw"
+            isNewServiceAdded={false}
+            onSearch={actions.onSearch}
+            result={{numberOfRecordsMatched: 4, numberOfRecordsReturned: 10}}
+            searchOptions={{startPosition: 1}}
+            setNewServiceStatus={actions.setNewServiceStatus}
+        />, document.getElementById("container"));
+        expect(item).toExist();
+        const catalogPagination = document.getElementsByClassName('catalog-pagination');
+        const buttons = TestUtils.scryRenderedDOMComponentsWithTag(item, "button");
+        expect(buttons.length).toBe(1);
+        const searchButton = buttons[0];
+        TestUtils.Simulate.click(searchButton);
+        expect(spyOnNewService).toNotHaveBeenCalled();
+        expect(spyOnSearch).toHaveBeenCalled();
+        expect(spyOnSearch.calls[0].arguments[0]).toEqual({ format: 'csw', url: 'url', startPosition: 1, maxRecords: 4, text: '', options: {service: SERVICE} });
+        expect(catalogPagination.length).toBe(1); // Pagination is displayed
+    });
 });

--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -17,7 +17,8 @@ const {
     openCatalogEpic,
     recordSearchEpic,
     getSupportedFormatsEpic,
-    updateGroupSelectedMetadataExplorerEpic
+    updateGroupSelectedMetadataExplorerEpic,
+    newCatalogServiceAdded
 } = catalog(API);
 import {SHOW_NOTIFICATION} from '../../actions/notifications';
 import {CLOSE_FEATURE_GRID} from '../../actions/featuregrid';
@@ -29,13 +30,21 @@ import {
     addLayersMapViewerUrl,
     getMetadataRecordById as initAction,
     changeText,
-    textSearch, TEXT_SEARCH,
+    textSearch,
+    TEXT_SEARCH,
     RECORD_LIST_LOADED,
     RECORD_LIST_LOAD_ERROR,
     SET_LOADING,
     formatOptionsFetch,
     FORMAT_OPTIONS_LOADING,
-    SET_FORMAT_OPTIONS, ADD_LAYER_AND_DESCRIBE, addLayerAndDescribe, DESCRIBE_ERROR
+    SET_FORMAT_OPTIONS,
+    ADD_LAYER_AND_DESCRIBE,
+    addLayerAndDescribe,
+    DESCRIBE_ERROR,
+    SAVING_SERVICE,
+    NEW_SERVICE_STATUS,
+    ADD_CATALOG_SERVICE,
+    addService
 } from '../../actions/catalog';
 
 
@@ -145,6 +154,82 @@ describe('catalog Epics', () => {
             });
             done();
         }, { });
+    });
+    it('recordSearchEpic with new service', (done) => {
+        const NUM_ACTIONS = 7;
+        const service = {type: "csw", url: "some_url"};
+        testEpic(addTimeoutEpic(recordSearchEpic), NUM_ACTIONS, textSearch({
+            format: "csw",
+            url: "base/web/client/test-resources/csw/getRecordsResponseDC.xml",
+            startPosition: 1,
+            maxRecords: 1,
+            text: "a",
+            options: {service, isNewService: true}
+        }), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case RECORD_LIST_LOADED:
+                    expect(action.result.records.length).toBe(4);
+                    const [rec0, rec1, rec2, rec3] = action.result.records;
+                    expect(rec0.boundingBox).toExist();
+                    expect(rec0.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec0.boundingBox.extent).toEqual([45.542, 11.874, 46.026, 12.718]);
+                    expect(rec1.boundingBox).toExist();
+                    expect(rec1.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec1.boundingBox.extent).toEqual([12.002717999999996, 45.760718, 12.429282000000002, 46.187282]);
+                    expect(rec2.boundingBox).toExist();
+                    expect(rec2.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec2.boundingBox.extent).toEqual([ -4.14168, 47.93257, -4.1149, 47.959353362144 ]);
+                    expect(rec3.boundingBox).toExist();
+                    expect(rec3.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec3.boundingBox.extent).toEqual([ 12.56, 47.46, 13.27, 48.13 ]);
+                    break;
+                case NEW_SERVICE_STATUS:
+                    expect(action.status).toBeTruthy();
+                    break;
+                case ADD_CATALOG_SERVICE:
+                    expect(action.service).toEqual(service);
+                    break;
+                case SHOW_NOTIFICATION:
+                    expect(action.level).toEqual('success');
+                    break;
+                case SAVING_SERVICE:
+                    break;
+                case TEST_TIMEOUT:
+                    break;
+                default:
+                    expect(true).toBe(false);
+                }
+            });
+            done();
+        }, { });
+    });
+    it('newCatalogServiceAdded', (done) => {
+        const NUM_ACTIONS = 2;
+        const service = {type: "csw", url: "base/web/client/test-resources/csw/getRecordsResponseDC.xml"};
+        testEpic(addTimeoutEpic(newCatalogServiceAdded), NUM_ACTIONS, addService(), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case TEXT_SEARCH:
+                    expect(action.format).toBe(service.type);
+                    expect(action.url).toBe(service.url);
+                    expect(action.startPosition).toBe(1);
+                    expect(action.maxRecords).toBe(4);
+                    expect(action.text).toBe("");
+                    expect(action.options).toEqual({service, isNewService: true});
+                    break;
+                case TEST_TIMEOUT:
+                    break;
+                default:
+                    expect(true).toBe(false);
+                }
+            });
+            done();
+        }, { catalog: {
+            newService: service
+        } });
     });
     it('recordSearchEpic with exception', (done) => {
         const NUM_ACTIONS = 2;

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -32,7 +32,11 @@ import {
     textSearch,
     changeSelectedService,
     formatsLoading,
-    setSupportedFormats, ADD_LAYER_AND_DESCRIBE, describeError, addLayer
+    setSupportedFormats,
+    ADD_LAYER_AND_DESCRIBE,
+    describeError,
+    addLayer,
+    setNewServiceStatus
 } from '../actions/catalog';
 import {showLayerMetadata, SELECT_NODE, changeLayerProperties, addLayer as addNewLayer} from '../actions/layers';
 import { error, success } from '../actions/notifications';
@@ -69,6 +73,20 @@ import { wrapStartStop } from '../observables/epics';
 import {zoomToExtent} from "../actions/map";
 import CSW from '../api/CSW';
 
+const onErrorRecordSearch = (isNewService, errObj) => {
+    if (isNewService) {
+        return Rx.Observable.of(
+            error({
+                title: "notification.warning",
+                message: "catalog.notification.errorServiceUrl",
+                autoDismiss: 6,
+                position: "tc"
+            }),
+            savingService(false)
+        );
+    }
+    return Rx.Observable.of(recordsLoadError(errObj));
+};
 /**
     * Epics for CATALOG
     * @name epics.catalog
@@ -85,24 +103,39 @@ export default (API) => ({
         action$.ofType(TEXT_SEARCH)
             .switchMap(({ format, url, startPosition, maxRecords, text, options }) => {
                 const filter = get(options, 'service.filter') || get(options, 'filter');
+                const isNewService = get(options, 'isNewService', false);
                 return Rx.Observable.defer(() =>
                     API[format].textSearch(url, startPosition, maxRecords, text, { options, filter, ...catalogSearchInfoSelector(store.getState()) })
                 )
                     .switchMap((result) => {
                         if (result.error) {
-                            return Rx.Observable.of(recordsLoadError(result));
+                            return onErrorRecordSearch(isNewService, result);
                         }
-                        return Rx.Observable.of(recordsLoaded({
+                        let $observable = Rx.Observable.empty();
+                        if (isNewService) {
+                            $observable = Rx.Observable.from([
+                                // The records are saved to catalog state on successful saving of the service.
+                                // The flag is used to show/hide records on load in Catalog
+                                setNewServiceStatus(true),
+                                addCatalogService(options.service),
+                                success({
+                                    title: "notification.success",
+                                    message: "catalog.notification.addCatalogService",
+                                    autoDismiss: 6,
+                                    position: "tc"
+                                }),
+                                savingService(false)
+                            ]);
+                        }
+                        return $observable.concat([recordsLoaded({
                             url,
                             startPosition,
                             maxRecords,
                             text
-                        }, result));
+                        }, result)]);
                     })
-                    .startWith(setLoading(true))
-                    .catch((e) => {
-                        return Rx.Observable.of(recordsLoadError(e));
-                    });
+                    .startWith(isNewService ? savingService(true) : setLoading(true))
+                    .catch((e) => onErrorRecordSearch(isNewService, e));
             }),
 
     /**
@@ -238,23 +271,25 @@ export default (API) => ({
             .switchMap(() => {
                 const state = store.getState();
                 const newService = newServiceSelector(state);
+                const maxRecords = pageSizeSelector(state);
                 return Rx.Observable.of(newService)
                     // validate
                     .switchMap((service) => API[service.type]?.preprocess?.(service) ?? ( Rx.Observable.of(service)))
                     .switchMap((service) => API[service.type]?.validate?.(service) ?? ( Rx.Observable.of(service)))
-                    .switchMap((service) => API[service.type]?.testService?.(service) ?? (Rx.Observable.of(service)))
-                    .switchMap(() => {
+                    .switchMap((service) => {
+                        // Dispatch action to test service and add records to catalog after successful saving of the service,
+                        // this prevents duplicate calls being fired for all the services
                         return Rx.Observable.of(
-                            addCatalogService(newService),
-                            success({
-                                title: "notification.success",
-                                message: "catalog.notification.addCatalogService",
-                                autoDismiss: 6,
-                                position: "tc"
+                            textSearch({
+                                format: service.type,
+                                url: service.url,
+                                startPosition: 1,
+                                maxRecords,
+                                text: "",
+                                options: {service, isNewService: true}
                             })
                         );
                     })
-                    .startWith(savingService(true))
                     .catch((e) => {
                         return Rx.Observable.of(error({
                             exception: e,
@@ -263,8 +298,7 @@ export default (API) => ({
                             autoDismiss: 6,
                             position: "tc"
                         }));
-                    })
-                    .concat(Rx.Observable.of(savingService(false)));
+                    });
             }),
     deleteCatalogServiceEpic: (action$, store) =>
         action$.ofType(DELETE_SERVICE)

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -39,7 +39,8 @@ import {
     textSearch,
     toggleAdvancedSettings,
     toggleTemplate,
-    toggleThumbnail
+    toggleThumbnail,
+    setNewServiceStatus
 } from '../actions/catalog';
 import { setControlProperty, toggleControl } from '../actions/controls';
 import { changeLayerProperties } from '../actions/layers';
@@ -73,7 +74,8 @@ import {
     tileSizeOptionsSelector,
     formatsLoadingSelector,
     getSupportedFormatsSelector,
-    getSupportedGFIFormatsSelector
+    getSupportedGFIFormatsSelector,
+    getNewServiceStatusSelector
 } from '../selectors/catalog';
 import { layersSelector } from '../selectors/layers';
 import { currentLocaleSelector, currentMessagesSelector } from '../selectors/locale';
@@ -117,7 +119,8 @@ const metadataExplorerSelector = createStructuredSelector({
     isLocalizedLayerStylesEnabled: isLocalizedLayerStylesEnabledSelector,
     formatsLoading: formatsLoadingSelector,
     formatOptions: getSupportedFormatsSelector,
-    infoFormatOptions: getSupportedGFIFormatsSelector
+    infoFormatOptions: getSupportedGFIFormatsSelector,
+    isNewServiceAdded: getNewServiceStatusSelector
 });
 
 
@@ -268,7 +271,8 @@ const MetadataExplorerPlugin = connect(metadataExplorerSelector, {
     onFormatOptionsFetch: formatOptionsFetch,
     onToggle: toggleControl.bind(null, 'backgroundSelector', null),
     onLayerChange: setControlProperty.bind(null, 'backgroundSelector'),
-    onStartChange: setControlProperty.bind(null, 'backgroundSelector', 'start')
+    onStartChange: setControlProperty.bind(null, 'backgroundSelector', 'start'),
+    setNewServiceStatus
 })(MetadataExplorerComponent);
 
 /**

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -30,7 +30,8 @@ import {
     TOGGLE_TEMPLATE,
     TOGGLE_ADVANCED_SETTINGS,
     FORMAT_OPTIONS_LOADING,
-    SET_FORMAT_OPTIONS
+    SET_FORMAT_OPTIONS,
+    NEW_SERVICE_STATUS
 } from '../actions/catalog';
 
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -212,6 +213,9 @@ function catalog(state = {
     }
     case SET_FORMAT_OPTIONS: {
         return set("newService.supportedFormats", action.formats, set("newService.formatUrlUsed", action.url, state));
+    }
+    case NEW_SERVICE_STATUS: {
+        return set("isNewServiceAdded", action.status, state);
     }
     default:
         return state;

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -59,3 +59,4 @@ export const formatsLoadingSelector = (state) => get(state, "catalog.formatsLoad
 export const getSupportedFormatsSelector = (state) => get(state, "catalog.newService.supportedFormats.imageFormats", DEFAULT_FORMAT_WMS);
 export const getSupportedGFIFormatsSelector = (state) => get(state, "catalog.newService.supportedFormats.infoFormats", getUniqueInfoFormats());
 export const getFormatUrlUsedSelector = (state) => get(state, "catalog.newService.formatUrlUsed", '');
+export const getNewServiceStatusSelector = (state) => get(state, "catalog.isNewServiceAdded", false);


### PR DESCRIPTION
## Description
This PR attempts to optimize the catalog services calls when adding a new service and searching records of new service

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#8137 

**What is the new behavior?**
Test service call is call skipped and instead dispacted text search and the records are saved to catalog. Which is later manipulated to be shown on Catalog based on `service on load` and user search. 
This prevents **example**  `GetCapabilties` call being fired twice in case WMS and WMTS. This optimization is applicable for all service

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
**Note for testers:**
Regression around Catalog and it's features