### PR TITLE
8170: Delete GeoStory and Dashboard from menu

### DIFF
--- a/web/client/actions/__tests__/dashboards-test.js
+++ b/web/client/actions/__tests__/dashboards-test.js
@@ -21,7 +21,9 @@ import {
     dashboardDeleted,
     DASHBOARD_DELETED,
     reloadDashboards,
-    RELOAD
+    RELOAD,
+    setControl,
+    SET_CONTROL
 } from '../dashboards';
 
 describe('dashboards (browse) actions', () => {
@@ -77,5 +79,12 @@ describe('dashboards (browse) actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(RELOAD);
     });
-
+    it('setControl', () => {
+        const control = 'delete.show';
+        const retval = setControl(control, true);
+        expect(retval).toExist();
+        expect(retval.type).toBe(SET_CONTROL);
+        expect(retval.control).toBe(control);
+        expect(retval.value).toBe(true);
+    });
 });

--- a/web/client/actions/dashboards.js
+++ b/web/client/actions/dashboards.js
@@ -13,6 +13,7 @@ export const DELETE_DASHBOARD = "DASHBOARDS:DELETE_DASHBOARD";
 export const DASHBOARD_DELETED = "DASHBOARDS:DASHBOARD_DELETED";
 export const RELOAD = "DASHBOARDS:RELOAD_DASHBOARDS";
 export const LOADING = "DASHBOARDS:LOADING";
+export const SET_CONTROL = "DASHBOARDS:SET_CONTROL";
 
 
 export const setDashboardsAvailable = (available) => ({ type: SET_DASHBOARDS_AVAILABLE, available });
@@ -30,3 +31,11 @@ export const dashboardListLoaded = ({ results, success, totalCount }, { searchTe
 export const deleteDashboard = id => ({type: DELETE_DASHBOARD, id});
 export const reloadDashboards = () => ({ type: RELOAD});
 export const dashboardDeleted = id => ({type: DASHBOARD_DELETED, id});
+
+/**
+ * Sets the variables for the controls of Dashboard. Can be used for dialogs or other tools
+ * specific of Dashboard.
+ * @param {string} control path to the control or control value to set
+ * @param {object} value any value you want to set for the control
+ */
+export const setControl = (control, value) => ({ type: SET_CONTROL, control, value });

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -771,6 +771,7 @@
           {
             "name": "GeoStory"
           },
+          { "name": "DeleteGeoStory" },
           "GeoStorySave",
           "GeoStorySaveAs",
           "MapEditor",

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -649,79 +649,89 @@
             "declineUrl" : "http://www.google.com"
           }
         }],
