### PR TITLE
#8348 Update "About" plugin configuration to make it visible in multiple containers by default

### DIFF
--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -402,11 +402,8 @@
                 "cfg": {
                     "wrap": true
                 }
-            }, {
-              "name": "About",
-              "showIn": ["BurgerMenu"]
-            }
-            , {
+            }, "About",
+            {
               "name": "MousePosition",
               "cfg": {
                 "editCRS": true,


### PR DESCRIPTION
## Description
Minor change to localConfig.json to make "About" plugin work in multiple containers simultaneously by default.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8348

**What is the new behavior?**
"About" plugin available when BurgerMenu and when SidebarMenu are in use.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
