### PR TITLE
#8559: Feature grid aliases and tooltips for columns

### DIFF
--- a/web/client/components/data/featuregrid/AttributeTable.jsx
+++ b/web/client/components/data/featuregrid/AttributeTable.jsx
@@ -7,34 +7,83 @@
  */
 
 import React from 'react';
-
 import ReactDataGrid from 'react-data-grid';
+import { castArray, includes, uniqBy, isEmpty } from "lodash";
+
 import Message from '../../I18N/Message';
+import FormatEditor from "../../data/featuregrid/editors/FormatEditor";
+
+// Update property name on row selection operation
+const updatePropertyName = (arr, names, hide) => {
+    const _names = castArray(names);
+    if (hide) {
+        return arr.filter(e => !includes(_names, e.name));
+    }
+    return uniqBy([...arr, ..._names.map(n => ({name: n}))], 'name');
+};
+const range = (start, end) => Array.from({length: (end + 1 - start)}, (v, k) => k + start);
+
+// Editor with format regex
+const getEditor = (formatRegex) => <FormatEditor dataType="string" formatRegex={formatRegex}/>;
+
+// Columns for configuring table options
+const columns = [{
+    name: 'Name',
+    key: 'attribute'
+}, {
+    name: 'Title',
+    key: 'title',
+    editor: getEditor("^[-@.\\/\#&+\\w\\s*]{0,100}$"),
+    width: 150,
+    editable: true
+}, {
+    name: 'Description',
+    key: 'description',
+    editor: getEditor("^[-@.,\\/\#&+\\w\\s*]{0,200}$"),
+    width: 200,
+    editable: true
+}];
 
 export default ({
     style = {},
     titleMsg = "featuregrid.columns",
     onChange = () => { },
-    attributes = []
-} = {}) => (
-    <div className="bg-body data-attribute-selector" style={style}>
-        <h4 className="text-center"><strong><Message msgId={titleMsg} /></strong></h4>
+    attributes = [],
+    options = {}
+} = {}) => {
+    const rowGetter = idx => attributes[idx];
+
+    const onGridRowsUpdated = ({fromRow, toRow, updated}) => {
+        const [{name} = {}] = range(fromRow, toRow).map((r) => rowGetter(r))
+            .filter(f => Object.keys(updated || {})
+                .filter(k => f[k] !== updated[k]).length > 0);
+
+        !isEmpty(name) && onChange("options.propertyName",
+            options.propertyName.map(p => name === p.name ? ({...p, ...updated}) : p)
+        );
+    };
+
+    const onRowsSelectOperation = (names, hide) => {
+        onChange("options.propertyName", updatePropertyName(options && options.propertyName || [], names, hide));
+    };
+
+    return (<div className="bg-body data-attribute-selector" style={style}>
+        <h4 className="text-center"><strong><Message msgId={titleMsg}/></strong></h4>
         <ReactDataGrid
             rowKey="id"
-            columns={[{
-                name: '',
-                key: 'attribute'
-            }]}
-            rowGetter={idx => attributes[idx]}
+            columns={columns}
+            enableCellSelect
+            rowGetter={rowGetter}
             rowsCount={attributes.length}
+            onGridRowsUpdated={onGridRowsUpdated}
             rowSelection={{
                 showCheckbox: true,
                 enableShiftSelect: true,
-                onRowsSelected: rows => onChange(rows.map(row => attributes[row.rowIdx].name), false),
-                onRowsDeselected: rows => onChange(rows.map(row => attributes[row.rowIdx].name), true),
+                onRowsSelected: rows => onRowsSelectOperation(rows.map(row => attributes[row.rowIdx].name), false),
+                onRowsDeselected: rows => onRowsSelectOperation(rows.map(row => attributes[row.rowIdx].name), true),
                 selectBy: {
-                    indexes: attributes.reduce( (acc, a, idx) => [...acc, ...(a.hide ? [] : [idx] )], [])
+                    indexes: attributes.reduce((acc, a, idx) => [...acc, ...(a.hide ? [] : [idx])], [])
                 }
-            }} />
-    </div>
-);
+            }}/>
+    </div>);
+};

