### PR TITLE
[Backport 2022.02.xx] #8564 Reduce amount of plugins initially loaded on the context page (#8565)

### DIFF
--- a/web/client/components/plugins/enhancers/__tests__/withModulePlugins-test.js
+++ b/web/client/components/plugins/enhancers/__tests__/withModulePlugins-test.js
@@ -18,11 +18,6 @@ const pluginConfig = [
     'ExamplePlugin'
 ];
 
-const getPluginConfig = () => {
-    return pluginConfig;
-};
-
-
 const pluginEntries = {
     ExamplePlugin: toModulePlugin('Example', () => import('../../../../test-resources/module-plugins/dummy'))
 };
@@ -75,19 +70,49 @@ describe('withModulePlugins enhancer', () => {
         document.body.innerHTML = '';
         setTimeout(done);
     });
-    it('test that module plugin successfully loaded', done => {
+    it('test that module plugin successfully loaded - loader component is a function', done => {
         const Listener = (props) => {
-            expect(props.plugins).toExist();
-            expect(props.plugins.ExamplePlugin).toExist();
-            expect(registeredEpics.Example).toBe(true);
-            expect(registeredReducers.example).toBe(true);
-            done();
+            if (Object.keys(props.plugins).length) {
+                expect(props.plugins).toExist();
+                expect(props.plugins.ExamplePlugin).toExist();
+                expect(registeredEpics.Example).toBe(true);
+                expect(registeredReducers.example).toBe(true);
+                done();
+            }
             return false;
         };
 
-        const Component = withModulePlugins(getPluginConfig)(Listener);
+        const Component = withModulePlugins(({pluginsConfig}) => pluginsConfig)(Listener);
         const Cmp = wrapWithStore(Component, store);
-        ReactDOM.render(<Cmp plugins={pluginEntries} pluginsConfig={pluginConfig} />, document.getElementById('container'));
+        ReactDOM.render(<Cmp plugins={pluginEntries} pluginsConfig={pluginConfig} loaderComponent={() => null} />, document.getElementById('container'));
+        const container = document.getElementById('container');
+        expect(container).toBeTruthy();
+    });
+
+    it('test that module plugin successfully loaded - no loader component', done => {
+        const Listener = (props) => {
+            if (Object.keys(props.plugins).length === 2) {
+                expect(props.plugins).toExist();
+                expect(props.plugins.Example2Plugin).toExist();
+                expect(registeredEpics.Example2).toBe(true);
+                expect(registeredReducers.example2).toBe(true);
+                done();
+            }
+            return false;
+        };
+
+        const Component = withModulePlugins(({pluginsConfig}) => pluginsConfig)(Listener);
+        const Cmp = wrapWithStore(Component, store);
+        ReactDOM.render(<Cmp
+            plugins={{
+                ExamplePlugin: toModulePlugin('Example', () => import('../../../../test-resources/module-plugins/dummy')),
+                Example2Plugin: toModulePlugin('Example2', () => import('../../../../test-resources/module-plugins/dummy2'))
+            }}
+            pluginsConfig={[
+                'ExamplePlugin',
+                'Example2Plugin'
+            ]}
+        />, document.getElementById('container'));
         const container = document.getElementById('container');
         expect(container).toBeTruthy();
     });

--- a/web/client/components/plugins/enhancers/withModulePlugins.js
+++ b/web/client/components/plugins/enhancers/withModulePlugins.js
@@ -27,7 +27,7 @@ const getPluginsConfig = ({pluginsConfig: config, mode = 'desktop', defaultMode}
  * @param {function(): string[]} getPluginsConfigCallback - callback to extract proper part of plugins configuration passed with `pluginsConfig` prop
  */
 const withModulePlugins = (getPluginsConfigCallback = getPluginsConfig) => (Component) => ({ onLoaded = () => {
-}, pluginsConfig, plugins = {}, loaderComponent = () => null, ...props }) => {
+}, pluginsConfig, plugins = {}, loaderComponent, ...props }) => {
     const config = getPluginsConfigCallback({pluginsConfig, ...props});
     const { plugins: loadedPlugins, pending } = useModulePlugins({
         pluginsEntries: getPlugins(plugins, 'module'),
@@ -42,7 +42,11 @@ const withModulePlugins = (getPluginsConfigCallback = getPluginsConfig) => (Comp
         if (!loading) onLoaded(true);
     }, [loading]);
 
-    return loading ? <Loader /> : <Component {...props} pluginsConfig={pluginsConfig} plugins={parsedPlugins} allPlugins={plugins} />;
+    if (loading && loaderComponent) {
+        return <Loader />;
+    }
+
+    return <Component {...props} pluginsConfig={pluginsConfig} plugins={parsedPlugins} allPlugins={plugins} />;
 };
 
 

--- a/web/client/product/pages/Context.jsx
+++ b/web/client/product/pages/Context.jsx
@@ -111,7 +111,7 @@ class Context extends React.Component {
         return (
             <>
                 <ConnectedContextTheme />
-                <MapViewerCmp {...this.props} onLoaded={this.onLoaded} />
+                <MapViewerCmp {...this.props} onLoaded={this.onLoaded} loaderComponent={null} />
             </>
         );
     }

--- a/web/client/selectors/__tests__/context-test.js
+++ b/web/client/selectors/__tests__/context-test.js
@@ -40,10 +40,10 @@ describe('context selectors', () => {
     it('pluginsSelector', () => {
         expect(pluginsSelector(stateMocker(setContext(CONTEXT_DATA)))).toEqual(CONTEXT_DATA.plugins);
         // when loading, use default plugins
-        const DUMMY_PLUGINS = { desktop: ["TEST"] };
+        const DUMMY_PLUGINS = { context: ["TEST"] };
         const OLD_PLUGINS = ConfigUtils.getConfigProp('plugins');
         ConfigUtils.setConfigProp('plugins', DUMMY_PLUGINS);
-        expect(pluginsSelector(stateMocker(loading(true)))).toEqual({desktop: ["TEST", "Context"]});
+        expect(pluginsSelector(stateMocker(loading(true)))).toEqual({desktop: ["TEST", "Context", "FeedbackMask"]});
         ConfigUtils.setConfigProp('plugins', OLD_PLUGINS);
     });
 

--- a/web/client/selectors/context.js
+++ b/web/client/selectors/context.js
@@ -34,12 +34,12 @@ export const isLoadingSelector = state => get(state, 'context.loading');
 export const loadFlagsSelector = state => get(state, 'context.loadFlags');
 
 /**
- * returns the default plugins for context. By default always adds the Context plugin
+ * returns the default plugins for context. By default always adds the Context plugin and FeedbackMask
  * (context plugin now provides epics and reducers, they should be anyway loaded)
  */
 export const defaultPluginsSelector = createSelector(
-    () => get(ConfigUtils.getConfigProp("plugins"), 'desktop'),
-    (plugins = []) => ({ desktop: [...plugins, "Context"] } )
+    () => get(ConfigUtils.getConfigProp("plugins"), 'context'),
+    (plugins = []) => ({ desktop: [...plugins, "Context", "FeedbackMask"] } )
 );
 export const loadingPluginsSelector = state => defaultPluginsSelector(state);
 export const errorPluginsSelector = state => loadingPluginsSelector(state);


### PR DESCRIPTION
[Backport 2022.02.xx] #8564 Reduce amount of plugins initially loaded on the context page (#8565)