### PR TITLE
#8225 Making annotations not toggled but forcefully activated whenever measurements are saved as annotation

### DIFF
--- a/web/client/epics/__tests__/measurement-test.jsx
+++ b/web/client/epics/__tests__/measurement-test.jsx
@@ -104,7 +104,7 @@ describe('measurement epics', () => {
                 addAnnotation(features, textLabels, uom, false, {id: 1})
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
-                expect(actions[0].type).toBe("TOGGLE_CONTROL");
+                expect(actions[0].type).toBe("SET_CONTROL_PROPERTY");
                 expect(actions[1].type).toBe("ANNOTATIONS:NEW");
                 expect(actions[2].type).toBe("MEASUREMENT:SET_MEASUREMENT_CONFIG");
                 expect(actions[2].property).toBe("exportToAnnotation");

--- a/web/client/epics/measurement.js
+++ b/web/client/epics/measurement.js
@@ -22,13 +22,12 @@ import {
 import {addLayer} from '../actions/layers';
 import {STYLE_TEXT} from '../utils/AnnotationsUtils';
 import {
-    toggleControl,
     setControlProperty,
     SET_CONTROL_PROPERTY,
     TOGGLE_CONTROL
 } from '../actions/controls';
 import {purgeMapInfoResults, hideMapinfoMarker} from '../actions/mapInfo';
-import {measureSelector} from '../selectors/controls';
+import {createControlEnabledSelector, measureSelector} from '../selectors/controls';
 import {geomTypeSelector, isActiveSelector} from '../selectors/measurement';
 import {CLICK_ON_MAP, registerEventListener, unRegisterEventListener} from '../actions/map';
 import {
@@ -40,7 +39,7 @@ import {
 import {updateDockPanelsList} from "../actions/maplayout";
 import {shutdownToolOnAnotherToolDrawing} from "../utils/ControlUtils";
 
-export const addAnnotationFromMeasureEpic = (action$) =>
+export const addAnnotationFromMeasureEpic = (action$, store) =>
     action$.ofType(ADD_MEASURE_AS_ANNOTATION)
         .switchMap((a) => {
             // transform measure feature into geometry collection
@@ -53,12 +52,12 @@ export const addAnnotationFromMeasureEpic = (action$) =>
                 visibility
             };
 
-            return Rx.Observable.of(
-                toggleControl('annotations', null),
+            return Rx.Observable.from([
+                ...(createControlEnabledSelector('annotations')(store.getState()) ? [] : [setControlProperty('annotations', 'enabled', true)]),
                 newAnnotation(),
                 setMeasurementConfig("exportToAnnotation", false),
                 setEditingFeature(newFeature)
-            );
+            ]);
         });
 
 export const addAsLayerEpic = (action$) =>


### PR DESCRIPTION
## Description
This PR changes behavior of "Save as annotation" tool of the measure plugin to make it not toggle annotations dock but activate it only when it is closed

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8225 

**What is the new behavior?**
Annotations dock state is properly controlled

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
