### PR TITLE
Update webpack-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vusion-webfonts-generator": "0.4.1",
     "webpack": "5.9.0",
     "webpack-bundle-size-analyzer": "2.0.2",
-    "webpack-cli": "4.9.0",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "3.11.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

Version 4.9 of `webpack-cli` is broken because of transitive dependencies.  
Now can cause error `cli.isMultipleCompiler is not a function`
See this:  https://github.com/webpack/webpack-cli/issues/3294

This happens if you emty node_modules and re-run `npm install`. 

The solution is to update package.json `webpack-cli` from `4.9.0` to `4.10.0`. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8326

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