--- a/web/client/components/data/featuregrid/AttributeTable.jsx
+++ b/web/client/components/data/featuregrid/AttributeTable.jsx
@@ -35,13 +35,13 @@ const columns = [{
     key: 'title',
     editor: getEditor("^[-@.\\/\#&+\\w\\s*]{0,100}$"),
     width: 150,
-    editable: true
+    editable: (rowData) => !rowData?.hide
 }, {
     name: 'Description',
     key: 'description',
     editor: getEditor("^[-@.,\\/\#&+\\w\\s*]{0,200}$"),
     width: 200,
-    editable: true
+    editable: (rowData) => !rowData?.hide
 }];
 
 export default ({

--- a/web/client/components/data/featuregrid/__tests__/AttributeTable-test.jsx
+++ b/web/client/components/data/featuregrid/__tests__/AttributeTable-test.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import AttributeSelector from '../AttributeTable';
 import expect from 'expect';
+import TestUtils from "react-dom/test-utils";
 const spyOn = expect.spyOn;
 
 
@@ -53,5 +54,74 @@ describe('Test for AttributeTable component', () => {
         expect(events.onChange).toHaveBeenCalled();
 
     });
+    it('click event onChange', () => {
+        const events = {
+            onChange: () => {}
+        };
+        const _spyOn = spyOn(events, "onChange");
+        ReactDOM.render(<AttributeSelector onChange={events.onChange} attributes={[{label: "label", name: "attr", attribute: "attr", hide: true}]}/>, document.getElementById("container"));
+        const checks = document.getElementsByTagName("input");
+        expect(checks.length).toBe(2);
+        checks[0].click();
+        expect(events.onChange).toHaveBeenCalled();
+        const [arg, value] = _spyOn.calls[0].arguments;
+        expect(arg).toEqual("options.propertyName");
+        expect(value).toEqual([{name: "attr"}]);
+    });
+    it('test title onGridRowsUpdated', () => {
+        const events = {
+            onChange: () => {}
+        };
+        const _spyOn = spyOn(events, "onChange");
+        ReactDOM.render(<AttributeSelector options={{propertyName: [{name: 'attr'}, {name: 'attr1'}]}} onChange={events.onChange} attributes={[{label: "label", name: "attr", attribute: "attr"}]}/>, document.getElementById("container"));
+        const checks = document.getElementsByClassName("react-grid-Cell");
+        TestUtils.Simulate.doubleClick(checks[2]); // Activate input field
+        const input = document.getElementsByTagName("input");
+        expect(input.length).toBe(3);
+        TestUtils.Simulate.change(input[1], {target: {value: 'Attribute title'}}); // Update value in title to trigger 'onGridRowsUpdated'
+        TestUtils.Simulate.keyDown(input[1], { key: 'Enter', keyCode: 13 });
+        expect(events.onChange).toHaveBeenCalled();
+        const [arg, value] = _spyOn.calls[0].arguments;
+        expect(arg).toEqual("options.propertyName");
+        expect(value).toEqual([{"name": "attr", "title": "Attribute title"}, {"name": "attr1"}]);
+    });
+    it('test description onGridRowsUpdated', () => {
+        const events = {
+            onChange: () => {}
+        };
+        const _spyOn = spyOn(events, "onChange");
+        ReactDOM.render(<AttributeSelector options={{propertyName: [{name: 'attr'}, {name: 'attr1'}]}} onChange={events.onChange} attributes={[{label: "label", name: "attr", attribute: "attr"}]}/>, document.getElementById("container"));
+        const checks = document.getElementsByClassName("react-grid-Cell");
+        TestUtils.Simulate.doubleClick(checks[3]); // Activate input field
+        const input = document.getElementsByTagName("input");
+        expect(input.length).toBe(3);
 
+        // Update value in title to trigger 'onGridRowsUpdated'
+        TestUtils.Simulate.change(input[1], {target: {value: 'Attribute description'}});
+        TestUtils.Simulate.keyDown(input[1], { key: 'Enter', keyCode: 13 });
+        expect(events.onChange).toHaveBeenCalled();
+
+        const [arg, value] = _spyOn.calls[0].arguments;
+        expect(arg).toEqual("options.propertyName");
+        expect(value).toEqual([{"name": "attr", "description": "Attribute description"}, {"name": "attr1"}]);
+    });
+    it('test retain attributes onGridRowsUpdated when no matching attribute name found', () => {
+        const options = { propertyName: [{name: 'attr1'}, {name: 'attr2'}]};
+        const events = {
+            onChange: () => {}
+        };
+        const _spyOn = spyOn(events, "onChange");
+        ReactDOM.render(<AttributeSelector options={options} onChange={events.onChange} attributes={[{label: "label", name: "attr", attribute: "attr"}]}/>, document.getElementById("container"));
+        const checks = document.getElementsByClassName("react-grid-Cell");
+        TestUtils.Simulate.doubleClick(checks[3]); // Activate input field
+        const input = document.getElementsByTagName("input");
+        expect(input.length).toBe(3);
+        TestUtils.Simulate.change(input[1], {target: {value: 'some val'}});
+        TestUtils.Simulate.keyDown(input[1], { key: 'Enter', keyCode: 13 });
+        expect(events.onChange).toHaveBeenCalled();
+
+        const [arg, value] = _spyOn.calls[0].arguments;
+        expect(arg).toEqual("options.propertyName");
+        expect(value).toEqual(options.propertyName);
+    });
 });

