### PR TITLE
#8580 Unmute epics on plugin registration

### DIFF
--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -78,7 +78,8 @@ function withExtensions(AppComponent) {
                     if (action.type === LOAD_EXTENSIONS) {
                         this.loadExtensions(
                             ConfigUtils.getConfigProp('extensionsRegistry'),
-                            (plugins, translations) => this.onPluginsLoaded(plugins, translations, store)
+                            (plugins, translations) => this.onPluginsLoaded(plugins, translations, store),
+                            store
                         );
                     }
                     if (action.type === PLUGIN_UNINSTALLED) {
@@ -164,6 +165,7 @@ function withExtensions(AppComponent) {
                                 reducersList.push(name);
                             });
                             store.storeManager.addEpics(impl.name, impl?.epics ?? {});
+                            store.storeManager.unmuteEpics(impl.name);
                             const pluginDef = {
                                 [pluginName + "Plugin"]: {
                                     [pluginName + "Plugin"]: {

--- a/web/client/hooks/useModulePlugins.js
+++ b/web/client/hooks/useModulePlugins.js
@@ -83,6 +83,7 @@ function useModulePlugins({
                         }
                         if (size(impl.epics)) {
                             store.storeManager.addEpics(impl.name, impl.epics);
+                            store.storeManager.unmuteEpics(impl.name);
                         }
                     });
                     if (reducersList.length) {

--- a/web/client/utils/StateUtils.js
+++ b/web/client/utils/StateUtils.js
@@ -275,10 +275,11 @@ export const createStoreManager = (initialReducers, initialEpics) => {
          * @param {string} key
          */
         muteEpics: (key) => {
-            const moduleEpicRegistrations = groupedByModule[key];
+            const normalizedName = normalizeName(key);
+            const moduleEpicRegistrations = groupedByModule[normalizedName];
             // try to mute everything registered by module. If epic is shared, remove current module from epicsListenedBy
             moduleEpicRegistrations && moduleEpicRegistrations.forEach(epicName => {
-                const indexOf = epicsListenedBy[epicName].indexOf(key);
+                const indexOf = epicsListenedBy[epicName].indexOf(normalizedName);
                 if (indexOf >= 0) {
                     epicsListenedBy[epicName].splice(indexOf, 1);
                 }
@@ -294,12 +295,13 @@ export const createStoreManager = (initialReducers, initialEpics) => {
          * @param {string} key
          */
         unmuteEpics: (key) => {
-            const moduleEpicRegistrations = groupedByModule[key];
+            const normalizedName = normalizeName(key);
+            const moduleEpicRegistrations = groupedByModule[normalizedName];
             // unmute epics if exactly one plugin wants to register specific epic
             moduleEpicRegistrations && moduleEpicRegistrations.forEach(epicName => {
-                const indexOf = epicsListenedBy[epicName].indexOf(key);
+                const indexOf = epicsListenedBy[epicName].indexOf(normalizedName);
                 if (indexOf === -1) {
-                    epicsListenedBy[epicName].push(key);
+                    epicsListenedBy[epicName].push(normalizedName);
                 }
                 // now if epic intended to be registered by first listener plugin - unmute it
                 if (epicsListenedBy[epicName].length === 1) {


### PR DESCRIPTION
## Description
This PR fixes couple of issues:
1. withExtensions hook was not passing store as a third argument to the `loadExtensions` method. This caused error logs and could potentially lead to incorrect registration of extension's reducers or epics.
2. App can have several plugins registering same epics and using side effects maintained by them (e.g. context manager and contexts grid on the home page). Flow of epics mute/unmute operations sometimes can cause the case when epic was muted while another plugin sharing same epic is not yet loaded. In this case epic will be muted mistakenly.
Example: Open contexts manager and refresh the page to make app have registered plugins only specific to this page. Pencil icon will allow you to edit context (as an admin or if it's permitted). Click on the home icon to jump back home. At this point, prior to the load of new plugins, app will mute epic that adds side effect that opens context wizard once you click on pencil. Even after `Contexts` extension is loaded - epic will still be muted.
This PR adds correction to this behavior by making an attempt to unmute all the epics that plugin/extension uses.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8580 
- Errors in log after saving the context if app has extensions registered.
- Incorrectly muted epics in some cases.

**What is the new behavior?**
See description

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
