### PR TITLE
#8346: Fix timeline error in epic setIsIntervalData

### DIFF
--- a/web/client/epics/__tests__/playback-test.js
+++ b/web/client/epics/__tests__/playback-test.js
@@ -291,7 +291,7 @@ describe('playback Epics', () => {
             }
         });
     });
-    it('setIsIntervalData', done => {
+    it('setIsIntervalData on layer select', done => {
         mock.onGet('MOCK_DOMAIN_VALUES').reply(200, DOMAIN_INTERVAL_VALUES_RESPONSE);
         testEpic(setIsIntervalData, 1, selectLayer("playback:selected_layer"), ([action]) => {
             try {
@@ -303,6 +303,29 @@ describe('playback Epics', () => {
                 done(e);
             }
         }, ANIMATION_MOCK_STATE);
+    });
+    it('setIsIntervalData on current time', done => {
+        mock.onGet('MOCK_DOMAIN_VALUES').reply(200, DOMAIN_INTERVAL_VALUES_RESPONSE);
+        testEpic(setIsIntervalData, 1, setCurrentTime("2016-09-04T00:00:00.000Z"), ([action]) => {
+            try {
+                const { type, timeIntervalData } = action;
+                expect(type).toBe(SET_INTERVAL_DATA);
+                expect(timeIntervalData).toBe(true);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }, ANIMATION_MOCK_STATE);
+    });
+    it('setIsIntervalData when no time layer selected', done => {
+        testEpic(addTimeoutEpic(setIsIntervalData, 100), 1, setCurrentTime("2016-09-04T00:00:00.000Z"), ([action]) => {
+            try {
+                expect(action.type).toBe(TEST_TIMEOUT);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }, {dimension: ANIMATION_MOCK_STATE.dimension, layers: ANIMATION_MOCK_STATE.layers});
     });
     it('switchOffSnapToLayer - layer selected visibility false', done => {
         testEpic(switchOffSnapToLayer, 1, changeLayerProperties("playback:selected_layer", {visibility: false}), ([action]) => {

--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -366,7 +366,7 @@ export const playbackCacheNextPreviousTimes = (action$, { getState = () => { } }
  */
 export const setIsIntervalData = (action$, { getState = () => { } } = {}) =>
     action$.ofType(SELECT_LAYER, SET_CURRENT_TIME)
-        .filter(({type, layerId}) => (type === SET_CURRENT_TIME || (type === SELECT_LAYER && layerId)))
+        .filter(({layerId}) => layerId || selectedLayerSelector(getState()))
         .switchMap(({time: actionTime}) => {
             const time = actionTime || currentTimeSelector(getState());
             const snapType = snapTypeSelector(getState());


### PR DESCRIPTION
## Description
This PR fixes the timeline error in epic `setIsIntervalData` when current time is set but no time layer selected

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#8346 

**What is the new behavior?**
setIsIntervalData epics is executed only when layer is selected in the timeline. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
