### PR TITLE
#8227 WFS  identify in Cesium and layer settings

### DIFF
--- a/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
@@ -14,6 +14,7 @@ import { Glyphicon } from 'react-bootstrap';
 import Message from '../../../I18N/Message';
 import includes from 'lodash/includes';
 import isEmpty from 'lodash/isEmpty';
+import { keys } from 'lodash';
 
 /**
  * Component for rendering FeatureInfo an Accordion with current available format for get feature info
@@ -42,8 +43,10 @@ export default class extends React.Component {
     };
 
     getInfoFormat = (infoFormats) => {
+        console.log(infoFormats, 'infoFormats')
         return Object.keys(infoFormats).map((infoFormat) => {
             const Body = this.props.formatCards[infoFormat] && this.props.formatCards[infoFormat].body;
+            console.log(this.props.formatCards, 'formatCardsformatCardsformatCardsformatCards')
             return {
                 id: infoFormat,
                 head: {
@@ -84,12 +87,15 @@ export default class extends React.Component {
      * @return {object} info formats
      */
     supportedInfoFormats = () => {
+        const excludedFormatsWfs = ['TEXT','HTML']
         const availableInfoFormats =  this.props.element?.infoFormats || [];
+        const supportedWfsFormats = Object.fromEntries(Object.entries(this.props.defaultInfoFormat).filter(([key, value]) => !excludedFormatsWfs.includes(key)))
+        const formats = this.props.element.type === 'wfs'?supportedWfsFormats:this.props.defaultInfoFormat
         const infoFormats = Object.assign({},
-            ...Object.entries(this.props.defaultInfoFormat)
+            ...Object.entries(formats)
                 .filter(([, value])=> includes(availableInfoFormats, value))
                 .map(([key, value])=> ({[key]: value}))
         );
-        return isEmpty(infoFormats) ? this.props.defaultInfoFormat : infoFormats;
+        return isEmpty(infoFormats) ? formats : infoFormats;
     }
 }

--- a/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
@@ -14,7 +14,6 @@ import { Glyphicon } from 'react-bootstrap';
 import Message from '../../../I18N/Message';
 import includes from 'lodash/includes';
 import isEmpty from 'lodash/isEmpty';
-import { keys } from 'lodash';
 
 /**
  * Component for rendering FeatureInfo an Accordion with current available format for get feature info
@@ -43,10 +42,8 @@ export default class extends React.Component {
     };
 
     getInfoFormat = (infoFormats) => {
-        console.log(infoFormats, 'infoFormats')
         return Object.keys(infoFormats).map((infoFormat) => {
             const Body = this.props.formatCards[infoFormat] && this.props.formatCards[infoFormat].body;
-            console.log(this.props.formatCards, 'formatCardsformatCardsformatCardsformatCards')
             return {
                 id: infoFormat,
                 head: {
@@ -87,10 +84,10 @@ export default class extends React.Component {
      * @return {object} info formats
      */
     supportedInfoFormats = () => {
-        const excludedFormatsWfs = ['TEXT','HTML']
+        const excludedFormatsWfs = ['TEXT', 'HTML'];
         const availableInfoFormats =  this.props.element?.infoFormats || [];
-        const supportedWfsFormats = Object.fromEntries(Object.entries(this.props.defaultInfoFormat).filter(([key, value]) => !excludedFormatsWfs.includes(key)))
-        const formats = this.props.element.type === 'wfs'?supportedWfsFormats:this.props.defaultInfoFormat
+        const supportedWfsFormats = Object.fromEntries(Object.entries(this.props.defaultInfoFormat).filter(([key]) => !excludedFormatsWfs.includes(key)));
+        const formats = this.props.element.type === 'wfs' ? supportedWfsFormats : this.props.defaultInfoFormat;
         const infoFormats = Object.assign({},
             ...Object.entries(formats)
                 .filter(([, value])=> includes(availableInfoFormats, value))

--- a/web/client/components/TOC/fragments/settings/__tests__/FeatureInfo-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/FeatureInfo-test.jsx
@@ -83,4 +83,15 @@ describe("test FeatureInfo", () => {
         const testComponent = document.getElementsByClassName('test-preview');
         expect(testComponent.length).toBe(2);
     });
+    it('test rendering supported infoFormats for wfs layer', () => {
+        ReactDOM.render(<FeatureInfo element={{infoFormats: ["text/html", "application/json"]}} formatCards={formatCards} defaultInfoFormat={defaultInfoFormat} />, document.getElementById("container"));
+        const testComponent = document.getElementsByClassName('test-preview');
+        expect(testComponent.length).toBe(3);
+    });
+
+    it('test rendering supported infoFormats for wms layer', () => {
+        ReactDOM.render(<FeatureInfo element={{infoFormats: ["text/html", "text/plain", "application/json"]}} formatCards={formatCards} defaultInfoFormat={defaultInfoFormat} />, document.getElementById("container"));
+        const testComponent = document.getElementsByClassName('test-preview');
+        expect(testComponent.length).toBe(4);
+    });
 });

