### PR TITLE
Issue #8283 - Error in parsring getCapabilities response for CSW `<dc:URI>` tags

### DIFF
--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -297,7 +297,7 @@ const Api = {
                     'Content-Type': 'application/xml'
                 }}).then(
                     (response) => {
-                        if (response ) {
+                        if (response) {
                             let json = unmarshaller.unmarshalString(response.data);
                             if (json && json.name && json.name.localPart === "GetRecordsResponse" && json.value && json.value.searchResults) {
                                 let rawResult = json.value;
@@ -357,6 +357,7 @@ const Api = {
                                                 crs: 'EPSG:4326'
                                             };
                                         }
+                                        // dcElement is an array of objects, each item is a dc tag in the XML
                                         let dcElement = rawRec.dcElement;
                                         if (dcElement) {
                                             let dc = {
@@ -364,6 +365,7 @@ const Api = {
                                             };
                                             for (let j = 0; j < dcElement.length; j++) {
                                                 let dcel = dcElement[j];
+                                                // here the element name is taken (i.e. "URI", "title", "description", etc)
                                                 let elName = dcel.name.localPart;
                                                 let finalEl = {};
                                                 /* Some services (e.g. GeoServer) support http://schemas.opengis.net/csw/2.0.2/record.xsd only
@@ -379,6 +381,10 @@ const Api = {
                                                 } else {
                                                     finalEl = dcel.value.content && dcel.value.content[0] || dcel.value.content || dcel.value;
                                                 }
+                                                /**
+                                                    grouping all tags with same property together (i.e <dc:subject>mobilità</dc:subject> <dc:subject>traffico</dc:subject>)
+                                                    will become { subject: ["mobilità", "traffico"] }
+                                                **/
                                                 if (dc[elName] && Array.isArray(dc[elName])) {
                                                     dc[elName].push(finalEl);
                                                 } else if (dc[elName]) {
@@ -387,7 +393,7 @@ const Api = {
                                                     dc[elName] = finalEl;
                                                 }
                                             }
-                                            const URIs = dc.references.length > 0 ? dc.references : dc.URI;
+                                            const URIs = castArray(dc.references.length > 0 ? dc.references : dc.URI);
                                             if (!_dcRef) {
                                                 _dcRef = URIs;
                                             } else {

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -242,8 +242,15 @@ describe("getLayerReferenceFromDc", () => {
         expect(layerRef.type).toBe('OGC:WMS');
         expect(layerRef.url).toBe('catalog_url/wmsurl?SERVICE=WMS&VERSION=1.3.0');
     });
-    it("test layer reference with dc.URI of scheme OGC:WMS", () => {
+    it("test layer reference with multiple dc.URI of scheme OGC:WMS", () => {
         const dc = {URI: [{value: "http://wmsurl", protocol: 'OGC:WMS', name: 'some_layer'}, {value: "wfsurl", protocol: 'OGC:WFS'}]};
+        const layerRef = getLayerReferenceFromDc(dc);
+        expect(layerRef.params.name).toBe('some_layer');
+        expect(layerRef.type).toBe('OGC:WMS');
+        expect(layerRef.url).toBe('http://wmsurl');
+    });
+    it("test layer reference with single dc.URI of scheme OGC:WMS", () => {
+        const dc = {URI: {value: "http://wmsurl", protocol: 'OGC:WMS', name: 'some_layer'}};
         const layerRef = getLayerReferenceFromDc(dc);
         expect(layerRef.params.name).toBe('some_layer');
         expect(layerRef.type).toBe('OGC:WMS');


### PR DESCRIPTION
This commit contains code that casts to array any `<dc:URI>` element found
in the CSW record, this is to avoid the bug of the `.concat()` method
called onto an object.

## Description
This PR aims at fixing the bug of catalog failing to display CSW records with a single `<dc:URI>` tag 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

#8382 

**What is the current behavior?**
Catalog is failing to parse single `<dc:URI>` tags
#<issue>

**What is the new behavior?**
Catalog will parse single `<dc:URI>` tags

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
