### PR TITLE
#8543 Make tutorial compatible with being module plugin.

### DIFF
--- a/web/client/actions/__tests__/storemanager-test.js
+++ b/web/client/actions/__tests__/storemanager-test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import {REDUCERS_LOADED, reducersLoaded} from "../storemanager";
+
+describe('Test correctness of the storemanager actions', () => {
+    it('test reducersLoaded action creator', (done) => {
+        const reducers = ['a', 'b'];
+        const action = reducersLoaded(reducers);
+        expect(action.reducers).toEqual(reducers);
+        expect(action.type).toBe(REDUCERS_LOADED);
+        done();
+    });
+});

--- a/web/client/actions/storemanager.js
+++ b/web/client/actions/storemanager.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+export const REDUCERS_LOADED = 'REDUCERS_LOADED';
+/**
+ * Action that should be dispatched whenever new reducers are added
+ * @param {string[]} reducers list of reducers loaded
+ * @returns {{reducers, type: string}}
+ */
+export const reducersLoaded = (reducers) => ({
+    type: REDUCERS_LOADED,
+    reducers
+});

--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -14,7 +14,7 @@ import axios from '../../libs/ajax';
 import ConfigUtils from '../../utils/ConfigUtils';
 import PluginsUtils from '../../utils/PluginsUtils';
 import { LOAD_EXTENSIONS, PLUGIN_UNINSTALLED } from '../../actions/contextcreator';
