### PR TITLE
8295 annotation node visible in 3d

### DIFF
--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -150,11 +150,7 @@ const tocSelector = createSelector(
             },
             {
                 options: { showComponent: false },
-                func: (node) => head((node.nodes || []).filter(l => l.hidden || l.id === "annotations" && isCesiumActive)) && node.nodes.length === 1
-            },
-            {
-                options: { showComponent: false },
-                func: (node) => node.id === "annotations" && isCesiumActive
+                func: (node) => head((node.nodes || []).filter(l => l.hidden)) && node.nodes.length === 1
             },
             {
                 options: { exclusiveMapType: true },

--- a/web/client/plugins/__tests__/TOC-test.jsx
+++ b/web/client/plugins/__tests__/TOC-test.jsx
@@ -58,37 +58,6 @@ describe('TOCPlugin Plugin', () => {
         expect(document.querySelectorAll('.mapstore-filter.form-group').length).toBe(1);
     });
 
-    it('TOCPlugin hides annotations layer and empty group in cesium mapType', () => {
-        const { Plugin } = getPluginForTest(TOCPlugin, {
-            layers: {
-                groups: [{ id: 'default', title: 'Default', nodes: ['annotations'] }],
-                flat: [{ id: 'annotations', title: 'Annotations' }]
-            },
-            maptype: {
-                mapType: 'cesium'
-            }
-        });
-        const WrappedPlugin = dndContext(Plugin);
-        ReactDOM.render(<WrappedPlugin />, document.getElementById("container"));
-        expect(document.querySelectorAll('.toc-title').length).toBe(0);
-        expect(document.querySelectorAll('.toc-group-title').length).toBe(0);
-    });
-
-    it('TOCPlugin hides annotations layer but not its group if not empty in cesium mapType', () => {
-        const { Plugin } = getPluginForTest(TOCPlugin, {
-            layers: {
-                groups: [{ id: 'default', title: 'Default', nodes: ['annotations', 'other'] }],
-                flat: [{ id: 'annotations', title: 'Annotations' }, { id: 'other', title: 'Other'}]
-            },
-            maptype: {
-                mapType: 'cesium'
-            }
-        });
-        const WrappedPlugin = dndContext(Plugin);
-        ReactDOM.render(<WrappedPlugin />, document.getElementById("container"));
-        expect(document.querySelectorAll('.toc-title').length).toBe(1);
-        expect(document.querySelectorAll('.toc-group-title').length).toBe(1);
-    });
     it('TOCPlugin hides filter layer if no groups and no layers are present', () => {
         const { Plugin } = getPluginForTest(TOCPlugin, {
             layers: {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR allows annotations layers and groups to be displayed on cesium viewer.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bug

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8295 
Annotation node in the TOC is hidden in the cesium viewer
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Annotation node in the TOC is visible on the cesium viewer
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
