### PR TITLE
Use annotations-like styling for printing of the vector layers

### DIFF
--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -128,7 +128,7 @@ export const hasOutline = (style) => {
 
 export const annStyleToOlStyle = (type, tempStyle, label = "") => {
     let style = tempStyle && tempStyle[type] ? tempStyle[type] : tempStyle;
-    const s = style;
+    const s = style ?? {};
     const dashArray = s.dashArray ? getDashArrayFromStyle(s.dashArray) : "solid";
     switch (type) {
     case "MultiPolygon":

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -579,7 +579,8 @@ export const specCreators = {
             },
             geoJson: reprojectGeoJson({
                 type: "FeatureCollection",
-                features: annotationsToPrint(layer.features)
+                features: (isAnnotationLayer(layer) || !layer.style) ? annotationsToPrint(layer.features)
+                    : layer.features.map( f => ({...f, properties: {...f.properties, ms_style: f && f.geometry && f.geometry.type && f.geometry.type.replace("Multi", "") || 1}}))
             },
             "EPSG:4326",
             spec.projection)

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -579,8 +579,7 @@ export const specCreators = {
             },
             geoJson: reprojectGeoJson({
                 type: "FeatureCollection",
-                features: isAnnotationLayer(layer) && annotationsToPrint(layer.features) ||
-                                layer.features.map( f => ({...f, properties: {...f.properties, ms_style: f && f.geometry && f.geometry.type && f.geometry.type.replace("Multi", "") || 1}}))
+                features: annotationsToPrint(layer.features)
             },
             "EPSG:4326",
             spec.projection)


### PR DESCRIPTION
## Description
This PR makes printed vector layer looks same as they are rendered on the map.
- Vector layer with global style defined on the layer level will use it.
- Vector layer where each feature is styled individually - will use annotations approach to style each feature collection or feature.

![изображение](https://user-images.githubusercontent.com/4226620/169516317-711f03dc-725f-4adf-a615-9c882a2fcb11.png)


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8216 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
