### PR TITLE
#8520: Reduce dashboards clutter and widget update

### DIFF
--- a/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
+++ b/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
@@ -163,7 +163,7 @@ describe('Test for FeatureGrid component', () => {
                 headerRowHeight: 28,
                 headerFiltersHeight: 28
             }}
-            describeFeatureType={describePois} enableColumnFilters features={[]}/>, document.getElementById("container"));
+            describeFeatureType={describePois} enableColumnFilters features={museam.features}/>, document.getElementById("container"));
         const gridHeaderRows = document.getElementsByClassName('react-grid-HeaderRow');
         const gridRow = document.getElementsByClassName('react-grid-Row');
         expect(gridHeaderRows.length).toBe(2);
@@ -171,6 +171,21 @@ describe('Test for FeatureGrid component', () => {
         expect(Number(headerRowHeight)).toBe(28);
         const headerFiltersHeight = gridHeaderRows[1]?.getAttribute('height');
         expect(Number(headerFiltersHeight)).toBe(28);
+        const rowHeight = gridRow[0]?.offsetHeight;
+        expect(rowHeight).toBe(28);
+    });
+    it('Test grid with custom grid height props with no filter', () => {
+        ReactDOM.render(<FeatureGrid  virtualScroll={false}
+            gridOpts= {{
+                rowHeight: 28,
+                headerRowHeight: 28
+            }}
+            describeFeatureType={describePois} enableColumnFilters={false} features={museam.features}/>, document.getElementById("container"));
+        const gridHeaderRows = document.getElementsByClassName('react-grid-HeaderRow');
+        const gridRow = document.getElementsByClassName('react-grid-Row');
+        expect(gridHeaderRows.length).toBe(1);
+        const headerRowHeight = gridHeaderRows[0]?.getAttribute('height');
+        expect(Number(headerRowHeight)).toBe(28);
         const rowHeight = gridRow[0]?.offsetHeight;
         expect(rowHeight).toBe(28);
     });

--- a/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
+++ b/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
@@ -156,4 +156,22 @@ describe('Test for FeatureGrid component', () => {
         expect(events.onTemporaryChanges).toHaveBeenCalled();
         expect(events.onTemporaryChanges).toHaveBeenCalledWith(true);
     });
+    it('Test grid with custom grid height props', () => {
+        ReactDOM.render(<FeatureGrid  virtualScroll={false}
+            gridOpts= {{
+                rowHeight: 28,
+                headerRowHeight: 28,
+                headerFiltersHeight: 28
+            }}
+            describeFeatureType={describePois} enableColumnFilters features={[]}/>, document.getElementById("container"));
+        const gridHeaderRows = document.getElementsByClassName('react-grid-HeaderRow');
+        const gridRow = document.getElementsByClassName('react-grid-Row');
+        expect(gridHeaderRows.length).toBe(2);
+        const headerRowHeight = gridHeaderRows[0]?.getAttribute('height');
+        expect(Number(headerRowHeight)).toBe(28);
+        const headerFiltersHeight = gridHeaderRows[1]?.getAttribute('height');
+        expect(Number(headerFiltersHeight)).toBe(28);
+        const rowHeight = gridRow[0]?.offsetHeight;
+        expect(rowHeight).toBe(28);
+    });
 });

