### PR TITLE
Fix tileprovider print requests for remote URLs containing a query

### DIFF
--- a/web/client/test-resources/layers/tileprovider.js
+++ b/web/client/test-resources/layers/tileprovider.js
@@ -36,3 +36,16 @@ export const NLS_CUSTOM_URL = {
     previousLoadingError: false,
     loadingError: false
 };
+
+export const LINZ_CUSTOM_URL = {
+    type: 'tileprovider',
+    visibility: true,
+    url: 'https://basemaps.linz.govt.nz/v1/tiles/aerial/EPSG:3857/{z}/{x}/{y}.png?api=myapikey',
+    title: 'LINZ',
+    provider: 'custom',
+    name: 'custom',
+    id: 'custom__7',
+    loading: false,
+    previousLoadingError: false,
+    loadingError: false
+};

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -773,9 +773,12 @@ export const specCreators = {
                     throw Error("No base URL found for this layer");
                 }
                 // transform in xyz format for mapfish-print.
+                const queryIndex = validURL.indexOf("?");
                 const firstBracketIndex = validURL.indexOf('{');
                 const baseURL = validURL.slice(0, firstBracketIndex);
-                const pathSection = validURL.slice(firstBracketIndex);
+                const pathSection = queryIndex < 0
+                    ? validURL.slice(firstBracketIndex)
+                    : validURL.slice(firstBracketIndex, queryIndex);
                 const pathFormat = pathSection
                     .replace("{x}", "${x}")
                     .replace("{y}", "${y}")
@@ -785,7 +788,7 @@ export const specCreators = {
                     baseURL,
                     path_format: pathFormat,
                     "type": 'xyz',
-                    "extension": validURL.split('.').pop() || "png",
+                    "extension": pathSection.split('.').pop() || "png",
                     "opacity": getOpacity(layer),
                     "tileSize": [256, 256],
                     "maxExtent": [-20037508.3392, -20037508.3392, 20037508.3392, 20037508.3392],
@@ -815,7 +818,8 @@ export const specCreators = {
                             isIncluded = isIncluded && i <= layerConfig.maxNativeZoom;
                         }
                         return isIncluded;
-                    })
+                    }),
+                    "customParams": Object.fromEntries((new URL(validURL)).searchParams)
                 };
             }
             return {};

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -30,7 +30,7 @@ import {
 import ConfigUtils from '../ConfigUtils';
 import { KVP1, REST1 } from '../../test-resources/layers/wmts';
 import { poi as TMS110_1 } from '../../test-resources/layers/tms';
-import { BasemapAT, NASAGIBS, NLS_CUSTOM_URL } from '../../test-resources/layers/tileprovider';
+import { BasemapAT, NASAGIBS, NLS_CUSTOM_URL, LINZ_CUSTOM_URL } from '../../test-resources/layers/tileprovider';
 import { setStore } from '../StateUtils';
 import { getGoogleMercatorScales } from '../MapUtils';
 
@@ -615,7 +615,7 @@ describe('PrintUtils', () => {
                 expect(layerSpec.resolutions).toExist();
                 expect(layerSpec.extension).toBe("png");
                 expect(layerSpec.resolutions.length).toBe(19);
-
+                expect(Object.keys(layerSpec.customParams).length).toBe(0);
             });
             it('NASAGIBS', () => {
                 const testLayer = NASAGIBS;
@@ -633,7 +633,7 @@ describe('PrintUtils', () => {
                 expect(layerSpec.resolutions).toExist();
                 expect(layerSpec.extension).toBe("jpg");
                 expect(layerSpec.resolutions.length).toBe(9);
-
+                expect(Object.keys(layerSpec.customParams).length).toBe(0);
             });
             it('tileprovider with custom URL', () => {
                 const testLayer = NLS_CUSTOM_URL;
@@ -651,7 +651,26 @@ describe('PrintUtils', () => {
                 expect(layerSpec.resolutions).toExist();
                 expect(layerSpec.extension).toBe("jpg");
                 expect(layerSpec.resolutions.length).toBe(19);
-
+                expect(Object.keys(layerSpec.customParams).length).toBe(0);
+            });
+            it('tileprovider with params', () => {
+                const testLayer = LINZ_CUSTOM_URL;
+                const layerSpec = specCreators.tileprovider.map(testLayer, { projection: "EPSG:3857" });
+                expect(layerSpec.type).toEqual("xyz");
+                // string with params
+                expect(layerSpec.baseURL).toEqual("https://basemaps.linz.govt.nz/v1/tiles/aerial/EPSG:3857/");
+                // parameter    s should be passed in pathSpec
+                expect(layerSpec.baseURL.indexOf(/\{[x,y,z]\}/)).toBeLessThan(0);
+                expect(layerSpec.path_format).toBe("${z}/${x}/${y}.png"); // use the format of mapfish print for variables
+                // mandatory values
+                expect(layerSpec.maxExtent).toExist();
+                expect(layerSpec.maxExtent).toExist();
+                expect(layerSpec.tileSize).toExist();
+                expect(layerSpec.resolutions).toExist();
+                expect(layerSpec.extension).toBe("png");
+                expect(layerSpec.resolutions.length).toBe(19);
+                expect(layerSpec.customParams.api).toBe('myapikey');
+                expect(Object.keys(layerSpec.customParams).length).toBe(1);
             });
         });
         describe('TMS', () => {


### PR DESCRIPTION
## Description

Fix for when a tileprovider URL for a base layer contains a query string and a print request is made. Requests to the print server will be malformed such that the specified `extension` JSON field will contain that query string. Also passes through any query parameters to tile requests via the `customParams` JSON field.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

#7816 

**What is the current behavior?**

Requests to the print server contain any query string in the `extension` JSON field and do not pass parameters through to individual tile requests.

**What is the new behavior?**

Query strings are trimmed from the `extension` field and instead passed through to individual tile requests via the `customParams` JSON field.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
