### PR TITLE
fix fr-FR translation for removegeometry

### DIFF
--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1107,7 +1107,7 @@
             "styleGeometry": "Changer le style",
             "deleteGeometry": "Supprimer toutes les géométries d'annotations",
             "removeannotation": "Voulez-vous supprimer l'annotation avec le titre : {title}?",
-            "removegeometry": "Voulez-vous supprimer toutes les annotations ?",
+            "removegeometry": "Voulez-vous supprimer cette géometrie ?",
             "confirm": "Confirmer",
             "mandatory": "Champ obligatoire",
             "add": "Nouvelle",


### PR DESCRIPTION
## Description
`removegeometry` key has a wrong translation in french, which asks the user if he wants to remove all annotations, while the button that was clicked is the trash near a single annotation - this is misleading ?

the english sentence is *Do you want to remove the annotation feature?* which makes more sense - talks about a single feature.

@MaelREBOUX @catmorales @jusabatier what do you think about it ?



**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix