### PR TITLE
#8377: Make time slider expanded state configurable

### DIFF
--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -45,7 +45,9 @@ import {
 import Timeline from './timeline/Timeline';
 import TimelineToggle from './timeline/TimelineToggle';
 import ButtonRB from '../components/misc/Button';
-import {isTimelineVisible} from "../utils/LayersUtils";
+import { isTimelineVisible } from "../utils/LayersUtils";
+import Loader from '../components/misc/Loader';
+
 const Button = tooltip(ButtonRB);
 
 
@@ -87,7 +89,8 @@ const TimelinePlugin = compose(
             playbackRangeSelector,
             statusSelector,
             rangeSelector,
-            (visible, layers, currentTime, currentTimeRange, offsetEnabled, playbackRange, status, viewRange) => ({
+            (state) => state.timeline?.loader !== undefined,
+            (visible, layers, currentTime, currentTimeRange, offsetEnabled, playbackRange, status, viewRange, timelineIsReady) => ({
                 visible,
                 layers,
                 currentTime,
@@ -95,7 +98,8 @@ const TimelinePlugin = compose(
                 offsetEnabled,
                 playbackRange,
                 status,
-                viewRange
+                viewRange,
+                timelineIsReady
             })
         ), {
             setCurrentTime: selectTime,
@@ -193,7 +197,8 @@ const TimelinePlugin = compose(
         snapType,
         endValuesSupport,
         onInit = () => {},
-        layers
+        layers,
+        timelineIsReady
     }) => {
         useEffect(()=>{
             // update state with configs coming from configuration file like localConfig.json so that can be used as props initializer
@@ -334,6 +339,9 @@ const TimelinePlugin = compose(
                 </Button>
 
             </div>
+            {!timelineIsReady && <div className="timeline-loader">
+                <Loader size={50} />
+            </div>}
             {!collapsed &&
                 <Timeline
                     offsetEnabled={offsetEnabled}

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -48,6 +48,7 @@ import ButtonRB from '../components/misc/Button';
 import {isTimelineVisible} from "../utils/LayersUtils";
 const Button = tooltip(ButtonRB);
 
+
 const isPercent = (val) => isString(val) && val.indexOf("%") !== -1;
 const getPercent = (val) => parseInt(val, 10) / 100;
 const isValidOffset = (start, end) => moment(end).diff(start) > 0;
@@ -59,6 +60,7 @@ const isValidOffset = (start, end) => moment(end).diff(start) > 0;
   * @class  Timeline
   * @memberof plugins
   * @static
+  * @prop cfg.expandedPanel {boolean} false by default
   * @prop cfg.showHiddenLayers {boolean} false by default, when *false* the layers in timeline gets in sync with time layer's visibility (TOC)
   * i.e when a time layer is hidden or removed, the timeline will not show the respective guide layer.
   * Furthermore, the timeline automatically selects the next available guide layer, if the **Snap to guide layer** option is enabled in the Timeline settings.
@@ -68,7 +70,8 @@ const isValidOffset = (start, end) => moment(end).diff(start) > 0;
   * {
   *   "name": "TimeLine",
   *   "cfg": {
-  *       "showHiddenLayers": false
+  *       "showHiddenLayers": false,
+  *       "expandedPanel": true
   *    }
   * }
   *
@@ -103,7 +106,10 @@ const TimelinePlugin = compose(
             onInit: initTimeline
         }),
     branch(({ visible = true, layers = [] }) => !visible || Object.keys(layers).length === 0, renderNothing),
-    withState('options', 'setOptions', {collapsed: true}),
+
+    withState('options', 'setOptions', ({expandedPanel}) => {
+        return { collapsed: !expandedPanel };
+    }),
     // add mapSync button handler and value
     connect(
         createSelector(isMapSync, mapSync => ({mapSync})),
@@ -228,12 +234,12 @@ const TimelinePlugin = compose(
                 }
             }
         };
+
         return (<div
             style={{
                 position: "absolute",
                 marginBottom: 35,
                 marginLeft: 100,
-                background: "transparent",
                 ...style,
                 right: collapsed ? 'auto' : (style.right || 0)
             }}

--- a/web/client/themes/default/less/timeline.less
+++ b/web/client/themes/default/less/timeline.less
@@ -11,6 +11,7 @@
 // **************
 #ms-components-theme(@theme-vars) {
     .timeline-plugin {
+        .background-color-var(@theme-vars[main-bg]);
         @ms-none-transparent: --ms-none, transparent;
         @ms-none-unset: --ms-none, unset;
         /* local mixin to highlight handlers on timeline, used on active and over */
@@ -38,9 +39,9 @@
                 .color-var(@a-color);
             }
         }
-    
+
         .vis-custom-time {
-    
+
             &.currentTime, &.startPlaybackTime, &.endPlaybackTime, &.offsetTime {
                 .background-color-var(@theme-vars[main-color]);
                 & > div {
@@ -78,7 +79,7 @@
                     }
                 }
             }
-    
+
             &.startPlaybackTime {
                 .background-color-var(@theme-vars[success]);
                 /* play icon */
@@ -104,7 +105,7 @@
                     }
                 }
             }
-    
+
             &.currentTime {
                 .background-color-var(@theme-vars[main-color]);
                 /* generate a triangle on top of the handler */
@@ -115,7 +116,7 @@
                 &:after, &::after {
                     .border-bottom-color-var(@theme-vars[main-color]);
                 }
-    
+
                 &:hover {
                     /* mixin hightlight handler, change background and triangles colors */
                     .ms-time-color-active-with-css-variables(
@@ -136,7 +137,7 @@
                 }
             }
         }
-    
+
         &.with-time-offset {
             .vis-custom-time {
                 &.currentTime {
@@ -159,7 +160,7 @@
                         );
                     }
                 }
-    
+
                 &.offsetTime {
                     /* generate a smaller tiangle on bottom of the handler */
                     &:before, &::before {
@@ -169,7 +170,7 @@
                     &:after, &::after {
                         .border-right-color-var(@theme-vars[main-color]);
                     }
-    
+
                     &:hover, &:active {
                         /* mixin hightlight handler, change background and triangles colors */
                         .ms-time-color-active-with-css-variables(
@@ -194,7 +195,7 @@
                 }
             }
         }
-    
+
         .vis-timeline {
             .background-color-var(@theme-vars[main-bg]);
             .vis-item {
@@ -236,7 +237,7 @@
                                 }
                             }
                         }
-    
+
                         .vis-item {
                             &.vis-dot {
                                 .border-color-var(@theme-vars[timeline-histogram-border-color]);
@@ -321,7 +322,7 @@
                     &.offsetTime {
                         .background-color-var(@theme-vars[main-color]);
                     }
-    
+
                     &.endPlaybackTime {
                         .background-color-var(@theme-vars[danger]);
                     }
@@ -331,14 +332,14 @@
                 }
             }
         }
-    
+
     }
-    
+
     .ms-inline-datetime {
         .border-right-color-var(@theme-vars[main-border-color]);
         .background-color-var(@theme-vars[main-bg]);
     }
-    
+
     .playback-plugin {
         .ms-playback-settings {
             .background-color-var(@theme-vars[main-bg]);

--- a/web/client/themes/default/less/timeline.less
+++ b/web/client/themes/default/less/timeline.less
@@ -919,7 +919,16 @@
             }
         }
     }
-
+    .timeline-loader {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
 }
 
 .ms-inline-datetime {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The Timeline plugin has been adjusted to be able to accept a 'collapsed' configuration parameter allowing it to start with an expanded time slider by default in the case it is present.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8377 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
A new config is added to Timeline for collapsed state

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