--- a/web/client/components/TOC/fragments/settings/__tests__/FeatureInfo-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/FeatureInfo-test.jsx
@@ -18,6 +18,12 @@ const defaultInfoFormat = getAvailableInfoFormat();
 
 
 const formatCards = {
+    HIDDEN: {
+        titleId: 'layerProperties.hideFormatTitle',
+        descId: 'layerProperties.hideFormatDescription',
+        glyph: 'hide-marker',
+        body: () => <div className="test-preview"/>
+    },
     TEXT: {
         titleId: 'layerProperties.textFormatTitle',
         descId: 'layerProperties.textFormatDescription',
@@ -83,27 +89,36 @@ describe("test FeatureInfo", () => {
         expect(testComponent.length).toBe(2);
     });
     it('test rendering supported infoFormats for wfs layer', () => {
-        ReactDOM.render(<FeatureInfo element={{infoFormats: ["text/html", "application/json"]}} formatCards={formatCards} defaultInfoFormat={defaultInfoFormat} />, document.getElementById("container"));
+        ReactDOM.render(<FeatureInfo element={{type: "wfs"}}
+            formatCards={formatCards}
+            defaultInfoFormat={{
+                HIDDEN: "text/html",
+                ...defaultInfoFormat
+            }} />, document.getElementById("container"));
         const testComponents = document.getElementsByClassName('test-preview');
         expect(testComponents.length).toBe(3);
         const sideCards = document.querySelectorAll('.mapstore-side-card-title span span');
         expect(sideCards.length).toBe(3);
-        expect(sideCards[0].textContent).toBe('layerProperties.htmlFormatTitle');
+        expect(sideCards[0].textContent).toBe('layerProperties.hideFormatTitle');
         expect(sideCards[1].textContent).toBe('layerProperties.propertiesFormatTitle');
         expect(sideCards[2].textContent).toBe('layerProperties.templateFormatTitle');
-
-
     });
 
     it('test rendering supported infoFormats for wms layer', () => {
-        ReactDOM.render(<FeatureInfo element={{infoFormats: ["text/html", "text/plain", "application/json"]}} formatCards={formatCards} defaultInfoFormat={defaultInfoFormat} />, document.getElementById("container"));
+        ReactDOM.render(<FeatureInfo  element={{type: "wms"}}
+            formatCards={formatCards}
+            defaultInfoFormat={{
+                HIDDEN: "text/html",
+                ...defaultInfoFormat
+            }} />, document.getElementById("container"));
         const testComponent = document.getElementsByClassName('test-preview');
-        expect(testComponent.length).toBe(4);
+        expect(testComponent.length).toBe(5);
         const sideCards = document.querySelectorAll('.mapstore-side-card-title span span');
-        expect(sideCards.length).toBe(4);
-        expect(sideCards[0].textContent).toBe('layerProperties.textFormatTitle');
-        expect(sideCards[1].textContent).toBe('layerProperties.htmlFormatTitle');
-        expect(sideCards[2].textContent).toBe('layerProperties.propertiesFormatTitle');
-        expect(sideCards[3].textContent).toBe('layerProperties.templateFormatTitle');
+        expect(sideCards.length).toBe(5);
+        expect(sideCards[0].textContent).toBe('layerProperties.hideFormatTitle');
+        expect(sideCards[1].textContent).toBe('layerProperties.textFormatTitle');
+        expect(sideCards[2].textContent).toBe('layerProperties.htmlFormatTitle');
+        expect(sideCards[3].textContent).toBe('layerProperties.propertiesFormatTitle');
+        expect(sideCards[4].textContent).toBe('layerProperties.templateFormatTitle');
     });
 });

