### PR TITLE
#8458 adding first commit creation in createproject.js script

### DIFF
--- a/createProject.js
+++ b/createProject.js
@@ -98,7 +98,6 @@ function doWork(params) {
             return project.updateSubmoduleBranch(params.outFolder);
         })
         .then(() => {
-            process.stdout.write('createFirstCommit\n');
             return project.createFirstCommit(params.outFolder);
         })
         .then(() => {

--- a/createProject.js
+++ b/createProject.js
@@ -49,7 +49,7 @@ function doWork(params) {
         name: params.projectName,
         version: params.projectVersion,
         description: params.projectDescription || params.projectName,
-        repository: params.repoURL,
+        repository: params.repoURL || "",
         eslintConfig: {
             "extends": [
                 "@mapstore/eslint-config-mapstore"
@@ -96,6 +96,10 @@ function doWork(params) {
         .then(() => {
             process.stdout.write('git init\n');
             return project.updateSubmoduleBranch(params.outFolder);
+        })
+        .then(() => {
+            process.stdout.write('createFirstCommit\n');
+            return project.createFirstCommit(params.outFolder);
         })
         .then(() => {
             process.stdout.write('git repo OK!\n');

--- a/docs/developer-guide/project-creation-script.md
+++ b/docs/developer-guide/project-creation-script.md
@@ -46,10 +46,9 @@ If you create a *standard* project, you can customize it editing **js/app.jsx**:
 
 The following steps are:
 
-* npm install to download dependencies
-* npm start to test the project
-* git add / push to publish the initial project on the git repo
-* ./build.sh to build the full war
+* `npm install` to download dependencies
+* `npm start` to test the project
+* `./build.sh` to build the full .war
 
 ## Create a new project type
 

--- a/docs/developer-guide/project-creation-script.md
+++ b/docs/developer-guide/project-creation-script.md
@@ -1,9 +1,7 @@
 # Create your own MapStore project
 
-
 !!! note
     From version 2021.02.xx MapStore introduced a new project system. Take a look [here](https://github.com/geosolutions-it/MapStore2/issues/6314) to learn more about the new project system.
-
 
 To create a new MapStore based project you can use the createProject script.
 First of all, if you don't have done it before, clone the MapStore2 repository master branch into a local folder:
@@ -18,9 +16,21 @@ Then, move into the folder that has just been created, containing MapStore2:
 cd MapStore2
 ```
 
+Choose from which branch you want the mapstore revision to be aligned, we suggest to use latest release or latest stable available
+
+```sh
+git checkout stable-branch
+```
+
+or
+
+```sh
+git checkout v2022.02.00
+```
+
 Install dependencies for MapStore:
 
-```
+```sh
 npm install
 ```
 
@@ -39,6 +49,12 @@ Note that projectName and outputFolder are mandatory:
 * **projectDescription**: project description, used in sample index page and as description in package.json
 * **gitRepositoryUrl**: full url to the github repository where the project will be published
 * **outputFolder**: folder where the project will be created
+
+Usage:
+
+```sh
+node ./createProject.js standard MyProject "1.0.0" "this is my awesome project" "" ../MY_PROJECT_NAME
+```
 
 At the end of the script execution, the given outputFolder will be populated by all the configuration files needed to start working on the project. Moreover, the local git repository will be initialized and the MapStore sub-module added and downloaded.
 
@@ -73,9 +89,11 @@ In addition to static and templates, the following files from the root MapStore 
 
 To update MapStore2 version enter the MapStore2 folder and pull desired git version.
 If MapStore2 devDependencies have been changed you can manually update these in the project package.json file or run the script updateDevDeps
+
 ```sh
 npm run updateDevDeps
 ```
+
 The script will automatically copy the devDependencies from MapStore2 package.json to the project package.json file. All the project existing devDependencies will be overwritten.
 
 To sync MapStore2 dependencies just run npm install from project root folder.

--- a/docs/developer-guide/release.md
+++ b/docs/developer-guide/release.md
@@ -50,6 +50,7 @@ Replacing:
   - [ ] for geostore, check if [here](https://maven.geo-solutions.it/it/geosolutions/geostore/geostore-webapp/) is present the version specified in the [release calendar 2022](https://github.com/geosolutions-it/MapStore2/wiki/MapStore-Releases-2022)
   - [ ] for http_proxy, check if [here](https://mvnrepository.com/artifact/proxy/http_proxy) is present the version specified in the [release calendar 2022](https://github.com/geosolutions-it/MapStore2/wiki/MapStore-Releases-2022)
 - [ ] If major release (YYYY.XX.00), create a branch `YYYY.XX.xx`  (`xx` is really `xx`, example: 2018.01.xx)
+- [ ] If major release, update the default stable branch used in createProject.js script , in particular the utility/projects/projectLib.js file
 - [ ] If major release, Change [QA Jenkins job](http://build.geosolutionsgroup.com/view/MapStore/job/MapStore/view/MapStore%20QA/job/MapStore2-QA-Build/) to build the new branch, enable the job continuous deploy by updating the `branch` parameter in the build configuration page to `YYYY.XX.xx`
 - [ ] Check version in `package.json`. (as for semantic versioning the major have to be 0 until the npm package has not a stable API).
     - [ ] Take note of current version of mapstore in `package.json` in master branch, it should be in the form 0.x.0

--- a/utility/projects/projectLib.js
+++ b/utility/projects/projectLib.js
@@ -46,7 +46,6 @@ const createFirstCommit = (outFolder) => {
     const git = require('simple-git')(outFolder);
     return new Promise((resolve, reject) => {
         git.add(["*"], () => {
-            process.stdout.write('adding all files...\n');
             git.commit('First Commit', (err) => {
                 if (err) {
                     reject(err);
@@ -69,23 +68,37 @@ const updateSubmoduleBranch = (outFolder) => {
     const git = require('simple-git')();
     const gitProjectMs2 = require('simple-git')(`${outFolder}/MapStore2`);
 
+    const stableBranch = "2022.02.xx";
+
     return new Promise((resolve, reject) => {
         try {
             git.branchLocal( (err, data) => {
                 if (err) {
                     reject(err);
                 }
-                process.stdout.write("doing checkout to the branch: " + data.current + "\n");
-                gitProjectMs2.checkout(data.current, null, (error) => {
-                    if (error) {
-                        reject(error);
+                git.fetch("origin", data.current, (er) => {
+                    if (er) {
+                        process.stdout.write(`Warning: It was not possible to checkout to ${data.current} so we checkout to latest stable: ${stableBranch}\n`);
+                        gitProjectMs2.checkout(stableBranch, null, (e) => {
+                            if (e) {
+                                reject(e);
+                            }
+                            process.stdout.write(`checkout to stable branch: ${stableBranch} done\n`);
+                            resolve();
+                        });
+                    } else {
+                        process.stdout.write("doing checkout to the branch: " + data.current + "\n");
+                        gitProjectMs2.checkout(data.current, null, (error) => {
+                            if (error) {
+                                reject(error);
+                            }
+                            resolve();
+                        });
                     }
-                    process.stdout.write("checkout done");
-                    resolve();
                 });
             });
         } catch (e) {
-            process.stdout.write("error");
+            process.stdout.write("error\n");
             process.stdout.write(e);
             reject(e);
         }

--- a/utility/projects/projectLib.js
+++ b/utility/projects/projectLib.js
@@ -22,16 +22,43 @@ const initGit = (outFolder) => {
     const git = require('simple-git')(outFolder);
     return new Promise((resolve, reject) => {
         git.init(() => {
+            process.stdout.write('initializing git repo...\n');
             git.submoduleAdd('https://github.com/geosolutions-it/MapStore2.git', 'MapStore2', (err) => {
                 if (err) {
                     reject(err);
                 } else {
                     resolve();
+                    process.stdout.write('MapStore2 submodule added...\n');
                 }
             });
         });
     });
 };
+
+
+/**
+ * it creates the first commit to be used in git versioning
+ * @return {Promise} the promise to continue the flow of project creation
+ */
+const createFirstCommit = (outFolder) => {
+    process.stdout.write('Creating first commit...\n');
+
+    const git = require('simple-git')(outFolder);
+    return new Promise((resolve, reject) => {
+        git.add(["*"], () => {
+            process.stdout.write('adding all files...\n');
+            git.commit('First Commit', (err) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                    process.stdout.write('First commit created...\n');
+                }
+            });
+        });
+    });
+};
+
 
 /**
  * it does a checkout to a specified folder which in general is rootProject/MapStore2
@@ -125,5 +152,6 @@ module.exports = {
     createPackageJSON,
     copyTemplates,
     copyStaticFiles,
-    updateSubmoduleBranch
+    updateSubmoduleBranch,
+    createFirstCommit
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
adding first commit creation in createproject.js script

training doc has been edited here including this change because

git add -A
git commit -m "First Commit"

now are no longer needed as part of the project creation

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8458

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
commit is created during project script creation 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

