### PR TITLE
[Backport 2022.01.xx] #8374: Request of BILTerrainProvider layer are not using proxy url

### DIFF
--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -1345,4 +1345,49 @@ describe('Cesium layer', () => {
             ]
         );
     });
+    it('should create a bil terrain provider from wms layer (deprecated)', () => {
+        const options = {
+            type: "wms",
+            useForElevation: true,
+            url: "https://host-sample/geoserver/wms",
+            format: "application/bil16",
+            name: "workspace:layername",
+            littleendian: false,
+            visibility: true
+        };
+        // create layers
+        const cmp = ReactDOM.render(
+            <CesiumLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        expect(cmp).toBeTruthy();
+        expect(cmp.layer).toBeTruthy();
+        expect(cmp.layer._options.url).toEqual('https://host-sample/geoserver/wms');
+        expect(cmp.layer._options.proxy.proxy).toBeTruthy();
+    });
+
+    it('should create a bil terrain provider from wms layer with no proxy (deprecated)', () => {
+        const options = {
+            type: "wms",
+            useForElevation: true,
+            url: "/geoserver/wms",
+            format: "application/bil16",
+            name: "workspace:layername",
+            littleendian: false,
+            visibility: true
+        };
+        // create layers
+        const cmp = ReactDOM.render(
+            <CesiumLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        expect(cmp).toBeTruthy();
+        expect(cmp.layer).toBeTruthy();
+        expect(cmp.layer._options.url).toEqual('/geoserver/wms');
+        expect(cmp.layer._options.proxy.proxy).toBeFalsy();
+    });
 });

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -130,7 +130,6 @@ function wmsToCesiumOptions(options) {
 }
 
 function wmsToCesiumOptionsBIL(options) {
-
     let url = options.url;
     let proxyUrl = ConfigUtils.getProxyUrl({});
     let proxy;
@@ -139,11 +138,9 @@ function wmsToCesiumOptionsBIL(options) {
     }
     const headers = getAuthenticationHeaders(url, options.securityToken);
     return assign({
-        url: new Cesium.Resource({
-            url,
-            headers,
-            proxy: proxy ? new WMSProxy(proxyUrl) : new NoProxy()
-        }),
+        url,
+        headers,
+        proxy: proxy ? new WMSProxy(proxyUrl) : new NoProxy(),
         littleEndian: options.littleendian || false,
         layerName: options.name
     });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes the proxy configuration for terrain layer providers

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8374

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

BIL Terrain layer will apply correctly the proxy configuration

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
