### PR TITLE
Making chart in sync with the map when map is saved

### DIFF
--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -8,7 +8,7 @@
 
 import expect from 'expect';
 import {head} from 'lodash';
-import { loadMapConfigAndConfigureMap, loadMapInfoEpic } from '../config';
+import {calculateBboxOnConfigureMap, loadMapConfigAndConfigureMap, loadMapInfoEpic} from '../config';
 import {LOAD_USER_SESSION} from '../../actions/usersession';
 import {
     loadMapConfig,
@@ -17,8 +17,10 @@ import {
     LOAD_MAP_INFO,
     MAP_INFO_LOADED,
     MAP_INFO_LOAD_START,
-    loadMapInfo
+    loadMapInfo,
+    configureMap
 } from '../../actions/config';
+import {CHANGE_MAP_VIEW} from "../../actions/map";
 
 import { testEpic } from './epicTestUtils';
 import Persistence from '../../api/persistence';
@@ -276,6 +278,37 @@ describe('config epics', () => {
             testEpic(loadMapInfoEpic,
                 2,
                 loadMapInfo(1234),
+                checkActions
+            );
+        });
+    });
+
+    describe('calculateBboxOnConfigureMap', () => {
+        Persistence.addApi("testConfig", api);
+        beforeEach(() => {
+            Persistence.setApi("testConfig");
+        });
+        afterEach(() => {
+            Persistence.setApi("geostore");
+        });
+
+        it('calculate bbox on map config loaded', (done) => {
+            const config = {
+                map: {
+                    center: { x: 0, y: 0, crs: "EPSG:4326" },
+                    zoom: 8,
+                    projection: 'EPSG:900913'
+                }
+            };
+
+            const checkActions = ([a]) => {
+                expect(a).toExist();
+                expect(a.type).toBe(CHANGE_MAP_VIEW);
+                done();
+            };
+            testEpic(calculateBboxOnConfigureMap,
+                1,
+                configureMap(config, 1, false),
                 checkActions
             );
         });

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -21,13 +21,14 @@ import {
     loadMapConfig,
     loadMapInfo
 } from '../actions/config';
-import { zoomToExtent } from '../actions/map';
+import {changeMapView, zoomToExtent} from '../actions/map';
 import Persistence from '../api/persistence';
 import { isLoggedIn, userSelector } from '../selectors/security';
 import { projectionDefsSelector } from '../selectors/map';
 import {loadUserSession, USER_SESSION_LOADED, userSessionStartSaving, saveMapConfig} from '../actions/usersession';
 import {userSessionEnabledSelector, buildSessionName} from "../selectors/usersession";
 import {getRequestParameterValue} from "../utils/QueryParamsUtils";
+import {getBbox} from "../utils/MapUtils";
 
 
 const prepareMapConfiguration = (data, override, state) => {
@@ -158,6 +159,14 @@ export const zoomToMaxExtentOnConfigureMap = action$ =>
         .filter(action => !!action.zoomToExtent)
         .delay(300) // without the delay the map zoom will not change
         .map(({config, zoomToExtent: extent}) => zoomToExtent(extent.bounds, extent.crs || get(config, 'map.projection')));
+
+export const calculateBboxOnConfigureMap = action$ =>
+    action$.ofType(MAP_CONFIG_LOADED)
+        .map(({config}) => {
+            const { center, zoom, size, mapStateSource, projection, viewerOptions, resolution } = (config?.map ?? {});
+            const bbox = getBbox(center, zoom);
+            return changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions, resolution);
+        });
 
 export const loadMapInfoEpic = action$ =>
     action$.ofType(LOAD_MAP_INFO)


### PR DESCRIPTION
## Description
Map save making map configuration reload into state, saved map doesn't contain information about bounding box of the viewport.
This PR adds an extra "CHANGE_MAP_VIEW" action dispatched after map config is loaded that doesn't really change anything, but only adds calculated bbox to the state.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7778 

**What is the new behavior?**
Charts become in sync after map save

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
