### PR TITLE
Make annotations reset drawing status on map info purge only if they were owner of the drawing

### DIFF
--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -388,6 +388,7 @@ export default {
             ]);
         }),
     purgeMapInfoEpic: (action$, store) => action$.ofType( PURGE_MAPINFO_RESULTS)
+        .filter(() => get(store.getState(), 'draw.drawOwner', '') === ANNOTATIONS)
         .switchMap(() => {
             return Rx.Observable.from([
                 changeDrawingStatus("clean", store.getState().annotations.featureType || '', ANNOTATIONS, [], {})


### PR DESCRIPTION
## Description
Annotation will reset drawing status on map info purge only if they were owner of the drawing interaction prior to the purge.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
There might be a problem when another drawing tool is controllable by identify status and if drawing tool controls identify status.
Without this change following scenario was possible:
User toggles on Identify (Map information) in toolbar -> User click on a tool that starts drawing interaction -> Identify is disabled to prevent conflicts -> Annotations run draw cleanup -> Drawing ownership changes while it shouldn't.

**What is the new behavior?**
Drawing ownership will not change.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
