### PR TITLE
#7952 Added pathPattern property support into authenticationRules

### DIFF
--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -15,6 +15,7 @@ import isNil from "lodash/isNil";
 import isArray from "lodash/isArray";
 
 import {setStore as stateSetStore, getState} from "./StateUtils";
+import {urlParts} from "./URLUtils";
 
 /**
  * Stores the logged user security information.
@@ -123,7 +124,11 @@ export function isAuthenticationActivated() {
  */
 export function getAuthenticationMethod(url) {
     const foundRule = head(getAuthenticationRules().filter(
-        rule => rule && rule.urlPattern && url.match(new RegExp(rule.urlPattern, "i"))));
+        rule =>
+            rule && (
+                (rule.urlPattern && url.match(new RegExp(rule.urlPattern, "i"))) ||
+                (rule.pathPattern && (urlParts(url).rootPath).match(new RegExp(rule.pathPattern, "i")))
+            )));
     return foundRule?.method;
 }
 
@@ -134,7 +139,11 @@ export function getAuthenticationMethod(url) {
  */
 export function getAuthenticationRule(url) {
     return head(getAuthenticationRules().filter(
-        rule => rule && rule.urlPattern && url.match(new RegExp(rule.urlPattern, "i"))));
+        rule =>
+            rule && (
+                (rule.urlPattern && url.match(new RegExp(rule.urlPattern, "i"))) ||
+                (rule.pathPattern && (urlParts(url).rootPath).match(new RegExp(rule.pathPattern, "i")))
+            )));
 }
 
 export function getAuthKeyParameter(url) {

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -71,6 +71,7 @@ const securityInfoToken = {
 const authenticationRules = [
     {
         "urlPattern": ".*geoserver.*",
+        "pathPattern": "/some-path/*",
         "method": "authkey"
     },
     {
@@ -183,6 +184,9 @@ describe('Test security utils methods', () => {
         expect(authenticationMethod).toBe('basic');
         // authkey authentication should be found
         authenticationMethod = SecurityUtils.getAuthenticationMethod('http://www.some-site.com/geoserver?parameter1=value1&parameter2=value2');
+        expect(authenticationMethod).toBe('authkey');
+        // authkey authentication should be found. Rule matched by rule.pathPattern property
+        authenticationMethod = SecurityUtils.getAuthenticationMethod('http://www.random-domain.com/some-path/test?parameter1=value1&parameter2=value2');
         expect(authenticationMethod).toBe('authkey');
         // not-supported authentication should be found
         authenticationMethod = SecurityUtils.getAuthenticationMethod('http://www.not-supported.com/?parameter1=value1&parameter2=value2');


### PR DESCRIPTION
## Description
This PR provides minor modification to the functions that return authentication rule and authentication method based on URL and rule URL pattern. It adds "pathPattern" property that can be optionally defined for rule and it will be used as a second alternative way to match rule against passed URL.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Small improvement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7952 

**What is the new behavior?**
It's possible to define "pathPattern" for the rule that will me used to check for a match of "path" part of the URL.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