--- a/web/client/components/data/featuregrid/__tests__/AttributeTable-test.jsx
+++ b/web/client/components/data/featuregrid/__tests__/AttributeTable-test.jsx
@@ -124,4 +124,16 @@ describe('Test for AttributeTable component', () => {
         expect(arg).toEqual("options.propertyName");
         expect(value).toEqual(options.propertyName);
     });
+    it('test disable editable cell when row is not selected', () => {
+        ReactDOM.render(<AttributeSelector options={{propertyName: [{name: 'attr'}, {name: 'attr1'}]}}  attributes={[{label: "label", name: "attr", attribute: "attr", hide: true}]}/>, document.getElementById("container"));
+        const checks = document.getElementsByClassName("react-grid-Cell");
+        TestUtils.Simulate.doubleClick(checks[2]); // Activate title field
+        let input = document.getElementsByTagName("input");
+        // Title input field is not enabled, as activated would result in 3 total fields
+        expect(input.length).toBe(2);
+
+        TestUtils.Simulate.doubleClick(checks[3]); // Activate description field
+        input = document.getElementsByTagName("input");
+        expect(input.length).toBe(2); // Description input field is not enabled
+    });
 });

--- a/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
+++ b/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
@@ -189,4 +189,17 @@ describe('Test for FeatureGrid component', () => {
         const rowHeight = gridRow[0]?.offsetHeight;
         expect(rowHeight).toBe(28);
     });
+    it('Test grid with default header title', () => {
+        ReactDOM.render(<FeatureGrid virtualScroll={false}
+            describeFeatureType={describePois} enableColumnFilters={false} features={museam.features}/>, document.getElementById("container"));
+        const gridHeaderCell = document.getElementsByClassName('react-grid-HeaderCell');
+        expect(gridHeaderCell[0].innerText).toBe('NAME');
+    });
+    it('Test grid with custom header title', () => {
+        ReactDOM.render(<FeatureGrid virtualScroll={false}
+            options={{propertyName: [{name: "NAME", title: "Some Name", description: "Some description"}]}}
+            describeFeatureType={describePois} enableColumnFilters={false} features={museam.features}/>, document.getElementById("container"));
+        const gridHeaderCell = document.getElementsByClassName('react-grid-HeaderCell');
+        expect(gridHeaderCell[0].innerText).toBe('Some Name');
+    });
 });

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -6,9 +6,12 @@
  * LICENSE file in the root directory of this source tree.
 */
 
+import React from 'react';
 import { isNil } from 'lodash';
-import { compose, createEventHandler, defaultProps, withHandlers, withPropsOnChange } from 'recompose';
+import { Tooltip } from "react-bootstrap";
+import { compose, createEventHandler, defaultProps, withHandlers, withProps, withPropsOnChange } from 'recompose';
 