--- a/web/client/components/widgets/builder/wizard/map/MapSwitcher.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapSwitcher.jsx
@@ -51,7 +51,6 @@ export default ({
             </Button>);
         }
         return (<Select
-            style={{width: 200}}
             className={className}
             disabled={disabled}
             noResultsText="widgets.mapSwitcher.noResults"

--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -25,9 +25,11 @@ export default pure(({
     style,
     className = "",
     toolsOptions = {},
-    rowHeight = 208,
+    rowHeight = 150,
     breakpoints = { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 },
     cols = { lg: 6, md: 6, sm: 4, xs: 2, xxs: 1 },
+    // eslint-disable-next-line no-unused-vars
+    widgetOpts = {},
     widgets = [],
     layouts,
     dependencies,
@@ -105,6 +107,7 @@ export default pure(({
                 data-grid={w.dataGrid}
                 {...actions}
                 {...w}
+                widgetOpts={widgetOpts}
                 quickFilters={getEnableColumnFilters(w) ? w.quickFilters : undefined}
                 toolsOptions={toolsOptions}
                 groups={getWidgetGroups(groups, w)}

--- a/web/client/components/widgets/widget/DefaultWidget.jsx
+++ b/web/client/components/widgets/widget/DefaultWidget.jsx
@@ -15,6 +15,8 @@ import {
     LegendWidget
 } from './enhancedWidgets';
 
+const getWidgetOpts = (w) => w?.widgetOpts?.[w.widgetType];
+
 /**
  * Renders proper widget by widgetType, binding props and methods
  */
@@ -33,6 +35,7 @@ const DefaultWidget = ({
         onEdit={onEdit}/>)
     : w.widgetType === "table"
         ? <TableWidget {...w}
+            {...getWidgetOpts(w)}
             toggleCollapse={toggleCollapse}
             exportCSV={exportCSV}
             dependencies={dependencies}
@@ -41,23 +44,27 @@ const DefaultWidget = ({
         />
         : w.widgetType === "counter"
             ? <CounterWidget {...w}
+                {...getWidgetOpts(w)}
                 toggleCollapse={toggleCollapse}
                 dependencies={dependencies}
                 onDelete={onDelete}
                 onEdit={onEdit} />
             : w.widgetType === "map"
                 ? <MapWidget {...w}
+                    {...getWidgetOpts(w)}
                     toggleCollapse={toggleCollapse}
                     dependencies={dependencies}
                     onDelete={onDelete}
                     onEdit={onEdit} />
                 : w.widgetType === "legend"
                     ? <LegendWidget {...w}
+                        {...getWidgetOpts(w)}
                         toggleCollapse={toggleCollapse}
                         dependencies={dependencies}
                         onDelete={onDelete}
                         onEdit={onEdit} />
                     : (<ChartWidget {...w}
+                        {...getWidgetOpts(w)}
                         toggleCollapse={toggleCollapse}
                         exportCSV={exportCSV}
                         dependencies={dependencies}

--- a/web/client/components/widgets/widget/MapWidget.jsx
+++ b/web/client/components/widgets/widget/MapWidget.jsx
@@ -41,7 +41,7 @@ export default ({
 } = {}) => {
     const { size: {height: mapHeight, width: mapWidth} = {}, mapInfoControl } = map;
     const enablePopupTools = mapHeight > 400 && mapWidth > 400 && mapInfoControl;
-    return (<WidgetContainer id={`widget-text-${id}`} title={title} confirmDelete={confirmDelete} onDelete={onDelete} toggleDeleteConfirm={toggleDeleteConfirm} headerStyle={headerStyle}
+    return (<WidgetContainer className={"map-widget-view"} id={`widget-text-${id}`} title={title} confirmDelete={confirmDelete} onDelete={onDelete} toggleDeleteConfirm={toggleDeleteConfirm} headerStyle={headerStyle}
         icons={icons}
         topRightItems={[
             <MapSwitcher
@@ -56,10 +56,11 @@ export default ({
         isDraggable={dataGrid.isDraggable}
     >
         <BorderLayout
-            footer={
-                <div style={{ height: "30px", overflow: "hidden"}}>
-                    {loading ? <span style={{ "float": "right"}}><LoadingSpinner /></span> : null}
+            footer={loading
+                ? <div className={"widget-footer"}>
+                    <span style={{ "float": "right"}}><LoadingSpinner /></span>
                 </div>
+                : null
             }>
             <MapView
                 tools={enablePopupTools ? ['popup'] : []}
@@ -71,7 +72,7 @@ export default ({
                 mapStateSource={mapStateSource}
                 hookRegister={hookRegister}
                 layers={map && map.layers}
-                options={{ style: { margin: 10, height: 'calc(100% - 20px)' }}}
+                options={{ style: { margin: '0 10px 10px 10px', height: 'calc(100% - 10px)' }}}
                 env={env}
             />
         </BorderLayout>

--- a/web/client/components/widgets/widget/TableWidget.jsx
+++ b/web/client/components/widgets/widget/TableWidget.jsx
@@ -20,6 +20,9 @@ import withSuspense from '../../misc/withSuspense';
 
 const FeatureGridComp = withSuspense()(lazy(() => import('../../data/featuregrid/FeatureGrid')));
 const FeatureGrid = errorChartState(loadingState(({ describeFeatureType }) => !describeFeatureType)(FeatureGridComp));
+const DEFAULT_GRID_HEIGHT = 28;
+const defaultGridOpts = ['rowHeight', 'headerRowHeight', 'headerFiltersHeight']
+    .reduce((acc, prop) => ({...acc, [prop]: DEFAULT_GRID_HEIGHT}), '');
 
 export default getWidgetFilterRenderers(({
     id,
@@ -45,7 +48,8 @@ export default getWidgetFilterRenderers(({
     error,
     pagination = {},
     dataGrid = {},
-    virtualScroll = true
+    virtualScroll = true,
+    gridOpts = defaultGridOpts
 }) =>
     (<WidgetContainer
         id={`widget-chart-${id}`}
@@ -59,10 +63,10 @@ export default getWidgetFilterRenderers(({
         topRightItems={topRightItems}>
         <BorderLayout
             footer={pagination.totalFeatures ? (
-                <div style={{ height: "30px", overflow: "hidden"}}>
+                <div className={"widget-footer"}>
                     {loading ? <span style={{ "float": "right"}}><LoadingSpinner /></span> : null}
                     {error === undefined &&
-                    <span style={{ "float": "left", margin: "5px" }} ><Message
+                    <span className={"result-info"} ><Message
                         msgId={"featuregrid.resultInfoVirtual"}
                         msgParams={{ total: pagination.totalFeatures }} /></span>}
                 </div>) : null}
@@ -85,7 +89,8 @@ export default getWidgetFilterRenderers(({
                 size={size}
                 rowKey="id"
                 describeFeatureType={describeFeatureType}
-                pagination={pagination} />
+                pagination={pagination}
+                gridOpts={gridOpts}/>
         </BorderLayout>
     </WidgetContainer>
 

--- a/web/client/components/widgets/widget/__tests__/TableWidget-test.jsx
+++ b/web/client/components/widgets/widget/__tests__/TableWidget-test.jsx
@@ -14,6 +14,7 @@ import { compose, defaultProps } from 'recompose';
 import { waitFor } from '@testing-library/react';
 
 import describePois from '../../../../test-resources/wfs/describe-pois.json';
+import museam from '../../../../test-resources/wfs/museam.json';
 import tableWidget from '../../enhancers/tableWidget';
 import TableWidgetComp from '../TableWidget';
 
@@ -68,6 +69,27 @@ describe('TableWidget component', () => {
         const container = document.getElementById('container');
         waitFor(() =>expect( container.querySelector('.react-grid-Empty')).toBeTruthy())
             .then(() => done());
+    });
+    it('TableWidget with default gridOpts', () => {
+        ReactDOM.render(<TableWidget
+            virtualScroll={false} describeFeatureType={describePois} enableColumnFilters features={museam.features}/>, document.getElementById("container"));
+        const gridHeaderRows = document.getElementsByClassName('react-grid-HeaderRow');
+        expect(gridHeaderRows.length).toBe(2);
+        const headerRowHeight = gridHeaderRows[0]?.getAttribute('height');
+        expect(Number(headerRowHeight)).toBe(28);
+        const headerFiltersHeight = gridHeaderRows[1]?.getAttribute('height');
+        expect(Number(headerFiltersHeight)).toBe(28);
+    });
+    it('TableWidget with custom gridOpts', () => {
+        ReactDOM.render(<TableWidget
+            gridOpts={{ headerRowHeight: 35, headerFiltersHeight: 35}}
+            virtualScroll={false} describeFeatureType={describePois} enableColumnFilters features={museam.features}/>, document.getElementById("container"));
+        const gridHeaderRows = document.getElementsByClassName('react-grid-HeaderRow');
+        expect(gridHeaderRows.length).toBe(2);
+        const headerRowHeight = gridHeaderRows[0]?.getAttribute('height');
+        expect(Number(headerRowHeight)).toBe(35);
+        const headerFiltersHeight = gridHeaderRows[1]?.getAttribute('height');
+        expect(Number(headerFiltersHeight)).toBe(35);
     });
     it('TableWidget onAddFilter', (done) => {
         const _d = {...describePois, featureTypes: [{...describePois.featureTypes[0], properties: [...describePois.featureTypes[0].properties, {

--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -125,13 +125,30 @@ const WidgetsView = compose(
  * @prop {object} cfg.cols Number of columns in this layout. default { lg: 6, md: 6, sm: 4, xs: 2, xxs: 1 }
  * @prop {object} cfg.minLayoutWidth minimum size of the layout, below this size the widgets are listed in a single column
  * for more info about rowHeight and cols, see https://github.com/STRML/react-grid-layout#grid-layout-props
+ * @prop {object} cfg.widgetOpts widget specific options
+ * @example
+ * {
+ *   "name": "Dashboard",
+ *   "cfg": {
+ *      "rowHeight": 150,
+ *      "cols": { lg: 6, md: 6, sm: 4, xs: 2, xxs: 1 },
+ *      "widgetOpts": {
+ *          "table": {
+ *              gridOpts: {
+ *                  rowHeight: 20
+ *              }
+ *          }
+ *      }
+ *   }
+ * }
  */
 class DashboardPlugin extends React.Component {
     static propTypes = {
         enabled: PropTypes.bool,
         rowHeight: PropTypes.number,
         cols: PropTypes.object,
-        minLayoutWidth: PropTypes.number
+        minLayoutWidth: PropTypes.number,
+        widgetOpts: PropTypes.object
     };
     static defaultProps = {
         enabled: true,
@@ -145,6 +162,7 @@ class DashboardPlugin extends React.Component {
                 rowHeight={this.props.rowHeight}
                 cols={this.props.cols}
                 minLayoutWidth={this.props.minLayoutWidth}
+                widgetOpts={this.props.widgetOpts}
             />
             : null;
 

--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -125,7 +125,8 @@ const WidgetsView = compose(
  * @prop {object} cfg.cols Number of columns in this layout. default { lg: 6, md: 6, sm: 4, xs: 2, xxs: 1 }
  * @prop {object} cfg.minLayoutWidth minimum size of the layout, below this size the widgets are listed in a single column
  * for more info about rowHeight and cols, see https://github.com/STRML/react-grid-layout#grid-layout-props
- * @prop {object} cfg.widgetOpts widget specific options
+ * @prop {object} cfg.widgetOpts can be used to configure widget specific options.
+ * Currently, it explicitly supports table widget with following options
  * @example
  * {
  *   "name": "Dashboard",
@@ -135,7 +136,9 @@ const WidgetsView = compose(
  *      "widgetOpts": {
  *          "table": {
  *              gridOpts: {
- *                  rowHeight: 20
+ *                  rowHeight: 20,
+ *                  headerRowHeight: 20,
+ *                  headerFiltersHeight: 20
  *              }
  *          }
  *      }

--- a/web/client/themes/default/bootstrap-variables.less
+++ b/web/client/themes/default/bootstrap-variables.less
@@ -42,6 +42,7 @@
 @font-family-base: var(--ms-font-family-base, @ms-font-family-base);
 @font-size-base: 14px;
 @font-size-large: ceil(@font-size-base * 1.25);
+@font-size-medium: ceil(@font-size-base * 1.14);
 @font-size-small: ceil(@font-size-base * 0.85);
 @font-size-h1: floor((@font-size-base * 1.9));
 @font-size-h2: floor((@font-size-base * 1.7));

--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -9,6 +9,12 @@
 // **************
 // Theme
 // **************
+.setFontSize (@val){
+    @fSize: @val
+};
+.em (@prop, @val) {
+    @{prop}: (@val/(@fSize*1em));
+};
 #ms-components-theme(@theme-vars) {
     .widget-container {
         &.selection-active {
@@ -132,53 +138,57 @@
         box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2), 0 2px 8px rgba(0, 0, 0, 0.2);
     }
     .mapstore-widget-card {
-        margin: 20px 0;
         overflow: visible;
         position: absolute;
         height: 100%;
         width: 100%;
         margin: 0;
+        .setFontSize(@font-size-medium);
+        font-size: @fSize;
         .shadow-far;
         .mapstore-widget-layer {
             text-align: center;
-            margin: 10px 5%;
+            .em(margin-top, 10);
+            .em(margin-right, 10);
+            margin-bottom: 5%;
+            margin-left: 5%;
             font-style: italic;
         }
         .mapstore-widget-header {
-            height: 32px;
-            text-align: center;
-            width: 90%;
-            margin: 10px 5%;
-            font-size: 22px;
+            font-size: @fSize;
+            .em(height, 28);
             font-weight: bold;
-            border-bottom: 1px solid @ms-main-border-color;
+            display: flex;
+            flex-direction: row;
+            align-items: center;
             .widget-title {
                 text-overflow: ellipsis;
                 width: calc(100% - 30px);
-                font-size: 14px;
+                .setFontSize(@font-size-base);
+                font-size: @fSize;
+                .em(margin-left, 6);
             }
             .mapstore-info-popover .glyphicon {
-                margin-top: 7px;
+                .setFontSize(@font-size-base);
+                font-size: @fSize;
+                .em(margin-top, 7);
                 position: absolute;
-                left: 22px;
-                font-size: 14px;
+                .em(left, 22);
             }
             .widget-icons {
-                text-align: left;
-                position: absolute;
-                width: 100%;
-                top: 0;
-                left: 0;
-                overflow: visible;
-                height: 10px;
+                .em(height, 10);
+                .em(margin-left, 4);
                 .btn-group {
-                    left: 0px;
+                    left: 0;
+                    span {
+                        display: flex;
+                    }
                     button {
                         background: transparent;
-                        top: -8px;
+                        .em(top, -8);
                         position: relative;
-                        padding-left:4px;
-                        padding-right:4px;
+                        .em(padding-left, 4);
+                        .em(padding-right, 4);
                         // rotate pin icon
                         .glyphicon.active::before {
                             transform: rotate(45deg);
@@ -190,44 +200,93 @@
                     }
                 }
             }
-            .map-switcher {
-                text-align: left;
-                font-weight: normal;
-                width: 200px;
-                bottom: 4px;
-                .Select-option {
-                    word-break: break-all;
+            .glyphicon {
+                cursor: pointer;
+            }
+        }
+        .react-grid-Grid {
+            .react-grid-Header {
+                .react-grid-HeaderCell {
+                    .setFontSize(@font-size-small);
+                    font-size: @fSize;
+                    .em(padding, 4);
+                    line-height: 1.6;
+                    input {
+                        .setFontSize(11px);
+                        font-size: @fSize;
+                        .em(width, 72);
+                        .em(height, 20);
+                        .em(padding-top, 5);
+                        .em(padding-right, 10);
+                        .em(padding-bottom, 5);
+                        .em(padding-left, 10);
+                    }
+                }
+            }
+            .react-grid-Viewport {
+                .react-grid-Cell {
+                    font-size: @font-size-small;
                 }
             }
         }
         .mapstore-widget-default-content {
             // avoid editor defaults for text-widget
             &.ql-editor {
+                .setFontSize(@font-size-small);
+                font-size: @fSize;
                 height: auto;
                 padding: 0;
+                .em(margin-top, 10);
+                .em(margin-right, 10);
+                margin-bottom: 5%;
+                margin-left: 5%;
             }
-            margin: 10px 5%;
             // avoid images to be wider than their container
             img {
                 max-width: 100%;
             }
         }
         .mapstore-widget-description {
+            font-size: @fSize;
             text-align: center;
             width: 90%;
-            margin: 5px 5%;
+            .em(margin-top, 5);
+            .em(margin-right, 5);
+            margin-bottom: 5%;
+            margin-left: 5%;
         }
         .mapstore-widget-options {
-            position: absolute;
-            font-size: 18px;
-            right: 7px;
-            top: 10px;
+            .setFontSize(@font-size-large);
+            font-size: @fSize;
             display: flex;
+            .em(margin-top, 4);
+            .em(margin-right, 10);
+            margin-bottom: 0;
+            margin-left: 0;
+            .map-switcher {
+                text-align: left;
+                font-weight: normal;
+                .em(width, 200);
+                .em(bottom, 4);
+                .Select-option {
+                    word-break: break-all;
+                }
+            }
         }
         .widget-menu {
             border: none;
-            top: -2px;
-            left: 7px;
+            display: flex;
+            .em(margin-top, -4);
+            .em(margin-right, -8);
+        }
+        .widget-footer {
+            .em(height, 30);
+            overflow: hidden;
+            .result-info {
+                font-size: @font-size-small;
+                float: left;
+                .em(margin, 5);
+            }
         }
         .mapstore-widget-chart {
             height: 100%;
@@ -242,6 +301,7 @@
             overflow: hidden;
         }
         .mapstore-widget-table {
+            font-size: @font-size-small;
             height: 100%;
             width: 90%;
             margin: 0 5%;
@@ -259,33 +319,46 @@
             position: relative;
         }
         .legend-widget {
-            padding: 0 15px;
+            .setFontSize(@font-size-small);
+            font-size: @fSize;
+            padding-top: 0;
+            .em(padding-right, 15);
+            .em(padding-bottom, 15);
+            .em(padding-left, 15);
             .widget-legend-toc {
                 -webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.06), 0 4px 8px rgba(0, 0, 0, 0.12), 2px -2px 6px rgba(0, 0, 0, 0.06);
                 -moz-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.06), 0 4px 8px rgba(0, 0, 0, 0.12), 2px -2px 6px rgba(0, 0, 0, 0.06);
                 box-shadow: 0 3px 6px rgba(0, 0, 0, 0.06), 0 4px 8px rgba(0, 0, 0, 0.12), 2px -2px 6px rgba(0, 0, 0, 0.06);
                 padding: 0;
-                margin-top: 10px;
+                .em(margin-top, 10);
                 .toc-default-layer-head {
-                    height: 52px;
+                    .em(height, 44);
                     width: 100%;
                     margin-bottom: 0;
-                    padding: 18px 0;
-                    border-bottom-width: 1px;
+                    .em(padding-top, 14);
+                    .em(padding-right, 14);
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    .em(border-bottom-width, 1);
                     border-bottom-style: solid;
                     .visibility-check{
                         &.glyphicon {
                             cursor: pointer;
                             float: left;
-                            font-size: 15px;
-                            margin: 0 10px;
+                            margin-top: 0;
+                            margin-right: 0;
+                            .em(margin-bottom, 10);
+                            .em(margin-left, 10);
                         }
                     }
                     .toc-title {
                         overflow: hidden;
-                        height: 15px;
-                        margin: 0 5px;
-                        width: 140px;
+                        .em(height, 15);
+                        margin-top: 0;
+                        margin-right: 0;
+                        .em(margin-bottom, 5);
+                        .em(margin-left, 5);
+                        .em(width, 140);
                         line-height: 1;
                     }
                     .toc-legend-icon {
@@ -295,12 +368,26 @@
                         &.glyphicon {
                             cursor: pointer;
                             float: right;
-                            margin-right: 10px;
+                            .em(margin-right, 10);
                         }
+                    }
+                    .mapstore-slider {
+                        .em(margin-top, -8);
                     }
                 }
                 .expanded-legend-view {
-                    margin-top: 15px;
+                    .em(margin-top, 15);
+                }
+            }
+        }
+        .map-widget-view {
+            .widget-icons, .widget-title {
+                .em(margin-bottom, 6);
+            }
+            .mapstore-widget-header {
+                .em(height, 45);
+                .btn-toolbar {
+                    .em(margin-top, 5);
                 }
             }
         }

--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -214,7 +214,6 @@
                     input {
                         .setFontSize(11px);
                         font-size: @fSize;
-                        .em(width, 72);
                         .em(height, 20);
                         .em(padding-top, 5);
                         .em(padding-right, 10);
@@ -263,15 +262,6 @@
             .em(margin-right, 10);
             margin-bottom: 0;
             margin-left: 0;
-            .map-switcher {
-                text-align: left;
-                font-weight: normal;
-                .em(width, 200);
-                .em(bottom, 4);
-                .Select-option {
-                    word-break: break-all;
-                }
-            }
         }
         .widget-menu {
             border: none;
@@ -385,9 +375,19 @@
                 .em(margin-bottom, 6);
             }
             .mapstore-widget-header {
-                .em(height, 45);
-                .btn-toolbar {
-                    .em(margin-top, 5);
+                height: max-content;
+                .mapstore-widget-options {
+                    align-items: center;
+                    .em(margin-top, 4);
+                    .em(margin-bottom, 4);
+                    .map-switcher {
+                        text-align: left;
+                        font-weight: normal;
+                        .em(width, 200);
+                        .Select-option {
+                            word-break: break-all;
+                        }
+                    }
                 }
             }
         }

--- a/web/client/themes/default/less/wizard.less
+++ b/web/client/themes/default/less/wizard.less
@@ -91,6 +91,9 @@
         .widget-empty-map {
             width: 250px;
         }
+        .Select {
+            width: 200px;
+        }
         .Select-option {
             word-break: break-all;
         }


### PR DESCRIPTION
## Description
This PR attempts to declutter the widgets in dashboard to allow more widgets to be viewed. Also provides a possibility to configure widgets options (especially `DataGrid` options) through dashboard plugin

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#8520 

**What is the new behavior?**
New dashboard (100%)
![2022-09-06 13_43_07-MapStore HomePage](https://user-images.githubusercontent.com/26929983/188589395-a84c5864-9049-47de-ba86-bc0f6d06609a.jpg)

Map viewer
![2022-09-06 13_42_05-DevTools - localhost_8081__debug=true](https://user-images.githubusercontent.com/26929983/188589462-e523000c-12dd-4ec7-a15c-1e70c934c4a7.jpg)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Ref: https://github.com/geosolutions-it/MapStore2-C040/issues/495