### PR TITLE
#8403: Fix - Map widget sync issue

### DIFF
--- a/web/client/components/widgets/enhancers/__tests__/dependenciesToMapProp-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/dependenciesToMapProp-test.jsx
@@ -39,4 +39,22 @@ describe('dependenciesToMapProp enhancer', () => {
         }));
         ReactDOM.render(<Sink mapSync selectedMapId={'MAP_ID'} maps={[{center: {x: 1, y: 1}, mapId: 'MAP_ID'}]} dependencies={{ center: { x: 2, y: 2 } }} />, document.getElementById("container"));
     });
+    it('dependenciesToMapProp for center rendering with selectedMapId and mapSync', (done) => {
+        const Sink = dependenciesToMapProp('center')(createSink(props => {
+            expect(props.map.center.x).toBe(2);
+            expect(props.map.center.y).toBe(2);
+            expect(props.maps).toEqual([{"center": {"x": 2, "y": 2}, "mapId": "MAP_ID"}]);
+            done();
+        }));
+        ReactDOM.render(<Sink mapSync selectedMapId={'MAP_ID'} maps={[{center: {x: 1, y: 1}, mapId: 'MAP_ID'}]} dependencies={{ center: { x: 2, y: 2 } }} />, document.getElementById("container"));
+    });
+    it('dependenciesToMapProp rendering for zoom with selectedMapId and mapSync', (done) => {
+        const Sink = dependenciesToMapProp('zoom')(createSink(props => {
+            expect(props.mapSync).toBeTruthy();
+            expect(props.maps).toEqual([{zoom: 7, mapId: "MAP_ID"}]);
+            expect(props.map.zoom).toBe(7);
+            done();
+        }));
+        ReactDOM.render(<Sink mapSync selectedMapId={'MAP_ID'} maps={[{zoom: 8, mapId: 'MAP_ID'}]} dependencies={{ zoom: 7 }} />, document.getElementById("container"));
+    });
 });

--- a/web/client/components/widgets/enhancers/dependenciesToMapProp.js
+++ b/web/client/components/widgets/enhancers/dependenciesToMapProp.js
@@ -18,11 +18,13 @@ export default (prop) => withPropsOnChange(
         newDependencies && shallowEqual(dependencies[prop], newDependencies[prop])
             || mapSync === newMapSync
         || selectedMapId === newSelectedMapId,
-    ({ maps, mapSync, dependencies = {}, selectedMapId }) => {
+    ({ maps = [], mapSync, dependencies = {}, selectedMapId }) => {
         const map = find(maps, {mapId: selectedMapId}) || {};
+        const updatedMap = dependencies[prop] && mapSync ? set(prop, dependencies[prop], map) : map;
         return {
             mapStateSource: "__dependency_system__",
-            map: dependencies[prop] && mapSync ? set(prop, dependencies[prop], map) : map
+            maps: maps.map((m)=> m.mapId === updatedMap.mapId ? updatedMap : m),
+            map: updatedMap
         };
     }
 );


### PR DESCRIPTION
## Description
This PR fixes map sync issue of panning when maps are connected in dashboard widget.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#8403 

**What is the new behavior?**
Connected map correctly syncs when zooming and panning (Dashboard map widgets)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
