### PR TITLE
[Backport 2022.01.xx] #8245: Map with mapbox or mapboxstyle background layers break the app when saved  (#8246)

### DIFF
--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -18,6 +18,7 @@
     "printUrl": "pdf/info.json",
     "bingApiKey": "AhuXBu7ipR1gNbBfXhtUAyCZ6rkC5PkWpxs2MnMRZ1ZupxQfivjLCch22ozKSCAn",
     "mapquestApiKey": "__API_KEY_MAPQUEST__",
+    "mapboxAccessToken": "__ACCESS_TOKEN_MAPBOX__",
     "initialMapFilter": "",
     "ignoreMobileCss": false,
     "useAuthenticationRules": true,

--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -40,6 +40,7 @@ let defaultConfig = {
     themePrefix: "ms2",
     bingApiKey: null,
     mapquestApiKey: null,
+    mapboxAccessToken: '',
     defaultSourceType: "gxp_wmssource",
     backgroundGroup: "background",
     userSessions: {
@@ -168,6 +169,10 @@ export const setApiKeys = function(layer) {
     }
     if (layer.type === 'mapquest') {
         layer.apiKey = defaultConfig.mapquestApiKey;
+    }
+    if (layer.type === 'tileprovider' && ['MapBoxStyle', 'MapBox'].includes(layer.provider)) {
+        // include an empty string if missing to avoid errors in the layer url template
+        layer.accessToken = defaultConfig.mapboxAccessToken;
     }
     return layer;
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

include access token to mapbox background layers

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8245

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
