### PR TITLE
#8228 loading spinner displays inline in Edit Mode

### DIFF
--- a/web/client/plugins/Toolbar.jsx
+++ b/web/client/plugins/Toolbar.jsx
@@ -112,7 +112,7 @@ class Toolbar extends React.Component {
 
     render() {
         const Container = this.props.disableAnimation ? NormalContainer : AnimatedContainer;
-        return (<ToolsContainer id={this.props.id} className={`${this.props.layout === "vertical" ? 'mapToolbar' : 'mapToolbarHorizontal' } btn-group-` + this.props.layout}
+        return (<ToolsContainer id={this.props.id} className={"mapToolbar btn-group-" + this.props.layout}
             toolCfg={this.props.btnConfig}
             container={Container}
             mapType={this.props.mapType}
@@ -123,7 +123,7 @@ class Toolbar extends React.Component {
             tools={this.getTools()}
             panels={this.getPanels()}
             activePanel={this.props.active}
-            style={this.props.style}
+            style={this.props.layout !== 'vertical' ? {...this.props.style, display: 'flex'} : this.props.style}
             panelStyle={this.props.panelStyle}
             panelClassName={this.props.panelClassName}
         />);

--- a/web/client/themes/default/less/map-toolbar.less
+++ b/web/client/themes/default/less/map-toolbar.less
@@ -27,15 +27,6 @@
     margin-bottom: 35px;
     margin-right: 5px;
 }
-.mapToolbarHorizontal {
-    display: flex;
-    position: absolute;
-    bottom: 5px;
-    right: 0;
-    z-index: 1000;
-    margin-bottom: 35px;
-    margin-right: 5px;
-}
 
 .toolbarexpand-enter {
     opacity: 0.01;


### PR DESCRIPTION
## Description
* The PR allows the loading spinner to display horizontally in the same line with other tools in edit mode

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
* #8228

**What is the current behavior?**
* The loading spinner is not inline to other buttons


**What is the new behavior?**
* The loading spinner is in  inline to other buttons

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
