### PR TITLE
8149/bug/layer group feature info

### DIFF
--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -804,7 +804,7 @@ describe('Test layers selectors', () => {
     });
 
     // eslint-disable-next-line no-only-tests/no-only-tests
-    it.only('test getSelectedLayers selector', () => {
+    it('test getSelectedLayers selector', () => {
         const queryableSelectedLayers = [
             {
                 type: 'wms',

--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -9,6 +9,7 @@
 import expect from 'expect';
 
 import {
+    getSelectedLayers,
     getLayerFromName,
     getLayerFromId,
     layersSelector,
@@ -800,5 +801,52 @@ describe('Test layers selectors', () => {
         };
         const props = getAdditionalLayerFromId(state, 'layer_001');
         expect(props.id).toBe('layer_001');
+    });
+
+    // eslint-disable-next-line no-only-tests/no-only-tests
+    it.only('test getSelectedLayers selector', () => {
+        const queryableSelectedLayers = [
+            {
+                type: 'wms',
+                visibility: true,
+                id: 'mapstore:states__7'
+            },
+            {
+                type: 'wms',
+                visibility: true,
+                id: 'mapstore:Types__6'
+            }
+        ];
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'mapnik__0',
+                        group: 'background',
+                        type: 'osm',
+                        visibility: true
+                    },
+                    {
+                        id: 'Night2012__1',
+                        group: 'background',
+                        type: 'tileprovider',
+                        visibility: false
+                    },
+                    {
+                        type: 'wms',
+                        visibility: true,
+                        id: 'mapstore:DE_USNG_UTM18__8'
+                    },
+                    ...queryableSelectedLayers
+                ],
+                selected: [
+                    'mapstore:states__7',
+                    'mapstore:Types__6',
+                    'mapstore:Meteorite_Landings_from_NASA_Open_Data_Portal__5',
+                    'Default'
+                ]
+            }
+        };
+        expect(getSelectedLayers(state)).toEqual(queryableSelectedLayers);
     });
 });

--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -803,7 +803,6 @@ describe('Test layers selectors', () => {
         expect(props.id).toBe('layer_001');
     });
 
-    // eslint-disable-next-line no-only-tests/no-only-tests
     it('test getSelectedLayers selector', () => {
         const queryableSelectedLayers = [
             {

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -90,12 +90,18 @@ export const rawGroupsSelector = (state) => state.layers && state.layers.flat &&
 export const groupsSelector = (state) => state.layers && state.layers.flat && state.layers.groups && denormalizeGroups(state.layers.flat, state.layers.groups).groups || [];
 
 export const selectedNodesSelector = (state) => state.layers && state.layers.selected || [];
+
+/**
+* Layers selected by the user on the TOC
+* @param {object} state the state
+* @return {array} array with the selected layers data obects
+*/
 export const getSelectedLayers = state => {
     const selectedIds = selectedNodesSelector(state);
     // We need to exclude undefined values from the result
-    const layers = selectedIds.map((id) => find(layersSelector(state), {id})).filter(l => l !== undefined);
-    return layers;
+    return selectedIds.map((id) => find(layersSelector(state), {id})).filter(l => l !== undefined);
 };
+
 export const getSelectedLayer = state => {
     const selected = getSelectedLayers(state) || [];
     return selected && selected[0];

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -92,7 +92,9 @@ export const groupsSelector = (state) => state.layers && state.layers.flat && st
 export const selectedNodesSelector = (state) => state.layers && state.layers.selected || [];
 export const getSelectedLayers = state => {
     const selectedIds = selectedNodesSelector(state);
-    return selectedIds.map((id) => find(layersSelector(state), {id}));
+    // We need to exclude undefined values from the result
+    const layers = selectedIds.map((id) => find(layersSelector(state), {id})).filter(l => l !== undefined);
+    return layers;
 };
 export const getSelectedLayer = state => {
     const selected = getSelectedLayers(state) || [];


### PR DESCRIPTION
## Description
The [issue](#8149) fixed on this PR avoided the info widget to be opened when the user clicked on the map if a layer group without an assigned `id` was selected (the auto assigned `id` is `'Default'`). 
The return value of the `getSelectedLayers` selector has been filtered in order to avoid `undefined` values.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
When a layer group (whose `id` attribute value is `'Default'`) is selected on the TOC and the user clicks in the map to get the info from the selected layers inside the group the info window is not displayed.
#8149 

**What is the new behavior?**
After filtering out `undefined` values the info widget gets displayed since the `identify` epic flow does not error. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
