### PR TITLE
backport 2022.02.xx - Revert "#8082 normalize longitude (#8325)" (#8512)

### DIFF
--- a/web/client/actions/__tests__/draw-test.js
+++ b/web/client/actions/__tests__/draw-test.js
@@ -38,7 +38,7 @@ describe('Test correctness of the draw actions', () => {
 
         let retval = changeDrawingStatus(status, method, owner, features);
 
-        expect(retval).toBeTruthy();
+        expect(retval).toExist();
         expect(retval.type).toBe(CHANGE_DRAWING_STATUS);
         expect(retval.status).toBe("start");
         expect(retval.method).toBe("Circle");
@@ -52,190 +52,83 @@ describe('Test correctness of the draw actions', () => {
 
         let retval = endDrawing(geometry, owner);
 
-        expect(retval).toBeTruthy();
+        expect(retval).toExist();
         expect(retval.type).toBe(END_DRAWING);
         expect(retval.geometry).toBe("geometry");
         expect(retval.owner).toBe("queryform");
     });
 
-    describe("geometryChanged tests", () => {
-
-        it('Test geometryChanged all properties', () => {
-            const features = [{
-                geometry: {
-                    type: "Point",
-                    coordinates: [1, 1]
-                }
-            }];
-            const owner = "annotations";
-            const enableEdit = true;
-            const textChanged = false;
-            const retval = geometryChanged(features, owner, enableEdit, textChanged);
-            expect(retval).toBeTruthy();
-            expect(retval.type).toBe(GEOMETRY_CHANGED);
-            expect(retval.features).toBeTruthy();
-            expect(retval.features).toEqual(features);
-        });
-        it('Test geometryChanged normalization for Point', () => {
-            const features = [{
-                geometry: {
-                    type: "Point",
-                    coordinates: [-210, 2]
-                }
-            }];
-            const retval = geometryChanged(features);
-            expect(retval).toBeTruthy();
-            expect(retval.type).toBe(GEOMETRY_CHANGED);
-            expect(retval.features).toBeTruthy();
-            expect(retval.features).toNotEqual(features);
-            expect(retval.features[0].geometry).toEqual({
+    it('Test geometryChanged action creator', () => {
+        const features = [{
+            geometry: {
                 type: "Point",
-                coordinates: [ 150, 2 ]
-            });
-        });
-        it('Test geometryChanged normalization for LineString ', () => {
-            const features = [{
-                geometry: {
-                    type: "LineString",
-                    "coordinates": [
-                        [-230.0, 10.0], [-210.0, 30.0], [-240.0, 40.0]
-                    ]
-                }
-            }];
-            const retval = geometryChanged(features);
-            expect(retval).toBeTruthy();
-            expect(retval.type).toBe(GEOMETRY_CHANGED);
-            expect(retval.features).toBeTruthy();
-            expect(retval.features).toNotEqual(features);
-            expect(retval.features[0].geometry).toEqual({
-                type: "LineString",
-                coordinates: [ [ 130.00000000000003, 10 ], [ 150, 30 ], [ 120, 40 ] ]
-            });
-        });
-        it('Test geometryChanged normalization for Polygon', () => {
-            const features = [{
-                geometry: {
-                    type: "Polygon",
-                    coordinates: [
-                        [[-190.0, 10.0], [-192.0, 45.0], [196.0, 40.0], [-198.0, 20.0], [-200.0, 10.0]],
-                        [[200.0, 30.0], [210.0, 35.0], [-220.0, 20.0], [230.0, 30.0]]
-                    ]
-                }
-            }];
-            const retval = geometryChanged(features);
-            expect(retval).toBeTruthy();
-            expect(retval.type).toBe(GEOMETRY_CHANGED);
-            expect(retval.features).toBeTruthy();
-            expect(retval.features).toNotEqual(features);
-            expect(retval.features[0].geometry).toEqual({
-                type: "Polygon",
-                coordinates: [ [ [ 170, 10 ], [ 168, 45 ], [ -164.00000000000003, 40 ], [ 161.99999999999997, 20 ], [ 160, 10 ] ], [ [ -160, 30 ], [ -150, 35 ], [ 139.99999999999997, 20 ], [ -130.00000000000003, 30 ] ] ]
-            });
-        });
+                coordinates: []
+            }
+        }];
 
-        it('Test geometryChanged normalization for MultiPoint ', () => {
-            const features = [{
-                geometry: {
-                    type: "MultiPoint",
-                    coordinates: [
-                        [-210.0, 40.0], [-140.0, 30.0], [-220.0, 20.0], [-230.0, 10.0]
-                    ]
-                }
-            }];
-            const retval = geometryChanged(features);
-            expect(retval).toBeTruthy();
-            expect(retval.type).toBe(GEOMETRY_CHANGED);
-            expect(retval.features).toBeTruthy();
-            expect(retval.features).toNotEqual(features);
-            expect(retval.features[0].geometry).toEqual({
-                type: "MultiPoint",
-                coordinates: [ [ 150, 40 ], [ -140, 30 ], [ 139.99999999999997, 20 ], [ 130.00000000000003, 10 ] ]
-            });
-        });
+        const retval = geometryChanged(features);
 
-        it('Test geometryChanged normalization for MultiLineString ', () => {
-            const features = [{
-                geometry: {
-                    type: "MultiLineString",
-                    coordinates: [
-                        [[-210.0, 10.0], [-220.0, 20.0], [-210.0, 40.0]],
-                        [[-189.0, 40.0], [-230.0, 30.0], [-240.0, 20.0], [230.0, 10.0]]
-                    ]
-                }
-            }];
-            const retval = geometryChanged(features);
-            expect(retval).toBeTruthy();
-            expect(retval.type).toBe(GEOMETRY_CHANGED);
-            expect(retval.features).toBeTruthy();
-            expect(retval.features).toNotEqual(features);
-            expect(retval.features[0].geometry).toEqual({
-                type: "MultiLineString",
-                coordinates: [ [ [ 150, 10 ], [ 139.99999999999997, 20 ], [ 150, 40 ] ],
-                    [ [ 171, 40 ], [ 130.00000000000003, 30 ], [ 120, 20 ], [ -130.00000000000003, 10 ] ] ]
-            });
-        });
+        expect(retval).toExist();
+        expect(retval.type).toBe(GEOMETRY_CHANGED);
+        expect(retval.features).toExist();
+        expect(retval.features).toBe(features);
+    });
+    it('Test geometryChanged features, owner, enableEdit, textChanged', () => {
+        const features = [{
+            geometry: {
+                type: "Point",
+                coordinates: []
+            }
+        }];
+        const owner = "annotations";
+        const enableEdit = true;
+        const textChanged = false;
+        const retval = geometryChanged(features, owner, enableEdit, textChanged);
 
-        it('Test geometryChanged normalization for MultiPolygon', () => {
-            const features = [{
-                geometry: {
-                    type: "MultiPolygon",
-                    coordinates: [
-                        [
-                            [[230.0, 20.0], [545.0, 40.0], [-210.0, 40.0], [330.0, 20.0]]
-                        ],
-                        [
-                            [[-215.0, 5.0], [240.0, 10.0], [310.0, 20.0], [-205.0, 10.0], [215.0, 5.0]]
-                        ]
-                    ]
-                }
-            }];
-            const retval = geometryChanged(features);
-            expect(retval).toBeTruthy();
-            expect(retval.type).toBe(GEOMETRY_CHANGED);
-            expect(retval.features).toBeTruthy();
-            expect(retval.features).toNotEqual(features);
-            expect(retval.features[0].geometry).toEqual({
-                type: "MultiPolygon",
-                coordinates: [ [ [ [ -130.00000000000003, 20 ], [ -175.00000000000003, 40 ], [ 150, 40 ], [ -30, 20 ] ] ], [ [ [ 145, 5 ], [ -120, 10 ], [ -50, 20 ], [ 155, 10 ], [ -145, 5 ] ] ] ]
-            });
-        });
+        expect(retval).toExist();
+        expect(retval.type).toBe(GEOMETRY_CHANGED);
+        expect(retval.features).toExist();
+        expect(retval.features).toBe(features);
+        expect(retval.owner).toBe(owner);
+        expect(retval.enableEdit).toBe(enableEdit);
+        expect(retval.textChanged).toBe(textChanged);
     });
     it('Test drawStopped action creator', () => {
         const retval = drawStopped();
-        expect(retval).toBeTruthy();
+        expect(retval).toExist();
         expect(retval.type).toBe(DRAW_SUPPORT_STOPPED);
     });
     it('Test setCurrentStyle action creator', () => {
         const retval = setCurrentStyle("somestyle");
-        expect(retval).toBeTruthy();
+        expect(retval).toExist();
         expect(retval.type).toBe(SET_CURRENT_STYLE);
         expect(retval.currentStyle).toBe("somestyle");
     });
     it('Test drawSupportReset action creator', () => {
         const retval = drawSupportReset();
-        expect(retval).toBeTruthy();
+        expect(retval).toExist();
         expect(retval.type).toBe(CHANGE_DRAWING_STATUS);
         expect(retval.status).toBe("clean");
     });
     it('Test toggleSnapping action creator', () => {
         const retval = toggleSnapping();
-        expect(retval).toBeTruthy();
+        expect(retval).toExist();
         expect(retval.type).toBe(TOGGLE_SNAPPING);
     });
     it('Test setSnappingLayer action creator', () => {
         const retval = setSnappingLayer('sample');
-        expect(retval).toBeTruthy();
+        expect(retval).toExist();
         expect(retval.type).toBe(SET_SNAPPING_LAYER);
         expect(retval.snappingLayer).toBe('sample');
     });
     it('Test toggleSnappingIsLoading action creator', () => {
         const retval = toggleSnappingIsLoading();
-        expect(retval).toBeTruthy();
+        expect(retval).toExist();
         expect(retval.type).toBe(SNAPPING_IS_LOADING);
     });
     it('Test setSnappingConfig action creator', () => {
         const retval = setSnappingConfig(true, 'edge', {edge: false, vertex: true, pixelTolerance: 20});
-        expect(retval).toBeTruthy();
+        expect(retval).toExist();
         expect(retval.type).toBe(SET_SNAPPING_CONFIG);
         expect(retval.value).toBe(true);
         expect(retval.prop).toBe('edge');

--- a/web/client/actions/draw.js
+++ b/web/client/actions/draw.js
@@ -18,14 +18,11 @@ export const SNAPPING_IS_LOADING = 'DRAW:SNAPPING_IS_LOADING';
 export const TOGGLE_SNAPPING = 'DRAW:TOGGLE_SNAPPING';
 export const SET_SNAPPING_CONFIG = 'DRAW:SET_SNAPPING_CONFIG';
 
-import  { normalizeGeometry } from '../../client/utils/CoordinatesUtils';
-import  { set } from '../../client/utils/ImmutableUtils';
 
 export function geometryChanged(features, owner, enableEdit, textChanged, circleChanged) {
-
     return {
         type: GEOMETRY_CHANGED,
-        features: set("[0].geometry", normalizeGeometry(features[0].geometry), features),
+        features,
         owner,
         enableEdit,
         textChanged,

--- a/web/client/reducers/__tests__/draw-test.js
+++ b/web/client/reducers/__tests__/draw-test.js
@@ -57,7 +57,7 @@ describe('Test the draw reducer', () => {
         expect(state.features.length).toBe(0);
     });
 
-    it('FeatureGrid SET_CURRENT_STYLE', () => {
+    it('FeatureGrid GEOMETRY_CHANGED', () => {
         const style = {
             fill: {
                 color: "red"

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -36,8 +36,6 @@ import overlap from '@turf/boolean-overlap';
 import contains from '@turf/boolean-contains';
 import turfBbox from '@turf/bbox';
 import { getConfigProp } from './ConfigUtils';
-import { set } from './ImmutableUtils';
-
 
 let CoordinatesUtils;
 
@@ -369,7 +367,6 @@ export const lineIntersectPolygon = function(linestring, polygon) {
     let polygonLines = polygonToLinestring(polygon).features[0];
     return lineIntersect(linestring, polygonLines).features.length !== 0;
 };
-
 export const normalizeLng = (lng) => {
     let tLng = lng / 360 % 1 * 360;
     if (tLng < -180) {
@@ -378,36 +375,6 @@ export const normalizeLng = (lng) => {
         tLng = tLng - 360;
     }
     return tLng;
-};
-
-/**
- * function used to normalize and entire geometry by checking all of the longitude values
- * @param {object} geometry the geojson geometry to parse
- */
-export const normalizeGeometry = (geometry) => {
-    let newCoords = [];
-    switch (geometry.type) {
-    case "Point": {
-        let item = geometry.coordinates;
-        newCoords = [normalizeLng(item[0]), item[1]];
-        break;
-    }
-    case "LineString": case "MultiPoint": {
-        newCoords = geometry.coordinates.map((item) => [normalizeLng(item[0]), item[1]]);
-        break;
-    }
-    case "Polygon": case "MultiLineString": {
-        newCoords = geometry.coordinates.map(x => x.map((item) => [normalizeLng(item[0]), item[1]]));
-        break;
-    }
-    case "MultiPolygon": {
-        newCoords = geometry.coordinates.map(i => i.map(x => x.map((item) => [normalizeLng(item[0]), item[1]])));
-        break;
-    }
-    default:
-        break;
-    }
-    return set("coordinates", newCoords, geometry);
 };
 /**
  * Reprojects a bounding box.

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -39,7 +39,6 @@ import {
     getProjections,
     getExtentForProjection,
     checkIfLayerFitsExtentForProjection,
-    normalizeGeometry,
     getLonLatFromPoint, convertRadianToDegrees, convertDegreesToRadian
 } from '../CoordinatesUtils';
 import { setConfigProp, removeConfigProp } from '../ConfigUtils';
@@ -164,6 +163,7 @@ describe('CoordinatesUtils', () => {
         expect(reprojectedTestPoint.features[0].geometry.coordinates[0].toFixed(4)).toBe((-12523490.492568726).toFixed(4));
         expect(reprojectedTestPoint.features[0].geometry.coordinates[1].toFixed(4)).toBe((5195238.005360028).toFixed(4));
     });
+
     it('test geojson extent', () => {
         let geojsonPoint = {
             "type": "Feature",
@@ -961,107 +961,4 @@ describe('CoordinatesUtils', () => {
         const val = valueIsApproximatelyEqual(rad, 100);
         expect(val).toBe(true);
     });
-
-    describe('normalizeGeometry tests', ()=> {
-        it('Test geometryChanged normalization for Point', () => {
-            const geometry = {
-                type: "Point",
-                coordinates: [-210, 2]
-            };
-            const newGeom = normalizeGeometry(geometry);
-            expect(newGeom).toBeTruthy();
-            expect(newGeom).toNotEqual(geometry);
-            expect(newGeom).toEqual({
-                type: "Point",
-                coordinates: [ 150, 2 ]
-            });
-        });
-        it('Test geometryChanged normalization for LineString ', () => {
-            const geometry = {
-                type: "LineString",
-                "coordinates": [
-                    [-230.0, 10.0], [-210.0, 30.0], [-240.0, 40.0]
-                ]
-            };
-            const newGeom = normalizeGeometry(geometry);
-            expect(newGeom).toBeTruthy();
-            expect(newGeom).toNotEqual(geometry);
-            expect(newGeom).toEqual({
-                type: "LineString",
-                coordinates: [ [ 130.00000000000003, 10 ], [ 150, 30 ], [ 120, 40 ] ]
-            });
-        });
-        it('Test geometryChanged normalization for Polygon', () => {
-            const geometry = {
-                type: "Polygon",
-                coordinates: [
-                    [[-190.0, 10.0], [-192.0, 45.0], [196.0, 40.0], [-198.0, 20.0], [-200.0, 10.0]],
-                    [[200.0, 30.0], [210.0, 35.0], [-220.0, 20.0], [230.0, 30.0]]
-                ]
-            };
-            const newGeom = normalizeGeometry(geometry);
-            expect(newGeom).toBeTruthy();
-            expect(newGeom).toNotEqual(geometry);
-            expect(newGeom).toEqual({
-                type: "Polygon",
-                coordinates: [ [ [ 170, 10 ], [ 168, 45 ], [ -164.00000000000003, 40 ], [ 161.99999999999997, 20 ], [ 160, 10 ] ], [ [ -160, 30 ], [ -150, 35 ], [ 139.99999999999997, 20 ], [ -130.00000000000003, 30 ] ] ]
-            });
-        });
-
-        it('Test geometryChanged normalization for MultiPoint ', () => {
-            const geometry = {
-                type: "MultiPoint",
-                coordinates: [
-                    [-210.0, 40.0], [-140.0, 30.0], [-220.0, 20.0], [-230.0, 10.0]
-                ]
-            };
-            const newGeom = normalizeGeometry(geometry);
-            expect(newGeom).toBeTruthy();
-            expect(newGeom).toNotEqual(geometry);
-            expect(newGeom).toEqual({
-                type: "MultiPoint",
-                coordinates: [ [ 150, 40 ], [ -140, 30 ], [ 139.99999999999997, 20 ], [ 130.00000000000003, 10 ] ]
-            });
-        });
-
-        it('Test geometryChanged normalization for MultiLineString ', () => {
-            const geometry = {
-                type: "MultiLineString",
-                coordinates: [
-                    [[-210.0, 10.0], [-220.0, 20.0], [-210.0, 40.0]],
-                    [[-189.0, 40.0], [-230.0, 30.0], [-240.0, 20.0], [230.0, 10.0]]
-                ]
-            };
-            const newGeom = normalizeGeometry(geometry);
-            expect(newGeom).toBeTruthy();
-            expect(newGeom).toNotEqual(geometry);
-            expect(newGeom).toEqual({
-                type: "MultiLineString",
-                coordinates: [ [ [ 150, 10 ], [ 139.99999999999997, 20 ], [ 150, 40 ] ],
-                    [ [ 171, 40 ], [ 130.00000000000003, 30 ], [ 120, 20 ], [ -130.00000000000003, 10 ] ] ]
-            });
-        });
-
-        it('Test geometryChanged normalization for MultiPolygon', () => {
-            const geometry = {
-                type: "MultiPolygon",
-                coordinates: [
-                    [
-                        [[230.0, 20.0], [545.0, 40.0], [-210.0, 40.0], [330.0, 20.0]]
-                    ],
-                    [
-                        [[-215.0, 5.0], [240.0, 10.0], [310.0, 20.0], [-205.0, 10.0], [215.0, 5.0]]
-                    ]
-                ]
-            };
-            const newGeom = normalizeGeometry(geometry);
-            expect(newGeom).toBeTruthy();
-            expect(newGeom).toNotEqual(geometry);
-            expect(newGeom).toEqual({
-                type: "MultiPolygon",
-                coordinates: [ [ [ [ -130.00000000000003, 20 ], [ -175.00000000000003, 40 ], [ 150, 40 ], [ -30, 20 ] ] ], [ [ [ 145, 5 ], [ -120, 10 ], [ -50, 20 ], [ 155, 10 ], [ -145, 5 ] ] ] ]
-            });
-        });
-    });
-
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This reverts commit cbb5a9d9eb1c621f67d309f90a288c40714ce4c9.

backport 2022.02.xx - Revert "#8082 normalize longitude (#8325)" (#8512)