### PR TITLE
#8586 Make eager option configurable for extensions shared libraries

### DIFF
--- a/build/createExtensionWebpackConfig.js
+++ b/build/createExtensionWebpackConfig.js
@@ -11,13 +11,14 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
  * @param {boolean} cfg.prod discriminates the production or development environment
  * @param {string} cfg.name the name of the plugin/extension
  * @param {object} cfg.exposes this is the main entry point of the module federation plugin. For MapStore extension plugin it must be { './plugin': "path/to/the/plugin/file>"}
+ * @param {boolean} cfg.sharedLibrariesEager this flag controls whether shared libraries should be included into index.js of extensions or loaded asynchronously
  * @param {object} cfg.alias aliases for the JS build
  * @param {object} cfg.publicPath the publicPath, useful for debugging
  * @param {string} cfg.destination the destination folder of the build packages
  * @param {array} cfg.plugins additional plugins, more then the default ones.
  * @param {object} cfg.overrides any other configuration you want to add to the configuration.
  */
-module.exports = ({ prod = true, name, exposes, alias = {}, publicPath, destination, plugins = [], overrides = {} }) => ({
+module.exports = ({ prod = true, name, exposes, sharedLibrariesEager = true, alias = {}, publicPath, destination, plugins = [], overrides = {} }) => ({
     target: "web",
     mode: prod ? "production" : "development",
     entry: {},
@@ -44,7 +45,10 @@ module.exports = ({ prod = true, name, exposes, alias = {}, publicPath, destinat
         name,
         filename: "index.js", // "bundle.[chunkhash:8].js", // [chunkhash:8]
         exposes,
-        shared
+        shared: Object.keys(shared).reduce((prev, el) => {
+            prev[el] = {...shared[el], eager: sharedLibrariesEager};
+            return prev;
+        }, {})
     }),
     new MiniCssExtractPlugin({
         filename: "assets/css/[name].css"


### PR DESCRIPTION
## Description
With the changes suggested in PR each extension will have a way to configure `eager` option for shared libraries.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8586 

**What is the new behavior?**
Eager option can be overridden by configuration passed from extension

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