-        "dashboard": [{
-            "name": "OmniBar",
+        "dashboard": [
+          "BurgerMenu",
+          "Dashboard",
+          "Notifications",
+          "Login",
+          "Language",
+          "NavMenu",
+          "DashboardSave",
+          "DashboardSaveAs",
+          "Attribution",
+          "Home",
+          { "name": "DeleteDashboard" },
+          { "name": "OmniBar",
             "cfg": {
                 "containerPosition": "header",
                 "className": "navbar shadow navbar-home"
             }
-        }, "Login", "Language", "NavMenu", "DashboardSave", "DashboardSaveAs", "Attribution", "Home", {
-          "name": "Share",
-          "cfg": {
-            "showAPI": false,
-            "advancedSettings": false,
-            "shareUrlRegex": "(h[^#]*)#\\/dashboard\\/([A-Za-z0-9]*)",
-            "shareUrlReplaceString": "$1dashboard-embedded.html#/$2",
-            "embedOptions": {
-              "showTOCToggle": false,
-              "showConnectionsParamToggle": true,
-              "allowFullScreen": false,
-              "sizeOptions": {
-                "Small": { "width": 600, "height": 500 },
-                "Medium": { "width": 800, "height": 600},
-                "Large": { "width": 1000, "height": 800},
-                "Custom": {"width": 0, "height": 0}
-            },
-            "selectedOption": "Small"
-            }
-          }
-        },
-          {
-          "name": "DashboardEditor",
-          "cfg": {
-            "selectedService": "GeoSolutions GeoServer CSW",
-            "services": {
-              "GeoSolutions GeoServer CSW": {
-                "url": "https://gs-stable.geo-solutions.it/geoserver/csw",
-                "type": "csw",
-                "title": "GeoSolutions GeoServer CSW"
+          },
+          { "name": "Share",
+            "cfg": {
+              "showAPI": false,
+              "advancedSettings": false,
+              "shareUrlRegex": "(h[^#]*)#\\/dashboard\\/([A-Za-z0-9]*)",
+              "shareUrlReplaceString": "$1dashboard-embedded.html#/$2",
+              "embedOptions": {
+                "showTOCToggle": false,
+                "showConnectionsParamToggle": true,
+                "allowFullScreen": false,
+                "sizeOptions": {
+                  "Small": { "width": 600, "height": 500 },
+                  "Medium": { "width": 800, "height": 600},
+                  "Large": { "width": 1000, "height": 800},
+                  "Custom": {"width": 0, "height": 0}
               },
-              "GeoSolutions GeoServer WMS": {
-                "url": "https://gs-stable.geo-solutions.it/geoserver/wms",
-                "type": "wms",
-                "title": "GeoSolutions GeoServer WMS"
-              },
-              "GeoSolutions GeoServer WMTS": {
-                "url": "https://gs-stable.geo-solutions.it/geoserver/gwc/service/wmts",
-                "type": "wmts",
-                "title": "GeoSolutions GeoServer WMTS"
+              "selectedOption": "Small"
               }
-            },
-            "containerPosition": "columns"
-          }
-        }, {
-          "name": "QueryPanel",
-          "cfg": {
-            "toolsOptions": {
-              "hideCrossLayer": true,
-              "hideSpatialFilter": true
-            },
-            "containerPosition": "columns"
-          }
-        }, "BurgerMenu", "Dashboard", "Notifications", {
-            "name": "Tutorial",
+            }
+          },
+          {"name": "DashboardEditor",
+            "cfg": {
+              "selectedService": "GeoSolutions GeoServer CSW",
+              "services": {
+                "GeoSolutions GeoServer CSW": {
+                  "url": "https://gs-stable.geo-solutions.it/geoserver/csw",
+                  "type": "csw",
+                  "title": "GeoSolutions GeoServer CSW"
+                },
+                "GeoSolutions GeoServer WMS": {
+                  "url": "https://gs-stable.geo-solutions.it/geoserver/wms",
+                  "type": "wms",
+                  "title": "GeoSolutions GeoServer WMS"
+                },
+                "GeoSolutions GeoServer WMTS": {
+                  "url": "https://gs-stable.geo-solutions.it/geoserver/gwc/service/wmts",
+                  "type": "wmts",
+                  "title": "GeoSolutions GeoServer WMTS"
+                }
+              },
+              "containerPosition": "columns"
+            }
+          },
+          { "name": "QueryPanel",
+            "cfg": {
+              "toolsOptions": {
+                "hideCrossLayer": true,
+                "hideSpatialFilter": true
+              },
+              "containerPosition": "columns"
+            }
+          },
+          { "name": "Tutorial",
             "cfg": {
                 "allowClicksThruHole": false,
                 "containerPosition": "header",
                 "preset": "dashboard_tutorial"
             }
-        },
-        {
-            "name": "FeedbackMask",
+          },
+          { "name": "FeedbackMask",
             "cfg": {
                 "containerPosition": "header"
             }
-        }],
+          }
+        ],
       "geostory-embedded": [
         "GeoStory",
         {

--- a/web/client/plugins/DeleteDashboard.jsx
+++ b/web/client/plugins/DeleteDashboard.jsx
@@ -11,19 +11,19 @@ import PropTypes from "prop-types";
 import { Glyphicon } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { setControl } from '../actions/geostory';
 import ConfirmDialog from '../components/misc/ConfirmDialog';
 import { createPlugin } from '../utils/PluginsUtils';
-import { Controls } from '../utils/GeoStoryUtils';
-import { deleteGeostory } from '../actions/geostories';
-import { geostoryIdSelector, deleteDialogSelector } from '../selectors/geostory';
+import { Controls } from '../utils/DashboardUtils';
+import { deleteDashboard, setControl } from '../actions/dashboards';
+import { getDashboardId } from '../selectors/dashboard';
+import { deleteDialogSelector } from '../selectors/dashboards';
 import Message from '../components/I18N/Message';
 
 class DeleteConfirmDialog extends React.Component {
 
     static propTypes = {
         show: PropTypes.bool,
-        geostoryId: PropTypes.string,
+        dashboardId: PropTypes.string,
         onConfirmDelete: PropTypes.func,
         onClose: PropTypes.func
     };
@@ -34,7 +34,7 @@ class DeleteConfirmDialog extends React.Component {
 
     static defaultProps = {
         show: false,
-        geostoryId: '',
+        dashboardId: '',
         onConfirmDelete: () => {},
         onClose: () => {}
     };
@@ -44,11 +44,11 @@ class DeleteConfirmDialog extends React.Component {
             <ConfirmDialog
                 show={this.props.show}
                 onClose={this.props.onClose}
-                title={<Message msgId="geostory.delete" />}
+                title={<Message msgId="dashboard.delete" />}
                 onConfirm={() => {
                     this.context.router.history.push("/");
                     this.props.onClose();
-                    this.props.onConfirmDelete(this.props.geostoryId);
+                    this.props.onConfirmDelete(this.props.dashboardId);
                 }}
                 fitContent
             >
@@ -60,24 +60,24 @@ class DeleteConfirmDialog extends React.Component {
     }
 }
 
-export default createPlugin('DeleteGeoStory', {
+export default createPlugin('DeleteDashboard', {
     component:
         connect(createSelector(
             deleteDialogSelector,
-            geostoryIdSelector,
-            (show, geostoryId) => {
-                return { show, geostoryId };
+            getDashboardId,
+            (show, dashboardId) => {
+                return { show, dashboardId };
             }
         ),
         {
-            onConfirmDelete: (geostoryId) => deleteGeostory(geostoryId),
+            onConfirmDelete: (dashboardId) => deleteDashboard(dashboardId),
             onClose: setControl.bind(null, Controls.SHOW_DELETE, false)
         })(DeleteConfirmDialog),
     containers: {
         BurgerMenu: {
-            name: 'geostoryDelete',
-            position: 5,
-            text: <Message msgId="geostory.delete"/>,
+            name: 'dashboardDelete',
+            position: 300,
+            text: <Message msgId="dashboard.delete"/>,
             icon: <Glyphicon glyph="trash"/>,
             action: setControl.bind(null, Controls.SHOW_DELETE, true),
             priority: 1,

--- a/web/client/plugins/DeleteDashboard.jsx
+++ b/web/client/plugins/DeleteDashboard.jsx
@@ -15,8 +15,9 @@ import ConfirmDialog from '../components/misc/ConfirmDialog';
 import { createPlugin } from '../utils/PluginsUtils';
 import { Controls } from '../utils/DashboardUtils';
 import { deleteDashboard, setControl } from '../actions/dashboards';
-import { getDashboardId } from '../selectors/dashboard';
+import { getDashboardId, dashboardResource } from '../selectors/dashboard';
 import { deleteDialogSelector } from '../selectors/dashboards';
+import { isLoggedIn } from '../selectors/security';
 import Message from '../components/I18N/Message';
 
 class DeleteConfirmDialog extends React.Component {
@@ -80,6 +81,13 @@ export default createPlugin('DeleteDashboard', {
             text: <Message msgId="dashboard.delete"/>,
             icon: <Glyphicon glyph="trash"/>,
             action: setControl.bind(null, Controls.SHOW_DELETE, true),
+            selector: createSelector(
+                isLoggedIn,
+                dashboardResource,
+                (loggedIn, {canEdit, id} = {}) => ({
+                    style: loggedIn && (id && canEdit) ? {} : { display: "none" } // save is present only if the resource already exists and you can save
+                })
+            ),
             priority: 1,
             doNotHide: true
         }

--- a/web/client/plugins/DeleteGeoStory.jsx
+++ b/web/client/plugins/DeleteGeoStory.jsx
@@ -16,7 +16,8 @@ import ConfirmDialog from '../components/misc/ConfirmDialog';
 import { createPlugin } from '../utils/PluginsUtils';
 import { Controls } from '../utils/GeoStoryUtils';
 import { deleteGeostory } from '../actions/geostories';
-import { geostoryIdSelector, deleteDialogSelector } from '../selectors/geostory';
+import { geostoryIdSelector, deleteDialogSelector, resourceSelector } from '../selectors/geostory';
+import { isLoggedIn } from '../selectors/security';
 import Message from '../components/I18N/Message';
 
 class DeleteConfirmDialog extends React.Component {
@@ -80,6 +81,13 @@ export default createPlugin('DeleteGeoStory', {
             text: <Message msgId="geostory.delete"/>,
             icon: <Glyphicon glyph="trash"/>,
             action: setControl.bind(null, Controls.SHOW_DELETE, true),
+            selector: createSelector(
+                isLoggedIn,
+                resourceSelector,
+                (loggedIn, {canEdit, id} = {}) => ({
+                    style: loggedIn && (id && canEdit) ? {} : { display: "none" } // save is present only if the resource already exists and you can save
+                })
+            ),
             priority: 1,
             doNotHide: true
         }

--- a/web/client/plugins/DeleteGeoStory.jsx
+++ b/web/client/plugins/DeleteGeoStory.jsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+import PropTypes from "prop-types";
+import { Glyphicon } from 'react-bootstrap';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { setControl } from '../actions/geostory';
+import ConfirmDialog from '../components/misc/ConfirmDialog';
+import { createPlugin } from '../utils/PluginsUtils';
+import { Controls } from '../utils/GeoStoryUtils';
+import { deleteGeostory } from '../actions/geostories';
+import { geostoryIdSelector, deleteDialogSelector } from '../selectors/geostory';
+import Message from '../components/I18N/Message';
+
+class DeleteConfirmDialog extends React.Component {
+
+    static propTypes = {
+        show: PropTypes.bool,
+        geostoryId: PropTypes.string,
+        onConfirmDelete: PropTypes.func,
+        onClose: PropTypes.func
+    };
+
+    static contextTypes = {
+        router: PropTypes.object
+    };
+
+    static defaultProps = {
+        show: false,
+        geostoryId: '',
+        onConfirmDelete: () => {},
+        onClose: () => {}
+    };
+
+    render() {
+        return (
+            <ConfirmDialog
+                show={this.props.show}
+                onClose={this.props.onClose}
+                title={<Message msgId="geostory.delete" />}
+                onConfirm={() => {
+                    this.context.router.history.push("/");
+                    this.props.onConfirmDelete(this.props.geostoryId);
+                }}
+                fitContent
+            >
+                <div className="ms-detail-body">
+                    <Message msgId="resources.deleteConfirmMessage" />
+                </div>
+            </ConfirmDialog>
+        );
+    }
+}
+
+export default createPlugin('DeleteGeoStory', {
+    component:
+        connect(createSelector(
+            deleteDialogSelector,
+            geostoryIdSelector,
+            (show, geostoryId) => {
+                return { show, geostoryId };
+            }
+        ),
+        {
+            onConfirmDelete: (geostoryId) => deleteGeostory(geostoryId),
+            onClose: setControl.bind(null, Controls.SHOW_DELETE, false)
+        })(DeleteConfirmDialog),
+    containers: {
+        BurgerMenu: {
+            name: 'geostoryDelete',
+            position: 5,
+            text: <Message msgId="geostory.delete"/>,
+            icon: <Glyphicon glyph="trash"/>,
+            action: setControl.bind(null, Controls.SHOW_DELETE, true),
+            priority: 1,
+            doNotHide: true
+        }
+    }
+});

--- a/web/client/plugins/__tests__/DeleteDashboard-test.jsx
+++ b/web/client/plugins/__tests__/DeleteDashboard-test.jsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+
+import { getPluginForTest } from './pluginsTestUtils';
+
+import DeleteDashboard from '../DeleteDashboard';
+
+describe('DeleteDashboard plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('displays the delete confirm dialog when enabled', () => {
+        const { Plugin } = getPluginForTest(DeleteDashboard, {
+            controls: {
+                dashboardDelete: {
+                    enabled: true
+                }
+            }
+        });
+        ReactDOM.render(<Plugin/>, document.getElementById('container'));
+        const rootDiv = document.getElementById('confirm-dialog');
+        expect(rootDiv).toExist();
+    });
+});

--- a/web/client/plugins/__tests__/DeleteGeoStory-test.jsx
+++ b/web/client/plugins/__tests__/DeleteGeoStory-test.jsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+
+import { getPluginForTest } from './pluginsTestUtils';
+
+import DeleteGeoStory from '../DeleteGeoStory';
+
+describe('DeleteGeoStory plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('displays the delete confirm dialog when enabled', () => {
+        const { Plugin } = getPluginForTest(DeleteGeoStory, {
+            controls: {
+                geostoryDelete: {
+                    enabled: true
+                }
+            }
+        });
+        ReactDOM.render(<Plugin/>, document.getElementById('container'));
+        const rootDiv = document.getElementById('confirm-dialog');
+        expect(rootDiv).toExist();
+    });
+});

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -39,6 +39,7 @@ export default {
         DashboardEditor: require('../plugins/DashboardEditor').default,
         DashboardsPlugin: require('../plugins/Dashboards').default,
         DeleteMapPlugin: require('../plugins/DeleteMap').default,
+        DeleteGeoStoryPlugin: require('../plugins/DeleteGeoStory').default,
         DetailsPlugin: require('../plugins/Details').default,
         DrawerMenuPlugin: require('../plugins/DrawerMenu').default,
         ExpanderPlugin: require('../plugins/Expander').default,

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -40,6 +40,7 @@ export default {
         DashboardsPlugin: require('../plugins/Dashboards').default,
         DeleteMapPlugin: require('../plugins/DeleteMap').default,
         DeleteGeoStoryPlugin: require('../plugins/DeleteGeoStory').default,
+        DeleteDashboardPlugin: require('../plugins/DeleteDashboard').default,
         DetailsPlugin: require('../plugins/Details').default,
         DrawerMenuPlugin: require('../plugins/DrawerMenu').default,
         ExpanderPlugin: require('../plugins/Expander').default,

--- a/web/client/reducers/__tests__/dashboards-test.js
+++ b/web/client/reducers/__tests__/dashboards-test.js
@@ -8,7 +8,7 @@
 import expect from 'expect';
 
 import dashboards from '../dashboards';
-import { setDashboardsAvailable, dashboardListLoaded, dashboardsLoading } from '../../actions/dashboards';
+import { setDashboardsAvailable, dashboardListLoaded, dashboardsLoading, setControl } from '../../actions/dashboards';
 
 
 describe('Test the dashboards reducer', () => {
@@ -41,5 +41,12 @@ describe('Test the dashboards reducer', () => {
         expect(state).toExist();
         expect(state.loading).toBe(true);
         expect(state.loadFlags.saving).toBe(true);
+    });
+    it('dashboards setControl', () => {
+        const action = setControl('delete.show', true);
+        const state = dashboards(undefined, action);
+        expect(state).toExist();
+        expect(state.controls).toExist();
+        expect(state.controls.delete.show).toBe(true);
     });
 });

--- a/web/client/reducers/dashboards.js
+++ b/web/client/reducers/dashboards.js
@@ -9,7 +9,7 @@
 import { MAPS_LIST_LOADING } from '../actions/maps';
 
 import { LOCATION_CHANGE } from 'connected-react-router';
-import { DASHBOARDS_LIST_LOADED, SET_DASHBOARDS_AVAILABLE, LOADING } from '../actions/dashboards';
+import { DASHBOARDS_LIST_LOADED, SET_DASHBOARDS_AVAILABLE, LOADING, SET_CONTROL } from '../actions/dashboards';
 import { set } from '../utils/ImmutableUtils';
 import { castArray } from 'lodash';
 
@@ -50,6 +50,10 @@ function dashboards(state = {
         return set(action.name === "loading" ? "loading" : `loadFlags.${action.name}`, action.value, set(
             "loading", action.value, state
         ));
+    }
+    case SET_CONTROL: {
+        const { control, value } = action;
+        return set(`controls.${control}`, value, state);
     }
     default:
         return state;

--- a/web/client/selectors/__tests__/dashboard-test.js
+++ b/web/client/selectors/__tests__/dashboard-test.js
@@ -8,6 +8,7 @@
 import expect from 'expect';
 
 import {
+    getDashboardId,
     isDashboardAvailable,
     isDashboardEditing,
     showConnectionsSelector,
@@ -114,6 +115,12 @@ describe('dashboard selectors', () => {
 
     it("test dashboardSaveServiceSelector", () => {
         expect(dashboardSaveServiceSelector({dashboard: {saveServiceLoading: true}})).toBe(true);
+    });
+    it("getDashboardId should return dashboard id in case it exists", () => {
+        expect(getDashboardId({dashboard: {resource: {id: '1234'}}})).toBe('1234');
+    });
+    it("getDashboardId should return undefined in case resource does not exists", () => {
+        expect(getDashboardId({dashboard: {resource: {}}})).toBe(undefined);
     });
 
 });

--- a/web/client/selectors/__tests__/dashboards-test.js
+++ b/web/client/selectors/__tests__/dashboards-test.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+
+import { Controls } from '../../utils/DashboardUtils';
+
+import {
+    controlSelectorCreator,
+    deleteDialogSelector
+} from '../dashboards';
+
+describe('dashboards selectors', () => {
+    it('controlSelectorCreator returns the value of the given control', () => {
+        const state = {dashboards: { controls: { 'delete': { show: true }}}};
+        expect(controlSelectorCreator(Controls.SHOW_DELETE)(state)).toBe(true);
+    });
+    it('deleteDialogSelector returns the value of the show attribute on the delete control', () => {
+        const state = {dashboards: { controls: { 'delete': { show: false }}}};
+        expect(deleteDialogSelector(state)).toBe(false);
+    });
+});

--- a/web/client/selectors/dashboard.js
+++ b/web/client/selectors/dashboard.js
@@ -5,11 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-
 import { createSelector } from 'reselect';
 import { pathnameSelector } from './router';
 
+export const getDashboardId = state => state?.dashboard?.resource?.id;
 export const isDashboardAvailable = state => state && state.dashboard && state.dashboard.editor && state.dashboard.editor.available;
 export const isShowSaveOpen = state => state && state.dashboard && state.dashboard.showSaveModal;
 export const isShowSaveAsOpen = state => state && state.dashboard && state.dashboard.showSaveAsModal;

--- a/web/client/selectors/dashboards.js
+++ b/web/client/selectors/dashboards.js
@@ -5,6 +5,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import get from 'lodash/get';
+import { Controls } from '../utils/DashboardUtils';
 
 
 export const searchTextSelector = state => state && state.dashboards && state.dashboards.searchText;
@@ -14,3 +16,15 @@ export const totalCountSelector = state => state && state.dashboards && state.da
 export const isLoadingSelector = state => state && state.dashboards && state.dashboards.loading;
 export const areDashboardsAvailable = state => state && state.dashboards && state.dashboards.available;
 export const isEditDialogOpen = state => state && state.dashboards && state.dashboards.showModal && state.dashboards.showModal.edit;
+/**
+ * Create a selector for the given control
+ * @param {string} control the control name
+ */
+export const controlSelectorCreator = control => state => get(state, `dashboards.controls.${control}`);
+
+/**
+ * Gets the state of the delete dialog
+ * @param {object} state the application state
+ * @returns the status of the delete dialog (if true the dialog is visible)
+ * */
+export const deleteDialogSelector = state => controlSelectorCreator(Controls.SHOW_DELETE)(state);

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -49,9 +49,10 @@ export const controlSelectorCreator = control => state => get(state, `geostory.c
 export const saveDialogSelector = state => controlSelectorCreator(Controls.SHOW_SAVE)(state);
 
 /**
- * Gets the state of the delete dialog ("save" or "saveAs" values typically identify what window is open)
+ * Gets the state of the delete dialog
  * @param {object} state the application state
- */
+ * @returns the status of the delete dialog (if true the dialog is visible)
+ * */
 export const deleteDialogSelector = state => controlSelectorCreator(Controls.SHOW_DELETE)(state);
 
 /**

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -49,6 +49,12 @@ export const controlSelectorCreator = control => state => get(state, `geostory.c
 export const saveDialogSelector = state => controlSelectorCreator(Controls.SHOW_SAVE)(state);
 
 /**
+ * Gets the state of the delete dialog ("save" or "saveAs" values typically identify what window is open)
+ * @param {object} state the application state
+ */
+export const deleteDialogSelector = state => controlSelectorCreator(Controls.SHOW_DELETE)(state);
+
+/**
  * Gets the resource for geostory (contains authorization and other useful information)
  * **NOTE** don't confuse this with the story resources. This is the single resource
  * of the whole geostory, containing permissions, id, and so on (e.g. the GeoStore resource)

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2067,7 +2067,8 @@
                 "showConnections": "Verbindungen anzeigen",
                 "hideConnections": "Verbindungen ausblenden"
             },
-            "emptyTitle": "Das Dashboard ist leer"
+            "emptyTitle": "Das Dashboard ist leer",
+            "delete": "Dashboard löschen"
         },
         "dashboardEmbedded": {
             "loadingSpinner": "Dashboard wird geladen",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2525,6 +2525,7 @@
             "zoomToContent": "Zum Inhalt zoomen",
             "addWebPageContent": "Webseitenabschnitt hinzufügen",
             "emptyTitle": "Diese GeoStory ist leer",
+            "delete": "Löschen geostory",
             "emptyDescription": "Erstellen Sie eine fantastische Geostory, indem Sie neuen Inhalt hinzufügen",
             "closeFullscreenMap": "Schließen der Vollbild-Karte",
             "showFullscreenMap": "Karte als Vollbild öffnen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2496,6 +2496,7 @@
             "addMediaContent": "Add Media Content",
             "addWebPageContent": "Add Web Page Content",
             "zoomToContent": "Zoom to content",
+            "delete": "Delete geostory",
             "emptyTitle": "This story is empty",
             "emptyDescription": "Start creating an awesome geostory by adding new content",
             "closeFullscreenMap": "Close fullscreen map",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2029,7 +2029,8 @@
                 "showConnections": "Show connections",
                 "hideConnections": "HideConnections"
             },
-            "emptyTitle": "The dashboard is empty"
+            "emptyTitle": "The dashboard is empty",
+            "delete": "Delete dashboard"
         },
         "dashboardEmbedded": {
             "loadingSpinner": "Loading Dashboard",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2029,7 +2029,8 @@
                 "showConnections": "Mostrar conexiones",
                 "hideConnections": "Ocultar conexiones"
             },
-            "emptyTitle": "El panel de control está vacío"
+            "emptyTitle": "El panel de control está vacío",
+            "delete": "Eliminar panel de control"
         },
         "dashboardEmbedded": {
             "loadingSpinner": "Cargando panel de control",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2487,6 +2487,7 @@
             "zoomToContent": "Zoom al contenido",
             "addWebPageContent": "Agregar contenido de página web",
             "emptyTitle": "Esta historia esta vacia",
+            "delete": "Eliminar geostory",
             "emptyDescription": "Comience a crear una increíble geografía agregando nuevo contenido",
             "closeFullscreenMap": "Cerrar mapa a pantalla completa",
             "showFullscreenMap": "Ver mapa en pantalla completa",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2030,7 +2030,8 @@
                 "showConnections": "Afficher les connexions",
                 "hideConnections": "Masquer les connexions"
             },
-            "emptyTitle": "Le tableau de bord est vide"
+            "emptyTitle": "Le tableau de bord est vide",
+            "delete": "Supprimer le tableau"
         },
         "dashboardEmbedded": {
             "loadingSpinner": "Chargement du tableau de bord",
@@ -2488,6 +2489,7 @@
             "zoomToContent": "Zoom sur le contenu",
             "addWebPageContent": "Ajouter du contenu de page web",
             "emptyTitle": "Cette story est vide",
+            "delete": "Supprimer geostory",
             "emptyDescription": "Commencer une story géniale en ajoutant du nouveau contenu",
             "closeFullscreenMap": "Fermer la carte plein écran",
             "showFullscreenMap": "Montrer la carte en plein écran",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2031,7 +2031,8 @@
                 "showConnections": "Mostra connessioni",
                 "hideConnections": "Nascondi connessioni"
             },
-            "emptyTitle": "La dashboard è vuota"
+            "emptyTitle": "La dashboard è vuota",
+            "delete": "Cancellare la dashboard"
         },
         "dashboardEmbedded": {
             "loadingSpinner": "Caricamento Dashboard",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2489,6 +2489,7 @@
             "zoomToContent": "Zoom al contenuto",
             "addWebPageContent": "Aggiungi contenuto alla pagina Web",
             "emptyTitle": "Questa storia è vuota",
+            "delete": "Cancellare geostory",
             "emptyDescription": "Inizia a creare una fantastica storia aggiungendo dei nuovi contenuti",
             "closeFullscreenMap": "Chiudi mappa",
             "showFullscreenMap": "Visualizza mappa a pieno schermo",

--- a/web/client/utils/DashboardUtils.js
+++ b/web/client/utils/DashboardUtils.js
@@ -1,0 +1,3 @@
+export const Controls = {
+    SHOW_DELETE: 'delete.show'
+};

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -64,6 +64,7 @@ export const Modes = {
 
 export const Controls = {
     SHOW_SAVE: 'save.show',
+    SHOW_DELETE: 'delete.show',
     LOADING: 'loading'
 };
 


### PR DESCRIPTION
## Description
This PR adds the functionality to remove a dashboard or a geostory from a BurgerMenu item when the logged in editor user is inside the given resource (geostory or dashboard)

https://user-images.githubusercontent.com/6906348/167625218-7538c137-67d5-4bcd-bf2a-23a627116586.mp4



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Currently there's no way of deleting a geostory or dashboard from within the given resource (being this only possible with maps)
<!-- You can also link to an existing issue here -->
#8170 

**What is the new behavior?**
This PR introduces the capability to trigger the removal of a geostory or a dashboard from the burgermenu inside the given resource.
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
