### PR TITLE
#8400: CSW - Manipulate getCapabilities based on capability flag

### DIFF
--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -8,11 +8,11 @@
 
 import urlUtil from 'url';
 
-import { get, head, last, template, isNil, castArray } from 'lodash';
+import { get, head, last, template, isNil, castArray, isEmpty } from 'lodash';
 import assign from 'object-assign';
 
 import axios from '../libs/ajax';
-import { cleanDuplicatedQuestionMarks, getConfigProp } from '../utils/ConfigUtils';
+import { cleanDuplicatedQuestionMarks } from '../utils/ConfigUtils';
 import { extractCrsFromURN, makeBboxFromOWS, makeNumericEPSG } from '../utils/CoordinatesUtils';
 import WMS from "../api/WMS";
 
@@ -179,31 +179,39 @@ export const getLayerReferenceFromDc = (dc, options, checkEsri = true) => {
 let capabilitiesCache = {};
 
 /**
- * Add capabilities data to CSW records if WMS url is found
+ * Add capabilities data to CSW records
+ * if corresponding capability flag is enabled and WMS url is found
  * Currently limited to only scale denominators (visibility limits)
  * @param {object[]} _dcRef dc.reference or dc.URI
  * @param {object} result csw results object
+ * @param {object} options csw service options
+ * @return {object} csw records
  */
-const addCapabilitiesToRecords = (_dcRef, result) => {
+const addCapabilitiesToRecords = (_dcRef, result, options) => {
+    // Currently, visibility limits is the only capability info added to the records
+    // hence `autoSetVisibilityLimits` flag is used to determine if `getCapabilities` is required
+    // This should be modified when additional capability info is required
+    const invokeCapabilities = get(options, "options.service.autoSetVisibilityLimits", false);
+
+    if (!invokeCapabilities) {
+        return result;
+    }
     const { value: _url } = _dcRef?.find(t =>
         REGEX_WMS_ALL.some(regex=> t?.scheme?.match(regex) || t?.protocol?.match(regex))) || {}; // Get WMS URL from references
     const [parsedUrl] = _url && _url.split('?') || [];
     if (!parsedUrl) return {...result}; // Return record when no url found
 
     const cached = capabilitiesCache[parsedUrl];
-    const isCached = cached && new Date().getTime() < cached.timestamp + (getConfigProp('cacheExpire') || 60) * 1000;
+    const isCached = !isEmpty(cached);
     return Promise.resolve(
         isCached
-            ? cached.data
+            ? cached
             : WMS.getCapabilities(parsedUrl + '?version=')
                 .then((caps)=> get(caps, 'capability.layer.layer', []))
                 .catch(()=> []))
         .then((layers) => {
             if (!isCached) {
-                capabilitiesCache[parsedUrl] = {
-                    timestamp: new Date().getTime(),
-                    data: layers
-                };
+                capabilitiesCache[parsedUrl] = layers;
             }
             // Add visibility limits scale data of the layer to the record
             return {
@@ -405,7 +413,7 @@ const Api = {
                                     }
                                 }
                                 result.records = records;
-                                return addCapabilitiesToRecords(_dcRef, result);
+                                return addCapabilitiesToRecords(_dcRef, result, options);
                             } else if (json && json.name && json.name.localPart === "ExceptionReport") {
                                 return {
                                     error: json.value.exception && json.value.exception.length && json.value.exception[0].exceptionText || 'GenericError'

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -96,12 +96,29 @@ describe('Test correctness of the CSW APIs', () => {
             }
         });
     });
-    it('getRecords update capabilities', (done) => {
+});
+
+describe('Test capabilities data in CSW records', () => {
+    const options = {options: {service: {autoSetVisibilityLimits: true}}};
+    it('getRecords update capabilities when autoSetVisibilityLimits is true', (done) => {
+        API.getRecords('base/web/client/test-resources/csw/getRecordsResponseDC.xml', 1, 1, null, options)
+            .then((result) => {
+                try {
+                    expect(result).toBeTruthy();
+                    expect(result.records).toBeTruthy();
+                    expect(result.records[0].capabilities).toBeTruthy();
+                    done();
+                } catch (ex) {
+                    done(ex);
+                }
+            });
+    });
+    it('getRecords skip capabilities update', (done) => {
         API.getRecords('base/web/client/test-resources/csw/getRecordsResponseDC.xml', 1, 1).then((result) => {
             try {
                 expect(result).toBeTruthy();
                 expect(result.records).toBeTruthy();
-                expect(result.records[0].capabilities).toBeTruthy();
+                expect(result.records[0].capabilities).toBeFalsy();
                 done();
             } catch (ex) {
                 done(ex);
@@ -110,7 +127,7 @@ describe('Test correctness of the CSW APIs', () => {
     });
 
     it('does not include capabilities when no parsedUrl in getRecords', (done) => {
-        API.getRecords('base/web/client/test-resources/csw/getRecordsNoWMS.xml', 1, 1).then((result) => {
+        API.getRecords('base/web/client/test-resources/csw/getRecordsNoWMS.xml', 1, 1, null, options).then((result) => {
             try {
                 expect(result).toBeTruthy();
                 expect(result.records[0].capabilities).toBeFalsy();
@@ -120,28 +137,29 @@ describe('Test correctness of the CSW APIs', () => {
             }
         });
     });
-
     it('obtains parsedUrl from dc:uri and gets capabilities', (done) => {
-        API.getRecords('base/web/client/test-resources/csw/getRecordsWithDcURI.xml', 1, 1).then((result) => {
-            try {
-                expect(result).toBeTruthy();
-                expect(result.records[0].capabilities).toBeTruthy();
-                done();
-            } catch (ex) {
-                done(ex);
-            }
-        });
+        API.getRecords('base/web/client/test-resources/csw/getRecordsWithDcURI.xml', 1, 1, null, options)
+            .then((result) => {
+                try {
+                    expect(result).toBeTruthy();
+                    expect(result.records[0].capabilities).toBeTruthy();
+                    done();
+                } catch (ex) {
+                    done(ex);
+                }
+            });
     });
     it("dc:uri do not add capabilities when layer name doesn't match", (done) => {
-        API.getRecords('base/web/client/test-resources/csw/getRecordsWithDcURI.xml', 1, 2).then((result) => {
-            try {
-                expect(result).toBeTruthy();
-                expect(result.records[1].capabilities).toBeFalsy();
-                done();
-            } catch (ex) {
-                done(ex);
-            }
-        });
+        API.getRecords('base/web/client/test-resources/csw/getRecordsWithDcURI.xml', 1, 2, null, options)
+            .then((result) => {
+                try {
+                    expect(result).toBeTruthy();
+                    expect(result.records[1].capabilities).toBeFalsy();
+                    done();
+                } catch (ex) {
+                    done(ex);
+                }
+            });
     });
 });
 


### PR DESCRIPTION
## Description
This PR improves handling capabilities info in CSW
i.e `getCapabilities` is called and cached only on the first effective status change of `Set visibility limits` to `true` in CSW service
This improves the performance when capability info is large and doesn't need any capability info when adding a layer to TOC from catalog service.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#8400 

**What is the new behavior?**
`getCapabilities` is called when fetching of records of csw only when `Set visibility limits` is to true.
The capability info is cached and used on subsequent change of the flag status

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
**Ref**: https://github.com/geosolutions-it/MapStore2-C027/issues/128