### PR TITLE
[Backport 2022.02.xx] #8513 Properly pass epic name into isolation function, so that muteState has all the epics listed correctly. (#8514)

### DIFF
--- a/web/client/utils/StateUtils.js
+++ b/web/client/utils/StateUtils.js
@@ -5,14 +5,15 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { createStore as createReduxStore, applyMiddleware, compose, combineReducers }  from 'redux';
+import {applyMiddleware, combineReducers, compose, createStore as createReduxStore} from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import logger from 'redux-logger';
-import { createEpicMiddleware, combineEpics } from 'redux-observable';
-import {wrapEpics} from "./EpicsUtils";
+import {combineEpics, createEpicMiddleware} from 'redux-observable';
+import {semaphore, wrapEpics} from "./EpicsUtils";
 import ConfigUtils from './ConfigUtils';
 import isEmpty from 'lodash/isEmpty';
-import { BehaviorSubject } from 'rxjs';
+import {BehaviorSubject, Subject} from 'rxjs';
+import {normalizeName} from "./PluginsUtils";
 
 /**
  * Returns a list of standard ReduxJS middlewares, augmented with user ones.
@@ -92,15 +93,6 @@ export const persistReducer = (reducer, storeName = PERSISTED_STORE_NAME, name =
 };
 
 /**
- * Returns a stored root reducer
- * @param {string} storeName optional store name the reducer is used by
- * @param {string} name optional name (if you want to persist more than one reducer)
- */
-const fetchReducer = (storeName = PERSISTED_STORE_NAME, name = 'rootReducer') => {
-    return ConfigUtils.getConfigProp(storeName + '.' + name) || {};
-};
-
-/**
  * Persists a redux-observable root epic.
  * A redux-observable epic can be persisted so that it can be modified after creation.
  * For example it is used by the dynamic plugin loading mechanism to update epics
@@ -115,16 +107,6 @@ export const persistEpic = (epic, storeName = PERSISTED_STORE_NAME, name = 'root
     ConfigUtils.setConfigProp(storeName + '.' + name, epic$);
     return (...args) =>
         epic$.mergeMap(e => e(...args));
-
-};
-
-/**
- * Returns a stored root epic
- * @param {string} storeName optional store name the epic is used by
- * @param {string} name optional name (if you want to persist more than one epic)
- */
-const fetchEpic = (storeName = PERSISTED_STORE_NAME, name = 'rootEpic') => {
-    return ConfigUtils.getConfigProp(storeName + '.' + name) || {};
 };
 
 /**
@@ -134,6 +116,154 @@ const fetchEpic = (storeName = PERSISTED_STORE_NAME, name = 'rootEpic') => {
  */
 export const getState = (name) => {
     return !isEmpty(getStore(name)) && getStore(name)?.getState() || {};
+};
+
+const isolateEpics = (epics, muteState) => {
+    const isolateEpic = (epic, name) => (action$, store, options) => {
+        const modifiedOptions = options ?? {};
+        muteState[name] = new Subject();
+        const pluginRenderStream$ = muteState[name].asObservable();
+
+        modifiedOptions.pluginRenderStream$ = pluginRenderStream$;
+        return epic(action$.let(semaphore(pluginRenderStream$.startWith(true))), store, modifiedOptions).let(semaphore(
+            pluginRenderStream$.startWith(true)
+        ));
+    };
+    return Object.entries(epics).reduce((out, [k, epic]) => ({ ...out, [k]: isolateEpic(epic, k) }), {});
+};
+
+
+export const createStoreManager = (initialReducers, initialEpics) => {
+    // Create an object which maps keys to reducers
+    const reducers = {...initialReducers};
+    const epics = {...initialEpics};
+    const addedEpics = {};
+    const epicsListenedBy = {};
+    const groupedByModule = {};
+    const muteState = {};
+
+    // Create the initial combinedReducer
+    let combinedReducer = combineReducers(reducers);
+    const subject = new Subject();
+    subject.next(true);
+    // appEpics should not be mutable, therefore do not add them into muteState
+    const isolated = isolateEpics(epics, []);
+
+    const epic$ = new BehaviorSubject(combineEpics(...wrapEpics(isolated)));
+    // An array which is used to delete state keys when reducers are removed
+    let keysToRemove = [];
+
+    const addToRegistry = (module, epicName) => {
+        groupedByModule[module] = [...(groupedByModule[module] ?? []), epicName];
+        epicsListenedBy[epicName] = [...(epicsListenedBy[epicName] ?? []), module];
+    };
+
+    return {
+        getReducerMap: () => reducers,
+
+        // Callback to get current state of epics registry, used for testing purposes
+        getEpicsRegistry: () => ({
+            addedEpics,
+            epicsListenedBy,
+            groupedByModule,
+            muteState
+        }),
+
+        // The root reducer function exposed by this object
+        // This will be passed to the store
+        reduce: (state, action) => {
+            // If any reducers have been removed, clean up their state first
+            if (keysToRemove.length > 0) {
+                // eslint-disable-next-line no-param-reassign
+                state = {...state};
+                for (let key of keysToRemove) {
+                    delete state[key];
+                }
+                keysToRemove = [];
+            }
+
+            // Delegate to the combined reducer
+            return combinedReducer(state, action);
+        },
+
+        // Adds a new reducer with the specified key
+        addReducer: (key, reducer) => {
+            if (!key || reducers[key]) {
+                return;
+            }
+
+            // Add the reducer to the reducer mapping
+            reducers[key] = reducer;
+
+            // Generate a new combined reducer
+            combinedReducer = combineReducers(reducers);
+        },
+
+        // Removes a reducer with the specified key
+        removeReducer: key => {
+            if (!key || !reducers[key]) {
+                return;
+            }
+
+            // Remove it from the reducer mapping
+            delete reducers[key];
+
+            // Add the key to the list of keys to clean up
+            keysToRemove.push(key);
+
+            // Generate a new combined reducer
+            combinedReducer = combineReducers(reducers);
+        },
+        // Adds a new epics set, mutable by the specified key
+        addEpics: (key, epicsList) => {
+            const normalizedName = normalizeName(key);
+            if (Object.keys(epicsList).length) {
+                const epicsToAdd = Object.keys(epicsList).reduce((prev, current) => {
+                    if (!addedEpics[current]) {
+                        addedEpics[current] = normalizedName;
+                        addToRegistry(normalizedName, current);
+                        return ({...prev, [current]: epicsList[current]});
+                    }
+                    addToRegistry(normalizedName, current);
+                    return prev;
+                }, {});
+                if (Object.keys(epicsToAdd).length) {
+                    const isolatedEpics = isolateEpics(epicsToAdd, muteState);
+                    wrapEpics(isolatedEpics).forEach(epic => epic$.next(epic));
+                }
+            }
+        },
+        // Mute epics set with a specified key
+        muteEpics: (key) => {
+            const moduleEpicRegistrations = groupedByModule[key];
+            // try to mute everything registered by module. If epic is shared, remove current module from epicsListenedBy
+            moduleEpicRegistrations && moduleEpicRegistrations.forEach(epicName => {
+                const indexOf = epicsListenedBy[epicName].indexOf(key);
+                if (indexOf >= 0) {
+                    epicsListenedBy[epicName].splice(indexOf, 1);
+                }
+                // check if epic is still listened by anything. If not - mute it
+                if (!epicsListenedBy[epicName].length) {
+                    muteState[epicName].next(false);
+                }
+            });
+        },
+        unmuteEpics: (key) => {
+            const moduleEpicRegistrations = groupedByModule[key];
+            // unmute epics if exactly one plugin wants to register specific epic
+            moduleEpicRegistrations && moduleEpicRegistrations.forEach(epicName => {
+                const indexOf = epicsListenedBy[epicName].indexOf(key);
+                if (indexOf === -1) {
+                    epicsListenedBy[epicName].push(key);
+                }
+                // now if epic intended to be registered by first listener plugin - unmute it
+                if (epicsListenedBy[epicName].length === 1) {
+                    muteState[epicName].next(true);
+                }
+            });
+        },
+        rootEpic: (...args) => epic$.mergeMap(e => e(...args))
+    };
 };
 
 /**
@@ -174,7 +304,7 @@ export const createStore = ({
 /**
  * Updates a Redux store with new reducers and epics.
  *
- * This method needs a new COMPLETE set of reducers / epics. If you want to add reducers / epics to existing ones, use augmentStore instead.
+ * This method needs a new COMPLETE set of reducers / epics. If you want to add reducers / epics to existing ones, use storeManager methods instead.
  *
  * @param {object} options options to update
  * @param {function} options.rootReducer optional root (combined) reducer for the store, if not specified it is built using the reducers.
@@ -201,28 +331,13 @@ export const updateStore = ({ rootReducer, rootEpic, reducers = {}, epics = {} }
  * @param {object} options.reducers list of reducers to add.
  * @param {object} options.epics list of epics to add.
  * @param {object} store the store to update, if not specified, the persisted one will be used
+ * @deprecated in favor of store.storeManager.addReducer & store.storeManager.addEpics
  */
 export const augmentStore = ({ reducers = {}, epics = {} } = {}, store) => {
-    const rootReducer = fetchReducer();
-    const reducer = persistReducer((state, action) => {
-        const initialStoreKeys = Object.keys(rootReducer({}, {}));
-        const newState = {...state, ...rootReducer(state, action)};
-        return Object.keys(reducers)
-            // avoid to update the state twice
-            // if the original store contains the same reducers
-            .filter((key) => initialStoreKeys.indexOf(key) === -1)
-            .reduce((previous, current) => {
-                return {
-                    ...previous,
-                    [current]: reducers[current](previous[current], action)
-                };
-            }, newState);
+    const persistedStore = store || getStore();
+    Object.keys(reducers).forEach((key) => {
+        persistedStore.storeManager.addReducer(key, reducers[key]);
     });
-    (store || getStore()).replaceReducer(reducer);
-
-    const rootEpic = fetchEpic();
-
-    wrapEpics(epics).forEach((epic) => {
-        rootEpic.next(epic);
-    });
+    persistedStore.dispatch({type: 'REDUCERS_LOADED'});
+    persistedStore.storeManager.addEpics('notMutable', wrapEpics(epics));
 };

--- a/web/client/utils/__tests__/StateUtils-test.js
+++ b/web/client/utils/__tests__/StateUtils-test.js
@@ -8,15 +8,14 @@
 import ReactDOM from 'react-dom';
 import expect from 'expect';
 import {
-    PERSISTED_STORE_NAME,
     setStore,
     getStore,
     createStore,
     updateStore,
-    augmentStore
+    createStoreManager
 } from '../StateUtils';
+import {createEpicMiddleware} from "redux-observable";
 import Rx from 'rxjs';
-import { setConfigProp } from '../ConfigUtils';
 
 describe('StateUtils', () => {
     beforeEach((done) => {
@@ -157,73 +156,115 @@ describe('StateUtils', () => {
         expect(spy2.calls.length > 0).toBe(true);
         expect(spy1.calls.length).toBe(beforeUpdateCalls);
     });
-    it('augmentStore should add all reducers if called many times', () => {
-        const rootReducer = () => ({});
-        let currentReducer = rootReducer;
-        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', rootReducer);
-        const store = {
-            replaceReducer: (reducer) => {
-                currentReducer = reducer;
-            }
-        };
-        augmentStore({ reducers: {
-            map: () => {
-                return {};
-            }
-        }}, store);
-        augmentStore({ reducers: {
-            controls: () => {
-                return {};
-            }
-        } }, store);
-        const newState = currentReducer({}, {});
-        expect(Object.keys(newState)).toEqual([ 'map', 'controls' ]);
-        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', undefined);
-    });
-    it('should use the new added reducers (augmentStore)', () => {
-        const rootReducer = () => ({});
-        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', rootReducer);
-        const store = {
-            replaceReducer: (reducer) => {
-                reducer();
-            }
-        };
-        let reducersKeys = [];
-        augmentStore({ reducers: {
-            map: () => {
-                reducersKeys.push('map');
-                return {};
-            },
-            controls: () => {
-                reducersKeys.push('controls');
-                return {};
-            }
-        } }, store);
-        expect(reducersKeys).toEqual([ 'map', 'controls' ]);
-        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', undefined);
-    });
-    it('should not use the new added reducers if they are available in the root reducer (augmentStore)', () => {
-        const rootReducer = () => ({
-            map: () => ({})
+
+    describe('storeManager', () => {
+        let storeManager;
+        let epicMiddleware;
+        beforeEach(() => {
+            storeManager = createStoreManager({}, {});
+            epicMiddleware = createEpicMiddleware(storeManager.rootEpic);
+            createStore({
+                rootReducer: (action, state) => state,
+                state: {},
+                middlewares: [epicMiddleware]
+            });
+            storeManager.addEpics('test', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        }),
+                epic2: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
         });
-        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', rootReducer);
-        const store = {
-            replaceReducer: (reducer) => {
-                reducer();
-            }
-        };
-        let reducersKeys = [];
-        augmentStore({ reducers: {
-            map: () => {
-                reducersKeys.push('map');
-                return {};
-            },
-            controls: () => {
-                reducersKeys.push('controls');
-                return {};
-            }
-        } }, store);
-        expect(reducersKeys).toEqual([ 'controls' ]);
-        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', undefined);
+        afterEach(() => {
+            storeManager = {};
+        });
+
+        it('addEpics and verify they are isolated', (done) => {
+            const subjects = storeManager.getEpicsRegistry().muteState;
+            expect(subjects.epic1).toExist();
+            expect(subjects.epic2).toExist();
+            done();
+        });
+        it('addEpics and verify they are added into registry', (done) => {
+            const added = storeManager.getEpicsRegistry().addedEpics;
+            expect(added.epic1).toBe('testPlugin');
+            expect(added.epic2).toBe('testPlugin');
+            done();
+        });
+        it('add same epics from two different plugins and make sure both of them are counted upon epic mute/unmute', (done) => {
+            storeManager.addEpics('test2', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+            const listenedBy = storeManager.getEpicsRegistry().epicsListenedBy;
+            expect(listenedBy.epic1.length).toBe(2);
+            expect(listenedBy.epic2.length).toBe(1);
+            done();
+        });
+        it('add same epics from two different plugins and make sure that all of the epics are properly grouped per plugin', (done) => {
+            storeManager.addEpics('test2', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+            const groupedByModule = storeManager.getEpicsRegistry().groupedByModule;
+            expect(groupedByModule.testPlugin).toInclude('epic1');
+            expect(groupedByModule.testPlugin).toInclude('epic2');
+            expect(groupedByModule.test2Plugin).toInclude('epic1');
+            done();
+        });
+        it('add same epics from two different plugins and make sure that repetitive epic is getting registered only from the first plugin attempting to register it', (done) => {
+            storeManager.addEpics('test2', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+            const addedEpics = storeManager.getEpicsRegistry().addedEpics;
+            expect(addedEpics.epic1).toBe('testPlugin');
+            expect(addedEpics.epic2).toBe('testPlugin');
+            done();
+        });
+        it('mute epic when plugin is missing on the page, assure that it updates listeners list', (done) => {
+            storeManager.addEpics('test2', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+            storeManager.muteEpics('testPlugin');
+            const listenedBy = storeManager.getEpicsRegistry().epicsListenedBy;
+            expect(listenedBy.epic1.length).toBe(1);
+            expect(listenedBy.epic2.length).toBe(0);
+            done();
+        });
+        it('unmute epic when plugin is added back to the page, assure that it updates listeners list', (done) => {
+            storeManager.addEpics('test2', {
+                epic1: (action$) =>
+                    action$.ofType('TEST')
+                        .switchMap(() => {
+                            return Rx.Observable.empty();
+                        })
+            });
+            storeManager.muteEpics('testPlugin');
+            storeManager.unmuteEpics('testPlugin');
+            const listenedBy = storeManager.getEpicsRegistry().epicsListenedBy;
+            expect(listenedBy.epic1.length).toBe(2);
+            expect(listenedBy.epic2.length).toBe(1);
+            done();
+        });
     });
 });


### PR DESCRIPTION
[DRAFT]
[Backport 2022.02.xx] #8513 Properly pass epic name into isolation function, so that muteState has all the epics listed correctly. (#8514)