### PR TITLE
#8372: Fix export after setting up a filter in attribute table

### DIFF
--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -110,7 +110,7 @@ const hasOutputFormat = (data) => {
 const getWFSFeature = ({ url, filterObj = {}, layerFilter, downloadOptions = {}, options } = {}) => {
     const { sortOptions, propertyNames } = options;
 
-    const data = mergeFiltersToOGC({ ogcVersion: '1.0.0', addXmlnsToRoot: true, xmlnsToAdd: ['xmlns:ogc="http://www.opengis.net/ogc"', 'xmlns:gml="http://www.opengis.net/gml"'] }, layerFilter, filterObj);
+    const data = mergeFiltersToOGC({ ogcVersion: '1.1.0', addXmlnsToRoot: true, xmlnsToAdd: ['xmlns:ogc="http://www.opengis.net/ogc"', 'xmlns:gml="http://www.opengis.net/gml"'] }, layerFilter, filterObj);
 
     return getXMLFeature(url, getFilterFeature(query(
         filterObj.featureTypeName, [...(sortOptions ? [sortBy(sortOptions.sortBy, sortOptions.sortOrder)] : []), ...(propertyNames ? [propertyName(propertyNames)] : []), ...(data ? castArray(data) : [])],

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -24,7 +24,8 @@ import {
     processOGCFilterFields,
     processOGCSimpleFilterField,
     processCQLFilterFields,
-    wrapIfNoWildcards
+    wrapIfNoWildcards,
+    mergeFiltersToOGC
 } from '../FilterUtils';
 
 
@@ -1957,5 +1958,68 @@ describe('FilterUtils', () => {
         testCases.forEach(([value, expected]) => {
             expect(wrapIfNoWildcards(value)).toBe(expected);
         });
+    });
+    it('mergeFiltersToOGC', () => {
+        let ogcVersion = "1.0.0";
+        let filterObj = {
+            featureTypeName: "test",
+            groupFields: [{id: 1, logic: "OR", index: 0}],
+            filterFields: [],
+            spatialField: {
+                method: "BBOX",
+                operation: "INTERSECTS",
+                geometry: {
+                    id: "some_id",
+                    type: "Polygon",
+                    extent: [-189291.52323397118, 6127042.8962688595, -189157.75843447214, 6127162.329125555],
+                    center: [-189224.64083422167, 6127102.612697207],
+                    coordinates: [[[-189291.52323397118, 6127162.329125555], [-189291.52323397118, 6127042.8962688595], [-189157.75843447214, 6127042.8962688595], [-189157.75843447214, 6127162.329125555], [-189291.52323397118, 6127162.329125555]]],
+                    style: {},
+                    projection: "EPSG:3857"
+                },
+                attribute: "shape"
+            },
+            pagination: { startIndex: 0, maxFeatures: 20 },
+            filterType: "OGC",
+            ogcVersion,
+            sortOptions: null,
+            crossLayerFilter: null,
+            hits: false
+        };
+        let filter = mergeFiltersToOGC({
+            ogcVersion,
+            addXmlnsToRoot: true,
+            xmlnsToAdd: ['xmlns:ogc="http://www.opengis.net/ogc"', 'xmlns:gml="http://www.opengis.net/gml"']
+        }, undefined, filterObj);
+        let expectedFilter = '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml"><ogc:And><ogc:Intersects><ogc:PropertyName>shape</ogc:PropertyName><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-189291.52323397118,6127162.329125555 -189291.52323397118,6127042.8962688595 -189157.75843447214,6127042.8962688595 -189157.75843447214,6127162.329125555 -189291.52323397118,6127162.329125555</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogc:Intersects></ogc:And></ogc:Filter>';
+        expect(filter).toEqual(expectedFilter);
+
+        // ogcVersion - 1.1.0
+        ogcVersion = '1.1.0';
+        filter = mergeFiltersToOGC({
+            ogcVersion,
+            addXmlnsToRoot: true,
+            xmlnsToAdd: ['xmlns:ogc="http://www.opengis.net/ogc"', 'xmlns:gml="http://www.opengis.net/gml"']
+        }, undefined, {...filterObj, ogcVersion});
+        expectedFilter = '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml"><ogc:And><ogc:Intersects><ogc:PropertyName>shape</ogc:PropertyName><gml:Polygon srsName="EPSG:3857"><gml:exterior><gml:LinearRing><gml:posList>-189291.52323397118 6127162.329125555 -189291.52323397118 6127042.8962688595 -189157.75843447214 6127042.8962688595 -189157.75843447214 6127162.329125555 -189291.52323397118 6127162.329125555</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogc:Intersects></ogc:And></ogc:Filter>';
+        expect(filter).toEqual(expectedFilter);
+
+        // ogcVersion - 2.0
+        ogcVersion = '2.0';
+        filter = mergeFiltersToOGC({
+            ogcVersion,
+            addXmlnsToRoot: true,
+            xmlnsToAdd: ['xmlns:ogc="http://www.opengis.net/ogc"', 'xmlns:gml="http://www.opengis.net/gml"']
+        }, undefined, {...filterObj, ogcVersion});
+        expect(filter).toEqual(expectedFilter);
+
+        // ogcVersion - 2.0.0
+        ogcVersion = '2.0.0';
+        filter = mergeFiltersToOGC({
+            ogcVersion,
+            addXmlnsToRoot: true,
+            xmlnsToAdd: ['xmlns:ogc="http://www.opengis.net/ogc"', 'xmlns:gml="http://www.opengis.net/gml"']
+        }, undefined, {...filterObj, ogcVersion});
+        expect(filter).toEqual(expectedFilter);
     });
 });


### PR DESCRIPTION
## Description
PR fixes the export of result from layer download tool after setting up a filter in attribute table

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#8372 

**What is the new behavior?**
Layer download exports filtered attribute results correctly

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
