### PR TITLE
#8202: Cesium ThirdParty libraries added to bundle

### DIFF
--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -164,7 +164,8 @@ module.exports = (...args) => mapArgumentsToObject(args, ({
         new CopyWebpackPlugin([
             { from: path.join(getCesiumPath({ paths, prod }), 'Workers'), to: path.join(paths.dist, 'cesium', 'Workers') },
             { from: path.join(getCesiumPath({ paths, prod }), 'Assets'), to: path.join(paths.dist, 'cesium', 'Assets') },
-            { from: path.join(getCesiumPath({ paths, prod }), 'Widgets'), to: path.join(paths.dist, 'cesium', 'Widgets') }
+            { from: path.join(getCesiumPath({ paths, prod }), 'Widgets'), to: path.join(paths.dist, 'cesium', 'Widgets') },
+            { from: path.join(getCesiumPath({ paths, prod }), 'ThirdParty'), to: path.join(paths.dist, 'cesium', 'ThirdParty') }
         ]),
         new ProvidePlugin({
             Buffer: ['buffer', 'Buffer']


### PR DESCRIPTION
## Description
This PR adds `ThirdParty` libraries of cesium to webpack bundle. This adds `draco decoder` to parse certain 3d tiles

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#8202 

**What is the new behavior?**
The 3d tiles are parsed correctly and displayed in map

**Note for tester**
_Example_
1. Import this [map](https://github.com/geosolutions-it/MapStore2-C040/files/8563499/map.zip) and switch to 3d
2. Toggle layer visibility of `fortebegato` to view on map (the 3d tiles are not configured properly hence the position and offset issue, so kindly ignore)
3. Layer is visible on the 3d map and tiles are rendered 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
