### PR TITLE
backport 2022.01.xx - #8083: Add an empty renderer for geometry types (#8084)

### DIFF
--- a/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
+++ b/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
@@ -46,4 +46,12 @@ describe('Tests for the formatter functions', () => {
         expect(formatter({value: undefined})).toBe(null);
         expect(formatter({value: 0}).props.value).toBe(0);
     });
+    it('test getFormatter for geometry', () => {
+        const formatter = getFormatter({localType: "Geometry"});
+        expect(typeof formatter).toBe("function");
+        expect(formatter()).toBe(null);
+        expect(formatter({value: {properties: {}, geometry: {type: "Point", coordinates: [1, 2]}}})).toBe(null);
+        expect(formatter({value: null})).toBe(null);
+        expect(formatter({value: undefined})).toBe(null);
+    });
 });

--- a/web/client/components/data/featuregrid/formatters/index.js
+++ b/web/client/components/data/featuregrid/formatters/index.js
@@ -16,6 +16,8 @@ export const getFormatter = (desc) => {
         return ({value} = {}) => !isNil(value) ? <span>{value.toString()}</span> : null;
     } else if (['int', 'number'].includes(desc.localType)) {
         return ({value} = {}) => !isNil(value) ? <NumberFormat value={value} numberParams={{maximumFractionDigits: 17}}/> : null;
+    } else if (desc.localType === 'Geometry') {
+        return () => null;
     }
     return null;
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
backport 2022.01.xx - #8083: Add an empty renderer for geometry types (#8084)