-import {reducersLoaded} from "../../utils/StateUtils";
+import {reducersLoaded} from "../../actions/storemanager";
 
 /**
  * This HOC adds to StandardApp (or whatever customization) the

--- a/web/client/epics/__tests__/tutorial-test.js
+++ b/web/client/epics/__tests__/tutorial-test.js
@@ -93,10 +93,10 @@ describe('tutorial Epics', () => {
     });
 
     it('switchTutorialEpic with path', (done) => {
-
+        const pathname = '/dashboard';
         testEpic(switchTutorialEpic, 1, [
             onLocationChanged({
-                pathname: '/dashboard'
+                pathname
             }),
             initTutorial('id', [], {}, null, {}, {})
         ], (actions) => {
@@ -119,16 +119,21 @@ describe('tutorial Epics', () => {
                     'default_tutorial': [],
                     'default_mobile_tutorial': []
                 }
+            },
+            router: {
+                location: {
+                    pathname
+                }
             }
         });
 
     });
 
     it('switchTutorialEpic with viewer path', (done) => {
-
+        const pathname = '/viewer/cesium/001';
         testEpic(switchTutorialEpic, 1, [
             onLocationChanged({
-                pathname: '/viewer/cesium/001'
+                pathname
             }),
             initTutorial('id', [], {}, null, {}, {})
         ], (actions) => {
@@ -151,16 +156,21 @@ describe('tutorial Epics', () => {
                     'default_tutorial': [],
                     'default_mobile_tutorial': []
                 }
+            },
+            router: {
+                location: {
+                    pathname
+                }
             }
         });
 
     });
 
     it('switchTutorialEpic with path and id', (done) => {
-
+        const pathname = '/dashboard/001';
         testEpic(switchTutorialEpic, 1, [
             onLocationChanged({
-                pathname: '/dashboard/001'
+                pathname
             }),
             initTutorial('id', [], {}, null, {}, {})
         ], (actions) => {
@@ -183,16 +193,21 @@ describe('tutorial Epics', () => {
                     'default_tutorial': [],
                     'default_mobile_tutorial': []
                 }
+            },
+            router: {
+                location: {
+                    pathname
+                }
             }
         });
 
     });
 
     it('switchTutorialEpic mobile', (done) => {
-
+        const pathname = '/dashboard/001';
         testEpic(switchTutorialEpic, 1, [
             onLocationChanged({
-                pathname: '/dashboard/001'
+                pathname
             }),
             initTutorial('id', [], {}, null, {}, {})
         ], (actions) => {
@@ -218,16 +233,21 @@ describe('tutorial Epics', () => {
             },
             browser: {
                 mobile: true
+            },
+            router: {
+                location: {
+                    pathname
+                }
             }
         });
 
     });
 
     it('switchTutorialEpic missing preset steps', (done) => {
-
+        const pathname = '/dashboard/001';
         testEpic(switchTutorialEpic, 1, [
             onLocationChanged({
-                pathname: '/dashboard/001'
+                pathname
             }),
             initTutorial('id', [], {}, null, {}, {})
         ], (actions) => {
@@ -248,14 +268,20 @@ describe('tutorial Epics', () => {
                     'default_tutorial': [],
                     'default_mobile_tutorial': []
                 }
+            },
+            router: {
+                location: {
+                    pathname
+                }
             }
         });
     });
     it('switchTutorialEpic selecting geostory_edit_tutorial preset for newgeostory page', (done) => {
         const NUM_ACTIONS = 1;
+        const pathname = '/geostory/newgeostory';
         testEpic(switchTutorialEpic, NUM_ACTIONS, [
             onLocationChanged({
-                pathname: '/geostory/newgeostory'
+                pathname
             }),
             initTutorial("", [], {}, null, {}, {})
         ], (actions) => {
@@ -283,15 +309,21 @@ describe('tutorial Epics', () => {
                     'geostory_view_tutorial': GEOSTORY_VIEW_STEPS
                 }
             },
-            geostory: {mode: "edit"}
+            geostory: {mode: "edit"},
+            router: {
+                location: {
+                    pathname
+                }
+            }
         });
 
     });
     it('switchTutorialEpic selecting geostory_view_tutorial preset for story viewer page', (done) => {
         const NUM_ACTIONS = 1;
+        const pathname = '/geostory/123';
         testEpic(switchTutorialEpic, NUM_ACTIONS, [
             onLocationChanged({
-                pathname: '/geostory/123'
+                pathname
             }),
             initTutorial("", [], {}, null, {}, {})
         ], (actions) => {
@@ -319,15 +351,21 @@ describe('tutorial Epics', () => {
                     'geostory_view_tutorial': GEOSTORY_VIEW_STEPS
                 }
             },
-            geostory: {mode: "view"}
+            geostory: {mode: "view"},
+            router: {
+                location: {
+                    pathname
+                }
+            }
         });
 
     });
     it('switchTutorialEpic selecting geostory_view_tutorial preset for story viewer page, missing presetList', (done) => {
         const NUM_ACTIONS = 1;
+        const pathname = '/geostory/newgeostory';
         testEpic(addTimeoutEpic(switchTutorialEpic, 50), NUM_ACTIONS, [
             onLocationChanged({
-                pathname: '/geostory/newgeostory'
+                pathname
             }),
             initTutorial("", [], {}, null, {}, {})
         ], (actions) => {
@@ -346,15 +384,21 @@ describe('tutorial Epics', () => {
                 presetList: {
                 }
             },
-            geostory: {mode: "view"}
+            geostory: {mode: "view"},
+            router: {
+                location: {
+                    pathname
+                }
+            }
         });
 
     });
     it('switchTutorialEpic loads correct tutorial for context', (done) => {
         const NUM_ACTIONS = 1;
+        const pathname = '/context-creator/new';
         testEpic(switchTutorialEpic, NUM_ACTIONS, [
             onLocationChanged({
-                pathname: '/context-creator/new'
+                pathname
             }),
             initTutorial("", [], {}, null, {}, {})
         ], (actions) => {
@@ -376,6 +420,11 @@ describe('tutorial Epics', () => {
                     "contextcreator_generalsettings_tutorial": {
                         context: "steps"
                     }
+                }
+            },
+            router: {
+                location: {
+                    pathname
                 }
             }
         });

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -25,13 +25,15 @@ import { modeSelector } from '../selectors/geostory';
 import { CHANGE_MODE } from '../actions/geostory';
 import { creationStepSelector } from '../selectors/contextcreator';
 import { CONTEXT_TUTORIALS } from '../actions/contextcreator';
-const findTutorialId = path => path.match(/\/(viewer)\/(\w+)\/(\d+)/) && path.replace(/\/(viewer)\/(\w+)\/(\d+)/, "$2")
-    || path.match(/\/(\w+)\/(\d+)/) && path.replace(/\/(\w+)\/(\d+)/, "$1")
-    || path.match(/\/(\w+)\//) && path.replace(/\/(\w+)\//, "$1");
 import { LOCATION_CHANGE } from 'connected-react-router';
 import { isEmpty, isArray, isObject } from 'lodash';
 import { getApi } from '../api/userPersistedStorage';
-import { mapSelector } from './../selectors/map';
+import { mapSelector } from '../selectors/map';
+import {REDUCERS_LOADED} from "../utils/StateUtils";
+
+const findTutorialId = path => path.match(/\/(viewer)\/(\w+)\/(\d+)/) && path.replace(/\/(viewer)\/(\w+)\/(\d+)/, "$2")
+    || path.match(/\/(\w+)\/(\d+)/) && path.replace(/\/(\w+)\/(\d+)/, "$1")
+    || path.match(/\/(\w+)\//) && path.replace(/\/(\w+)\//, "$1");
 
 /**
  * Closes the tutorial if 3D button has been toggled
@@ -53,21 +55,22 @@ export const closeTutorialEpic = (action$) =>
  */
 
 export const switchTutorialEpic = (action$, store) =>
