### PR TITLE
#8319 Making POST method of getting query parameters work again on master

### DIFF
--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -497,6 +497,47 @@ describe('queryparam epics', () => {
                 done();
             }, state);
     });
+    it('Test readQueryParamsOnMapEpic / actions dispatched on Change View with POST parameters', (done)=>{
+        const viewerOptions = {
+            orientation: {
+                heading: 0.1,
+                pitch: -0.7,
+                roll: 6.2
+            }
+        };
+        const state = {
+            maptype: {
+                mapType: 'cesium'
+            },
+            router: {
+                location: {
+                    search: ""
+                }
+            }
+        };
+        sessionStorage.setItem('queryParams', JSON.stringify({
+            center: '-74.2,40.7',
+            zoom: '16.5',
+            heading: '0.1',
+            pitch: '-0.7',
+            roll: '6.2'
+        }));
+
+        testEpic(
+            addTimeoutEpic(readQueryParamsOnMapEpic, 1000),
+            1, [
+                onLocationChanged({}),
+                changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions, '')
+            ], actions => {
+                expect(actions.length).toBe(1);
+                try {
+                    expect(actions[0].type).toBe("MAP:ORIENTATION");
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }, state);
+    });
     //
     it('Test readQueryParamsOnMapEpic / changeMapView does not trigger orientateMap if map type is not cesium', (done)=>{
         const viewerOptions = {
@@ -577,6 +618,39 @@ describe('queryparam epics', () => {
                 }
             }
         };
+        const NUMBER_OF_ACTIONS = 2;
+        testEpic(addTimeoutEpic(readQueryParamsOnMapEpic, 10), NUMBER_OF_ACTIONS, [
+            onLocationChanged({}),
+            initMap(true)
+        ], (actions) => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+            try {
+                expect(actions[0].type).toBe(MAP_TYPE_CHANGED);
+                expect(actions[0].mapType).toBe('cesium');
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }, state);
+    });
+    it('switch map type to cesium if cesium viewer options are found in sessionStorage', (done) => {
+        const state = {
+            maptype: {
+                mapType: 'openlayers'
+            },
+            router: {
+                location: {
+                    search: ""
+                }
+            }
+        };
+        sessionStorage.setItem('queryParams', JSON.stringify({
+            center: '-74.2,40.7',
+            zoom: '16.5',
+            heading: '0.1',
+            pitch: '-0.7',
+            roll: '6.2'
+        }));
         const NUMBER_OF_ACTIONS = 2;
         testEpic(addTimeoutEpic(readQueryParamsOnMapEpic, 10), NUMBER_OF_ACTIONS, [
             onLocationChanged({}),

--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -9,11 +9,9 @@
 import expect from 'expect';
 import { addTimeoutEpic, testEpic, TEST_TIMEOUT } from './epicTestUtils';
 import {
-    checkMapOrientation,
     disableGFIForShareEpic,
     onMapClickForShareEpic,
-    readQueryParamsOnMapEpic,
-    switchMapType
+    readQueryParamsOnMapEpic
 } from '../queryparams';
 import { changeMapView, ZOOM_TO_EXTENT, CHANGE_MAP_VIEW, clickOnMap, initMap } from '../../actions/map';
 import { MAP_TYPE_CHANGED } from '../../actions/maptype';
@@ -21,8 +19,6 @@ import { SHOW_NOTIFICATION } from '../../actions/notifications';
 import { onLocationChanged } from 'connected-react-router';
 import {toggleControl} from "../../actions/controls";
 import {layerLoad} from "../../actions/layers";
-import {ActionsObservable} from "redux-observable";
-import Rx from "rxjs";
 import {FEATURE_INFO_CLICK} from "../../actions/mapInfo";
 
 const center = {
@@ -468,7 +464,7 @@ describe('queryparam epics', () => {
                 done();
             }, state);
     });
-    it('Test actions dispatched on Change View', (done)=>{
+    it('Test readQueryParamsOnMapEpic / actions dispatched on Change View', (done)=>{
         const viewerOptions = {
             orientation: {
                 heading: 0.1,
@@ -487,8 +483,9 @@ describe('queryparam epics', () => {
             }
         };
         testEpic(
-            addTimeoutEpic(checkMapOrientation, 1000),
+            addTimeoutEpic(readQueryParamsOnMapEpic, 1000),
             1, [
+                onLocationChanged({}),
                 changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions, '')
             ], actions => {
                 expect(actions.length).toBe(1);
@@ -501,7 +498,7 @@ describe('queryparam epics', () => {
             }, state);
     });
     //
-    it('changeMapView does not trigger orientateMap if map type is not cesium', (done)=>{
+    it('Test readQueryParamsOnMapEpic / changeMapView does not trigger orientateMap if map type is not cesium', (done)=>{
         const viewerOptions = {
             orientation: {
                 heading: 0.1,
@@ -519,16 +516,24 @@ describe('queryparam epics', () => {
                 }
             }
         };
-        const action = changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions, '');
-        const checkActions = actions => {
-            expect(actions.length).toBe(0);
-            done();
-        };
-        checkMapOrientation(new ActionsObservable(Rx.Observable.of(action)), {getState: () => state})
-            .toArray()
-            .subscribe(checkActions);
+
+        testEpic(
+            addTimeoutEpic(readQueryParamsOnMapEpic, 100),
+            1, [
+                onLocationChanged({}),
+                changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions, '')
+            ], actions => {
+                expect(actions.length).toBe(2);
+                try {
+                    expect(actions[0].type).toBe(TEST_TIMEOUT);
+                    expect(actions[1].type).toBe("EPIC_COMPLETED");
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }, state, false, true);
     });
-    it('changeMapView does not trigger orientateMap if any of the viewerOptions values is undefined', (done)=>{
+    it('changeMapView does not trigger orientateMap if any of the viewerOptions values are undefined', (done)=>{
         const viewerOptions = {
             orientation: {
                 pitch: -0.7,
@@ -545,14 +550,21 @@ describe('queryparam epics', () => {
                 }
             }
         };
-        const action = changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions, '');
-        const checkActions = actions => {
-            expect(actions.length).toBe(0);
-            done();
-        };
-        checkMapOrientation(new ActionsObservable(Rx.Observable.of(action)), {getState: () => state})
-            .toArray()
-            .subscribe(checkActions);
+        testEpic(
+            addTimeoutEpic(readQueryParamsOnMapEpic, 100),
+            1, [
+                onLocationChanged({}),
+                changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions, '')
+            ], actions => {
+                expect(actions.length).toBe(2);
+                try {
+                    expect(actions[0].type).toBe(TEST_TIMEOUT);
+                    expect(actions[1].type).toBe("EPIC_COMPLETED");
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }, state, false, true);
     });
     it('switch map type to cesium if cesium viewer options are found', (done) => {
         const state = {
@@ -566,7 +578,7 @@ describe('queryparam epics', () => {
             }
         };
         const NUMBER_OF_ACTIONS = 2;
-        testEpic(addTimeoutEpic(switchMapType, 10), NUMBER_OF_ACTIONS, [
+        testEpic(addTimeoutEpic(readQueryParamsOnMapEpic, 10), NUMBER_OF_ACTIONS, [
             onLocationChanged({}),
             initMap(true)
         ], (actions) => {
@@ -592,7 +604,7 @@ describe('queryparam epics', () => {
             }
         };
         const NUMBER_OF_ACTIONS = 1;
-        testEpic(addTimeoutEpic(switchMapType, 10), NUMBER_OF_ACTIONS, [
+        testEpic(addTimeoutEpic(readQueryParamsOnMapEpic, 10), NUMBER_OF_ACTIONS, [
             onLocationChanged({}),
             initMap(true)
         ], (actions) => {

--- a/web/client/epics/queryparams.js
+++ b/web/client/epics/queryparams.js
@@ -163,15 +163,12 @@ export const readQueryParamsOnMapEpic = (action$, store) => {
                 .do(() => {skipProcessing = false;})
         ))
         .switchMap(() => {
-            const state = store.getState();
-            const map = mapSelector(state);
-            const parameters = getParametersValues(paramActions, state);
-            const cesiumViewerOptions = getCesiumViewerOptions(parameters, map);
-
+            const parameters = getParametersValues(paramActions, store.getState());
             return Rx.Observable.merge(
                 action$.ofType(INIT_MAP)
                     .take(1)
                     .switchMap(() => {
+                        const cesiumViewerOptions = getCesiumViewerOptions(parameters, mapSelector(store.getState()));
                         if (cesiumViewerOptions) {
                             skipProcessing = true;
                             return Rx.Observable.of(changeMapType('cesium'));

--- a/web/client/epics/queryparams.js
+++ b/web/client/epics/queryparams.js
@@ -155,7 +155,7 @@ export const paramActions = {
 export const readQueryParamsOnMapEpic = (action$, store) => {
     let skipProcessing = false;
     return action$.ofType(LOCATION_CHANGE)
-        // this stop / start listening for une LOCATION_CHANGE event if `skipProcessing` is true, useful when this action is triggered by switching map-type
+        // this stop / start listening for one LOCATION_CHANGE event if `skipProcessing` is true, useful when this action is triggered by switching map-type
         .let(semaphore(
             action$.ofType(LOCATION_CHANGE)
                 .map(() => !skipProcessing)

--- a/web/client/epics/queryparams.js
+++ b/web/client/epics/queryparams.js
@@ -153,7 +153,7 @@ export const readQueryParamsOnMapEpic = (action$, store) =>
 
 /**
  * Intercept on `LOCATION_CHANGE` to get query params from router.location.search string.
- * If speficic maps viewer options are found (atm just cesium) fire an action to change
+ * If specific map viewer options are found (atm just cesium) fire an action to change
  * the map type to the appropriate one
  * @param {*} action$ manages `LOCATION_CHANGE`
  * @memberof epics.share
@@ -167,7 +167,7 @@ export const switchMapType = (action$, store) =>
                 .switchMap(() => {
                     const state = store.getState();
                     const map = mapSelector(state);
-                    const parameters = getParametersValues(paramActions, state);
+                    const parameters = getParametersValues(paramActions, state, true);
                     const cesiumViewerOptions = getCesiumViewerOptions(parameters, map);
                     if (cesiumViewerOptions) {
                         return Rx.Observable.of(changeMapType('cesium'));

--- a/web/client/epics/queryparams.js
+++ b/web/client/epics/queryparams.js
@@ -155,6 +155,7 @@ export const paramActions = {
 export const readQueryParamsOnMapEpic = (action$, store) => {
     let skipProcessing = false;
     return action$.ofType(LOCATION_CHANGE)
+        // this stop / start listening for une LOCATION_CHANGE event if `skipProcessing` is true, useful when this action is triggered by switching map-type
         .let(semaphore(
             action$.ofType(LOCATION_CHANGE)
                 .map(() => !skipProcessing)

--- a/web/client/epics/queryparams.js
+++ b/web/client/epics/queryparams.js
@@ -166,7 +166,6 @@ export const readQueryParamsOnMapEpic = (action$, store) => {
             const state = store.getState();
             const map = mapSelector(state);
             const parameters = getParametersValues(paramActions, state);
-            const queryActions = getQueryActions(parameters, paramActions, state);
             const cesiumViewerOptions = getCesiumViewerOptions(parameters, map);
 
             return Rx.Observable.merge(
@@ -182,6 +181,7 @@ export const readQueryParamsOnMapEpic = (action$, store) => {
                 action$.ofType(LAYER_LOAD)
                     .take(1)
                     .switchMap(() => {
+                        const queryActions = getQueryActions(parameters, paramActions, store.getState());
                         return head(queryActions)
                             ? Rx.Observable.of(...queryActions)
                             : Rx.Observable.empty();

--- a/web/client/product/appConfigEmbedded.js
+++ b/web/client/product/appConfigEmbedded.js
@@ -7,7 +7,7 @@
 */
 
 import {updateActiveDockEpic, updateMapLayoutEpic} from '../epics/maplayout';
-import {readQueryParamsOnMapEpic, switchMapType, checkMapOrientation} from '../epics/queryparams';
+import {readQueryParamsOnMapEpic} from '../epics/queryparams';
 import maplayout from '../reducers/maplayout';
 import searchconfig from '../reducers/searchconfig';
 import version from '../reducers/version';
@@ -57,9 +57,7 @@ export default {
     baseEpics: {
         updateMapLayoutEpic,
         updateActiveDockEpic,
-        readQueryParamsOnMapEpic,
-        switchMapType,
-        checkMapOrientation
+        readQueryParamsOnMapEpic
     },
     storeOpts: {
         persist: {

--- a/web/client/product/main.jsx
+++ b/web/client/product/main.jsx
@@ -18,7 +18,7 @@ import { themeLoaded } from '../actions/theme';
 
 import { updateMapLayoutEpic, updateActiveDockEpic } from '../epics/maplayout';
 import { setSupportedLocales } from '../epics/localconfig';
-import { readQueryParamsOnMapEpic, switchMapType } from '../epics/queryparams';
+import { readQueryParamsOnMapEpic } from '../epics/queryparams';
 
 import maptype from '../reducers/maptype';
 import maps from '../reducers/maps';
@@ -86,7 +86,6 @@ export default (config = {}, pluginsDef, overrideConfig = cfg => cfg) => {
                 updateActiveDockEpic,
                 setSupportedLocales,
                 readQueryParamsOnMapEpic,
-                switchMapType,
                 ...configAppEpics
             }),
 

--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -47,15 +47,14 @@ export const getRequestLoadValue = (name, state) => {
  * </pre>
  * @param {string} name - name of the parameter to get
  * @param {Storage} storage - sessionStorage or localStorage
- * @param {boolean} preserve - variable won't be removed from the storage after reading if true
  */
-export const postRequestLoadValue = (name, storage = sessionStorage, preserve = false) => {
+export const postRequestLoadValue = (name, storage = sessionStorage) => {
     const queryParams = storage.getItem('queryParams') ?? null;
     if (queryParams) {
         try {
             const params = JSON.parse(queryParams);
             const { [name]: item, ...rest } = params;
-            if (item && typeof params === 'object' && !preserve) {
+            if (item && typeof params === 'object') {
                 const { length } = Object.keys(params);
                 length > 1 && storage.setItem('queryParams', JSON.stringify(rest));
                 length === 1 && storage.removeItem('queryParams');
@@ -81,8 +80,8 @@ export const postRequestLoadValue = (name, storage = sessionStorage, preserve = 
  * @param {*} state - app state
  * @param {Storage} storage - sessionStorage or localStorage
  */
-export const getRequestParameterValue = (name, state, storage = sessionStorage, preserve = false) => {
-    return getRequestLoadValue(name, state) ?? postRequestLoadValue(name, storage, preserve);
+export const getRequestParameterValue = (name, state, storage = sessionStorage) => {
+    return getRequestLoadValue(name, state) ?? postRequestLoadValue(name, storage);
 };
 
 
@@ -92,13 +91,12 @@ export const getRequestParameterValue = (name, state, storage = sessionStorage, 
  * mapping is based on an object that maps each query string param to a redux action
  * @param {object} paramActions objects that maps each parameter to its respective action to trigger
  * @param {object} state the application state
- * @param {boolean} preserve - by default parameter values obtained from storage will be removed after reading. This flag allows to preserve variable in storage upon reading
  * @returns {object} { param: value } KVP object
  */
-export const getParametersValues = (paramActions, state, preserve = false) => (
+export const getParametersValues = (paramActions, state) => (
     Object.keys(paramActions)
         .reduce((params, parameter) => {
-            const value = getRequestParameterValue(parameter, state, sessionStorage, preserve);
+            const value = getRequestParameterValue(parameter, state, sessionStorage);
             return {
                 ...params,
                 ...(value ? { [parameter]: value } : {})

--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -47,14 +47,15 @@ export const getRequestLoadValue = (name, state) => {
  * </pre>
  * @param {string} name - name of the parameter to get
  * @param {Storage} storage - sessionStorage or localStorage
+ * @param {boolean} preserve - variable won't be removed from the storage after reading if true
  */
-export const postRequestLoadValue = (name, storage = sessionStorage) => {
+export const postRequestLoadValue = (name, storage = sessionStorage, preserve = false) => {
     const queryParams = storage.getItem('queryParams') ?? null;
     if (queryParams) {
         try {
             const params = JSON.parse(queryParams);
             const { [name]: item, ...rest } = params;
-            if (item && typeof params === 'object') {
+            if (item && typeof params === 'object' && !preserve) {
                 const { length } = Object.keys(params);
                 length > 1 && storage.setItem('queryParams', JSON.stringify(rest));
                 length === 1 && storage.removeItem('queryParams');
@@ -80,8 +81,8 @@ export const postRequestLoadValue = (name, storage = sessionStorage) => {
  * @param {*} state - app state
  * @param {Storage} storage - sessionStorage or localStorage
  */
-export const getRequestParameterValue = (name, state, storage = sessionStorage) => {
-    return getRequestLoadValue(name, state) ?? postRequestLoadValue(name, storage);
+export const getRequestParameterValue = (name, state, storage = sessionStorage, preserve = false) => {
+    return getRequestLoadValue(name, state) ?? postRequestLoadValue(name, storage, preserve);
 };
 
 
@@ -91,12 +92,13 @@ export const getRequestParameterValue = (name, state, storage = sessionStorage) 
  * mapping is based on an object that maps each query string param to a redux action
  * @param {object} paramActions objects that maps each parameter to its respective action to trigger
  * @param {object} state the application state
+ * @param {boolean} preserve - by default parameter values obtained from storage will be removed after reading. This flag allows to preserve variable in storage upon reading
  * @returns {object} { param: value } KVP object
  */
-export const getParametersValues = (paramActions, state) => (
+export const getParametersValues = (paramActions, state, preserve = false) => (
     Object.keys(paramActions)
         .reduce((params, parameter) => {
-            const value = getRequestParameterValue(parameter, state);
+            const value = getRequestParameterValue(parameter, state, sessionStorage, preserve);
             return {
                 ...params,
                 ...(value ? { [parameter]: value } : {})

--- a/web/client/utils/__tests__/QueryParamsUtils-test.js
+++ b/web/client/utils/__tests__/QueryParamsUtils-test.js
@@ -59,6 +59,18 @@ describe('QueryParamsUtils', () => {
         expect(zoom).toBe(5);
         expect(center).toBe("41,0");
     });
+    it('test postRequestLoadValue preserving variable in storage', () => {
+        sessionStorage.setItem('queryParams', JSON.stringify({featureinfo: {lat: 38.72, lng: -95.625, filterNameList: []}, zoom: 5, center: "41,0"}));
+        let featureinfo = postRequestLoadValue('featureinfo', sessionStorage, true);
+        expect(featureinfo.lat).toBe(38.72);
+        expect(featureinfo.lng).toBe(-95.625);
+        expect(featureinfo.filterNameList).toEqual([]);
+
+        featureinfo = postRequestLoadValue('featureinfo', sessionStorage);
+        expect(featureinfo).toNotBe(undefined);
+        featureinfo = postRequestLoadValue('featureinfo', sessionStorage);
+        expect(featureinfo).toBe(undefined);
+    });
     it('test getRequestParameterValue', () => {
         const state = {
             router: {

--- a/web/client/utils/__tests__/QueryParamsUtils-test.js
+++ b/web/client/utils/__tests__/QueryParamsUtils-test.js
@@ -59,18 +59,6 @@ describe('QueryParamsUtils', () => {
         expect(zoom).toBe(5);
         expect(center).toBe("41,0");
     });
-    it('test postRequestLoadValue preserving variable in storage', () => {
-        sessionStorage.setItem('queryParams', JSON.stringify({featureinfo: {lat: 38.72, lng: -95.625, filterNameList: []}, zoom: 5, center: "41,0"}));
-        let featureinfo = postRequestLoadValue('featureinfo', sessionStorage, true);
-        expect(featureinfo.lat).toBe(38.72);
-        expect(featureinfo.lng).toBe(-95.625);
-        expect(featureinfo.filterNameList).toEqual([]);
-
-        featureinfo = postRequestLoadValue('featureinfo', sessionStorage);
-        expect(featureinfo).toNotBe(undefined);
-        featureinfo = postRequestLoadValue('featureinfo', sessionStorage);
-        expect(featureinfo).toBe(undefined);
-    });
     it('test getRequestParameterValue', () => {
         const state = {
             router: {


### PR DESCRIPTION
## Description
Fix for regression by using single epic to process query parameters.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8319 
This regression was introduced by changes in #7966. It appears because `switchMapType` epic at ` epics/queryparams.js` is running before `readQueryParamsOnMapEpic` where query parameters are processed and actions are dispatched. It means that prior to the fix query parameters values in sessionStorage were removed before they read by the epic that process parameters.

**What is the new behavior?**
All epics that process query parameters are combined into single one. Parameters reading and processing happens only once per outer stream run. Parameters obtained from sessionStorage are available for inner streams,

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
