### PR TITLE
#8397: Fix - 3D mode remains enabled on other map

### DIFF
--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -666,6 +666,65 @@ describe('queryparam epics', () => {
             }
         }, state);
     });
+    it('do not switch map type to cesium if cesium viewer options are present only in map state', (done) => {
+        const state = {
+            maptype: {
+                mapType: 'openlayers'
+            },
+            router: {
+                location: {
+                    search: "?center=-74.2,40.7&zoom=16.5"
+                }
+            },
+            map: {
+                present: {
+                    viewerOptions: {
+                        heading: '0.1',
+                        pitch: '-0.7',
+                        roll: '6.2'
+                    }
+                }
+            }
+        };
+        const NUMBER_OF_ACTIONS = 1;
+        testEpic(addTimeoutEpic(readQueryParamsOnMapEpic, 10), NUMBER_OF_ACTIONS, [
+            onLocationChanged({}),
+            initMap(true)
+        ], (actions) => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+            try {
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }, state);
+    });
+    it('retain map type if cesium viewer options is not present query params', (done) => {
+        const state = {
+            maptype: {
+                mapType: 'cesium'
+            },
+            router: {
+                location: {
+                    search: "?center=-74.2,40.7&zoom=16.5"
+                }
+            }
+        };
+        const NUMBER_OF_ACTIONS = 1;
+        testEpic(addTimeoutEpic(readQueryParamsOnMapEpic, 10), NUMBER_OF_ACTIONS, [
+            onLocationChanged({}),
+            initMap(true)
+        ], (actions) => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+            try {
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }, state);
+    });
     it('do nothing if cesium viewer options are not found', (done) => {
         const state = {
             maptype: {

--- a/web/client/epics/queryparams.js
+++ b/web/client/epics/queryparams.js
@@ -16,7 +16,6 @@ import {setControlProperty, TOGGLE_CONTROL} from '../actions/controls';
 
 import {getLonLatFromPoint} from '../utils/CoordinatesUtils';
 import {hideMapinfoMarker, purgeMapInfoResults, toggleMapInfoState} from "../actions/mapInfo";
-import {mapSelector} from '../selectors/map';
 import {clickPointSelector, isMapInfoOpen, mapInfoEnabledSelector} from '../selectors/mapInfo';
 import {shareSelector} from "../selectors/controls";
 import {LAYER_LOAD} from "../actions/layers";
@@ -63,7 +62,9 @@ export const readQueryParamsOnMapEpic = (action$, store) => {
                 action$.ofType(INIT_MAP)
                     .take(1)
                     .switchMap(() => {
-                        const cesiumViewerOptions = getCesiumViewerOptions(parameters, mapSelector(store.getState()));
+                        // On map initialization, query params containing cesium viewer options
+                        // is used to determine cesium map type
+                        const cesiumViewerOptions = getCesiumViewerOptions(parameters);
                         if (cesiumViewerOptions) {
                             skipProcessing = true;
                             return Rx.Observable.of(changeMapType('cesium'));


### PR DESCRIPTION
## Description
This PR fixes map type changing to cesium even when query param doesn't contain cesium viewer options

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#8397 

**What is the new behavior?**
The map changes to cesium only when query param contains cesium viewer options (including embedded map and share url)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
