### PR TITLE
#8336 clamp to ground for polylines on style editor

### DIFF
--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -895,7 +895,7 @@ The `symbolizer` could be of following `kinds`:
   - `opacity` stroke opacity of the line
   - `width` stroke width of the line
   - `dasharray` array that represent the dashed line intervals
-  - `clampToGround` this boolean will allow setting the `clampToGround` value for the feature. This would only apply on Cesium maps.
+  - `msClampToGround` this boolean will allow setting the `clampToGround` value for the feature. This would only apply on Cesium maps.
 
 - `Fill` symbolizer properties
   - `kind` must be equal to `Fill`

--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -895,6 +895,7 @@ The `symbolizer` could be of following `kinds`:
   - `opacity` stroke opacity of the line
   - `width` stroke width of the line
   - `dasharray` array that represent the dashed line intervals
+  - `clampToGround` this boolean will allow setting the `clampToGround` value for the feature. This would only apply on Cesium maps.
 
 - `Fill` symbolizer properties
   - `kind` must be equal to `Fill`
@@ -903,6 +904,7 @@ The `symbolizer` could be of following `kinds`:
   - `outlineColor` outline color of the polygon
   - `outlineOpacity` outline opacity of the polygon
   - `outlineWidth` outline width of the polygon
+  - `clampToGround` this boolean will allow setting the `clampToGround` value for the feature. This would only apply on Cesium maps.
 
 - `Text` symbolizer properties
   - `kind` must be equal to `Text`

--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -904,7 +904,7 @@ The `symbolizer` could be of following `kinds`:
   - `outlineColor` outline color of the polygon
   - `outlineOpacity` outline opacity of the polygon
   - `outlineWidth` outline width of the polygon