-    action$.ofType(LOCATION_CHANGE)
+    action$.ofType(LOCATION_CHANGE, REDUCERS_LOADED)
         .filter(action =>
-            action.payload
-            && action.payload.location
-            && action.payload.location.pathname)
+            (action.payload && action.payload.location && action.payload.location.pathname)
+            || (action.type === REDUCERS_LOADED && action.reducers.includes('tutorial'))
+        )
         .switchMap( (action) =>
             action$.ofType(MAPS_LIST_LOADED, CHANGE_MAP_VIEW, INIT_TUTORIAL)
                 .take(1)
                 .switchMap( () => {
-                    let id = findTutorialId(action.payload.location.pathname);
                     const state = store.getState();
+                    const location = action?.payload?.location ?? state.router.location;
+                    let id = findTutorialId(location.pathname);
                     const presetList = state.tutorial && state.tutorial.presetList || {};
                     const browser = state.browser;
                     const mobile = browser && browser.mobile ? '_mobile' : '';
-                    const defaultName = id ? 'default' : action.payload && action.payload.location && action.payload.location.pathname || 'default';
+                    const defaultName = id ? 'default' : location.pathname || 'default';
                     const prevTutorialId = state.tutorial && state.tutorial.id;
                     let presetName = id + mobile + '_tutorial';
                     if (defaultName.indexOf("context") !== -1) {

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -57,15 +57,14 @@ export const closeTutorialEpic = (action$) =>
 export const switchTutorialEpic = (action$, store) =>
     action$.ofType(LOCATION_CHANGE, REDUCERS_LOADED)
         .filter(action =>
-            (action.payload && action.payload.location && action.payload.location.pathname)
-            || (action.type === REDUCERS_LOADED && action.reducers.includes('tutorial'))
+            action.payload?.location?.pathname || (action.type === REDUCERS_LOADED && action.reducers.includes('tutorial'))
         )
-        .switchMap( (action) =>
+        .switchMap( () =>
             action$.ofType(MAPS_LIST_LOADED, CHANGE_MAP_VIEW, INIT_TUTORIAL)
                 .take(1)
                 .switchMap( () => {
                     const state = store.getState();
-                    const location = action?.payload?.location ?? state.router.location;
+                    const location = state.router.location;
                     let id = findTutorialId(location.pathname);
                     const presetList = state.tutorial && state.tutorial.presetList || {};
                     const browser = state.browser;

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -57,9 +57,11 @@ export const closeTutorialEpic = (action$) =>
 
 export const switchTutorialEpic = (action$, store) =>
     action$.ofType(LOCATION_CHANGE, REDUCERS_LOADED)
-        .filter(action =>
-            action.payload?.location?.pathname || (action.type === REDUCERS_LOADED && action.reducers.includes('tutorial'))
-        )
+        .filter(action => {
+            const state = store.getState();
+            return (action.type === LOCATION_CHANGE && state.router?.location?.pathname)
+                    || (action.type === REDUCERS_LOADED && action.reducers.includes('tutorial'));
+        })
         .switchMap( () =>
             action$.ofType(MAPS_LIST_LOADED, CHANGE_MAP_VIEW, INIT_TUTORIAL)
                 .take(1)

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -29,7 +29,7 @@ import { LOCATION_CHANGE } from 'connected-react-router';
 import { isEmpty, isArray, isObject } from 'lodash';
 import { getApi } from '../api/userPersistedStorage';
 import { mapSelector } from '../selectors/map';
-import {REDUCERS_LOADED} from "../utils/StateUtils";
+import {REDUCERS_LOADED} from "../actions/storemanager";
 
 const findTutorialId = path => path.match(/\/(viewer)\/(\w+)\/(\d+)/) && path.replace(/\/(viewer)\/(\w+)\/(\d+)/, "$2")
     || path.match(/\/(\w+)\/(\d+)/) && path.replace(/\/(\w+)\/(\d+)/, "$1")
@@ -50,7 +50,8 @@ export const closeTutorialEpic = (action$) =>
 /**
  * Setup new steps based on the current path
  * @memberof epics.tutorial
- * @param {external:Observable} action$ manages `LOCATION_CHANGE`
+ * @param {external:Observable} action$ manages `LOCATION_CHANGE`, `REDUCERS_LOADED`
+ * @param {external:Observable} store
  * @return {external:Observable}
  */
 

--- a/web/client/hooks/useModulePlugins.js
+++ b/web/client/hooks/useModulePlugins.js
@@ -8,7 +8,7 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {createPlugin, getPlugins, isMapStorePlugin, normalizeName} from '../utils/PluginsUtils';
-import {getStore} from '../utils/StateUtils';
+import {getStore, reducersLoaded} from '../utils/StateUtils';
 import join from 'lodash/join';
 import {size} from "lodash";
 
@@ -70,18 +70,20 @@ function useModulePlugins({
             Promise.all(loadPlugins)
                 .then((impls) => {
                     const store = getStore();
-                    let reducersLoaded = false;
+                    const reducersList = [];
                     impls.forEach(impl => {
                         if (size(impl.reducers)) {
-                            Object.keys(impl.reducers).forEach((name) => store.storeManager.addReducer(name, impl.reducers[name]));
-                            reducersLoaded = true;
+                            Object.keys(impl.reducers).forEach((name) => {
+                                store.storeManager.addReducer(name, impl.reducers[name]);
+                                reducersList.push(name);
+                            });
                         }
                         if (size(impl.epics)) {
                             store.storeManager.addEpics(impl.name, impl.epics);
                         }
                     });
-                    if (reducersLoaded) {
-                        store.dispatch({type: 'REDUCERS_LOADED'});
+                    if (reducersList.length) {
+                        store.dispatch(reducersLoaded(reducersList));
                     }
                     return getPlugins({
                         ...filterRemoved(impls.map(impl => {

--- a/web/client/hooks/useModulePlugins.js
+++ b/web/client/hooks/useModulePlugins.js
@@ -8,9 +8,10 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {createPlugin, getPlugins, isMapStorePlugin, normalizeName} from '../utils/PluginsUtils';
-import {getStore, reducersLoaded} from '../utils/StateUtils';
+import {getStore} from '../utils/StateUtils';
 import join from 'lodash/join';
 import {size} from "lodash";
+import {reducersLoaded} from "../actions/storemanager";
 
 function filterRemoved(registry, removed = []) {
     return Object.keys(registry).reduce((acc, p) => {

--- a/web/client/utils/StateUtils.js
+++ b/web/client/utils/StateUtils.js
@@ -15,6 +15,18 @@ import isEmpty from 'lodash/isEmpty';
 import {BehaviorSubject, Subject} from 'rxjs';
 import {normalizeName} from "./PluginsUtils";
 
+export const REDUCERS_LOADED = 'REDUCERS_LOADED';
+
+/**
+ * Action that should be dispatched whenever new reducers are added
+ * @param reducers
+ * @returns {{reducers, type: string}}
+ */
+export const reducersLoaded = (reducers) => ({
+    type: REDUCERS_LOADED,
+    reducers
+});
+
 /**
  * Returns a list of standard ReduxJS middlewares, augmented with user ones.
  *
@@ -338,6 +350,6 @@ export const augmentStore = ({ reducers = {}, epics = {} } = {}, store) => {
     Object.keys(reducers).forEach((key) => {
         persistedStore.storeManager.addReducer(key, reducers[key]);
     });
-    persistedStore.dispatch({type: 'REDUCERS_LOADED'});
+    persistedStore.dispatch(reducersLoaded(reducers));
     persistedStore.storeManager.addEpics('notMutable', wrapEpics(epics));
 };

--- a/web/client/utils/StateUtils.js
+++ b/web/client/utils/StateUtils.js
@@ -14,18 +14,7 @@ import ConfigUtils from './ConfigUtils';
 import isEmpty from 'lodash/isEmpty';
 import {BehaviorSubject, Subject} from 'rxjs';
 import {normalizeName} from "./PluginsUtils";
-
-export const REDUCERS_LOADED = 'REDUCERS_LOADED';
-
-/**
- * Action that should be dispatched whenever new reducers are added
- * @param reducers
- * @returns {{reducers, type: string}}
- */
-export const reducersLoaded = (reducers) => ({
-    type: REDUCERS_LOADED,
-    reducers
-});
+import {reducersLoaded} from "../actions/storemanager";
 
 /**
  * Returns a list of standard ReduxJS middlewares, augmented with user ones.

--- a/web/client/utils/__tests__/StateUtils-test.js
+++ b/web/client/utils/__tests__/StateUtils-test.js
@@ -12,10 +12,11 @@ import {
     getStore,
     createStore,
     updateStore,
-    createStoreManager, reducersLoaded, REDUCERS_LOADED
+    createStoreManager
 } from '../StateUtils';
 import {createEpicMiddleware} from "redux-observable";
 import Rx from 'rxjs';
+import {REDUCERS_LOADED, reducersLoaded} from "../../actions/storemanager";
 
 describe('StateUtils', () => {
     beforeEach((done) => {

--- a/web/client/utils/__tests__/StateUtils-test.js
+++ b/web/client/utils/__tests__/StateUtils-test.js
@@ -12,7 +12,7 @@ import {
     getStore,
     createStore,
     updateStore,
-    createStoreManager
+    createStoreManager, reducersLoaded, REDUCERS_LOADED
 } from '../StateUtils';
 import {createEpicMiddleware} from "redux-observable";
 import Rx from 'rxjs';
@@ -266,5 +266,13 @@ describe('StateUtils', () => {
             expect(listenedBy.epic2.length).toBe(1);
             done();
         });
+    });
+
+    it('test reducersLoaded action creator', (done) => {
+        const reducers = ['a', 'b'];
+        const action = reducersLoaded(reducers);
+        expect(action.reducers).toEqual(reducers);
+        expect(action.type).toBe(REDUCERS_LOADED);
+        done();
     });
 });


### PR DESCRIPTION


## Description
There is a problem caused by the fact that plugins reducers are loaded after LOCATION_CHANGE action dispatched. It makes plugin epic first run skipped. This PR corrects this behavior

- Improved REDUCERS_LOADED action to make it pass list of added reducers as a payload.
- Updated switchTutorialEpic to make it actually triggered once tutorial reducer is added & one of the subsequent actions dispatched.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8543 

**What is the new behavior?**
Epic is not skipped, tracked actions list is extended to work correctly both on initial load & on location changes.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
