### PR TITLE
Fix for the printing of overlay layers & inability to open feature editor in some cases

### DIFF
--- a/web/client/epics/maplayout.js
+++ b/web/client/epics/maplayout.js
@@ -172,13 +172,13 @@ export const updateActiveDockEpic = (action$, store) =>
     action$.ofType(SET_CONTROL_PROPERTIES, SET_CONTROL_PROPERTY, TOGGLE_CONTROL, UPDATE_DOCK_PANELS)
         .filter(({
             control, property, properties = [],
-            type}) => {
+            type, action}) => {
             let assertion = false;
             const state = store.getState();
             const controlState = state?.controls[control]?.enabled;
             switch (type) {
             case UPDATE_DOCK_PANELS:
-                return true;
+                return action === 'add';
             case SET_CONTROL_PROPERTY:
             case TOGGLE_CONTROL:
                 assertion = (property === 'enabled' || !property) && controlState;

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -589,7 +589,16 @@ export default {
                     pdfUrl,
                     error,
                     map,
-                    layers: [...layers.filter(l => !l.loadingError), ...(printSpec?.additionalLayers ? additionalLayers.map(l => l.options).filter(l => !l.loadingError) : [])],
+                    layers: [
+                        ...layers.filter(l => !l.loadingError),
+                        ...(printSpec?.additionalLayers ? additionalLayers.map(l => l.options).filter(
+                            l => {
+                                const isVector = l.type === 'vector';
+                                const hasFeatures = Array.isArray(l.features) && l.features.length > 0;
+                                return !l.loadingError && (!isVector || (isVector && hasFeatures));
+                            }
+                        ) : [])
+                    ],
                     scales,
                     usePreview,
                     currentLocale,


### PR DESCRIPTION
## Description
- Fix issue of print with overlays when empty vector layer caused an error
- Fix inability to open featuregrid when cadastrapp is open by extra check in epic.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
[#530](https://github.com/georchestra/mapstore2-georchestra/issues/530)

**What is the new behavior?**
- Feature editor can be open when there is a removal action for dock panel list.
- Print works fine if additional layers have vector layers with no features.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
