### PR TITLE
#8580 Register context manager epics by "Contexts" plugin

### DIFF
--- a/web/client/plugins/Contexts.jsx
+++ b/web/client/plugins/Contexts.jsx
@@ -35,6 +35,7 @@ import { loadMaps } from '../actions/maps';
 import { setContextsAvailable } from '../actions/contexts';
 
 import * as contextsEpics from '../epics/contexts';
+import * as contextManagerEpics from '../epics/contextmanager';
 import maps from '../reducers/maps';
 import contexts from '../reducers/contexts';
 import {CONTEXT_DEFAULT_SHARE_OPTIONS} from "../utils/ShareUtils";
@@ -210,6 +211,7 @@ export default createPlugin('Contexts', {
         contexts
     },
     epics: {
-        ...contextsEpics
+        ...contextsEpics,
+        ...contextManagerEpics
     }
 });


### PR DESCRIPTION
## Description
Contexts plugin utilize one of the epics from context manager to redirect user whenever there is a click on "Pencil" icon that should open context editor/wizard. Previously all plugins were static so this usage was not causing the problem, but with the changes epics from context manager need to be added to "Contexts" plugins so that they are registered properly on home page and not getting muted.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8580 

**What is the new behavior?**
Pencil icon will open context editor

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
