### PR TITLE
Add default clamp to ground to billboard and labels

### DIFF
--- a/web/client/utils/styleparser/CesiumStyleParser.js
+++ b/web/client/utils/styleparser/CesiumStyleParser.js
@@ -119,6 +119,7 @@ function getStyleFuncFromRules({
                                     scale,
                                     rotation: Cesium.Math.toRadians(-1 * symbolizer.rotate || 0),
                                     disableDepthTestDistance: symbolizer.msBringToFront ? Number.POSITIVE_INFINITY : 0,
+                                    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
                                     color: getCesiumColor({
                                         color: '#ffffff',
                                         opacity: 1 * globalOpacity
@@ -136,6 +137,7 @@ function getStyleFuncFromRules({
                                     scale,
                                     rotation: Cesium.Math.toRadians(-1 * symbolizer.rotate || 0),
                                     disableDepthTestDistance: symbolizer.msBringToFront ? Number.POSITIVE_INFINITY : 0,
+                                    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
                                     color: getCesiumColor({
                                         color: '#ffffff',
                                         opacity: symbolizer.opacity * globalOpacity
@@ -199,6 +201,7 @@ function getStyleFuncFromRules({
                                     color: symbolizer.color,
                                     opacity: 1 * globalOpacity
                                 }),
+                                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
                                 pixelOffset: new Cesium.Cartesian2(symbolizer?.offset?.[0] ?? 0, symbolizer?.offset?.[1] ?? 0),
                                 // outline is not working
                                 // rotation is not available as property

--- a/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
+++ b/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
@@ -210,6 +210,7 @@ describe('CesiumStyleParser', () => {
                             expect(entities[0].billboard.scale.getValue()).toBe(1);
                             expect(entities[0].billboard.rotation.getValue()).toBe(-Math.PI / 2);
                             expect(entities[0].billboard.disableDepthTestDistance.getValue()).toBe(Number.POSITIVE_INFINITY);
+                            expect(entities[0].billboard.heightReference.getValue()).toBe(Cesium.HeightReference.CLAMP_TO_GROUND);
                         } catch (e) {
                             done(e);
                         }
@@ -266,6 +267,7 @@ describe('CesiumStyleParser', () => {
                             expect(entities[0].billboard.scale.getValue()).toBe(0.125);
                             expect(entities[0].billboard.rotation.getValue()).toBe(-Math.PI / 2);
                             expect(entities[0].billboard.disableDepthTestDistance.getValue()).toBe(Number.POSITIVE_INFINITY);
+                            expect(entities[0].billboard.heightReference.getValue()).toBe(Cesium.HeightReference.CLAMP_TO_GROUND);
                         } catch (e) {
                             done(e);
                         }
@@ -321,6 +323,7 @@ describe('CesiumStyleParser', () => {
                             expect({ ...entities[0].label.fillColor.getValue() }).toEqual({ red: 0, green: 0, blue: 0, alpha: 1 });
                             expect({ ...entities[0].label.outlineColor.getValue() }).toEqual({ red: 1, green: 1, blue: 1, alpha: 1 });
                             expect(entities[0].label.outlineWidth.getValue()).toBe(2);
+                            expect(entities[0].label.heightReference.getValue()).toBe(Cesium.HeightReference.CLAMP_TO_GROUND);
 
                         } catch (e) {
                             done(e);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR sets `CLAMP_TO_GROUND` as the default `heightReference` for `LabelGraphics` and `BillboardGraphics` on Cesium viewer.  

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8339 
On the current implementation label and marks/icons have the `heightReference` property set as `NONE` (this is the default value provided by Cesium), this produces some unexpected behaviours when the features are displayed over a terrain. Serve this image as an example 👇🏼 (markers are displayed underground, hence not visible).
 
![NONE](https://user-images.githubusercontent.com/6906348/177755758-31952c0c-1ec6-46d2-8f7b-ee15d8f53307.png)



**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
With the new default value `CLAMP_TO_GROUND`, features `heightReference` adapts to the terrain elevation profile 👇🏼 

![CLAMP_TO_GROUND](https://user-images.githubusercontent.com/6906348/177756099-ebbe9f62-990e-4028-a12c-67452f2b9b6d.png)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
In order to be able provide the user with the ability to update the value of this property some UX decisions should be made. Does this belongs to the style editor (it probably does, since a different value could be set per feature)?
Also the different values this property allows (`NONE`, `CLAMP_TO_GROUND`, `RELATIVE_TO_GROUND`) are tied to the position height set for the features, so probably would also need to let the user set, through the interface, the positioning of the features.
