### PR TITLE
#8424: enable snapping when single tile is checked

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -25,7 +25,7 @@ import axios from '../../../libs/ajax';
 import {isSimpleGeomType, getSimpleGeomType} from '../../../utils/MapUtils';
 import {reprojectGeoJson, calculateDistance, reproject} from '../../../utils/CoordinatesUtils';
 import {createStylesAsync} from '../../../utils/VectorStyleUtils';
-import {transformPolygonToCircle} from '../../../utils/openlayers/DrawSupportUtils';
+import {transformPolygonToCircle, VECTOR, TILE, IMAGE} from '../../../utils/openlayers/DrawSupportUtils';
 import {isCompletePolygon} from '../../../utils/AnnotationsUtils';
 import { parseStyles, getStyle, defaultStyles, getMarkerStyle, getMarkerStyleLegacy } from './VectorStyle';
 
@@ -475,11 +475,11 @@ export default class DrawSupport extends React.Component {
 
         this.removeSnapInteraction();
         if (mapLayerInstance) {
-            switch (true) {
-            case (mapLayerInstance.type === "VECTOR"):
+            switch (mapLayerInstance?.type) {
+            case VECTOR:
                 this.snapInteraction = new Snap({...snapConfig, source: mapLayerInstance.getSource()});
                 break;
-            case (mapLayerInstance.type === "TILE" || mapLayerInstance.type === "IMAGE"):
+            case TILE: case IMAGE:
                 if (layerType === 'wms') {
                     const source = this.getWMSSnapSource(snappingLayerInstance, snapConfig);
                     this.snapLayer = new VectorLayer({

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -475,11 +475,11 @@ export default class DrawSupport extends React.Component {
 
         this.removeSnapInteraction();
         if (mapLayerInstance) {
-            switch (mapLayerInstance.type) {
-            case "VECTOR":
+            switch (true) {
+            case (mapLayerInstance.type === "VECTOR"):
                 this.snapInteraction = new Snap({...snapConfig, source: mapLayerInstance.getSource()});
                 break;
-            case "TILE":
+            case (mapLayerInstance.type === "TILE" || mapLayerInstance.type === "IMAGE"):
                 if (layerType === 'wms') {
                     const source = this.getWMSSnapSource(snappingLayerInstance, snapConfig);
                     this.snapLayer = new VectorLayer({

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -2566,5 +2566,46 @@ describe('Test DrawSupport', () => {
         );
         expect(support.drawInteraction).toBeFalsy();
     });
+    it('test snapping interaction creation when single tile option is checked', () => {
+        const fakeMap = {
+            ol_uid: "1",
+            addLayer: () => {},
+            removeLayer: () => {},
+            disableEventListener: () => {},
+            enableEventListener: () => {},
+            addInteraction: () => {},
+            updateOnlyFeatureStyles: () => {},
+            on: () => {},
+            removeInteraction: () => {},
+            getInteractions: () => ({
+                getLength: () => 0
+            }),
+            getView: () => ({
+                getProjection: () => ({
+                    getCode: () => 'EPSG:4326'
+                })
+            }),
+            getLayers: () => ({
+                getArray: () => [{
+                    get: () => 'snap_layer_1',
+                    getSource: () => new VectorSource(),
+                    type: 'IMAGE'
+                }]
+            })
+        };
+
+        let support = renderDrawSupport({ map: fakeMap});
+        support = renderDrawSupport({
+            map: fakeMap,
+            snapping: true,
+            options: {geodesic: true},
+            snappingLayer: "snap_layer_1",
+            snappingLayerInstance: { id: 'snap_layer_1', type: "wms" },
+            snapConfig: { edge: true, vertex: true, pixelTolerance: 10, strategy: 'bbox'},
+            features: []
+        });
+        const snappingInteraction = !!support?.snapInteraction;
+        expect(snappingInteraction).toBe(true);
+    });
 });
 

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -12,7 +12,7 @@ import assign from 'object-assign';
 import DrawSupport from '../DrawSupport';
 import {DEFAULT_ANNOTATIONS_STYLES} from '../../../../utils/AnnotationsUtils';
 import {circle, geomCollFeature} from '../../../../test-resources/drawsupport/features';
-
+import {IMAGE} from '../../../../utils/openlayers/DrawSupportUtils';
 import {Map, View, Feature} from 'ol';
 import {Point, Circle, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString} from 'ol/geom';
 import Collection from 'ol/Collection';
@@ -2589,7 +2589,7 @@ describe('Test DrawSupport', () => {
                 getArray: () => [{
                     get: () => 'snap_layer_1',
                     getSource: () => new VectorSource(),
-                    type: 'IMAGE'
+                    type: IMAGE
                 }]
             })
         };

--- a/web/client/utils/openlayers/DrawSupportUtils.js
+++ b/web/client/utils/openlayers/DrawSupportUtils.js
@@ -12,6 +12,10 @@ import { reproject } from '../CoordinatesUtils';
 import { getCenter } from 'ol/extent';
 import { Circle } from 'ol/geom';
 
+export const VECTOR = "VECTOR";
+export const TILE = "TILE";
+export const IMAGE = "IMAGE";
+
 const calculateRadius = (center, coordinates, mapCrs, coordinateCrs) => {
     if (isArray(coordinates) && isArray(coordinates[0]) && isArray(coordinates[0][0])) {
         const point = reproject(coordinates[0][0], coordinateCrs, mapCrs);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8424 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The snapping feature works even when the Single Tile checkbox is checked
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
