### PR TITLE
[Backport 2022.01.xx] #8136: Default switch maptype from 3d (#8144)

### DIFF
--- a/web/client/epics/__tests__/globeswitcher-test.js
+++ b/web/client/epics/__tests__/globeswitcher-test.js
@@ -42,7 +42,7 @@ describe('globeswitcher Epics', () => {
             actions.map((action) => {
                 switch (action.type) {
                 case MAP_TYPE_CHANGED:
-                    expect(action.mapType).toBe("leaflet");
+                    expect(action.mapType).toBe("openlayers");
                     break;
                 default:
                     expect(true).toBe(false);
@@ -51,7 +51,7 @@ describe('globeswitcher Epics', () => {
             });
             done();
         }, {
-            globeswitcher: { last2dMapType: "leaflet" }
+            mapType: { last2dMapType: null }
         });
     });
 });

--- a/web/client/epics/__tests__/maptype-test.js
+++ b/web/client/epics/__tests__/maptype-test.js
@@ -61,6 +61,20 @@ describe('maptype epics', () => {
             done();
         }, STATE_3D);
     });
+    it('restore default last2d cesium when changing location from a 3d mode', (done) => {
+        const STATE_3D = {
+            maptype: {
+                mapType: "cesium",
+                last2dMapType: null
+            }
+        };
+        testEpic(restore2DMapTypeOnLocationChange, NUM_ACTIONS, onLocationChanged({pathname: "/"}, "PUSH" ), (actions) => {
+            expect(actions.length).toEqual(NUM_ACTIONS);
+            expect(actions[0].type).toEqual(MAP_TYPE_CHANGED);
+            expect(actions[0].mapType).toEqual("openlayers");
+            done();
+        }, STATE_3D);
+    });
     it('update location when map type changes', (done) => {
         const STATE = {
             maptype: {

--- a/web/client/selectors/__tests__/maptype-test.js
+++ b/web/client/selectors/__tests__/maptype-test.js
@@ -9,7 +9,14 @@
 
 import expect from 'expect';
 
-import { mapTypeSelector, isCesium, isOpenlayers, isLeaflet, mapTypeLoadedSelector } from '../maptype';
+import {
+    mapTypeSelector,
+    isCesium,
+    isOpenlayers,
+    isLeaflet,
+    mapTypeLoadedSelector,
+    last2dMapTypeSelector
+} from '../maptype';
 
 describe('Test maptype', () => {
     it('test mapTypeSelector default', () => {
@@ -57,5 +64,23 @@ describe('Test maptype', () => {
         });
         expect(state).toExist();
         expect(state).toEqual({"openlayers": true});
+    });
+    it('test default last2dMapTypeSelector', () => {
+        const state = last2dMapTypeSelector({
+            maptype: {
+                last2dMapType: null
+            }
+        });
+        expect(state).toExist();
+        expect(state).toEqual("openlayers");
+    });
+    it('test last2dMapTypeSelector', () => {
+        const state = last2dMapTypeSelector({
+            maptype: {
+                last2dMapType: "leaflet"
+            }
+        });
+        expect(state).toExist();
+        expect(state).toEqual("leaflet");
     });
 });

--- a/web/client/selectors/maptype.js
+++ b/web/client/selectors/maptype.js
@@ -34,4 +34,4 @@ export const isCesium = state => mapTypeSelector(state) === "cesium";
 export const isLeaflet = state => mapTypeSelector(state) === "leaflet";
 export const isOpenlayers = state => mapTypeSelector(state) === "openlayers";
 
-export const last2dMapTypeSelector = state => get(state, "maptype.last2dMapType") || 'leaflet';
+export const last2dMapTypeSelector = state => get(state, "maptype.last2dMapType") || 'openlayers';


### PR DESCRIPTION
#8136: Default switch maptype from 3d (#8144)