### PR TITLE
#8266 Use mapType from state to properly display cesium sharing options

### DIFF
--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -28,6 +28,7 @@ import { addMarker, hideMarker } from '../actions/search';
 import { updateMapView } from '../actions/map';
 import { updateUrlOnScrollSelector } from '../selectors/geostory';
 import { shareSelector } from "../selectors/controls";
+import {mapTypeSelector} from "../selectors/maptype";
 /**
  * Share Plugin allows to share the current URL (location.href) in some different ways.
  * You can share it on socials networks(facebook,twitter,google+,linkedIn)
@@ -65,19 +66,21 @@ const Share = connect(createSelector([
     shareSelector,
     versionSelector,
     mapSelector,
+    mapTypeSelector,
     currentContextSelector,
     state => get(state, 'controls.share.settings', {}),
     (state) => state.mapInfo && state.mapInfo.formatCoord || ConfigUtils.getConfigProp("defaultCoordinateFormat"),
     state => state.search && state.search.markerPosition || {},
     updateUrlOnScrollSelector,
     state => get(state, 'map.present.viewerOptions')
-], (isVisible, version, map, context, settings, formatCoords, point, isScrollPosition, viewerOptions) => ({
+], (isVisible, version, map, mapType, context, settings, formatCoords, point, isScrollPosition, viewerOptions) => ({
     isVisible,
     shareUrl: location.href,
     shareApiUrl: getApiUrl(location.href),
     shareConfigUrl: getConfigUrl(location.href, ConfigUtils.getConfigProp('geoStoreUrl')),
     version,
     viewerOptions,
+    mapType,
     bbox: isVisible && map && map.bbox && getExtentFromViewport(map.bbox),
     center: map && map.center && ConfigUtils.getCenter(map.center),
     zoom: map && map.zoom,


### PR DESCRIPTION
## Description
Make Share plugin use mapType from the state instead of getting it from the router.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8266 

**What is the new behavior?**
Share plugin is not relying on information about mapType from route anymore.
This data is taken from the state via selector.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