-  - `clampToGround` this boolean will allow setting the `clampToGround` value for the feature. This would only apply on Cesium maps.
+  - `msClampToGround` this boolean will allow setting the `clampToGround` value for the feature. This would only apply on Cesium maps.
 
 - `Text` symbolizer properties
   - `kind` must be equal to `Text`

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -175,7 +175,7 @@ const getBlocks = ({
                 opacity: 1,
                 cap: 'round',
                 join: 'round',
-                clampToGround: true
+                msClampToGround: true
             }
         },
         Fill: {

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -14,13 +14,13 @@ import {SUPPORTED_MIME_TYPES} from "../../../utils/StyleEditorUtils";
 
 const vector3dStyleOptions = {
     clampToGround: property.clampToGround({
-        label: 'Clamp to ground'
+        label: 'styleeditor.clampToGround'
     })
 };
 
 const billboard3dStyleOptions = {
     msBringToFront: property.msBringToFront({
-        label: 'Bring to front'
+        label: 'styleeditor.msBringToFront'
     })
 };
 
@@ -74,7 +74,8 @@ const getBlocks = ({
                 strokeOpacity: 1,
                 strokeWidth: 1,
                 radius: 16,
-                rotate: 0
+                rotate: 0,
+                msBringToFront: false
             }
         },
         Icon: {
@@ -118,7 +119,8 @@ const getBlocks = ({
                 image: '',
                 opacity: 1,
                 size: 32,
-                rotate: 0
+                rotate: 0,
+                msBringToFront: false
             }
         },
         Line: {
@@ -172,7 +174,8 @@ const getBlocks = ({
                 width: 1,
                 opacity: 1,
                 cap: 'round',
-                join: 'round'
+                join: 'round',
+                clampToGround: true
             }
         },
         Fill: {
@@ -210,14 +213,16 @@ const getBlocks = ({
                 outlineWidth: property.width({
                     key: 'outlineWidth',
                     label: 'styleeditor.outlineWidth'
-                })
+                }),
+                ...(enable3dStyleOptions ? vector3dStyleOptions : {})
             },
             defaultProperties: {
                 kind: 'Fill',
                 color: '#dddddd',
                 fillOpacity: 1,
                 outlineColor: '#777777',
-                outlineWidth: 1
+                outlineWidth: 1,
+                clampToGround: true
             }
         },
         PointCloud: {

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -13,7 +13,7 @@ import isObject from 'lodash/isObject';
 import {SUPPORTED_MIME_TYPES} from "../../../utils/StyleEditorUtils";
 
 const vector3dStyleOptions = {
-    clampToGround: property.clampToGround({
+    msClampToGround: property.msClampToGround({
         label: 'styleeditor.clampToGround'
     })
 };

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -12,8 +12,15 @@ import includes from 'lodash/includes';
 import isObject from 'lodash/isObject';
 import {SUPPORTED_MIME_TYPES} from "../../../utils/StyleEditorUtils";
 
+const vector3dStyleOptions = {
+    clampToGround: property.clampToGround({
+        label: 'Clamp to ground'
+    })
+};
+
 const getBlocks = ({
-    exactMatchGeometrySymbol
+    exactMatchGeometrySymbol,
+    enable3dStyleOptions
 } = {}) => {
     const symbolizerBlock = {
         Mark: {
@@ -148,7 +155,8 @@ const getBlocks = ({
                 join: property.join({
                     label: 'styleeditor.lineJoin',
                     key: 'join'
-                })
+                }),
+                ...(enable3dStyleOptions ? vector3dStyleOptions : {})
             },
             defaultProperties: {
                 kind: 'Line',

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -222,7 +222,7 @@ const getBlocks = ({
                 fillOpacity: 1,
                 outlineColor: '#777777',
                 outlineWidth: 1,
-                clampToGround: true
+                msClampToGround: true
             }
         },
         PointCloud: {

--- a/web/client/components/styleeditor/config/property.js
+++ b/web/client/components/styleeditor/config/property.js
@@ -276,7 +276,7 @@ const property = {
             };
         }
     }),
-    clampToGround: ({ key = 'clampToGround', label = 'Clamp to ground' }) => ({
+    msClampToGround: ({ key = 'msClampToGround', label = 'Clamp to ground' }) => ({
         type: 'toolbar',
         label,
         config: {

--- a/web/client/components/styleeditor/config/property.js
+++ b/web/client/components/styleeditor/config/property.js
@@ -276,6 +276,25 @@ const property = {
             };
         }
     }),
+    clampToGround: ({ key = 'clampToGround', label = 'Clamp to ground' }) => ({
+        type: 'toolbar',
+        label,
+        config: {
+            options: [{
+                labelId: 'styleeditor.boolTrue',
+                value: true
+            }, {
+                labelId: 'styleeditor.boolFalse',
+                value: false
+            }]
+        },
+        getValue: (value) => {
+            return {
+                [key]: value
+            };
+        },
+        setValue: (value) => !!value
+    }),
     shape: ({ label, key = 'wellKnownName' }) => ({
         type: 'mark',
         label,

--- a/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
+++ b/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
@@ -51,7 +51,7 @@ const ConnectedDisplay = connect(
 )(Display);
 
 const ConnectedVectorStyleEditor = connect(
-    createSelector([isCesium], ({ enable3dStyleOptions }) => ({ enable3dStyleOptions }))
+    createSelector([isCesium], (enable3dStyleOptions) => ({ enable3dStyleOptions }))
 )(VectorStyleEditor);
 
 const isLayerNode = ({settings = {}} = {}) => settings.nodeType === 'layers';

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2247,6 +2247,8 @@
             "addMarkRule": "Markerregel hinzufügen",
             "shape": "Form",
             "fill": "Füllfarbe",
+            "clampToGround": "Klemme an Masse",
+            "msBringToFront": "In den Vordergrund bringen",
             "strokeColor": "Linienfarbe",
             "strokeWidth": "Linienbreite",
             "radius": "Radius",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2210,6 +2210,8 @@
             "addMarkRule": "Add mark rule",
             "shape": "Shape",
             "fill": "Fill color",
+            "clampToGround": "Clamp to ground",
+            "msBringToFront": "Bring to front",
             "strokeColor": "Stroke color",
             "strokeWidth": "Stroke width",
             "radius": "Radius",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2209,6 +2209,8 @@
             "addMarkRule": "Agregar regla de marca",
             "shape": "Forma",
             "fill": "Color de relleno",
+            "clampToGround": "Adaptar al terreno",
+            "msBringToFront": "Traer al frente",
             "strokeColor": "Color de línea",
             "strokeWidth": "Ancho de línea",
             "radius": "Radio",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2210,6 +2210,8 @@
             "addMarkRule": "Ajouter une règle de marque",
             "shape": "Forme",
             "fill": "Fill color",
+            "clampToGround": "S'adapter au terrain",
+            "msBringToFront": "Mettre en avant",
             "strokeColor": "Couleur de ligne",
             "strokeWidth": "Largeur de ligne",
             "radius": "Rayon",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2211,6 +2211,8 @@
             "addMarkRule": "Aggiungi regola marker",
             "shape": "Forma",
             "fill": "Colore riempimento",
+            "clampToGround": "Adattarsi al terreno",
+            "msBringToFront": "Portare in primo piano",
             "strokeColor": "Colore linea",
             "strokeWidth": "Spessore linea",
             "radius": "Raggio",

--- a/web/client/utils/styleparser/CesiumStyleParser.js
+++ b/web/client/utils/styleparser/CesiumStyleParser.js
@@ -157,7 +157,7 @@ function getStyleFuncFromRules({
                                 width: symbolizer.width,
                                 positions: entity._msStoredCoordinates.polyline,
                                 // by default the line will try to follow the terrain/3d tiles profile
-                                clampToGround: true
+                                clampToGround: symbolizer.clampToGround
                             });
                         }
                         if (symbolizer.kind === 'Fill' && entity._msStoredCoordinates.polygon) {
@@ -184,7 +184,7 @@ function getStyleFuncFromRules({
                                     width: symbolizer.outlineWidth,
                                     positions: entity._msStoredCoordinates.polygon.getValue().positions,
                                     // by default the line will try to follow the terrain/3d tiles profile
-                                    clampToGround: true
+                                    clampToGround: symbolizer.clampToGround
                                 });
                             }
                         }

--- a/web/client/utils/styleparser/CesiumStyleParser.js
+++ b/web/client/utils/styleparser/CesiumStyleParser.js
@@ -158,7 +158,7 @@ function getStyleFuncFromRules({
                                 width: symbolizer.width,
                                 positions: entity._msStoredCoordinates.polyline,
                                 // by default the line will try to follow the terrain/3d tiles profile
-                                clampToGround: symbolizer.clampToGround
+                                clampToGround: symbolizer.clampToGround || true
                             });
                         }
                         if (symbolizer.kind === 'Fill' && entity._msStoredCoordinates.polygon) {
@@ -185,7 +185,7 @@ function getStyleFuncFromRules({
                                     width: symbolizer.outlineWidth,
                                     positions: entity._msStoredCoordinates.polygon.getValue().positions,
                                     // by default the line will try to follow the terrain/3d tiles profile
-                                    clampToGround: symbolizer.clampToGround
+                                    clampToGround: symbolizer.clampToGround || true
                                 });
                             }
                         }

--- a/web/client/utils/styleparser/CesiumStyleParser.js
+++ b/web/client/utils/styleparser/CesiumStyleParser.js
@@ -183,7 +183,7 @@ function getStyleFuncFromRules({
                                     }),
                                     width: symbolizer.outlineWidth,
                                     positions: entity._msStoredCoordinates.polygon.getValue().positions,
-                                    clampToGround: symbolizer.clampToGround
+                                    clampToGround: symbolizer.msClampToGround
                                 });
                             }
                         }

--- a/web/client/utils/styleparser/CesiumStyleParser.js
+++ b/web/client/utils/styleparser/CesiumStyleParser.js
@@ -157,7 +157,7 @@ function getStyleFuncFromRules({
                                     }),
                                 width: symbolizer.width,
                                 positions: entity._msStoredCoordinates.polyline,
-                                clampToGround: symbolizer.clampToGround
+                                clampToGround: symbolizer.msClampToGround
                             });
                         }
                         if (symbolizer.kind === 'Fill' && entity._msStoredCoordinates.polygon) {

--- a/web/client/utils/styleparser/CesiumStyleParser.js
+++ b/web/client/utils/styleparser/CesiumStyleParser.js
@@ -157,8 +157,7 @@ function getStyleFuncFromRules({
                                     }),
                                 width: symbolizer.width,
                                 positions: entity._msStoredCoordinates.polyline,
-                                // by default the line will try to follow the terrain/3d tiles profile
-                                clampToGround: symbolizer.clampToGround || true
+                                clampToGround: symbolizer.clampToGround
                             });
                         }
                         if (symbolizer.kind === 'Fill' && entity._msStoredCoordinates.polygon) {
@@ -184,8 +183,7 @@ function getStyleFuncFromRules({
                                     }),
                                     width: symbolizer.outlineWidth,
                                     positions: entity._msStoredCoordinates.polygon.getValue().positions,
-                                    // by default the line will try to follow the terrain/3d tiles profile
-                                    clampToGround: symbolizer.clampToGround || true
+                                    clampToGround: symbolizer.clampToGround
                                 });
                             }
                         }

