### PR TITLE
#8513 Properly pass epic name into isolation function, so that muteState has all the epics listed correctly.

### DIFF
--- a/web/client/utils/StateUtils.js
+++ b/web/client/utils/StateUtils.js
@@ -128,7 +128,7 @@ const isolateEpics = (epics, muteState) => {
             pluginRenderStream$.startWith(true)
         ));
     };
-    return Object.entries(epics).reduce((out, [k, epic]) => ({ ...out, [k]: isolateEpic(epic) }), {});
+    return Object.entries(epics).reduce((out, [k, epic]) => ({ ...out, [k]: isolateEpic(epic, k) }), {});
 };
 
 

--- a/web/client/utils/__tests__/StateUtils-test.js
+++ b/web/client/utils/__tests__/StateUtils-test.js
@@ -11,8 +11,10 @@ import {
     setStore,
     getStore,
     createStore,
-    updateStore
+    updateStore,
+    createStoreManager
 } from '../StateUtils';
+import {createEpicMiddleware} from "redux-observable";
 import Rx from 'rxjs';
 
 describe('StateUtils', () => {
@@ -153,5 +155,116 @@ describe('StateUtils', () => {
         store.dispatch({ type: "fake" });
         expect(spy2.calls.length > 0).toBe(true);
         expect(spy1.calls.length).toBe(beforeUpdateCalls);
+    });
+
+    describe('storeManager', () => {
+        let storeManager;
+        let epicMiddleware;
+        beforeEach(() => {
+            storeManager = createStoreManager({}, {});
+            epicMiddleware = createEpicMiddleware(storeManager.rootEpic);
+            createStore({
+                rootReducer: (action, state) => state,
+                state: {},
+                middlewares: [epicMiddleware]
+            });
+            storeManager.addEpics('test', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        }),
+                epic2: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+        });
+        afterEach(() => {
+            storeManager = {};
+        });
+
+        it('addEpics and verify they are isolated', (done) => {
+            const subjects = storeManager.getEpicsRegistry().muteState;
+            expect(subjects.epic1).toExist();
+            expect(subjects.epic2).toExist();
+            done();
+        });
+        it('addEpics and verify they are added into registry', (done) => {
+            const added = storeManager.getEpicsRegistry().addedEpics;
+            expect(added.epic1).toBe('testPlugin');
+            expect(added.epic2).toBe('testPlugin');
+            done();
+        });
+        it('add same epics from two different plugins and make sure both of them are counted upon epic mute/unmute', (done) => {
+            storeManager.addEpics('test2', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+            const listenedBy = storeManager.getEpicsRegistry().epicsListenedBy;
+            expect(listenedBy.epic1.length).toBe(2);
+            expect(listenedBy.epic2.length).toBe(1);
+            done();
+        });
+        it('add same epics from two different plugins and make sure that all of the epics are properly grouped per plugin', (done) => {
+            storeManager.addEpics('test2', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+            const groupedByModule = storeManager.getEpicsRegistry().groupedByModule;
+            expect(groupedByModule.testPlugin).toInclude('epic1');
+            expect(groupedByModule.testPlugin).toInclude('epic2');
+            expect(groupedByModule.test2Plugin).toInclude('epic1');
+            done();
+        });
+        it('add same epics from two different plugins and make sure that repetitive epic is getting registered only from the first plugin attempting to register it', (done) => {
+            storeManager.addEpics('test2', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+            const addedEpics = storeManager.getEpicsRegistry().addedEpics;
+            expect(addedEpics.epic1).toBe('testPlugin');
+            expect(addedEpics.epic2).toBe('testPlugin');
+            done();
+        });
+        it('mute epic when plugin is missing on the page, assure that it updates listeners list', (done) => {
+            storeManager.addEpics('test2', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+            storeManager.muteEpics('testPlugin');
+            const listenedBy = storeManager.getEpicsRegistry().epicsListenedBy;
+            expect(listenedBy.epic1.length).toBe(1);
+            expect(listenedBy.epic2.length).toBe(0);
+            done();
+        });
+        it('unmute epic when plugin is added back to the page, assure that it updates listeners list', (done) => {
+            storeManager.addEpics('test2', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+            storeManager.muteEpics('testPlugin');
+            storeManager.unmuteEpics('testPlugin');
+            const listenedBy = storeManager.getEpicsRegistry().epicsListenedBy;
+            expect(listenedBy.epic1.length).toBe(2);
+            expect(listenedBy.epic2.length).toBe(1);
+            done();
+        });
     });
 });


### PR DESCRIPTION
## Description
There is an issue preventing epics from being muted correctly because epics name is not passed as an argument into function that creates RxJS subject per epic.
Also, when plugin name is not normalized in plugins.js, mute of the epic can't happen properly under specific conditions.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8513 

**What is the new behavior?**
Mute/unmute action is managed properly regardless of plugin name. All epics are isolated properly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
