### PR TITLE
#7256 Replace urls in attribute values / feature editor plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
     "react-share": "1.15.1",
     "react-sidebar": "2.3.2",
     "react-spinkit": "2.1.2",
-    "react-string-replace": "^1.1.0",
+    "react-string-replace": "1.1.0",
     "react-swipeable": "5.5.1",
     "react-swipeable-views": "0.12.2",
     "react-textfit": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -257,6 +257,7 @@
     "react-share": "1.15.1",
     "react-sidebar": "2.3.2",
     "react-spinkit": "2.1.2",
+    "react-string-replace": "^1.1.0",
     "react-swipeable": "5.5.1",
     "react-swipeable-views": "0.12.2",
     "react-textfit": "1.1.0",

--- a/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
+++ b/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
@@ -26,6 +26,18 @@ describe('Tests for the formatter functions', () => {
         expect(formatter({value: null})).toBe(null);
         expect(formatter({value: undefined})).toBe(null);
     });
+    it('test getFormatter for string', () => {
+        const value = 'Test https://google.com with google link';
+        const formatter = getFormatter({localType: "string"});
+        expect(typeof formatter).toBe("function");
+        expect(formatter()).toBe(null);
+        expect(formatter({value: 'Test no links'})[0]).toBe('Test no links');
+        expect(formatter({value})[0]).toBe('Test ');
+        expect(formatter({value})[1].props.href).toBe('https://google.com');
+        expect(formatter({value})[2]).toBe(' with google link');
+        expect(formatter({value: null})).toBe(null);
+        expect(formatter({value: undefined})).toBe(null);
+    });
     it('test getFormatter for number', () => {
         const formatter = getFormatter({localType: "number"});
         expect(typeof formatter).toBe("function");

--- a/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
+++ b/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
@@ -12,10 +12,6 @@ import NumberFormat from '../../../../I18N/Number';
 import {getFormatter} from '../index';
 
 describe('Tests for the formatter functions', () => {
-    it('test getFormatter for strings', () => {
-        const formatter = getFormatter({localType: "string"});
-        expect(formatter).toBe(null);
-    });
     it('test getFormatter for booleans', () => {
         const formatter = getFormatter({localType: "boolean"});
         expect(typeof formatter).toBe("function");
@@ -26,7 +22,7 @@ describe('Tests for the formatter functions', () => {
         expect(formatter({value: null})).toBe(null);
         expect(formatter({value: undefined})).toBe(null);
     });
-    it('test getFormatter for string', () => {
+    it('test getFormatter for strings', () => {
         const value = 'Test https://google.com with google link';
         const formatter = getFormatter({localType: "string"});
         expect(typeof formatter).toBe("function");

--- a/web/client/components/data/featuregrid/formatters/index.js
+++ b/web/client/components/data/featuregrid/formatters/index.js
@@ -8,6 +8,7 @@
 
 import { isNil } from 'lodash';
 import React from 'react';
+import reactStringReplace from "react-string-replace";
 
 import NumberFormat from '../../../I18N/Number';
 
@@ -16,6 +17,10 @@ export const getFormatter = (desc) => {
         return ({value} = {}) => !isNil(value) ? <span>{value.toString()}</span> : null;
     } else if (['int', 'number'].includes(desc.localType)) {
         return ({value} = {}) => !isNil(value) ? <NumberFormat value={value} numberParams={{maximumFractionDigits: 17}}/> : null;
+    } else if (desc.localType === 'string') {
+        return ({value} = {}) => reactStringReplace(value, /(https?:\/\/\S+)/g, (match, i) => (
+            <a key={match + i} href={match} target={"_blank"}>{match}</a>
+        ));
     } else if (desc.localType === 'Geometry') {
         return () => null;
     }

--- a/web/client/components/data/featuregrid/formatters/index.js
+++ b/web/client/components/data/featuregrid/formatters/index.js
@@ -18,9 +18,9 @@ export const getFormatter = (desc) => {
     } else if (['int', 'number'].includes(desc.localType)) {
         return ({value} = {}) => !isNil(value) ? <NumberFormat value={value} numberParams={{maximumFractionDigits: 17}}/> : null;
     } else if (desc.localType === 'string') {
-        return ({value} = {}) => reactStringReplace(value, /(https?:\/\/\S+)/g, (match, i) => (
+        return ({value} = {}) => !isNil(value) ? reactStringReplace(value, /(https?:\/\/\S+)/g, (match, i) => (
             <a key={match + i} href={match} target={"_blank"}>{match}</a>
-        ));
+        )) : null;
     } else if (desc.localType === 'Geometry') {
         return () => null;
     }


### PR DESCRIPTION
## Description
Feature editor grid didn't have urls in text properly replaced by a clickable links.
This PR aims to change this behavior and make urls replaced with clickable links in grid cells with "string" formatter.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7256 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