+import OverlayTrigger from "../../../misc/OverlayTrigger";
 import EditorRegistry from '../../../../utils/featuregrid/EditorRegistry';
 import {
     applyAllChanges,
@@ -147,7 +150,8 @@ const featuresToGrid = compose(
                     .concat(featureTypeToGridColumns(props.describeFeatureType, props.columnSettings, {
                         editable: props.mode === "EDIT",
                         sortable: props.sortable && !props.isFocused,
-                        defaultSize: props.defaultSize
+                        defaultSize: props.defaultSize,
+                        options: props.options?.propertyName
                     }, {
                         getEditor: (desc) => {
                             const generalProps = {
@@ -214,7 +218,17 @@ const featuresToGrid = compose(
             };
         }
     ),
-    propsStreamFactory
+    propsStreamFactory,
+    withProps(({columns}) => ({
+        columns: columns?.map(c => ({
+            ...c,
+            name: !c.showTitleTooltip
+                ? (c.title || c.name)
+                : <OverlayTrigger  placement="top" overlay={<Tooltip id={c.name}>{c.description}</Tooltip>}>
+                    <span>{c.title}</span>
+                </OverlayTrigger>
+        }))
+    }))
 );
 
 export default featuresToGrid;

--- a/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
@@ -6,10 +6,9 @@
   * LICENSE file in the root directory of this source tree.
   */
 
-import { castArray, includes, uniq } from 'lodash';
 import React from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
-import {compose, withHandlers, withProps} from 'recompose';
+import {compose, withProps} from 'recompose';
 
 import { isGeometryType } from '../../../../../utils/ogc/WFS/base';
 import AttributeTable from '../../../../data/featuregrid/AttributeTable';
@@ -18,30 +17,25 @@ import StepHeader from '../../../../misc/wizard/StepHeader';
 import noAttributes from '../common/noAttributesEmptyView';
 import Button from '../../../../misc/Button';
 
-const updatePropertyName = (arr, name, hide) => {
-    const names = castArray(name);
-    if (hide) {
-        return arr.filter(e => !includes(names, e));
-    }
-    return uniq([...arr, ...names]);
-};
 const AttributeSelector = compose(
     withProps(
         ({ attributes = [], options = {}} = {}) => ({ // TODO manage hide condition
             attributes: attributes
                 .filter(a => !isGeometryType(a))
-                .map( a => ({
-                    ...a,
-                    label: a.name,
-                    attribute: a.name,
-                    hide: options.propertyName && (options.propertyName.indexOf( a.name ) < 0)
+                .map( a => {
+                    const propertyNames = options?.propertyName?.map(p => p.name);
+                    const currPropertyName = options?.propertyName?.find(p => p.name === a.name);
+                    return {
+                        ...a,
+                        label: a.name,
+                        attribute: a.name,
+                        hide: propertyNames?.indexOf( a.name ) < 0,
+                        title: currPropertyName?.title || '',
+                        description: currPropertyName?.description || ''
+                    };
                 })
-                )
         })),
-    noAttributes(({ attributes = []}) => attributes.length === 0),
-    withHandlers({
-        onChange: ({ onChange = () => {}, options = {}}) => (name, hide) => onChange("options.propertyName", updatePropertyName(options && options.propertyName || [], name, hide))
-    })
+    noAttributes(({ attributes = []}) => attributes.length === 0)
 )(AttributeTable);
 
 

--- a/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
@@ -18,6 +18,12 @@ import noAttributes from '../common/noAttributesEmptyView';
 import Button from '../../../../misc/Button';
 
 const AttributeSelector = compose(
+    withProps(({options = {}})=>({
+        options: {
+            // Parse to allow compatibility for existing table
+            propertyName: (options?.propertyName || [])?.map(p => typeof p === "string" ? ({name: p}) : p)
+        }
+    })),
     withProps(
         ({ attributes = [], options = {}} = {}) => ({ // TODO manage hide condition
             attributes: attributes

--- a/web/client/components/widgets/enhancers/utils.js
+++ b/web/client/components/widgets/enhancers/utils.js
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { find, get, isEmpty, reduce } from 'lodash';
+import {find, get, isEmpty, reduce} from 'lodash';
 
-import { gridUpdateToQueryUpdate } from '../../../utils/FeatureGridUtils';
+import { gridUpdateToQueryUpdate, getAttributesNames } from '../../../utils/FeatureGridUtils';
 import { composeAttributeFilters } from '../../../utils/FilterUtils';
 
 /**
@@ -27,7 +27,7 @@ export const getDependencyLayerParams = (layer, dependencies) =>
 export const composeFilterObject =  (filterObj, quickFilters, options) => {
     const quickFiltersForVisibleProperties = quickFilters && options &&
         Object.keys(quickFilters)
-            .filter(qf => find(options.propertyName, f => f === qf))
+            .filter(qf => find(getAttributesNames(options.propertyName), f => f === qf))
             .reduce((p, c) => {
                 return {...p, [c]: quickFilters[c]};
             }, {});

--- a/web/client/components/widgets/enhancers/wfsTable/__tests__/wfsTable-test.js
+++ b/web/client/components/widgets/enhancers/wfsTable/__tests__/wfsTable-test.js
@@ -84,5 +84,34 @@ describe('wfsTable enhancer', () => {
             }
         }} />, document.getElementById("container"));
     });
-
+    it('test columnsettings with options propertyName', (done) => {
+        let triggered = false;
+        const Sink = wfsTable(createSink(props => {
+            expect(props).toExist();
+            if (props.features.length > 0 && props?.pages?.[0] === 0 && !triggered) {
+                expect(props.pages[1]).toBe(20);
+                triggered = true;
+                props.pageEvents.moreFeatures({ startPage: 2, endPage: 3 });
+            } else if (props.features.length > 0 && props?.pages?.[0] === 40) {
+                expect(props.pages[1]).toBe(60);
+                done();
+            }
+            if (props.columnSettings) {
+                expect(Object.keys(props.columnSettings).includes('NAME')).toBeFalsy();
+            }
+        }));
+        ReactDOM.render(<Sink virtualScroll
+            describeFeatureType = {{
+                featureTypes: [{properties: []}]
+            }}
+            options={{propertyName: [{name: "NAME"}]}}
+            layer={{
+                name: "pois",
+                describeFeatureTypeURL: "DESCRIBE",
+                search: {
+                    type: "wfs",
+                    url: "WFS"
+                }
+            }} />, document.getElementById("container"));
+    });
 });

--- a/web/client/components/widgets/enhancers/wfsTable/index.js
+++ b/web/client/components/widgets/enhancers/wfsTable/index.js
@@ -14,6 +14,7 @@ import describeFetch from './describeFetch';
 import noPaginationFetch from './noPaginationFetch';
 import triggerFetch from './triggerFetch';
 import virtualScrollFetch from './virtualScrollFetch';
+import { getAttributesNames } from "../../../../utils/FeatureGridUtils";
 
 const fetchDataStream = (props$, pages$, virtualScroll = true) =>
     triggerFetch(props$)
@@ -97,7 +98,7 @@ export default compose(
         columnSettings: merge(
             dft ?
                 getFeatureTypeProperties(dft)
-                    .filter(p => !includes(options.propertyName || [], p.name))
+                    .filter(p => !includes(getAttributesNames(options.propertyName) || [], p.name))
                     .reduce((acc, p) => ({
                         ...acc,
                         [p.name]: {

--- a/web/client/components/widgets/enhancers/wfsTable/noPaginationFetch.js
+++ b/web/client/components/widgets/enhancers/wfsTable/noPaginationFetch.js
@@ -13,6 +13,7 @@
 import Rx from 'rxjs';
 
 import { getLayerJSONFeature } from '../../../../observables/wfs';
+import { getAttributesNames } from "../../../../utils/FeatureGridUtils";
 
 export default props$ => props$.switchMap(
     ({
@@ -24,7 +25,7 @@ export default props$ => props$.switchMap(
     }) =>
         getLayerJSONFeature(layer, filter, {
             timeout: 15000,
-            params: { propertyName: options.propertyName, viewParams: options.viewParams }
+            params: { propertyName: getAttributesNames(options.propertyName), viewParams: options.viewParams }
             // TODO totalFeatures
             // TODO sortOptions - default
         })

--- a/web/client/components/widgets/enhancers/wfsTable/virtualScrollFetch.js
+++ b/web/client/components/widgets/enhancers/wfsTable/virtualScrollFetch.js
@@ -9,7 +9,7 @@
 import Rx from 'rxjs';
 
 import { getLayerJSONFeature } from '../../../../observables/wfs';
-import { getCurrentPaginationOptions, updatePages } from '../../../../utils/FeatureGridUtils';
+import { getAttributesNames, getCurrentPaginationOptions, updatePages } from '../../../../utils/FeatureGridUtils';
 
 /**
  * Create an operator that resonds to a fetch data trigger event to retrives data on scroll.
@@ -33,7 +33,7 @@ export default pages$ => props$ => props$.switchMap(({
     sortOptions: sortOptions,
     timeout: 15000,
     totalFeatures: pagination.totalFeatures, // this is needed to allow workaround of GEOS-7233
-    propertyName: options.propertyName,
+    propertyName: getAttributesNames(options.propertyName),
     viewParams: options.viewParams
     // TODO: defaultSortOptions - to skip primary-key issues
 })

--- a/web/client/components/widgets/widget/TableWidget.jsx
+++ b/web/client/components/widgets/widget/TableWidget.jsx
@@ -49,7 +49,8 @@ export default getWidgetFilterRenderers(({
     pagination = {},
     dataGrid = {},
     virtualScroll = true,
-    gridOpts = defaultGridOpts
+    gridOpts = defaultGridOpts,
+    options = {}
 }) =>
     (<WidgetContainer
         id={`widget-chart-${id}`}
@@ -90,7 +91,8 @@ export default getWidgetFilterRenderers(({
                 rowKey="id"
                 describeFeatureType={describeFeatureType}
                 pagination={pagination}
-                gridOpts={gridOpts}/>
+                gridOpts={gridOpts}
+                options={options}/>
         </BorderLayout>
     </WidgetContainer>
 

--- a/web/client/plugins/widgetbuilder/TableBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/TableBuilder.jsx
@@ -52,7 +52,7 @@ const Builder = connect(
             .do(({ featureTypeProperties = [], onChange = () => { }, data = {} } = {}) => {
                 // initialize attribute list if empty (first time)
                 if (onChange && featureTypeProperties.length > 0 && !get(data, "options.propertyName")) {
-                    onChange("options.propertyName", featureTypeProperties.filter(a => !isGeometryType(a)).map(ft => ft.name));
+                    onChange("options.propertyName", featureTypeProperties.filter(a => !isGeometryType(a)).map(ft => ({name: ft.name})));
                 }
             }).ignoreElements()
     ))

--- a/web/client/plugins/widgets/getWidgetFilterRenderers.js
+++ b/web/client/plugins/widgets/getWidgetFilterRenderers.js
@@ -10,7 +10,7 @@ import { find } from 'lodash';
 import { compose, mapPropsStream, withProps, withPropsOnChange } from 'recompose';
 
 import { getFilterRenderer } from '../../components/data/featuregrid/filterRenderers';
-import { getAttributeFields } from '../../utils/FeatureGridUtils';
+import { getAttributeFields, getAttributesNames } from '../../utils/FeatureGridUtils';
 
 /**
  * Uses the quickFilterStream$ to generate the value prop.
@@ -22,7 +22,9 @@ const mergeQuickFiltersStream = compose(
             // extract the quickFilterStream$ from props
             props$.pluck('quickFilterStream$').distinctUntilChanged().switchMap(quickFilterStream$ => quickFilterStream$).startWith(undefined),
             (props, quickFilters) => {
-                const attributeQuickFilter = quickFilters && props.options && find(props.options.propertyName, f => f === props.attributeName) && quickFilters[props.attributeName] || {};
+                const attributeQuickFilter = quickFilters && props.options
+                    && find(getAttributesNames(props.options?.propertyName), f => f === props.attributeName)
+                    && quickFilters[props.attributeName] || {};
                 const value = attributeQuickFilter && (attributeQuickFilter.rawValue || attributeQuickFilter.value);
                 return {
                     ...props,

--- a/web/client/selectors/__tests__/widgets-test.js
+++ b/web/client/selectors/__tests__/widgets-test.js
@@ -108,6 +108,35 @@ describe('widgets selectors', () => {
         expect(widgetFilter).toEqual({ rawValue: 'y', value: 'y', operator: 'ilike', type: 'string', attribute: 'state' });
 
     });
+    it('getWidgetAttributeFilter propertyName with array of objects', () => {
+        const state = {
+            widgets: {
+                containers: {
+                    floating: {
+                        widgets: [{
+                            id: "wId",
+                            quickFilters: {
+                                state: {
+                                    rawValue: 'y',
+                                    value: 'y',
+                                    operator: 'ilike',
+                                    type: 'string',
+                                    attribute: 'state'
+                                }
+                            },
+                            options: {
+                                propertyName: [{name: 'state'}]
+                            }
+                        }]
+                    }
+                }
+            }
+        };
+        const widgetFilter = getWidgetAttributeFilter("wId", "state")(state);
+        expect(widgetFilter).toExist();
+        expect(widgetFilter).toEqual({ rawValue: 'y', value: 'y', operator: 'ilike', type: 'string', attribute: 'state' });
+
+    });
     it('getWidgetLayer', () => {
         const tocLayerState = {'layers': { selected: ["TEST1"], flat: [{id: "TEST1", name: "TEST1"}] }};
         expect(getWidgetLayer(tocLayerState)).toExist();

--- a/web/client/selectors/widgets.js
+++ b/web/client/selectors/widgets.js
@@ -16,6 +16,7 @@ import { getWidgetsGroups, getWidgetDependency } from '../utils/WidgetsUtils';
 import { dashboardServicesSelector, isDashboardAvailable, isDashboardEditing } from './dashboard';
 import { createSelector, createStructuredSelector } from 'reselect';
 import { createShallowSelector } from '../utils/ReselectUtils';
+import { getAttributesNames } from "../utils/FeatureGridUtils";
 
 export const getEditorSettings = state => get(state, "widgets.builder.settings");
 export const getDependenciesMap = s => get(s, "widgets.dependencies") || {};
@@ -50,7 +51,7 @@ export const getWidgetAttributeFilter = (id, attributeName) => createSelector(
     getVisibleFloatingWidgets,
     (widgets) => {
         const widget = find(widgets, {id});
-        return widget && widget.quickFilters && widget.options && find(widget.options.propertyName, f => f === attributeName) && widget.quickFilters[attributeName] || {};
+        return widget && widget.quickFilters && widget.options && find(getAttributesNames(widget.options?.propertyName), f => f === attributeName) && widget.quickFilters[attributeName] || {};
     });
 
 export const getCollapsedIds = createSelector(

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -6,7 +6,7 @@
   * LICENSE file in the root directory of this source tree.
   */
 
-import { identity, trim, fill, findIndex, get, isArray, isNil, isString } from 'lodash';
+import { identity, trim, fill, findIndex, get, isArray, isNil, isString, isPlainObject } from 'lodash';
 
 import {
     findGeometryProperty,
@@ -117,20 +117,26 @@ export const getCurrentPaginationOptions = ({ startPage, endPage }, oldPages, si
 export const featureTypeToGridColumns = (
     describe,
     columnSettings = {},
-    {editable = false, sortable = true, resizable = true, filterable = true, defaultSize = 200} = {},
+    {editable = false, sortable = true, resizable = true, filterable = true, defaultSize = 200, options = []} = {},
     {getEditor = () => {}, getFilterRenderer = () => {}, getFormatter = () => {}} = {}) =>
-    getAttributeFields(describe).filter(e => !(columnSettings[e.name] && columnSettings[e.name].hide)).map( (desc) => ({
-        sortable,
-        key: desc.name,
-        width: columnSettings[desc.name] && columnSettings[desc.name].width || (defaultSize ? defaultSize : undefined),
-        name: columnSettings[desc.name] && columnSettings[desc.name].label || desc.name,
-        resizable,
-        editable,
-        filterable,
-        editor: getEditor(desc),
-        formatter: getFormatter(desc),
-        filterRenderer: getFilterRenderer(desc, desc.name)
-    }));
+    getAttributeFields(describe).filter(e => !(columnSettings[e.name] && columnSettings[e.name].hide)).map((desc) => {
+        const option = options.find(o => o.name === desc.name);
+        return {
+            sortable,
+            key: desc.name,
+            width: columnSettings[desc.name] && columnSettings[desc.name].width || (defaultSize ? defaultSize : undefined),
+            name: columnSettings[desc.name] && columnSettings[desc.name].label || desc.name,
+            description: option?.description || '',
+            title: option?.title || desc.name,
+            showTitleTooltip: !!option?.description,
+            resizable,
+            editable,
+            filterable,
+            editor: getEditor(desc),
+            formatter: getFormatter(desc),
+            filterRenderer: getFilterRenderer(desc, desc.name)
+        };
+    });
 /**
  * Create a column from the configruation. Maps the events to call a function with the whole property
  * @param  {array} toolColumns Array of the tools configurations
@@ -330,4 +336,13 @@ export const getAttributesList = (attributes, customAttributesSettings) => {
         }
     }
     return result;
+};
+
+/**
+ * Get attributes names based on prop type
+ * @param {object[] | string[]} attributes
+ * @returns {object[]} attribute names
+ */
+export const getAttributesNames = (attributes) => {
+    return attributes?.map(attribute => isPlainObject(attribute) ? attribute.name : attribute);
 };

--- a/web/client/utils/__tests__/FeatureGridUtils-test.js
+++ b/web/client/utils/__tests__/FeatureGridUtils-test.js
@@ -6,7 +6,13 @@
  * LICENSE file in the root directory of this source tree.
 */
 import expect from 'expect';
-import {updatePages, gridUpdateToQueryUpdate, getAttributesList} from '../FeatureGridUtils';
+import {
+    updatePages,
+    gridUpdateToQueryUpdate,
+    getAttributesList,
+    getAttributesNames,
+    featureTypeToGridColumns
+} from '../FeatureGridUtils';
 
 
 describe('FeatureGridUtils', () => {
@@ -214,5 +220,45 @@ describe('FeatureGridUtils', () => {
         expect(customSettings).toEqual(['ATTR1', 'ATTR3']);
         expect(noSettings).toBe(undefined);
         expect(allDeselected).toEqual([]);
+    });
+    it('getAttributesNames', () => {
+        const attributes = ['ATTR1', 'ATTR2', 'ATTR3'];
+        expect(getAttributesNames(attributes)).toEqual(['ATTR1', 'ATTR2', 'ATTR3']);
+    });
+    it('getAttributesNames from array of object', () => {
+        const attributes = [
+            {
+                "label": "ATTR1",
+                "attribute": "ATTR1",
+                "name": "ATTR1",
+                "title": "Attribute 1",
+                "description": "Some attribute 1",
+                "type": "number",
+                "valueId": "id",
+                "valueLabel": "name",
+                "values": []
+            }
+        ];
+        expect(getAttributesNames(attributes)).toEqual(['ATTR1']);
+    });
+    it('test featureTypeToGridColumns', () => {
+        const describe = {featureTypes: [{properties: [{name: 'Test1', type: "xsd:number"}, {name: 'Test2', type: "xsd:number"}]}]};
+        const columnSettings = {name: 'Test1', hide: false};
+        const options = [{name: 'Test1', title: 'Some title', description: 'Some description'}];
+        const featureGridColumns = featureTypeToGridColumns(describe, columnSettings, {options});
+        expect(featureGridColumns.length).toBe(2);
+        featureGridColumns.forEach((fgColumns, index) => {
+            if (index === 0) {
+                expect(fgColumns.description).toBe('Some description');
+                expect(fgColumns.title).toBe('Some title');
+                expect(fgColumns.showTitleTooltip).toBeTruthy();
+            }
+            expect(['Test1', 'Test2'].includes(fgColumns.name)).toBeTruthy();
+            expect(fgColumns.resizable).toBeTruthy();
+            expect(fgColumns.filterable).toBeTruthy();
+            expect(fgColumns.editable).toBeFalsy();
+            expect(fgColumns.sortable).toBeTruthy();
+            expect(fgColumns.width).toBe(200);
+        });
     });
 });


### PR DESCRIPTION
## Description
This PR allows adding alias and description to the attribute columns in table widgets

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#8559 

**What is the new behavior?**

![image](https://user-images.githubusercontent.com/26929983/189912615-26238b18-9851-4374-8d25-6e033d2bfdf5.png)

![image](https://user-images.githubusercontent.com/26929983/189912478-b1a83889-4ae0-4c66-bf72-50706ad786eb.png)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
