### PR TITLE
#8148: Fix geometry draw and modify from featuregrid

### DIFF
--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -828,6 +828,7 @@ export const closeRightPanelOnFeatureGridOpen = (action$, store) =>
  */
 export const onFeatureGridGeometryEditing = (action$, store) => action$.ofType(GEOMETRY_CHANGED)
     .filter(a => a.owner === "featureGrid")
+    .delay(500) // delay to avoid race condition in draw interactions
     .switchMap( (a) => {
         const state = store.getState();
         const defaultFeatureProj = getDefaultFeatureProjection();


### PR DESCRIPTION
## Description
PR fixes the issue with geometry creation and modification from featuregrid

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#8148 

**What is the new behavior?**
Once a new geometry is drawn the same can be modified after.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