--- a/web/client/components/TOC/fragments/settings/__tests__/FeatureInfo-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/FeatureInfo-test.jsx
@@ -77,7 +77,6 @@ describe("test FeatureInfo", () => {
         expect(sideCards.length).toBe(4);
         TestUtils.Simulate.click(sideCards[0]);
     });
-
     it('test rendering with supported infoFormats from layer props', () => {
         ReactDOM.render(<FeatureInfo element={{infoFormats: ["text/html", "text/plain"]}} formatCards={formatCards} defaultInfoFormat={defaultInfoFormat} />, document.getElementById("container"));
         const testComponent = document.getElementsByClassName('test-preview');
@@ -85,13 +84,26 @@ describe("test FeatureInfo", () => {
     });
     it('test rendering supported infoFormats for wfs layer', () => {
         ReactDOM.render(<FeatureInfo element={{infoFormats: ["text/html", "application/json"]}} formatCards={formatCards} defaultInfoFormat={defaultInfoFormat} />, document.getElementById("container"));
-        const testComponent = document.getElementsByClassName('test-preview');
-        expect(testComponent.length).toBe(3);
+        const testComponents = document.getElementsByClassName('test-preview');
+        expect(testComponents.length).toBe(3);
+        const sideCards = document.querySelectorAll('.mapstore-side-card-title span span');
+        expect(sideCards.length).toBe(3)
+        expect(sideCards[0].textContent).toBe('layerProperties.htmlFormatTitle')
+        expect(sideCards[1].textContent).toBe('layerProperties.propertiesFormatTitle')
+        expect(sideCards[2].textContent).toBe('layerProperties.templateFormatTitle')
+
+
     });
 
     it('test rendering supported infoFormats for wms layer', () => {
         ReactDOM.render(<FeatureInfo element={{infoFormats: ["text/html", "text/plain", "application/json"]}} formatCards={formatCards} defaultInfoFormat={defaultInfoFormat} />, document.getElementById("container"));
         const testComponent = document.getElementsByClassName('test-preview');
         expect(testComponent.length).toBe(4);
+        const sideCards = document.querySelectorAll('.mapstore-side-card-title span span');
+        expect(sideCards.length).toBe(4)
+        expect(sideCards[0].textContent).toBe('layerProperties.textFormatTitle')
+        expect(sideCards[1].textContent).toBe('layerProperties.htmlFormatTitle')
+        expect(sideCards[2].textContent).toBe('layerProperties.propertiesFormatTitle')
+        expect(sideCards[3].textContent).toBe('layerProperties.templateFormatTitle')
     });
 });

--- a/web/client/components/TOC/fragments/settings/__tests__/FeatureInfo-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/FeatureInfo-test.jsx
@@ -87,10 +87,10 @@ describe("test FeatureInfo", () => {
         const testComponents = document.getElementsByClassName('test-preview');
         expect(testComponents.length).toBe(3);
         const sideCards = document.querySelectorAll('.mapstore-side-card-title span span');
-        expect(sideCards.length).toBe(3)
-        expect(sideCards[0].textContent).toBe('layerProperties.htmlFormatTitle')
-        expect(sideCards[1].textContent).toBe('layerProperties.propertiesFormatTitle')
-        expect(sideCards[2].textContent).toBe('layerProperties.templateFormatTitle')
+        expect(sideCards.length).toBe(3);
+        expect(sideCards[0].textContent).toBe('layerProperties.htmlFormatTitle');
+        expect(sideCards[1].textContent).toBe('layerProperties.propertiesFormatTitle');
+        expect(sideCards[2].textContent).toBe('layerProperties.templateFormatTitle');
 
 
     });