--- a/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
+++ b/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
@@ -48,7 +48,7 @@ describe('CesiumStyleParser', () => {
                                 outlineColor: '#00ff00',
                                 outlineOpacity: 0.25,
                                 outlineWidth: 2,
-                                clampToGround: true
+                                msClampToGround: true
                             }
                         ]
                     }

--- a/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
+++ b/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
@@ -47,7 +47,8 @@ describe('CesiumStyleParser', () => {
                                 fillOpacity: 0.5,
                                 outlineColor: '#00ff00',
                                 outlineOpacity: 0.25,
-                                outlineWidth: 2
+                                outlineWidth: 2,
+                                clampToGround: true
                             }
                         ]
                     }
@@ -69,6 +70,7 @@ describe('CesiumStyleParser', () => {
                             expect({ ...entities[0].polygon.material.color.getValue() }).toEqual({ red: 1, green: 0, blue: 0, alpha: 0.5 });
                             expect(entities[0].polyline.width.getValue()).toBe(2);
                             expect({ ...entities[0].polyline.material.color.getValue() }).toEqual({ red: 0, green: 1, blue: 0, alpha: 0.25 });
+                            expect(entities[0].polyline.clampToGround.getValue()).toBe(true);
                         } catch (e) {
                             done(e);
                         }
@@ -88,7 +90,8 @@ describe('CesiumStyleParser', () => {
                                 kind: 'Line',
                                 color: '#ff0000',
                                 opacity: 0.5,
-                                width: 2
+                                width: 2,
+                                clampToGround: true
                             }
                         ]
                     }
@@ -109,6 +112,7 @@ describe('CesiumStyleParser', () => {
                             styleFunc({ entities });
                             expect({ ...entities[0].polyline.material.color.getValue() }).toEqual({ red: 1, green: 0, blue: 0, alpha: 0.5 });
                             expect(entities[0].polyline.width.getValue()).toBe(2);
+                            expect(entities[0].polyline.clampToGround.getValue()).toBe(true);
                         } catch (e) {
                             done(e);
                         }

--- a/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
+++ b/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
@@ -91,7 +91,7 @@ describe('CesiumStyleParser', () => {
                                 color: '#ff0000',
                                 opacity: 0.5,
                                 width: 2,
-                                clampToGround: true
+                                msClampToGround: true
                             }
                         ]
                     }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR allows users to set the `clampToGround` value of polyline features on 3d maps through style editor UI.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
There's no way to set the `clampToGround` property for polylines through the UI 
#8336 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
There's a field inside the style editor to set `clampToGround` value for polyline graphics.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
