### PR TITLE
#8483 Properly mute epics with nested PluginsContainer

### DIFF
--- a/web/client/hooks/__tests__/useModulePlugins-test.js
+++ b/web/client/hooks/__tests__/useModulePlugins-test.js
@@ -49,6 +49,7 @@ describe('useModulePlugins hook', () => {
     });
     afterEach((done) => {
         setStore(originalStore);
+        window.history.back();
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
         document.body.innerHTML = '';
         setTimeout(done);

--- a/web/client/hooks/useModulePlugins.js
+++ b/web/client/hooks/useModulePlugins.js
@@ -11,6 +11,7 @@ import {createPlugin, getPlugins, isMapStorePlugin, normalizeName} from '../util
 import {getStore} from '../utils/StateUtils';
 import join from 'lodash/join';
 import {size} from "lodash";
+import {reducersLoaded} from "../actions/storemanager";
 import url from "url";
 
 function filterRemoved(registry, removed = []) {

--- a/web/client/test-resources/module-plugins/dummy2.js
+++ b/web/client/test-resources/module-plugins/dummy2.js
@@ -1,0 +1,21 @@
+import {createPlugin} from "../../utils/PluginsUtils";
+import Rx from "rxjs";
+
+const Dummy2 = createPlugin('Example2',
+    {
+        component: () => {
+            return null;
+        },
+        reducers: {
+            example2: (state) => { return state;}
+        },
+        epics: {
+            anotherTestEpic: (action$) => action$.ofType('FAKE_TYPE')
+                .switchMap(() => {
+                    return Rx.Observable.empty();
+                })
+        }
+    }
+);
+
+export default Dummy2;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
We have faced similar type of  issue (https://github.com/geosolutions-it/MapStore2/issues/8481#issuecomment-1237022102 & https://github.com/geosolutions-it/MapStore2/issues/8483#issuecomment-1237022941) when some plugins stops working after map is rendered.
Further investigation shown that this is related to nested instances of `PluginsContainer` that is wrapped with `useModulePlugins` hook.

Short loopback on how module plugins are working (considering functionality affected by this issue):
- Plugins are loaded on-demand, only those are on the rendered page.
- When user change route and new set of plugins have to be rendered on the page, new plugins will be loaded. already loaded plugins that are missing on the page will have their epics muted, plugins that are got back to the page will have their epics unmuted.

Issue is caused by the fact that nested instance of `PluginsContainer` has different subset of plugins, part of plugins loaded in parent `PluginsContainer` does not intersect. This makes logic of 'useModulePlugins' hook to force such plugn's epics being muted because it thinks that they are not on the page anymore (whilst they just missing in plugins passed to the nested instance of container and rendered by outer instance).

Proposed PR provides a really simple fix that should solve problem for similar case: multiple `PluginsContainer` components on the same page while path in URL is not changed. It adds a check to see if path has changed since the last run of the code that mutes epics. If path is not changed - epics mute logic won't be triggered, while unmute logic will run as always.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8483
#8481

**What is the new behavior?**
Plugins load by nested `PluginsContainer` does not cause mute of epics.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
