### PR TITLE
Do not crash on unregister event for a non-existing branch of state

### DIFF
--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -133,7 +133,7 @@ function mapConfig(state = {eventListeners: {}}, action) {
     case UNREGISTER_EVENT_LISTENER: {
         let data = state;
         if (state?.eventListeners) {
-            const filteredEventNameTools = state.eventListeners[action.eventName].filter(tool => tool !== action.toolName) || [];
+            const filteredEventNameTools = (state.eventListeners && state.eventListeners[action.eventName] || []).filter(tool => tool !== action.toolName) || [];
             data = assign({}, state,
                 {eventListeners: assign({}, state.eventListeners,
                     {[action.eventName]: filteredEventNameTools})});


### PR DESCRIPTION
## Description
There is an issue that makes all epics crash in case if plugin or extension tries to unregister event of a type that was not registered before. This fix adds a proper check and prevents such issue.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
- All epics will crash if described case appear

**What is the new behavior?**
Empty array will be written for the passed event type.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
