### PR TITLE
#7553 unsaved changes to a polygon are rolled back when a user cancels

### DIFF
--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -550,7 +550,9 @@ class AnnotationsEditor extends React.Component {
                 show
                 modal
                 onClose={this.props.onToggleUnsavedGeometryModal}
-                onConfirm={() => { this.props.onResetCoordEditor(); }}
+                onConfirm={() => { this.props.onResetCoordEditor();
+                    this.props.onCancelEdit(this.props.editing?.properties);
+                 }}
                 confirmButtonBSStyle="default"
                 closeGlyph="1-close"
                 title={<Message msgId="annotations.titleUndoGeom" />}


### PR DESCRIPTION
## Description
* This PR allows for unsaved changes to a polygon to roll back   when a user decides to cancel editing geometry

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
* #7553
**What is the current behavior?**
* Polygon on the map still rendered as if changes were saved.

**What is the new behavior?**
* Unsaved changes to polygons are rolled back to their initial shapes

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
