### PR TITLE
7928 Redundant panels inside identify results on mobile & swiping

### DIFF
--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -77,7 +77,7 @@ class DefaultViewer extends React.Component {
     getResponseProperties = () => {
         const validator = this.props.validator(this.props.format);
         const responses = this.props.responses.map(res => res === undefined ? {} : res); // Replace any undefined responses
-        const validResponses = this.props.renderValidOnly ? validator.getValidResponses(responses) : responses;
+        const validResponses = validator.getValidResponses(responses);
         const invalidResponses = validator.getNoValidResponses(this.props.responses);
         const emptyResponses = this.props.requests.length === invalidResponses.length;
         const currResponse = this.getCurrentResponse(validResponses[this.props.index]);
@@ -143,6 +143,7 @@ class DefaultViewer extends React.Component {
 
     renderPages = () => {
         const {validResponses: responses} = this.getResponseProperties();
+
         return responses.map((res, i) => {
             const {response, layerMetadata} = res;
             const format = getFormatForResponse(res, this.props);
@@ -151,8 +152,10 @@ class DefaultViewer extends React.Component {
             if (layerMetadata?.viewer?.type) {
                 customViewer = getViewer(layerMetadata.viewer.type);
             }
+            const validator = this.props.validator(this.props.format);
+            const validResponse = !!validator.getValidResponses([res]).length;
             const size = responses.filter(resp => !startsWith(resp.response, "no features were found")).length;
-            return (<Panel
+            return validResponse ? (<Panel
                 eventKey={i}
                 key={i}
                 collapsible={this.props.collapsible}
@@ -170,8 +173,8 @@ class DefaultViewer extends React.Component {
                     format={format}
                     viewers={customViewer || this.props.viewers}
                     layer={layerMetadata}/>
-            </Panel>);
-        });
+            </Panel>) : false;
+        }).filter(Boolean);
     };
 
     render() {

--- a/web/client/components/data/identify/LayerSelector.jsx
+++ b/web/client/components/data/identify/LayerSelector.jsx
@@ -19,8 +19,9 @@ const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, e
     const [title, setTitle] = useState("");
 
     useEffect(()=>{
-        if (!isEmpty(responses)) {
-            setOptions(responses.map((opt, idx)=> {
+        const validResponses = validator(format)?.getValidResponses(responses);
+        if (!isEmpty(validResponses)) {
+            setOptions(validResponses.map((opt, idx)=> {
                 const value = opt?.layerMetadata?.title;
                 // Display only valid responses in the drop down
                 const valid = !!validator(format)?.getValidResponses([opt]).length;
@@ -30,7 +31,8 @@ const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, e
     }, [responses]);
 
     useEffect(()=>{
-        loaded && setTitle(responses[index]?.layerMetadata?.title || "");
+        const validResponses = validator(format)?.getValidResponses(responses);
+        loaded && setTitle(validResponses[index]?.layerMetadata?.title || "");
     }, [responses, index, loaded]);
 
     const onChange = (event) => {

--- a/web/client/components/data/identify/LayerSelector.jsx
+++ b/web/client/components/data/identify/LayerSelector.jsx
@@ -31,7 +31,7 @@ const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, e
     }, [responses]);
 
     useEffect(()=>{
-        const validResponses = validator(format)?.getValidResponses(responses);
+        const validResponses = validator(format)?.getValidResponses(responses) ?? [];
         loaded && setTitle(validResponses[index]?.layerMetadata?.title || "");
     }, [responses, index, loaded]);
 

--- a/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
+++ b/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
@@ -127,7 +127,7 @@ describe('DefaultViewer', () => {
         expect(viewer).toExist();
         const dom = ReactDOM.findDOMNode(viewer);
         expect(dom.getElementsByClassName("alert").length).toBe(1);
-        expect(dom.getElementsByClassName("panel").length).toBe(2);
+        expect(dom.getElementsByClassName("panel").length).toBe(1);
 
         // Desktop view
         const gfiViewer = document.querySelector('.mapstore-identify-viewer');

--- a/web/client/components/data/identify/__tests__/LayerSelector-test.jsx
+++ b/web/client/components/data/identify/__tests__/LayerSelector-test.jsx
@@ -50,11 +50,8 @@ describe("LayerSelector component", () => {
             TestUtils.Simulate.keyDown(input, { key: 'ArrowDown', keyCode: 40 });
         });
         const options = select.querySelectorAll(".Select-option");
-        // Invalid response - first option is hidden
-        expect(options[0].style.display).toBe('none');
-
-        // Valid response - second option is displayed
-        expect(options[1].style.display).toBe('block');
+        expect(options.length).toBe(1);
+        expect(options[0].style.display).toBe('block');
     });
     it('test LayerSelector with value and setIndex', (done) => {
 
@@ -62,7 +59,9 @@ describe("LayerSelector component", () => {
             responses: [
                 {layerMetadata: {title: "Layer 1"}, response: "GetFeatureInfo results1"},
                 {layerMetadata: {title: "Layer 2"}, response: "GetFeatureInfo results2"}],
-            index: 0
+            index: 0,
+            validator: getValidator,
+            format: "text/plain"
         };
 
         TestUtils.act(() => {

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -120,7 +120,7 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[1].response).toBe("data");
         expect(state.responses[1].queryParams).toBe("params");
         expect(state.responses[1].layerMetadata).toBe("meta");
-        expect(state.index).toBe(1);
+        expect(state.index).toBe(0);
     });
     it('creates a feature info data from successful request on showInMapPopup', () => {
         let testAction = {
@@ -207,7 +207,7 @@ describe('Test the mapInfo reducer', () => {
         let state = mapInfo({requests: [{}], configuration: {}}, testAction);
         expect(state.responses).toExist();
         expect(state.loaded).toBe(true);
-        expect(state.index).toBe(1);
+        expect(state.index).toBe(0);
         expect(state.responses.length).toBe(2);
         expect(state.responses[1].response).toExist();
         expect(state.responses[1].response.features.length).toBe(1);

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -39,7 +39,7 @@ import { MAP_CONFIG_LOADED } from '../actions/config';
 import { RESET_CONTROLS } from '../actions/controls';
 import assign from 'object-assign';
 import { findIndex, isUndefined, isEmpty } from 'lodash';
-import { MAP_TYPE_CHANGED } from './../actions/maptype';
+import { MAP_TYPE_CHANGED } from '../actions/maptype';
 
 import { getValidator } from '../utils/MapInfoUtils';
 
@@ -108,7 +108,7 @@ function receiveResponse(state, action, type) {
         if (isHover) {
             indexObj = {loaded: true, index: 0};
         } else if (!isHover && isIndexValid(state, responses, requestIndex, isVector)) {
-            indexObj = {loaded: true, index: requestIndex};
+            indexObj = {loaded: true, index: 0};
         } else if (responses.length === requests.length && !indexObj?.loaded) {
             // if all responses are empty hence valid but with no valid index
             // then set loaded to true


### PR DESCRIPTION
## Description
Identify panel allows to switch between results of map info requests using select element that contains layers that DO have data in a certain point user clicked/hovered.
In mobile mode user is able to swipe left or right to switch between available layers easily.

The problem is that in mobile view there were redundant empty panels appearing upon swipe from time to time as it described in the ticket connected to this PR.

The reason of such behavior was in the way how data was rendered inside the container that allows to swipe:
- All the responses (in other words - all the layers) got a panel in results list regardless of response validity.
- Index was set to the first valid response, meaning that swipeable container "moved" viewport to make it show valid result.

It was working quite well on desktop, but on mobile it still allowed to swipe back and forth to the invalid results because they, eventually, were rendered as empty panels inside of swipe container.

This PR suggest following change to prevent the issue:
1. Layer selector will list ONLY layers where response was valid.
2. Swipe container will render panel ONLY per valid response.
3. Indexing of the select options and panels will change accordingly, 0 for the first valid result and so on.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7928 

**What is the new behavior?**
As per PR description. No redundant panels that user can swipe to in mobile view.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