@@ -100,10 +100,10 @@ describe("test FeatureInfo", () => {
         const testComponent = document.getElementsByClassName('test-preview');
         expect(testComponent.length).toBe(4);
         const sideCards = document.querySelectorAll('.mapstore-side-card-title span span');
-        expect(sideCards.length).toBe(4)
-        expect(sideCards[0].textContent).toBe('layerProperties.textFormatTitle')
-        expect(sideCards[1].textContent).toBe('layerProperties.htmlFormatTitle')
-        expect(sideCards[2].textContent).toBe('layerProperties.propertiesFormatTitle')
-        expect(sideCards[3].textContent).toBe('layerProperties.templateFormatTitle')
+        expect(sideCards.length).toBe(4);
+        expect(sideCards[0].textContent).toBe('layerProperties.textFormatTitle');
+        expect(sideCards[1].textContent).toBe('layerProperties.htmlFormatTitle');
+        expect(sideCards[2].textContent).toBe('layerProperties.propertiesFormatTitle');
+        expect(sideCards[3].textContent).toBe('layerProperties.templateFormatTitle');
     });
 });

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -227,7 +227,8 @@ class CesiumMap extends React.Component {
                         lng: longitude
                     },
                     crs: "EPSG:4326",
-                    intersectedFeatures
+                    intersectedFeatures,
+                    resolution: getResolutions()[Math.round(this.props.zoom)]
                 });
             }
         }

--- a/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
+++ b/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
@@ -51,6 +51,8 @@ const ConnectedDisplay = connect(
 const isLayerNode = ({settings = {}} = {}) => settings.nodeType === 'layers';
 const isVectorStylableLayer = ({element = {}} = {}) => element.type === "wfs" || element.type === "3dtiles" || element.type === "vector" && element.id !== "annotations";
 const isWMS = ({element = {}} = {}) => element.type === "wms";
+const isWFS = ({element = {}} = {}) => element.type === "wfs";
+
 const isStylableLayer = (props) =>
     isLayerNode(props)
     && (isWMS(props) || isVectorStylableLayer(props));
@@ -244,7 +246,7 @@ export default ({ showFeatureInfoTab = true, loadedPlugins, items, onToggleStyle
             titleId: 'layerProperties.featureInfo',
             tooltipId: 'layerProperties.featureInfo',
             glyph: 'map-marker',
-            visible: showFeatureInfoTab && isLayerNode(props) && isWMS(props) && !(props.element.featureInfo && props.element.featureInfo.viewer),
+            visible: showFeatureInfoTab && isLayerNode(props) && (isWMS(props) || isWFS(props)) && !(props.element.featureInfo && props.element.featureInfo.viewer),
             Component: FeatureInfo,
             toolbar: [
                 {

--- a/web/client/utils/IdentifyUtils.js
+++ b/web/client/utils/IdentifyUtils.js
@@ -45,12 +45,13 @@ export const updatePointWithGeometricFilter = (point, projection) => {
         pixel = point.pixel;
     }
     const hook = getHook(GET_COORDINATES_FROM_PIXEL_HOOK);
-    const radius = calculateCircleRadiusFromPixel(
+    const PIXEL_RADIUS = 5;
+    const radius = hook ? calculateCircleRadiusFromPixel(
         hook,
         pixel,
         pos,
-        5
-    );
+        PIXEL_RADIUS
+    ) : point.resolution * PIXEL_RADIUS;
     // emulation of feature info filter to query WFS services (edit and/or WFS layer)
     const geometricFilter = {
         type: 'geometry',


### PR DESCRIPTION
## Description
* This Pull Request allows one to display feature info of WFS layer in Cesium . It also allows the identity settings to add 
possibility to control the Identify type  for WFS layers in 2D and 3D  from layer settings. Allowing only the 
DISABLE IDENTIFY
PROPERTIES
TEMPLATE 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**

* Does not add support for Get feature info requests for wfs layers in cesium
*  Does not make Identify settings available for this type of layer both 2d/3d
* #8227

**What is the new behavior?**

 * Adds support for Get feature info requests for wfs layers in cesium
 * Makes Identify settings available for this type of layer both 2d/3d

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
