### PR TITLE
#8373: BILTerrainProvider enhancement of WMS parser

### DIFF
--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -1149,18 +1149,56 @@ In order to create a `wms` based mesh there are some requirements that need to b
 
 - a GeoServer WMS service with the [DDS/BIL plugin](https://docs.geoserver.org/stable/en/user/community/dds/index.html)
 - A WMS layer configured with **BIL 16 bit** output in **big endian mode** and **-9999 nodata value**
-
+  - BILTerrainProvider is used to parse `wms` based mesh. Supports three ways in parsing the metadata of the layer
+    1. Layer configuration with **sufficient metadata** of the layer. This prevents a call to `getCapabilities` eventually improving performance of the parsing of the layer.
+        Mandatory fields are `url`, `name`, `format`, `version`, `crs`
+    ```json
+    {
+      "type": "terrain",
+      "provider": "wms",
+      "url": "http://hot-sample/geoserver/wms",
+      "name": "workspace:layername",
+      "format": "image/bil", // Supports only "image/bil" format for WMS 
+      "littleendian": false,
+      "visibility": true,
+      "version": "1.3.0",
+      "fixedHeight": null, // Map height. Max value is < 65
+      "fixedWidth": null, // Map width. Max value is < 65
+      "crs": "CRS:84" // Supports only CRS:84 | EPSG:4326 | EPSG:3857 | OSGEO:41001
+    }
+    ```
+    2. Layer configuration of `geoserver` layer with layer name prefixed with workspace, then the `getCapabilities` is requested only for that layer
+    ```json
+    {
+    "type": "terrain",
+    "provider": "wms",
+    "url": "https://host-sample/geoserver/wms", // 'geoserver' url
+    "name": "workspace:layername", // name of the geoserver resource with workspace prefixed
+    "format": "image/bil",
+    "littleendian": false
+    }
+    ```
+    3. Layer configuration of geoserver layer with layer name not prefixed with workspace then `getCapabilities` is requested in global scope.
+    ```json
+    { 
+      "type": "terrain",
+      "provider": "wms",
+      "url": "https://host-sample/geoserver/wms",
+      "name": "layername",
+      "format": "image/bil",
+      "littleendian": false
+    }
+    ```
+Generic layer configuration of type `terrain` and provide `wms` is as follows. 
 The layer configuration needs to point to the geoserver resource and define the type of layer and the type of provider:
-
 ```json
 { 
   "type": "terrain",
   "provider": "wms",
   "url": "https://host-sample/geoserver/wms",
   "name": "workspace:layername", // name of the geoserver resource
-  "format": "application/bil16",
-  "littleendian": false,
-  "visibility": true
+  "format": "image/bil",
+  "littleendian": false
 }
 ```
 

--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -1151,14 +1151,13 @@ In order to create a `wms` based mesh there are some requirements that need to b
 - A WMS layer configured with **BIL 16 bit** output in **big endian mode** and **-9999 nodata value**
   - BILTerrainProvider is used to parse `wms` based mesh. Supports three ways in parsing the metadata of the layer
     1. Layer configuration with **sufficient metadata** of the layer. This prevents a call to `getCapabilities` eventually improving performance of the parsing of the layer.
-        Mandatory fields are `url`, `name`, `format`, `version`, `crs`
+        Mandatory fields are `url`, `name`, `version`, `crs`.
     ```json
     {
       "type": "terrain",
       "provider": "wms",
       "url": "http://hot-sample/geoserver/wms",
-      "name": "workspace:layername",
-      "format": "image/bil", // Supports only "image/bil" format for WMS 
+      "name": "workspace:layername", 
       "littleendian": false,
       "visibility": true,
       "version": "1.3.0",
@@ -1167,28 +1166,29 @@ In order to create a `wms` based mesh there are some requirements that need to b
       "crs": "CRS:84" // Supports only CRS:84 | EPSG:4326 | EPSG:3857 | OSGEO:41001
     }
     ```
-    2. Layer configuration of `geoserver` layer with layer name prefixed with workspace, then the `getCapabilities` is requested only for that layer
+    2. Layer configuration of `geoserver` layer with layer name _prefixed with workspace_, then the `getCapabilities` is requested only for that layer
     ```json
     {
     "type": "terrain",
     "provider": "wms",
     "url": "https://host-sample/geoserver/wms", // 'geoserver' url
     "name": "workspace:layername", // name of the geoserver resource with workspace prefixed
-    "format": "image/bil",
     "littleendian": false
     }
     ```
-    3. Layer configuration of geoserver layer with layer name not prefixed with workspace then `getCapabilities` is requested in global scope.
+    3. Layer configuration of geoserver layer with layer name _not prefixed with workspace_ then `getCapabilities` is requested in global scope.
     ```json
     { 
       "type": "terrain",
       "provider": "wms",
       "url": "https://host-sample/geoserver/wms",
       "name": "layername",
-      "format": "image/bil",
       "littleendian": false
     }
     ```
+!!! note
+With `wms` as provider, the format option is not needed, as Mapstore supports only `image/bil` format and is used by default
+
 Generic layer configuration of type `terrain` and provide `wms` is as follows. 
 The layer configuration needs to point to the geoserver resource and define the type of layer and the type of provider:
 ```json
@@ -1197,7 +1197,6 @@ The layer configuration needs to point to the geoserver resource and define the 
   "provider": "wms",
   "url": "https://host-sample/geoserver/wms",
   "name": "workspace:layername", // name of the geoserver resource
-  "format": "image/bil",
   "littleendian": false
 }
 ```

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -264,13 +264,14 @@ Serve the following code as an example:
             "provider": "wms",
             "url": "https://host-sample/geoserver/wms",
             "name": "workspace:layername",  // name of the geoserver resource
-            "format": "application/bil16",
             "littleendian": false,
             "visibility": true
         }]
     }
 }
 ```
+!!! note
+    When using `terrain` layer with `wms` provider, the format option in layer configuration is not needed anymore as Mapstore supports only `image/bil` format and is used by default
 
 ## Migration from 2022.01.00 to 2022.01.01
 

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -312,23 +312,7 @@
                 "scalebar": {
                   "container" : "#footer-scalebar-container"
                 }
-              },
-              "additionalLayers": [{
-                "type": "terrain",
-                "provider": "wms",
-                "url": "http://gs-stable.geo-solutions.it/geoserver/wms",
-                "name": "austrocontrol:DTM250_Austria_EPSG3857_LZW",
-                "format": "image/bil",
-                "littleendian": false,
-                "visibility": true,
-                "version": "1.3.0",
-                "fixedHeight": null,
-                "fixedWidth": null,
-                "tilesetHeight": 65,
-                "tilesetWidth": 65,
-                "CRS1": "CRS:84",
-                "styleName": null
-              }]
+              }
             }
           }, "AutoMapUpdate", "HelpLink", "DrawerMenu", "Version", "Notifications", "BackgroundSelector", "Swipe", {
             "name": "Annotations",

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -312,7 +312,23 @@
                 "scalebar": {
                   "container" : "#footer-scalebar-container"
                 }
-              }
+              },
+              "additionalLayers": [{
+                "type": "terrain",
+                "provider": "wms",
+                "url": "http://gs-stable.geo-solutions.it/geoserver/wms",
+                "name": "austrocontrol:DTM250_Austria_EPSG3857_LZW",
+                "format": "image/bil",
+                "littleendian": false,
+                "visibility": true,
+                "version": "1.3.0",
+                "fixedHeight": null,
+                "fixedWidth": null,
+                "tilesetHeight": 65,
+                "tilesetWidth": 65,
+                "CRS1": "CRS:84",
+                "styleName": null
+              }]
             }
           }, "AutoMapUpdate", "HelpLink", "DrawerMenu", "Version", "Notifications", "BackgroundSelector", "Swipe", {
             "name": "Annotations",

--- a/web/client/utils/cesium/WMSUtils.js
+++ b/web/client/utils/cesium/WMSUtils.js
@@ -6,8 +6,76 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const WMSUtils = {
-    PARAM_OPTIONS: ["layers", "styles", "style", "format", "transparent", "version", "tiled", "opacity", "zindex", "srs", "singletile", "_v_", "filterobj" ]
+import { getAuthenticationHeaders } from "../SecurityUtils";
+import { getProxyUrl, needProxy } from "../ProxyUtils";
+import ConfigUtils from "../ConfigUtils";
+
+const PARAM_OPTIONS = ["layers", "styles", "style", "format", "transparent", "version", "tiled", "opacity", "zindex", "srs", "singletile", "_v_", "filterobj" ];
+
+
+function splitUrl(originalUrl) {
+    let url = originalUrl;
+    let queryString = "";
+    if (originalUrl.indexOf('?') !== -1) {
+        url = originalUrl.substring(0, originalUrl.indexOf('?') + 1);
+        if (originalUrl.indexOf('%') !== -1) {
+            url = decodeURIComponent(url);
+        }
+        queryString = originalUrl.substring(originalUrl.indexOf('?') + 1);
+    }
+    return {url, queryString};
+}
+
+function WMSProxy(proxy) {
+    this.proxy = proxy;
+}
+
+WMSProxy.prototype.getURL = function(resource) {
+    let {url, queryString} = splitUrl(resource);
+    return getProxyUrl() + encodeURIComponent(url + queryString);
 };
 
-module.exports = WMSUtils;
+function NoProxy() {}
+
+NoProxy.prototype.getURL = function(resource) {
+    const { url, queryString } = splitUrl(resource);
+    return url + queryString;
+};
+
+// Check and apply proxy to source url
+export const getProxy = (options) => {
+    let proxyUrl = ConfigUtils.getProxyUrl({});
+    let proxy;
+    if (proxyUrl) {
+        proxy = options.noCors || needProxy(options.url);
+    }
+    return proxy ? new WMSProxy(proxyUrl) : new NoProxy();
+};
+
+/**
+ * Generate cesium BIL option for BILTerrainProvider from wms layer option
+ * @param {object} options
+ * @returns {object} converted BIL options
+ */
+export const wmsToCesiumOptionsBIL = (options) => {
+    let url = options.url;
+    const headers = getAuthenticationHeaders(url, options.securityToken);
+    return {
+        url,
+        headers,
+        proxy: getProxy(options),
+        littleEndian: options.littleendian || false,
+        layerName: options.name,
+        version: options.version,
+        fixedHeight: options.fixedHeight,
+        fixedWidth: options.fixedWidth,
+        crs: options.crs, // Support only CRS:84 | EPSG:4326 | EPSG:3857 | OSGEO:41001
+        format: options.format // MapStore only supports WMS "image/bil"
+    };
+};
+
+export default {
+    PARAM_OPTIONS,
+    wmsToCesiumOptionsBIL,
+    getProxy
+};

--- a/web/client/utils/cesium/WMSUtils.js
+++ b/web/client/utils/cesium/WMSUtils.js
@@ -70,7 +70,7 @@ export const wmsToCesiumOptionsBIL = (options) => {
         fixedHeight: options.fixedHeight,
         fixedWidth: options.fixedWidth,
         crs: options.crs, // Support only CRS:84 | EPSG:4326 | EPSG:3857 | OSGEO:41001
-        format: options.format // MapStore only supports WMS "image/bil"
+        format: "image/bil" // MapStore only supports "image/bil" format for WMS provider
     };
 };
 

--- a/web/client/utils/cesium/__tests__/WMSUtils-test.js
+++ b/web/client/utils/cesium/__tests__/WMSUtils-test.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+import expect from 'expect';
+import { wmsToCesiumOptionsBIL } from '../WMSUtils';
+
+const testLayerConfig = {
+    "type": "terrain",
+    "provider": "wms",
+    "url": "http://sample.com/geoserver/wms",
+    "name": "workspace:layername",
+    "format": "image/bil",
+    "littleendian": false,
+    "visibility": true,
+    "version": "1.3.0",
+    "fixedHeight": null,
+    "fixedWidth": null,
+    "crs": "CRS:84",
+    "styleName": null
+};
+
+describe('Test the WMSUtil for Cesium', () => {
+    it('wmsToCesiumOptionsBIL with proxy', () => {
+        let config = wmsToCesiumOptionsBIL(testLayerConfig);
+        expect(config.url).toBe(testLayerConfig.url);
+        expect(config.proxy.getURL("test")).toBe("/mapstore/proxy/?url=test");
+        expect(config.layerName).toBe(testLayerConfig.name);
+        expect(config.format).toBe(testLayerConfig.format);
+        expect(config.littleEndian).toBe(testLayerConfig.littleendian);
+        expect(config.version).toBe(testLayerConfig.version);
+        expect(config.crs).toBe(testLayerConfig.crs);
+    });
+    it('wmsToCesiumOptionsBIL with no proxy', () => {
+        const testConfig = {...testLayerConfig, url: [location.href], noCors: false};
+        let config = wmsToCesiumOptionsBIL(testConfig);
+        expect(config.url).toBe(testConfig.url);
+        expect(config.proxy.getURL("test")).toBe("test");
+        expect(config.layerName).toBe(testConfig.name);
+        expect(config.crs).toBe(testConfig.crs);
+    });
+});


### PR DESCRIPTION
## Description
This PR improves the BILTerrainProvider of WMS parser

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#8373 

**What is the new behavior?**
- When layer is configured with **sufficient paramter**, the `getCapabilities` call is _skipped_ eventually improving parser performance. Mandatory props includes (`url`, `name`, `format`, `version`, `crs`)
- When layer is configured with geoserver layer and the layer name has **workspace** prefix, then `getCapabilities` is performed on that specific layer
- When layer is configured with layer name **not prefixed** with workspace, then `getCapabilities` is performed on global scale.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
**Example - Test configuration**
Layer config with sufficient parameter
```
{
  "type": "terrain",
  "provider": "wms",
  "url": "http://gs-stable.geo-solutions.it/geoserver/wms",
  "name": "sf:sfdem",
  "format": "image/bil",
  "littleendian": false,
  "visibility": true,
  "version": "1.3.0",
  "crs": "CRS:84"
}
```
