### PR TITLE
fixes #7554 annotations circle radius changing

### DIFF
--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -284,18 +284,10 @@ describe('annotations Epics', () => {
     it('set style', (done) => {
         store.subscribe(() => {
             const actions = store.getActions();
-            const state = {
-                annotations: {
-                    config: {
-                        geodesic: true
-                    }
-                }
-            };
             if (actions.length >= 2) {
                 expect(actions[0].type).toBe(SET_STYLE);
                 expect(actions[1].type).toBe(CHANGE_DRAWING_STATUS);
                 expect(actions[1].status).toBe("updateStyle");
-                expect(state.annotations.config.geodesic).toBe(true);
                 done();
             }
         });
@@ -1050,6 +1042,45 @@ describe('annotations Epics', () => {
         const action = selectFeatures([ft]);
         store.dispatch(action);
 
+    });
+    it('clicked on map selecting a Circle ', (done) => {
+        store = mockStore( {
+            ...defaultState,
+            annotations: {
+                ...defaultState.annotations,
+                config: {
+                    geodesic: true
+                },
+                editing: {
+                    ...defaultState.annotations.editing,
+                    features: [{
+                        type: "Feature",
+                        geometry: {
+                            type: "Polygon",
+                            coordinates: [[[1, 2], [1, 3], [1, undefined], [1, 5], [1, 2]]]
+                        },
+                        properties: {
+                            id: "is a circle",
+                            isCircle: true
+                        }
+                    }
+                    ]
+
+                }
+            }
+        } );
+
+        store.subscribe(() => {
+            const actions = store.getActions();
+            if (actions.length >= 3) {
+                expect(actions[1].type).toBe(CHANGE_DRAWING_STATUS);
+                expect(actions[2].type).toBe(CHANGE_DRAWING_STATUS);
+                expect(actions[2].options.geodesic).toBe(true);
+                done();
+            }
+        });
+        const action = selectFeatures([ft]);
+        store.dispatch(action);
     });
     it('changed the radius from the coordinate editor ', (done) => {
         store = mockStore( defaultState );

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -51,6 +51,7 @@ import { toggleControl, SET_CONTROL_PROPERTY } from '../../actions/controls';
 import { STYLE_POINT_MARKER } from '../../utils/AnnotationsUtils';
 import annotationsEpics from '../annotations';
 import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
+import config from '../../components/geostory/contents/texteditor/getLinkDecorator';
 
 const {
     addAnnotationsLayerEpic, editAnnotationEpic, removeAnnotationEpic, saveAnnotationEpic, setEditingFeatureEpic, newAnnotationEpic, addAnnotationEpic,
@@ -284,10 +285,20 @@ describe('annotations Epics', () => {
     it('set style', (done) => {
         store.subscribe(() => {
             const actions = store.getActions();
+            const state = {
+                annotations: {
+                    config: {
+                        geodesic: true
+                    },
+
+                },
+
+            };
             if (actions.length >= 2) {
                 expect(actions[0].type).toBe(SET_STYLE);
                 expect(actions[1].type).toBe(CHANGE_DRAWING_STATUS);
                 expect(actions[1].status).toBe("updateStyle");
+                expect(state.annotations.config.geodesic).toBe(true)
                 done();
             }
         });

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -51,7 +51,6 @@ import { toggleControl, SET_CONTROL_PROPERTY } from '../../actions/controls';
 import { STYLE_POINT_MARKER } from '../../utils/AnnotationsUtils';
 import annotationsEpics from '../annotations';
 import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
-import config from '../../components/geostory/contents/texteditor/getLinkDecorator';
 
 const {
     addAnnotationsLayerEpic, editAnnotationEpic, removeAnnotationEpic, saveAnnotationEpic, setEditingFeatureEpic, newAnnotationEpic, addAnnotationEpic,

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -1057,7 +1057,7 @@ describe('annotations Epics', () => {
                         type: "Feature",
                         geometry: {
                             type: "Polygon",
-                            coordinates: [[[1, 2], [1, 3], [1, undefined], [1, 5], [1, 2]]]
+                            coordinates: [[[1, 2], [1, 3], [1, 1], [1, 5], [1, 2]]]
                         },
                         properties: {
                             id: "is a circle",

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -288,16 +288,14 @@ describe('annotations Epics', () => {
                 annotations: {
                     config: {
                         geodesic: true
-                    },
-
-                },
-
+                    }
+                }
             };
             if (actions.length >= 2) {
                 expect(actions[0].type).toBe(SET_STYLE);
                 expect(actions[1].type).toBe(CHANGE_DRAWING_STATUS);
                 expect(actions[1].status).toBe("updateStyle");
-                expect(state.annotations.config.geodesic).toBe(true)
+                expect(state.annotations.config.geodesic).toBe(true);
                 done();
             }
         });

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -123,7 +123,7 @@ const validateFeatureCollection = (feature) => {
  * @return {boolean}
  */
 const getGeodesicProperty = (state) => {
-    return get(state.annotations, "config.geodesic");
+    return get(state.annotations, "config.geodesic", false);
 };
 
 const getSelectDrawStatus = (state) => {
@@ -154,7 +154,7 @@ const getReadOnlyDrawStatus = (state) => {
         translateEnabled: false,
         drawEnabled: false,
         transformToFeatureCollection: true,
-        geodesic: getGeodesicProperty(state, state.draw.drawMethod)
+        geodesic: getGeodesicProperty(state)
     };
     feature = validateFeatureCollection(feature);
     return changeDrawingStatus("drawOrEdit", state.draw.drawMethod, ANNOTATIONS, [feature], drawOptions, feature.style);
@@ -173,7 +173,7 @@ const getEditingGeomDrawStatus = (state) => {
         addClickCallback: true,
         useSelectedStyle: true,
         transformToFeatureCollection: true,
-        geodesic: getGeodesicProperty(state, state.draw.drawMethod)
+        geodesic: getGeodesicProperty(state)
     };
     feature = validateFeatureCollection(feature);
     return changeDrawingStatus("drawOrEdit", state.draw.drawMethod, ANNOTATIONS, [feature], drawOptions, feature.style);
@@ -264,7 +264,7 @@ export default {
                 selectEnabled: true,
                 drawEnabled: false,
                 transformToFeatureCollection: true,
-                geodesic: getGeodesicProperty(state, type)
+                geodesic: getGeodesicProperty(state)
             };
             const isMeasureType = feature.properties?.type === MEASURE_TYPE || false;
             let actions = [
@@ -327,7 +327,7 @@ export default {
                     useSelectedStyle: true,
                     transformToFeatureCollection: true,
                     addClickCallback: true,
-                    geodesic: getGeodesicProperty(state, type)
+                    geodesic: getGeodesicProperty(state)
                 };
 
                 return Rx.Observable.from([
@@ -414,7 +414,7 @@ export default {
                 defaultTextAnnotation,
                 transformToFeatureCollection: true,
                 addClickCallback: true,
-                geodesic: getGeodesicProperty(state, type)
+                geodesic: getGeodesicProperty(state)
             };
             return Rx.Observable.of(changeDrawingStatus("drawOrEdit", type, ANNOTATIONS, [feature], drawOptions, assign({}, feature.style, {highlight: false})));
         }),
@@ -615,7 +615,7 @@ export default {
                 drawEnabled: false,
                 transformToFeatureCollection: true,
                 addClickCallback: true,
-                geodesic: getGeodesicProperty(state, method)
+                geodesic: getGeodesicProperty(state)
             }, assign({}, style, {highlight: false}));
             return Rx.Observable.of(action);
         }),
@@ -740,7 +740,7 @@ export default {
                 useSelectedStyle: true,
                 transformToFeatureCollection: true,
                 addClickCallback: true,
-                geodesic: getGeodesicProperty(state, method)
+                geodesic: getGeodesicProperty(state)
             }, assign({}, style, {highlight: false}));
             return Rx.Observable.of( changeDrawingStatus("clean"), action);
         }),

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -122,8 +122,8 @@ const validateFeatureCollection = (feature) => {
  * @param drawMethod
  * @return {boolean}
  */
-const getGeodesicProperty = (state, drawMethod = "Circle") => {
-    return drawMethod === "Circle" && get(state.annotations, "config.geodesic", false);
+const getGeodesicProperty = (state) => {
+    return get(state.annotations, "config.geodesic");
 };
 
 const getSelectDrawStatus = (state) => {
@@ -137,7 +137,7 @@ const getSelectDrawStatus = (state) => {
         drawEnabled: false,
         translateEnabled: false,
         transformToFeatureCollection: true,
-        geodesic: getGeodesicProperty(state, state.draw.drawMethod)
+        geodesic: getGeodesicProperty(state)
     };
 
     feature = validateFeatureCollection(feature);


### PR DESCRIPTION
## Description
* This PR fixes annotations - circle radius changing when users clicks on a different geometries in the list

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
* #7554
* Circle radius changes when user switch to another geometry and then back to the circle.


**What is the new behavior?**
* Circle is rendered with the consistent radius.
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
