### PR TITLE
Fix for the regression bug with regular expression in Safari

### DIFF
--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -34,9 +34,8 @@ const wrapValueWithWildcard = (value, condition) => {
     return condition(value) ? '*' + value + '*' : value;
 };
 
-const wrapIfNoWildcards = (value) => {
-    const wildcards = value.match(/(?<!!)[*.]/);
-    return !wildcards?.length;
+export const wrapIfNoWildcards = (value) => {
+    return !/(^|[^!])[*.]/.test(value);
 };
 
 export const escapeCQLStrings = str => str && str.replace ? str.replace(/\'/g, "''") : str;

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -23,7 +23,8 @@ import {
     cqlArrayField,
     processOGCFilterFields,
     processOGCSimpleFilterField,
-    processCQLFilterFields
+    processCQLFilterFields,
+    wrapIfNoWildcards
 } from '../FilterUtils';
 
 
@@ -1938,5 +1939,23 @@ describe('FilterUtils', () => {
         };
         filter = processCQLFilterFields(group, objFilter);
         expect(filter).toEqual("");
+    });
+
+    it('wrapIfNoWildcards', () => {
+        const testCases = [
+            // True if no unescaped wildcards
+            ["testString", true],
+            ["*testString", false],
+            ["!*testString", true],
+            ["!*test.String", false],
+            ["!te*st!.String", false],
+            ["!te!*st!.String*", false],
+            ["!te!*st!.String!*", true],
+            ["*!te!*st!.String!*", false],
+            ["!*!te!**st!.String!*", false]
+        ];
+        testCases.forEach(([value, expected]) => {
+            expect(wrapIfNoWildcards(value)).toBe(expected);
+        });
     });
 });


### PR DESCRIPTION
## Description
There is a regression bug preventing MapStore to run in Safari (desktop/mobile)
Regexp check is replaced with suggested function and test coverage is added.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue


**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8154 

**What is the new behavior?**
It should work on Safari as it's not using unsupported regular expression anymore.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
