### PR TITLE
8054/bug/disable 3d layers on toc

### DIFF
--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -96,15 +96,12 @@ class DefaultLayer extends React.Component {
     };
 
     getVisibilityMessage = () => {
+        if (this.props.node.exclusiveMapType) return this.props.node?.type === '3dtiles' && 'toc.notVisibleSwitchTo3D';
         const maxResolution = this.props.node.maxResolution || Infinity;
         return this.props.resolution >=  maxResolution
             ? 'toc.notVisibleZoomIn'
             : 'toc.notVisibleZoomOut';
     };
-
-    getExclusiveMapTypeMessage = () => {
-        return this.props.node?.type === '3dtiles' && 'toc.notVisibleSwitchTo3D';
-    }
 
     renderOpacitySlider = (hideOpacityTooltip) => {
         return (this.props.activateOpacityTool && this.props.node?.type !== '3dtiles') ? (
@@ -185,8 +182,7 @@ class DefaultLayer extends React.Component {
                     onContextMenu={this.props.onContextMenu}
                 />
                 {this.props.node.loading ? <div className="toc-inline-loader"></div> : this.renderToolsLegend(isEmpty)}
-                {!isInsideResolutionsLimits(this.props.node, this.props.resolution) && <GlyphIndicator glyph="info-sign" tooltipId={this.getVisibilityMessage()} style={{ 'float': 'right' }}/>}
-                {this.props.node.exclusiveMapType && <GlyphIndicator glyph="info-sign" tooltipId={this.getExclusiveMapTypeMessage()} style={{ 'float': 'right' }}/>}
+                {!isInsideResolutionsLimits(this.props.node, this.props.resolution) || this.props.node.exclusiveMapType ? <GlyphIndicator glyph="info-sign" tooltipId={this.getVisibilityMessage()} style={{ 'float': 'right' }}/> : null}
                 {this.props.indicators ? this.renderIndicators() : null}
             </div>
         );

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -102,6 +102,10 @@ class DefaultLayer extends React.Component {
             : 'toc.notVisibleZoomOut';
     };
 
+    getExclusiveMapTypeMessage = () => {
+        return this.props.node?.type === '3dtiles' && 'toc.notVisibleSwitchTo3D';
+    }
+
     renderOpacitySlider = (hideOpacityTooltip) => {
         return (this.props.activateOpacityTool && this.props.node?.type !== '3dtiles') ? (
             <OpacitySlider
@@ -182,6 +186,7 @@ class DefaultLayer extends React.Component {
                 />
                 {this.props.node.loading ? <div className="toc-inline-loader"></div> : this.renderToolsLegend(isEmpty)}
                 {!isInsideResolutionsLimits(this.props.node, this.props.resolution) && <GlyphIndicator glyph="info-sign" tooltipId={this.getVisibilityMessage()} style={{ 'float': 'right' }}/>}
+                {this.props.node.exclusiveMapType && <GlyphIndicator glyph="info-sign" tooltipId={this.getExclusiveMapTypeMessage()} style={{ 'float': 'right' }}/>}
                 {this.props.indicators ? this.renderIndicators() : null}
             </div>
         );
@@ -196,7 +201,7 @@ class DefaultLayer extends React.Component {
 
     render() {
         let {children, propertiesChangeHandler, onToggle, connectDragSource, connectDropTarget, ...other } = this.props;
-        const hide = !this.props.node.visibility || this.props.node.invalid || !isInsideResolutionsLimits(this.props.node, this.props.resolution) ? ' visibility' : '';
+        const hide = !this.props.node.visibility || this.props.node.invalid || this.props.node.exclusiveMapType || !isInsideResolutionsLimits(this.props.node, this.props.resolution) ? ' visibility' : '';
         const selected = this.props.selectedNodes.filter((s) => s === this.props.node.id).length > 0 ? ' selected' : '';
         const error = this.props.node.loadingError === 'Error' ? ' layer-error' : '';
         const warning = this.props.node.loadingError === 'Warning' ? ' layer-warning' : '';

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -154,6 +154,10 @@ const tocSelector = createSelector(
             {
                 options: { showComponent: false },
                 func: (node) => node.id === "annotations" && isCesiumActive
+            },
+            {
+                options: { invalid: true },
+                func: (node) => node.type === "3dtiles" && !isCesiumActive
             }
         ]),
         catalogActive,

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -156,7 +156,7 @@ const tocSelector = createSelector(
                 func: (node) => node.id === "annotations" && isCesiumActive
             },
             {
-                options: { invalid: true },
+                options: { exclusiveMapType: true },
                 func: (node) => node.type === "3dtiles" && !isCesiumActive
             }
         ]),

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -575,6 +575,7 @@
             "filterIconDisabled": "Ebenenfilter aktivieren",
             "notVisibleZoomIn": "Die Ebene ist nicht sichtbar, da sie außerhalb der Auflösungsgrenzen liegt. Zoomen Sie hinein, um die Ebene anzuzeigen",
             "notVisibleZoomOut": "Die Ebene ist nicht sichtbar, da sie außerhalb der Auflösungsgrenzen liegt. Verkleinern Sie die Ansicht, um die Ebene anzuzeigen",
+            "notVisibleSwitchTo3D": "Wechseln Sie in den 3D-Kartenmodus, um diesen Layer anzuzeigen",
             "refreshOptions": {
                 "bbox": "BBOX aktualisieren",
                 "search": "Suchoptionen aktualisieren",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -536,6 +536,7 @@
             "filterIconDisabled": "Enable layer filter",
             "notVisibleZoomIn": "The layer is not visible because it is outside the resolution limits. Zoom in to show the layer",
             "notVisibleZoomOut": "The layer is not visible because it is outside the resolution limits. Zoom out to show the layer",
+            "notVisibleSwitchTo3D": "Switch to 3D map mode in order to see this layer",
             "refreshOptions": {
                 "bbox": "Update BBOX",
                 "search": "Update search options",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -536,6 +536,7 @@
             "filterIconDisabled": "Habilitar filtro de capa",
             "notVisibleZoomIn": "La capa no es visible porque está fuera de los límites de resolución. Acercar para mostrar la capa",
             "notVisibleZoomOut": "La capa no es visible porque está fuera de los límites de resolución. Alejar para mostrar la capa",
+            "notVisibleSwitchTo3D": "Cambie al modo de mapa 3D para ver esta capa",
             "refreshOptions": {
                 "bbox": "Refrescar BBOX",
                 "search": "Refrescar las opciones de búsqueda",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -536,6 +536,7 @@
             "filterIconDisabled": "Activer le filtre de couche",
             "notVisibleZoomIn": "Le calque n'est pas visible car il est en dehors des limites de résolution. Zoomez pour afficher le calque",
             "notVisibleZoomOut": "Le calque n'est pas visible car il est en dehors des limites de résolution. Faites un zoom arrière pour afficher le calque",
+            "notVisibleSwitchTo3D": "Passer en mode carte 3D pour voir cette couche",
             "refreshOptions": {
                 "bbox": "Mettre à jour la BBOX",
                 "search": "Mettre à jour les options de recherche",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -536,6 +536,7 @@
             "filterIconDisabled": "Attiva il filtro",
             "notVisibleZoomIn": "Il layer non è visibile perchè al di fuori dei limiti di risoluzione. Zoom in per mostrare il layer",
             "notVisibleZoomOut": "Il layer non è visibile perchè al di fuori dei limiti di risoluzione. Zoom out per mostrare il layer",
+            "notVisibleSwitchTo3D": "Passa alla modalità mappa 3D per vedere questo layer",
             "refreshOptions": {
                 "bbox": "Aggiorna area di zoom",
                 "search": "Aggiorna opzioni di ricerca",


### PR DESCRIPTION
## Description
This PR aims to inform the user that 3D layer would only be displayed in the map only if the 3D view is selected. Although the 3D layer will remain visible in the layer tree (on the TOC) even when the map is not 3D, it will be grayed out and an info tooltip would be displayed prompting the user to switch to 3D in order to see the layer displayed on the map.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Currently no info or visual clue is given to the user on why this layer is not being displayed in the map.
Check this issue for more context: #8054 

**What is the new behavior?**
With the introduced changes whenever the selected map type is not the one compatible with the given layer this would be greyed out and an info tooltip would explain the user what is needed in order to display the layer in the map.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
