### PR TITLE
#8358: Bring back annotations to burger menu

### DIFF
--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -354,6 +354,16 @@ export default createPlugin('Annotations', {
                 }
                 return false;
             })
+        },
+        BurgerMenu: {
+            name: 'annotations',
+            position: 40,
+            text: <Message msgId="annotationsbutton"/>,
+            tooltip: "annotations.tooltip",
+            icon: <Glyphicon glyph="comment"/>,
+            action: conditionalToggle,
+            priority: 2,
+            doNotHide: true
         }
     },
     reducers: {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR brings annotations back to burger menu on context creator.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Annotations are no longer present on the context creation (step 2 map configuration)
#8358 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Annotations are now available again in the burger menu.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
