### PR TITLE
Porting part of the changes from #7881 to the target branch to make standard print items configurable using localConfig/ print plugin config in context

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -374,7 +374,8 @@ export default {
                         const {validations, ...options } = opts;
                         const Comp = item.component ?? item.plugin;
                         const {style, ...other} = this.props;
-                        return <Comp role="body" {...other} {...item.cfg} {...options} validation={validations?.[item.id ?? item.name]}/>;
+                        const itemOptions = this.props[item.id + "Options"];
+                        return <Comp role="body" {...other} {...item.cfg} {...options} {...itemOptions} validation={validations?.[item.id ?? item.name]}/>;
                     };
                     renderItems = (target, options) => {
                         return this.getItems(target)

--- a/web/client/plugins/print/index.js
+++ b/web/client/plugins/print/index.js
@@ -141,6 +141,13 @@ export const standardItems = {
         plugin: Description,
         cfg: {},
         position: 2
+    }, {
+        id: "overlayLayers",
+        plugin: AdditionalLayers,
+        cfg: {
+            enabled: false
+        },
+        position: 5
     }],
     "left-panel-accordion": [{
         id: "layout",
@@ -156,13 +163,6 @@ export const standardItems = {
             "title": "print.legendoptions"
         },
         position: 2
-    }, {
-        id: "overlayLayers",
-        plugin: AdditionalLayers,
-        cfg: {
-            enabled: false
-        },
-        position: 5
     }],
     "right-panel": [{
         id: "resolution",


### PR DESCRIPTION
## Description
Title is pretty descriptive. #7881 was merged only to the master and it is missing in 2022.01.xx that was a source branch for 2022.01.xx-geOrchestra. That PR contains minor but important change that makes it's possible to override default configuration of standard print item with config passed via localConfig or print plugin configuration inside of the context.
This item also solves issue when overlayLayers checkbox was incorrectly put into accordion list upon resolving merge conflict.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Overlay layers are missing on geOrchestra because of the missing support of

**What is the new behavior?**
Visibility option can be overridden in localConfig/context properly

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
