### PR TITLE
Make time slider expanded state configurable

### DIFF
--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -482,7 +482,8 @@
             {
               "name": "Timeline",
               "cfg": {
-                "expandLimit": 20
+                "expandLimit": 20,
+                "collapsed": true
               }
             },
             "Playback",

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -103,7 +103,9 @@ const TimelinePlugin = compose(
             onInit: initTimeline
         }),
     branch(({ visible = true, layers = [] }) => !visible || Object.keys(layers).length === 0, renderNothing),
-    withState('options', 'setOptions', {collapsed: true}),
+    withState('options', 'setOptions', ({pluginCfg = {}}) => {
+        return { collapsed: pluginCfg.collapsed };
+    }),
     // add mapSync button handler and value
     connect(
         createSelector(isMapSync, mapSync => ({mapSync})),


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The Timeline plugin has been adjusted to be able to accept a 'collapsed' configuration parameter allowing it to start with an expanded time slider by default in the case it is present.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8377 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
A new config is added to Timeline for collapsed state

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
