### PR TITLE
#8523 Extended condition of sidebar menu visibility

### DIFF
--- a/web/client/plugins/SidebarMenu.jsx
+++ b/web/client/plugins/SidebarMenu.jsx
@@ -100,7 +100,7 @@ class SidebarMenu extends React.Component {
         const { hidden } = this.state;
         const burgerMenuEnabled = this.props.state?.controls?.burgermenu?.enabled;
         const visibleElements = this.visibleItems('sidebar').length;
-        visibleElements && prevProps.isActive === false && onInit();
+        visibleElements.length && !burgerMenuEnabled && prevProps.isActive === false && onInit();
 
         if ((visibleElements === 0 || burgerMenuEnabled) && !hidden) {
             onDetach();

--- a/web/client/plugins/SidebarMenu.jsx
+++ b/web/client/plugins/SidebarMenu.jsx
@@ -102,7 +102,7 @@ class SidebarMenu extends React.Component {
         const { hidden } = this.state;
         const burgerMenuIsActive = this.props.burgerMenuIsActive;
         const visibleElements = this.visibleItems('sidebar').length;
-        visibleElements.length && !burgerMenuIsActive && prevProps.isActive === false && onInit();
+        visibleElements && !burgerMenuIsActive && prevProps.isActive === false && onInit();
 
         if ((visibleElements === 0 || burgerMenuIsActive) && !hidden) {
             onDetach();

--- a/web/client/plugins/SidebarMenu.jsx
+++ b/web/client/plugins/SidebarMenu.jsx
@@ -98,13 +98,14 @@ class SidebarMenu extends React.Component {
     componentDidUpdate(prevProps) {
         const { onInit, onDetach } = this.props;
         const { hidden } = this.state;
+        const burgerMenuEnabled = this.props.state?.controls?.burgermenu?.enabled;
         const visibleElements = this.visibleItems('sidebar').length;
         visibleElements && prevProps.isActive === false && onInit();
 
-        if (visibleElements === 0 && !hidden) {
+        if ((visibleElements === 0 || burgerMenuEnabled) && !hidden) {
             onDetach();
             this.setState((state) => ({ ...state, hidden: true}));
-        } else if (visibleElements > 0 && hidden) {
+        } else if (visibleElements > 0 && !burgerMenuEnabled && hidden) {
             onInit();
             this.setState((state) => ({ ...state, hidden: false}));
         }

--- a/web/client/plugins/__tests__/SidebarMenu-test.jsx
+++ b/web/client/plugins/__tests__/SidebarMenu-test.jsx
@@ -11,6 +11,7 @@ import ReactDOM from 'react-dom';
 import SidebarMenu from "../SidebarMenu";
 import { getPluginForTest } from './pluginsTestUtils';
 
+
 describe('SidebarMenu Plugin', () => {
     beforeEach(() => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -38,5 +39,28 @@ describe('SidebarMenu Plugin', () => {
         expect(sidebarMenuContainer).toExist();
         const elements = document.querySelectorAll('#mapstore-sidebar-menu > button, #mapstore-sidebar-menu #extra-items + .dropdown-menu li');
         expect(elements.length).toBe(2);
+    });
+
+    it('hide sidebar if burger menu is on the page', () => {
+        document.getElementById('container').style.height = '600px';
+        const { Plugin } = getPluginForTest(SidebarMenu, {
+            controls: {
+                burgermenu: {
+                    enabled: true
+                }
+            } });
+        const items = [{
+            name: 'test',
+            position: 1,
+            text: 'Test Item'
+        }, {
+            name: 'test2',
+            position: 2,
+            text: 'Test Item 2'
+        }];
+        ReactDOM.render(<Plugin items={items}/>, document.getElementById("container"));
+        ReactDOM.render(<Plugin items={[...items]}/>, document.getElementById("container"));
+        const sidebarMenuContainer = document.getElementById('mapstore-sidebar-menu-container');
+        expect(sidebarMenuContainer).toNotExist();
     });
 });


### PR DESCRIPTION
## Description
This PR adds extra check to make sure that sidebar menu is hidden whenever burger menu is rendered on the page, regardless of the length of items to render in sidebar.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8523 

**What is the new behavior?**
Sidebar menu will be hidden whenever burger menu is rendered on the page.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
