### PR TITLE
#7778 Fix for regression bug that was preventing cesium to properly use orientation on map load

### DIFF
--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -312,6 +312,34 @@ describe('config epics', () => {
                 checkActions
             );
         });
+
+        it('calculate bbox on map config loaded - cesium viewer', (done) => {
+            const config = {
+                map: {
+                    center: { x: 0, y: 0, crs: "EPSG:4326" },
+                    zoom: 8,
+                    projection: 'EPSG:900913'
+                }
+            };
+
+            const checkActions = ([a]) => {
+                expect(a).toExist();
+                expect(a.type).toBe('EPIC_COMPLETED');
+                done();
+            };
+            testEpic(calculateBboxOnConfigureMap,
+                0,
+                configureMap(config, 1, false),
+                checkActions,
+                {
+                    maptype: {
+                        mapType: 'cesium'
+                    }
+                },
+                false,
+                true
+            );
+        });
     });
 });
 

--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -8,7 +8,7 @@
 
 import expect from 'expect';
 import {head} from 'lodash';
-import {calculateBboxOnConfigureMap, loadMapConfigAndConfigureMap, loadMapInfoEpic} from '../config';
+import {loadMapConfigAndConfigureMap, loadMapInfoEpic} from '../config';
 import {LOAD_USER_SESSION} from '../../actions/usersession';
 import {
     loadMapConfig,
@@ -17,10 +17,8 @@ import {
     LOAD_MAP_INFO,
     MAP_INFO_LOADED,
     MAP_INFO_LOAD_START,
-    loadMapInfo,
-    configureMap
+    loadMapInfo
 } from '../../actions/config';
-import {CHANGE_MAP_VIEW} from "../../actions/map";
 
 import { testEpic } from './epicTestUtils';
 import Persistence from '../../api/persistence';
@@ -279,65 +277,6 @@ describe('config epics', () => {
                 2,
                 loadMapInfo(1234),
                 checkActions
-            );
-        });
-    });
-
-    describe('calculateBboxOnConfigureMap', () => {
-        Persistence.addApi("testConfig", api);
-        beforeEach(() => {
-            Persistence.setApi("testConfig");
-        });
-        afterEach(() => {
-            Persistence.setApi("geostore");
-        });
-
-        it('calculate bbox on map config loaded', (done) => {
-            const config = {
-                map: {
-                    center: { x: 0, y: 0, crs: "EPSG:4326" },
-                    zoom: 8,
-                    projection: 'EPSG:900913'
-                }
-            };
-
-            const checkActions = ([a]) => {
-                expect(a).toExist();
-                expect(a.type).toBe(CHANGE_MAP_VIEW);
-                done();
-            };
-            testEpic(calculateBboxOnConfigureMap,
-                1,
-                configureMap(config, 1, false),
-                checkActions
-            );
-        });
-
-        it('calculate bbox on map config loaded - cesium viewer', (done) => {
-            const config = {
-                map: {
-                    center: { x: 0, y: 0, crs: "EPSG:4326" },
-                    zoom: 8,
-                    projection: 'EPSG:900913'
-                }
-            };
-
-            const checkActions = ([a]) => {
-                expect(a).toExist();
-                expect(a.type).toBe('EPIC_COMPLETED');
-                done();
-            };
-            testEpic(calculateBboxOnConfigureMap,
-                0,
-                configureMap(config, 1, false),
-                checkActions,
-                {
-                    maptype: {
-                        mapType: 'cesium'
-                    }
-                },
-                false,
-                true
             );
         });
     });

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -21,15 +21,13 @@ import {
     loadMapConfig,
     loadMapInfo
 } from '../actions/config';
-import {changeMapView, zoomToExtent} from '../actions/map';
+import {zoomToExtent} from '../actions/map';
 import Persistence from '../api/persistence';
 import { isLoggedIn, userSelector } from '../selectors/security';
 import { projectionDefsSelector } from '../selectors/map';
 import {loadUserSession, USER_SESSION_LOADED, userSessionStartSaving, saveMapConfig} from '../actions/usersession';
 import {userSessionEnabledSelector, buildSessionName} from "../selectors/usersession";
 import {getRequestParameterValue} from "../utils/QueryParamsUtils";
-import {getBbox} from "../utils/MapUtils";
-import {mapTypeSelector} from "../selectors/maptype";
 
 
 const prepareMapConfiguration = (data, override, state) => {
@@ -160,18 +158,6 @@ export const zoomToMaxExtentOnConfigureMap = action$ =>
         .filter(action => !!action.zoomToExtent)
         .delay(300) // without the delay the map zoom will not change
         .map(({config, zoomToExtent: extent}) => zoomToExtent(extent.bounds, extent.crs || get(config, 'map.projection')));
-
-export const calculateBboxOnConfigureMap = (action$, store) =>
-    action$.ofType(MAP_CONFIG_LOADED)
-        .switchMap(({config}) => {
-            const mapType = mapTypeSelector(store.getState());
-            if (mapType !== 'cesium') {
-                const { center, zoom, size, mapStateSource, projection, viewerOptions, resolution } = (config?.map ?? {});
-                const bbox = getBbox(center, zoom);
-                return Observable.of(changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions, resolution));
-            }
-            return Observable.empty();
-        });
 
 export const loadMapInfoEpic = action$ =>
     action$.ofType(LOAD_MAP_INFO)

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -30,6 +30,9 @@ function mapConfig(state = null, action) {
     switch (action.type) {
     case MAP_CONFIG_LOADED:
         let size = state && state.map && state.map.present && state.map.present.size || state && state.map && state.map.size;
+        // bbox is taken from the state to keep widgets having correct dataset after map is saved or saved as.
+        // bbox is not getting written to the map configuration on backend
+        let bbox = state && state.map && state.map.present && state.map.present.bbox || state && state.map && state.map.bbox;
 
         let hasVersion = action.config && action.config.version >= 2;
         // we get from the configuration what will be used as the initial state
@@ -72,7 +75,7 @@ function mapConfig(state = null, action) {
         // if map is loaded from an already saved map keep the same id
         let mapId = state?.map?.mapId || state?.map?.present?.mapId;
         mapId = action.config?.fileName && mapId ? mapId : action.mapId;
-        newMapState.map = assign({}, newMapState.map, {mapId, size, version: hasVersion ? action.config.version : 1});
+        newMapState.map = assign({}, newMapState.map, {mapId, size, bbox, version: hasVersion ? action.config.version : 1});
         // we store the map initial state for future usage
         return assign({}, newMapState, {mapInitialConfig: {...newMapState.map, mapId: action.mapId}});
     case MAP_CONFIG_LOAD_ERROR:


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
As it was stated https://github.com/geosolutions-it/MapStore2/issues/7778#issuecomment-1141177328 here original implementation is breaking one of the aspects of the sharing tool. Orientation on cesium map load is not triggered correctly, zooming/panning to the coordinates passed in url is not happening.
This PR changes the way how `bbox` is preserved upon map saving and saving as.

**What is the current behavior?**
#7778
Orientation action is not triggered correctly for Cesium viewer

**What is the new behavior?**
No bbox calculation. Bbox is taken from the existing state and map view update is not triggered.
Map orientation works as expected.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
