### PR TITLE
Backport 2022.02.xx - #8562 Fixing printing version in migration guidelines (#8563)

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -196,7 +196,7 @@ Also, remember to update your project pom.xml with the updated dependency:
 <dependency>
     <groupId>org.mapfish.print</groupId>
     <artifactId>print-lib</artifactId>
-    <version>geosolutions-2.1-SNAPSHOT</version>
+    <version>geosolutions-2.1.0</version>
     <exclusions>
         <exclusion>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
Backport 2022.02.xx - #8562 Fixing printing version in migration guidelines (#8563)