### PR TITLE
backport #7554 Resolves changes to annotations circle radius

### DIFF
--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -1043,6 +1043,45 @@ describe('annotations Epics', () => {
         store.dispatch(action);
 
     });
+    it('clicked on map selecting a Circle ', (done) => {
+        store = mockStore( {
+            ...defaultState,
+            annotations: {
+                ...defaultState.annotations,
+                config: {
+                    geodesic: true
+                },
+                editing: {
+                    ...defaultState.annotations.editing,
+                    features: [{
+                        type: "Feature",
+                        geometry: {
+                            type: "Polygon",
+                            coordinates: [[[1, 2], [1, 3], [1, 1], [1, 5], [1, 2]]]
+                        },
+                        properties: {
+                            id: "is a circle",
+                            isCircle: true
+                        }
+                    }
+                    ]
+
+                }
+            }
+        } );
+
+        store.subscribe(() => {
+            const actions = store.getActions();
+            if (actions.length >= 3) {
+                expect(actions[1].type).toBe(CHANGE_DRAWING_STATUS);
+                expect(actions[2].type).toBe(CHANGE_DRAWING_STATUS);
+                expect(actions[2].options.geodesic).toBe(true);
+                done();
+            }
+        });
+        const action = selectFeatures([ft]);
+        store.dispatch(action);
+    });
     it('changed the radius from the coordinate editor ', (done) => {
         store = mockStore( defaultState );
 

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -121,8 +121,8 @@ const validateFeatureCollection = (feature) => {
  * @param drawMethod
  * @return {boolean}
  */
-const getGeodesicProperty = (state, drawMethod = "Circle") => {
-    return drawMethod === "Circle" && get(state.annotations, "config.geodesic", false);
+const getGeodesicProperty = (state) => {
+    return get(state.annotations, "config.geodesic", false);
 };
 
 const getSelectDrawStatus = (state) => {
@@ -136,7 +136,7 @@ const getSelectDrawStatus = (state) => {
         drawEnabled: false,
         translateEnabled: false,
         transformToFeatureCollection: true,
-        geodesic: getGeodesicProperty(state, state.draw.drawMethod)
+        geodesic: getGeodesicProperty(state)
     };
 
     feature = validateFeatureCollection(feature);
@@ -153,7 +153,7 @@ const getReadOnlyDrawStatus = (state) => {
         translateEnabled: false,
         drawEnabled: false,
         transformToFeatureCollection: true,
-        geodesic: getGeodesicProperty(state, state.draw.drawMethod)
+        geodesic: getGeodesicProperty(state)
     };
     feature = validateFeatureCollection(feature);
     return changeDrawingStatus("drawOrEdit", state.draw.drawMethod, ANNOTATIONS, [feature], drawOptions, feature.style);
@@ -172,7 +172,7 @@ const getEditingGeomDrawStatus = (state) => {
         addClickCallback: true,
         useSelectedStyle: true,
         transformToFeatureCollection: true,
-        geodesic: getGeodesicProperty(state, state.draw.drawMethod)
+        geodesic: getGeodesicProperty(state)
     };
     feature = validateFeatureCollection(feature);
     return changeDrawingStatus("drawOrEdit", state.draw.drawMethod, ANNOTATIONS, [feature], drawOptions, feature.style);
@@ -263,7 +263,7 @@ export default {
                 selectEnabled: true,
                 drawEnabled: false,
                 transformToFeatureCollection: true,
-                geodesic: getGeodesicProperty(state, type)
+                geodesic: getGeodesicProperty(state)
             };
             const isMeasureType = feature.properties?.type === MEASURE_TYPE || false;
             let actions = [
@@ -326,7 +326,7 @@ export default {
                     useSelectedStyle: true,
                     transformToFeatureCollection: true,
                     addClickCallback: true,
-                    geodesic: getGeodesicProperty(state, type)
+                    geodesic: getGeodesicProperty(state)
                 };
 
                 return Rx.Observable.from([
@@ -413,7 +413,7 @@ export default {
                 defaultTextAnnotation,
                 transformToFeatureCollection: true,
                 addClickCallback: true,
-                geodesic: getGeodesicProperty(state, type)
+                geodesic: getGeodesicProperty(state)
             };
             return Rx.Observable.of(changeDrawingStatus("drawOrEdit", type, ANNOTATIONS, [feature], drawOptions, assign({}, feature.style, {highlight: false})));
         }),
@@ -614,7 +614,7 @@ export default {
                 drawEnabled: false,
                 transformToFeatureCollection: true,
                 addClickCallback: true,
-                geodesic: getGeodesicProperty(state, method)
+                geodesic: getGeodesicProperty(state)
             }, assign({}, style, {highlight: false}));
             return Rx.Observable.of(action);
         }),
@@ -739,7 +739,7 @@ export default {
                 useSelectedStyle: true,
                 transformToFeatureCollection: true,
                 addClickCallback: true,
-                geodesic: getGeodesicProperty(state, method)
+                geodesic: getGeodesicProperty(state)
             }, assign({}, style, {highlight: false}));
             return Rx.Observable.of( changeDrawingStatus("clean"), action);
         }),


### PR DESCRIPTION
## Description
* This PR fixes annotations - circle radius changing when users clicks on a different geometries in the list

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
* #7554
**What is the current behavior?**
* Circle radius changes when user switch to another geometry and then back to the circle.
#<issue>

**What is the new behavior?**
* Circle is rendered with the consistent radius.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
