### PR TITLE
[Backport 2022.01.xx] #8347: Fix time cursor when loading time layer (#8368)

### DIFF
--- a/web/client/reducers/__tests__/timeline-test.js
+++ b/web/client/reducers/__tests__/timeline-test.js
@@ -136,6 +136,17 @@ describe('Test the timeline reducer', () => {
         expect(isMapSync({timeline: timeline({}, setMapSync(true))})).toBe(true);
         expect(isMapSync({ timeline: timeline({}, setMapSync(false)) })).toBe(false);
     });
+    it('initTimeline with defaults', () => {
+        const state = timeline(
+            {settings: {autoLoad: true, collapsed: false}},
+            initTimeline(true, 20, 'start')
+        );
+        expect(state.settings.autoLoad).toBeTruthy();
+        expect(state.settings.collapsed).toBeFalsy();
+        expect(state.settings.showHiddenLayers).toBe(true);
+        expect(state.settings.expandLimit).toBe(20);
+        expect(state.settings.snapType).toBe('start');
+    });
     it('initTimeline with endValuesSupport set as undefined', () => {
         const state = timeline({}, initTimeline(true, 20, 'start'));
         expect(state.settings.showHiddenLayers).toBe(true);

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -130,6 +130,7 @@ export default (state = {
         const endValuesSupport = state?.settings?.endValuesSupport;
         const snapRadioButtonEnabled = state?.settings?.snapRadioButtonEnabled;
         return set(`settings`, {
+            ...state.settings,
             showHiddenLayers: action.showHiddenLayers,
             expandLimit: action.expandLimit,
             snapType: action.snapType,


### PR DESCRIPTION
## Description
This PR fixes the timeline cursor when loading (add a layer/loading a map) time layer even when autoload is set to true

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#8347 

**What is the new behavior?**
The cursor is now displayed when time layer is loaded when autoload is true

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
ref #8347 