### PR TITLE
[Backport geonode-3.3.x] #8377: Make time slider expanded state configurable (#8386)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs-material==3.2.0
+jinja2==3.0.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ markdown_extensions:
   - markdown.extensions.attr_list
   - codehilite:
       linenums: true
-pages:
+nav:
   - User Guide:
     - Home Page Overview: 'user-guide/home-page.md'
     - Managing Users and Groups:

--- a/web/client/themes/default/less/timeline.less
+++ b/web/client/themes/default/less/timeline.less
@@ -11,6 +11,7 @@
 // **************
 #ms-components-theme(@theme-vars) {
     .timeline-plugin {
+        .background-color-var(@theme-vars[main-bg]);
         @ms-none-transparent: --ms-none, transparent;
         @ms-none-unset: --ms-none, unset;
         /* local mixin to highlight handlers on timeline, used on active and over */
@@ -38,9 +39,9 @@
                 .color-var(@a-color);
             }
         }
-    
+
         .vis-custom-time {
-    
+
             &.currentTime, &.startPlaybackTime, &.endPlaybackTime, &.offsetTime {
                 .background-color-var(@theme-vars[main-color]);
                 & > div {
@@ -78,7 +79,7 @@
                     }
                 }
             }
-    
+
             &.startPlaybackTime {
                 .background-color-var(@theme-vars[success]);
                 /* play icon */
@@ -104,7 +105,7 @@
                     }
                 }
             }
-    
+
             &.currentTime {
                 .background-color-var(@theme-vars[main-color]);
                 /* generate a triangle on top of the handler */
@@ -115,7 +116,7 @@
                 &:after, &::after {
                     .border-bottom-color-var(@theme-vars[main-color]);
                 }
-    
+
                 &:hover {
                     /* mixin hightlight handler, change background and triangles colors */
                     .ms-time-color-active-with-css-variables(
@@ -136,7 +137,7 @@
                 }
             }
         }
-    
+
         &.with-time-offset {
             .vis-custom-time {
                 &.currentTime {
@@ -159,7 +160,7 @@
                         );
                     }
                 }
-    
+
                 &.offsetTime {
                     /* generate a smaller tiangle on bottom of the handler */
                     &:before, &::before {
@@ -169,7 +170,7 @@
                     &:after, &::after {
                         .border-right-color-var(@theme-vars[main-color]);
                     }
-    
+
                     &:hover, &:active {
                         /* mixin hightlight handler, change background and triangles colors */
                         .ms-time-color-active-with-css-variables(
@@ -194,7 +195,7 @@
                 }
             }
         }
-    
+
         .vis-timeline {
             .background-color-var(@theme-vars[main-bg]);
             .vis-item {
@@ -236,7 +237,7 @@
                                 }
                             }
                         }
-    
+
                         .vis-item {
                             &.vis-dot {
                                 .border-color-var(@theme-vars[timeline-histogram-border-color]);
@@ -317,7 +318,7 @@
                     &.offsetTime {
                         .background-color-var(@theme-vars[main-color]);
                     }
-    
+
                     &.endPlaybackTime {
                         .background-color-var(@theme-vars[danger]);
                     }
@@ -327,14 +328,14 @@
                 }
             }
         }
-    
+
     }
-    
+
     .ms-inline-datetime {
         .border-right-color-var(@theme-vars[main-border-color]);
         .background-color-var(@theme-vars[main-bg]);
     }
-    
+
     .playback-plugin {
         .ms-playback-settings {
             .background-color-var(@theme-vars[main-bg]);
@@ -901,7 +902,16 @@
             }
         }
     }
-
+    .timeline-loader {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
 }
 
 .ms-inline-datetime {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The Timeline plugin has been adjusted to be able to accept a 'collapsed' configuration parameter allowing it to start with an expanded time slider by default in the case it is present.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8377 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
A new config is added to Timeline for collapsed state

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
