### PR TITLE
[Backport 2022.01.xx-geOrchestra] #8225 Making annotations not toggled but forcefully activated whenever measurements are saved as annotation (#8226)

### DIFF
--- a/web/client/epics/__tests__/measurement-test.jsx
+++ b/web/client/epics/__tests__/measurement-test.jsx
@@ -104,7 +104,7 @@ describe('measurement epics', () => {
                 addAnnotation(features, textLabels, uom, false, {id: 1})
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
-                expect(actions[0].type).toBe("TOGGLE_CONTROL");
+                expect(actions[0].type).toBe("SET_CONTROL_PROPERTY");
                 expect(actions[1].type).toBe("ANNOTATIONS:NEW");
                 expect(actions[2].type).toBe("MEASUREMENT:SET_MEASUREMENT_CONFIG");
                 expect(actions[2].property).toBe("exportToAnnotation");

--- a/web/client/epics/measurement.js
+++ b/web/client/epics/measurement.js
@@ -22,13 +22,12 @@ import {
 import {addLayer} from '../actions/layers';
 import {STYLE_TEXT} from '../utils/AnnotationsUtils';
 import {
-    toggleControl,
     setControlProperty,
     SET_CONTROL_PROPERTY,
     TOGGLE_CONTROL
 } from '../actions/controls';
 import {purgeMapInfoResults, hideMapinfoMarker} from '../actions/mapInfo';
-import {measureSelector} from '../selectors/controls';
+import {createControlEnabledSelector, measureSelector} from '../selectors/controls';
 import {geomTypeSelector, isActiveSelector} from '../selectors/measurement';
 import {CLICK_ON_MAP, registerEventListener, unRegisterEventListener} from '../actions/map';
 import {
@@ -40,7 +39,7 @@ import {
 import {updateDockPanelsList} from "../actions/maplayout";
 import {shutdownToolOnAnotherToolDrawing} from "../utils/ControlUtils";
 
-export const addAnnotationFromMeasureEpic = (action$) =>
+export const addAnnotationFromMeasureEpic = (action$, store) =>
     action$.ofType(ADD_MEASURE_AS_ANNOTATION)
         .switchMap((a) => {
             // transform measure feature into geometry collection
@@ -53,12 +52,12 @@ export const addAnnotationFromMeasureEpic = (action$) =>
                 visibility
             };
 
-            return Rx.Observable.of(
-                toggleControl('annotations', null),
+            return Rx.Observable.from([
+                ...(createControlEnabledSelector('annotations')(store.getState()) ? [] : [setControlProperty('annotations', 'enabled', true)]),
                 newAnnotation(),
                 setMeasurementConfig("exportToAnnotation", false),
                 setEditingFeature(newFeature)
-            );
+            ]);
         });
 
 export const addAsLayerEpic = (action$) =>


### PR DESCRIPTION
[Backport 2022.01.xx-geOrchestra] #8225 Making annotations not toggled but forcefully activated whenever measurements are saved as annotation (#8226)