### PR TITLE
CQL INCLUDE filter support for MapStore

### DIFF
--- a/web/client/utils/ogc/Filter/CQL/__tests__/parser-test.js
+++ b/web/client/utils/ogc/Filter/CQL/__tests__/parser-test.js
@@ -68,6 +68,12 @@ const COMPARISON_TESTS = [
             type: "like",
             value: 'a'
         }
+    },
+    {
+        cql: "INCLUDE",
+        expected: {
+            type: "include"
+        }
     }
 ];
 const VARIANTS = [{

--- a/web/client/utils/ogc/Filter/CQL/parser.js
+++ b/web/client/utils/ogc/Filter/CQL/parser.js
@@ -16,6 +16,7 @@ const spatialOperators = {
     WITHIN: "WITHIN"
 };
 const patterns = {
+    INCLUDE: /^INCLUDE$/,
     PROPERTY: /^"?[_a-zA-Z"]\w*"?/,
     COMPARISON: /^(=|<>|<=|<|>=|>|LIKE)/i,
     IS_NULL: /^IS NULL/i,
@@ -55,6 +56,7 @@ const patterns = {
     END: /^$/
 };
 const follows = {
+    INCLUDE: ['END'],
     LPAREN: ['GEOMETRY', 'SPATIAL', 'PROPERTY', 'VALUE', 'LPAREN'],
     RPAREN: ['NOT', 'LOGICAL', 'END', 'RPAREN'],
     PROPERTY: ['COMPARISON', 'BETWEEN', 'COMMA', 'IS_NULL'],
@@ -87,6 +89,9 @@ const logical = {
     'AND': "and",
     'OR': "or",
     'NOT': "not"
+};
+const cql = {
+    "INCLUDE": "include"
 };
 
 const precedence = {
@@ -136,7 +141,7 @@ const nextToken = (text, tokens) => {
 const tokenize = (text) => {
     let results = [];
     let token;
-    const expect = ["NOT", "GEOMETRY", "SPATIAL", "PROPERTY", "LPAREN"];
+    const expect = ["INCLUDE", "NOT", "GEOMETRY", "SPATIAL", "PROPERTY", "LPAREN"];
     let text2 = text;
     let expect2 = expect;
     do {
@@ -168,6 +173,7 @@ const buildAst = (tokens) => {
         case "COMPARISON":
         case "BETWEEN":
         case "IS_NULL":
+        case "INCLUDE":
         case "LOGICAL":
             let p = precedence[tok.type];
 
@@ -259,6 +265,11 @@ const buildAst = (tokens) => {
                 return match[1].replace(/''/g, "'");
             }
             return Number(tok.text);
+        case "INCLUDE": {
+            return ({
+                type: cql.INCLUDE
+            });
+        }
         case "SPATIAL":
             switch (tok.text.toUpperCase()) {
             case "BBOX": {

--- a/web/client/utils/ogc/Filter/__tests__/fromObject-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/fromObject-test.js
@@ -100,6 +100,12 @@ const LOGICAL = [
     }
 ];
 
+// NOTE: INCLUDE and PROP = VALUE is not supported by the parser
+const CQL_SPECIFIC = [{
+    cql: "INCLUDE",
+    expected: ""
+}];
+
 const REAL_WORLD = [
     // real world example
     {
@@ -143,6 +149,11 @@ describe('Convert CQL filter to OGC Filter', () => {
     it('logical operators', () => {
         const toOGCFilter = fromObject(filterBuilder({ gmlVersion: "3.1.1" }));
         testRules(LOGICAL, toOGCFilter);
+
+    });
+    it('cql_specific operators (include)', () => {
+        const toOGCFilter = fromObject(filterBuilder({ gmlVersion: "3.1.1" }));
+        testRules(CQL_SPECIFIC, toOGCFilter);
 
     });
     it('more real world examples', () => {

--- a/web/client/utils/ogc/Filter/fromObject.js
+++ b/web/client/utils/ogc/Filter/fromObject.js
@@ -1,5 +1,6 @@
 import {includes, isNil} from 'lodash';
 const logical = ["and", "or", "not"];
+const cql = ["include"];
 const operators = {
     '=': "equalTo",
     "<>": "notEqualTo",
@@ -30,6 +31,9 @@ const fromObject = (filterBuilder = {}) => ({type, filters = [], value, property
         return filterBuilder[type](
             ...filters.map(fromObject(filterBuilder))
         );
+    }
+    if (includes(cql, type)) {
+        return "";
     }
     return filterBuilder.property(property)[operators[type]](isNil(value) ? lowerBoundary : value, upperBoundary);
 };


### PR DESCRIPTION
## Description
With this small fix we support the "INCLUDE" filter from CQL translating into an empty string in OGC, accordingly with the GeoServer behavior (INCLUDE filter is not standard). 

This cql filter conversion (done in feature grid) to not fail when encounter "INCLUDE" in the cql filter

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8435

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
