### PR TITLE
#8294 Allow import/export on cesium viewer

### DIFF
--- a/web/client/plugins/MapExport.jsx
+++ b/web/client/plugins/MapExport.jsx
@@ -88,9 +88,6 @@ const MapExport = enhanceExport(
  */
 const MapExportPlugin = createPlugin('MapExport', {
     component: MapExport,
-    options: {
-        disablePluginIf: "{state('mapType') === 'cesium'}"
-    },
     containers: {
         SidebarMenu: config => {
             const enabledFormats = get(config, 'cfg.enabledFormats', DEFAULTS);

--- a/web/client/plugins/MapImport.jsx
+++ b/web/client/plugins/MapImport.jsx
@@ -83,7 +83,6 @@ export default {
             resolve(ImportPlugin);
         });
     }, enabler: (state) => state.mapimport && state.mapimport.enabled || state.toolbar && state.toolbar.active === 'import'}, {
-        disablePluginIf: "{state('mapType') === 'cesium'}",
         BurgerMenu: {
             name: 'import',
             position: 4,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR allows the `MapImport` and `MapExport` plugins to be displayed on the cesium viewer.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bug

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8294 
import and export plugins are not visible on the cesium viewer
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
import and export plugins are visible on the cesium viewer
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
