### PR TITLE
#7672 Ability to fix table widget in case if attribute become not available

### DIFF
--- a/web/client/components/data/featuregrid/AttributeTable.jsx
+++ b/web/client/components/data/featuregrid/AttributeTable.jsx
@@ -6,10 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {forwardRef} from 'react';
 
 import ReactDataGrid from 'react-data-grid';
 import Message from '../../I18N/Message';
+import withHint from "./enhancers/withHint";
+import {Glyphicon} from "react-bootstrap";
+
+const TooltipSpan = withHint(forwardRef(({glyph, className = "attribute error", children, ...props }, ref) => {
+    return (<span ref={ref} {...props} className={className}><s>{children}</s><Glyphicon glyph={glyph} /></span>);
+}));
 
 export default ({
     style = {},
@@ -23,7 +29,12 @@ export default ({
             rowKey="id"
             columns={[{
                 name: '',
-                key: 'attribute'
+                key: 'attribute',
+                formatter(props) {
+                    return props?.row?.error
+                        ? <TooltipSpan glyph="alert" tooltipId="widgets.builder.wizard.attributeIsNotAvailable">{props.row.name}</TooltipSpan>
+                        : (props.row.name ?? null);
+                }
             }]}
             rowGetter={idx => attributes[idx]}
             rowsCount={attributes.length}
@@ -35,6 +46,7 @@ export default ({
                 selectBy: {
                     indexes: attributes.reduce( (acc, a, idx) => [...acc, ...(a.hide ? [] : [idx] )], [])
                 }
-            }} />
+            }}
+        />
     </div>
 );

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1862,6 +1862,7 @@
                     "connectToTheMap": "Verbinden Sie sich mit der Karte",
                     "selectMapToConnect": "Wählen Sie das zu verbindende Widget aus",
                     "clearConnection": "Verbindung löschen",
+                    "attributeIsNotAvailable": "Attribut ist nicht verfügbar",
                     "classAttributes": {
                         "classColor": "Klasse Farbe",
                         "classLabel": "Klassenbezeichnung",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1824,6 +1824,7 @@
                     "connectToTheMap": "Connect to the map",
                     "selectMapToConnect": "Select the widget to connect",
                     "clearConnection": "Clear connection",
+                    "attributeIsNotAvailable": "Attribute is not available",
                     "classAttributes": {
                         "classColor": "Class Color",
                         "classLabel": "Class Label",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1824,6 +1824,7 @@
                     "connectToTheMap": "Conectar al mapa",
                     "selectMapToConnect": "Seleccione el widget para conectarse",
                     "clearConnection": "Borrar conexión",
+                    "attributeIsNotAvailable": "El atributo no está disponible",
                     "classAttributes": {
                         "classColor": "Color de la Clase",
                         "classLabel": "Etiqueta de la Clase",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1825,6 +1825,7 @@
                     "connectToTheMap": "Connectez-vous à la carte",
                     "selectMapToConnect": "Sélectionnez le widget pour vous connecter",
                     "clearConnection": "Effacer la connexion",
+                    "attributeIsNotAvailable": "L'attribut n'est pas disponible",
                     "classAttributes": {
                         "classColor": "Couleur de la Classe",
                         "classLabel": "Étiquette de la Classe",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1824,6 +1824,7 @@
                     "connectToTheMap": "Collegati alla mappa",
                     "selectMapToConnect": "Seleziona il widget da connettere",
                     "clearConnection": "Disconnetti",
+                    "attributeIsNotAvailable": "L'attributo non è disponibile",
                     "classAttributes": {
                         "classColor": "Colore della Classe",
                         "classLabel": "Etichetta della Classe",


### PR DESCRIPTION
## Description
User should be able to fix table widget in case if one of the attributes become not available on the backend.
This PR introduces minor changes to the attributes list to list problematic attributes and allow to deselect them and update widget configuration to fix it.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7672 

**What is the new behavior?**
- Problematic attribute is in the list.
- Deselecting it will make it disappear right away.
- Sorting of the data will be reset if widget had sorting by not available attribute.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
