### PR TITLE
Using 'vh' units instead of % to prevent calculations issue on layout…

### DIFF
--- a/web/client/plugins/SidebarMenu.jsx
+++ b/web/client/plugins/SidebarMenu.jsx
@@ -116,8 +116,8 @@ class SidebarMenu extends React.Component {
     }
 
     getStyle = (style) => {
-        const hasBottomOffset = parseInt(style?.bottom, 10) !== 0;
-        return { ...style, height: hasBottomOffset ? 'auto' : '100%', maxHeight: style?.height ?? null, bottom: hasBottomOffset ? `calc(${style.bottom} + 30px)` : null };
+        const hasBottomOffset = style?.dockSize > 0;
+        return { ...style, height: hasBottomOffset ? 'auto' : '100%', maxHeight: style?.height ?? null, bottom: hasBottomOffset ? `calc(${style.dockSize}vh + 30px)` : null };
     };
 
     getPanels = () => {
@@ -268,7 +268,7 @@ class SidebarMenu extends React.Component {
 const sidebarMenuSelector = createSelector([
     state => state,
     state => lastActiveToolSelector(state),
-    state => mapLayoutValuesSelector(state, {bottom: true, height: true}),
+    state => mapLayoutValuesSelector(state, {dockSize: true, bottom: true, height: true}),
     sidebarIsActiveSelector
 ], (state, lastActiveTool, style, isActive) => ({
     style,


### PR DESCRIPTION
## Description
Using 'vh' units instead of % to prevent calculations issue on layouts where map containers is not 100% of the window height

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Sidebar height is not calculated correctly e.g. in geOrchestra with header.

**What is the new behavior?**
Proper calculation of sidebar height in environments where map container is not 100% height of the screen

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
