### PR TITLE
Fixes #8184 BurgerMenu missing target

### DIFF
--- a/web/client/plugins/BurgerMenu.jsx
+++ b/web/client/plugins/BurgerMenu.jsx
@@ -34,8 +34,8 @@ const InnerContainer = ({children, ...props}) => (
     </div>
 );
 
-const AnchorElement = ({children, href, onClick}) => (
-    <a href={href} onClick={onClick}>{children}</a>
+const AnchorElement = ({children, href, target, onClick}) => (
+    <a href={href} target={target} onClick={onClick}>{children}</a>
 );
 
 import ToolsContainer from './containers/ToolsContainer';


### PR DESCRIPTION
## Description
Fixes #8184 

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue

**What is the current behavior?**
The BurgerMenu plugin ignores target attribute
#8184 

**What is the new behavior?**
The BurgerMenu plugin attaches the target attribute to the link

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No