### PR TITLE
#8388 Making sure that numeric 0 values of query params are processed properly

### DIFF
--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -1,5 +1,5 @@
 import url from "url";
-import {get, includes, inRange, isEmpty, isNaN, isObject, toNumber} from "lodash";
+import {get, includes, inRange, isEmpty, isNaN, isNil, isObject, toNumber} from "lodash";
 
 import {getBbox} from "./MapUtils";
 import {isValidExtent} from "./CoordinatesUtils";
@@ -111,7 +111,7 @@ export const getParametersValues = (paramActions, state) => (
             const value = getRequestParameterValue(parameter, state, sessionStorage);
             return {
                 ...params,
-                ...(value ? { [parameter]: value } : {})
+                ...(!isNil(value) ? { [parameter]: value } : {})
             };
         }, {})
 );

--- a/web/client/utils/__tests__/QueryParamsUtils-test.js
+++ b/web/client/utils/__tests__/QueryParamsUtils-test.js
@@ -99,6 +99,19 @@ describe('QueryParamsUtils', () => {
         expect(pitch).toBe(-0.2123635014967287);
         expect(roll).toBe(0.000010414279262072055);
     });
+    it('test getParametersValues - check that numeric zero values are processed properly', () => {
+        const state = {
+            router: {
+                location: {
+                    search: '?center=11.558466796428766,41.415232026624764&zoom=12.344643329999036&heading=6.158556550454258&pitch=0&roll=0'
+                }
+            }
+        };
+        const parameters = getParametersValues(paramActions, state);
+        const { pitch, roll } = parameters;
+        expect(pitch).toBe(0);
+        expect(roll).toBe(0);
+    });
     it('test getQueryActions with center querystring parameter', () => {
         const state = {
             router: {


### PR DESCRIPTION
## Description
This small PR provides a minor change to properly handle cases when passed query parameter was mistakenly counted as not passed in request whenever it was a numeric 0 value.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8388 

**What is the new behavior?**
0 as parameter is properly processed

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
