### PR TITLE
#8310: Improving Cesium performance with explicit rendering

### DIFF
--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -125,6 +125,7 @@ class CesiumLayer extends React.Component {
                         this.props.map.imageryLayers[diff > 0 ? 'raise' : 'lower'](this.provider);
                     });
             }
+            this.props.map.scene.requestRender();
         }
     };
 
@@ -142,6 +143,7 @@ class CesiumLayer extends React.Component {
                     this.removeLayer();
                 }
             }
+            newProps.map.scene.requestRender();
         }
     };
 
@@ -172,6 +174,7 @@ class CesiumLayer extends React.Component {
         var oldOpacity = this.props.options && this.props.options.opacity !== undefined ? this.props.options.opacity : 1.0;
         if (opacity !== oldOpacity && this.layer && this.provider) {
             this.provider.alpha = opacity;
+            this.props.map.scene.requestRender();
         }
     };
 
@@ -187,7 +190,7 @@ class CesiumLayer extends React.Component {
             if (this.layer === null) {
                 this.props.onCreationError(options);
             }
-
+            this.props.map.scene.requestRender();
         }
     };
 
@@ -200,6 +203,7 @@ class CesiumLayer extends React.Component {
                 this.addLayer(newProps);
             }
         }
+        newProps.map.scene.requestRender();
     };
 
     addLayerInternal = (newProps) => {
@@ -212,6 +216,7 @@ class CesiumLayer extends React.Component {
                 this.provider.alpha = newProps.options.opacity;
             }
         }
+        newProps.map.scene.requestRender();
     };
 
     addLayer = (newProps) => {
@@ -226,6 +231,7 @@ class CesiumLayer extends React.Component {
                     this.removeLayer();
                     this.layer = newLayer;
                     this.addLayerInternal(newProps);
+                    this.props.map.scene.requestRender();
                 }, this.props.options.refresh);
             }
         }
@@ -241,6 +247,7 @@ class CesiumLayer extends React.Component {
         if (this.layer?.detached && this.layer?.remove) {
             this.layer.remove();
         }
+        this.props.map.scene.requestRender();
     };
 }
 

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -114,7 +114,10 @@ class CesiumMap extends React.Component {
             // to avoid error on mount
             creditContainer: creditContainer
                 ? creditContainer
-                : undefined
+                : undefined,
+            requestRenderMode: true,
+            maximumRenderTimeChange: Infinity,
+            skyBox: false
         }, this.getMapOptions(this.props.mapOptions)));
 
         if (this.props.errorPanel) {
@@ -163,6 +166,7 @@ class CesiumMap extends React.Component {
         scene.globe.depthTestAgainstTerrain = this.props.mapOptions?.depthTestAgainstTerrain ?? false;
 
         this.forceUpdate();
+        map.scene.requestRender();
     }
 
     UNSAFE_componentWillReceiveProps(newProps) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The 3D viewer should not continuously update at 60 fps but only when an action is preformed eg pan, zoom, style change, ... . There is also an improvement on the vector layer visibility where we are loading features only if actually visible

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: Improvement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8310

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The 3D viewer should not continuously update at 60 fps but only when an action is preformed eg pan, zoom, style change, ... . There is also an improvement on the vector layer visibility where we are loading features only if actually visible

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
