### PR TITLE
#8393 Fetching parameters data from sessionStorage using inner object and unique identifier

### DIFF
--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -1,3 +1,11 @@
+/**
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import url from "url";
 import {get, includes, inRange, isEmpty, isNaN, isNil, isObject, toNumber} from "lodash";
 
@@ -12,14 +20,6 @@ import {mapSelector} from "../selectors/map";
 import {featureInfoClick} from "../actions/mapInfo";
 import {warning} from "../actions/notifications";
 import {addMarker, SEARCH_LAYER_WITH_FILTER} from "../actions/search";
-
-/**
- * Copyright 2022, GeoSolutions Sas.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree.
- */
 
 /**
  * Retrieves parameters from hash "query string" of react router

--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -1,5 +1,5 @@
 import url from "url";
-import {get, includes, inRange, isEmpty, isNaN, isNil, isObject, omit, toNumber} from "lodash";
+import {get, includes, inRange, isEmpty, isNaN, isNil, isObject, toNumber} from "lodash";
 
 import {getBbox} from "./MapUtils";
 import {isValidExtent} from "./CoordinatesUtils";
@@ -62,25 +62,16 @@ export const getRequestLoadValue = (name, state) => {
  * @param {Storage} storage - sessionStorage or localStorage
  */
 export const postRequestLoadValue = (name, queryParamsID, storage = sessionStorage) => {
-    const queryParams = storage.getItem('queryParams') ?? null;
+    const itemName = queryParamsID ? `queryParams-${queryParamsID}` : 'queryParams';
+    const queryParams = storage.getItem(itemName) ?? null;
     if (queryParams) {
         try {
-            const paramsObject = JSON.parse(queryParams) ?? {};
-            let params = paramsObject;
-            if (queryParamsID) {
-                params = paramsObject[queryParamsID] ?? {};
-            }
+            const params = JSON.parse(queryParams);
             const { [name]: item, ...rest } = params;
             if (item && typeof params === 'object') {
                 const { length } = Object.keys(params);
-                let values;
-                if (queryParamsID) {
-                    values = length > 1 ? { ...paramsObject, [queryParamsID]: rest} : omit(paramsObject, [queryParamsID]);
-                    storage.setItem('queryParams', JSON.stringify(values));
-                } else {
-                    length > 1 && storage.setItem('queryParams', JSON.stringify(rest));
-                    length === 1 && storage.removeItem('queryParams');
-                }
+                length > 1 && storage.setItem('queryParams', JSON.stringify(rest));
+                length === 1 && storage.removeItem('queryParams');
             }
             return item;
         } catch (e) {

--- a/web/client/utils/__tests__/QueryParamsUtils-test.js
+++ b/web/client/utils/__tests__/QueryParamsUtils-test.js
@@ -51,7 +51,7 @@ describe('QueryParamsUtils', () => {
     });
     it('test postRequestLoadValue', () => {
         const uuid = '8158d9c3-155d-44c0-834a-5274161c241e';
-        sessionStorage.setItem('queryParams', JSON.stringify({[uuid]: {featureinfo: {lat: 38.72, lng: -95.625, filterNameList: []}, zoom: 5, center: "41,0"}}));
+        sessionStorage.setItem(`queryParams-${uuid}`, JSON.stringify({featureinfo: {lat: 38.72, lng: -95.625, filterNameList: []}, zoom: 5, center: "41,0"}));
         let featureinfo = postRequestLoadValue('featureinfo', uuid, sessionStorage);
         expect(featureinfo.lat).toBe(38.72);
         expect(featureinfo.lng).toBe(-95.625);

--- a/web/client/utils/__tests__/QueryParamsUtils-test.js
+++ b/web/client/utils/__tests__/QueryParamsUtils-test.js
@@ -50,18 +50,19 @@ describe('QueryParamsUtils', () => {
         expect(center).toBe(null);
     });
     it('test postRequestLoadValue', () => {
-        sessionStorage.setItem('queryParams', JSON.stringify({featureinfo: {lat: 38.72, lng: -95.625, filterNameList: []}, zoom: 5, center: "41,0"}));
-        let featureinfo = postRequestLoadValue('featureinfo', sessionStorage);
+        const uuid = '8158d9c3-155d-44c0-834a-5274161c241e';
+        sessionStorage.setItem('queryParams', JSON.stringify({[uuid]: {featureinfo: {lat: 38.72, lng: -95.625, filterNameList: []}, zoom: 5, center: "41,0"}}));
+        let featureinfo = postRequestLoadValue('featureinfo', uuid, sessionStorage);
         expect(featureinfo.lat).toBe(38.72);
         expect(featureinfo.lng).toBe(-95.625);
         expect(featureinfo.filterNameList).toEqual([]);
 
         const storageItem = sessionStorage.getItem('queryParams');
-        featureinfo = JSON.parse(storageItem)?.featureinfo;
+        featureinfo = JSON.parse(storageItem)[uuid]?.featureinfo;
         expect(featureinfo).toBe(undefined);
 
-        const zoom = postRequestLoadValue('zoom', sessionStorage);
-        const center = postRequestLoadValue('center', sessionStorage);
+        const zoom = postRequestLoadValue('zoom', uuid, sessionStorage);
+        const center = postRequestLoadValue('center', uuid, sessionStorage);
         expect(zoom).toBe(5);
         expect(center).toBe("41,0");
     });


### PR DESCRIPTION
## Description
This PR contains minor changes to the way of fetching query parameters data from the sessionStorage. It adds parameter "queryParamsID" that is used to build unique item name inside sessionStorage. Name will be unique per request to the POST method endpoint. This, along with the backend changes (to be implemented), provides the way to make any page have multiple maps embed via POST method.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8393 

**What is the new behavior?**
Values are fetched from the item inside sessionStorage with a name that is unique per request.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
