### PR TITLE
#8573 Fix permissions dropdowns

### DIFF
--- a/web/client/components/resources/modals/fragments/PermissionEditor.jsx
+++ b/web/client/components/resources/modals/fragments/PermissionEditor.jsx
@@ -191,7 +191,7 @@ class PermissionEditor extends React.Component {
                         </tr>
 
 
-                        <tr key="addRowKey">
+                        <tr key="addRowKey" className="insert-row">
                             <td>
                                 <Select
                                     noResultsText={getMessageById(this.context.messages, "map.permissions.noResult")}

--- a/web/client/components/resources/modals/fragments/__tests__/PermissionEditor-test.jsx
+++ b/web/client/components/resources/modals/fragments/__tests__/PermissionEditor-test.jsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from "expect";
+import React from "react";
+import ReactDOM from "react-dom";
+import ReactTestUtils from "react-dom/test-utils";
+
+import PermissionEditor from "../PermissionEditor";
+
+describe("PermissionEditor component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = "";
+        setTimeout(done);
+    });
+
+    it('Should render', () => {
+        ReactDOM.render(<PermissionEditor />, document.getElementById('container'));
+        const permissionsTable = document.getElementsByClassName('permissions-table')[0];
+        expect(permissionsTable).toExist();
+    });
+
+    it('Should open insert dropdown', () => {
+        const availableGroups = [
+            { label: 'Group 1', value: 'group1' },
+            { label: 'Group 2', value: 'group2' },
+            { label: 'Group 3', value: 'group3' },
+            { label: 'Group 4', value: 'group4' }
+        ];
+        ReactDOM.render(<PermissionEditor availableGroups={availableGroups} />, document.getElementById('container'));
+        const permissionsTable = document.getElementsByClassName('permissions-table')[0];
+        const input = ReactDOM.findDOMNode(permissionsTable).querySelector('input');
+        expect(input).toBeTruthy();
+        ReactTestUtils.act(() => {
+            ReactTestUtils.Simulate.focus(input);
+            ReactTestUtils.Simulate.keyDown(input, { key: 'ArrowDown', keyCode: 40 });
+        });
+        const selectMenuOuter = ReactDOM.findDOMNode(permissionsTable).querySelector('.insert-row .Select-menu-outer');
+        expect(selectMenuOuter).toExist();
+    });
+});

--- a/web/client/themes/default/less/maps-properties.less
+++ b/web/client/themes/default/less/maps-properties.less
@@ -36,6 +36,16 @@
                 }
             }
         }
+
+        .permissions-table {
+            .insert-row {
+                .Select {
+                    .Select-menu-outer {
+                        transform: translateY(-34px) translateY(-100%);
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Open group permissions dropdowns to up direction
![Screenshot from 2022-09-19 10-08-59](https://user-images.githubusercontent.com/18549629/190966144-5c10530d-c3fc-4137-b239-cc96501dd7b5.png)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8573 

**What is the new behavior?**
The dropdowns of the insert row open in up direction to assure they won't be hidden

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
I tried to change styles of parent containers to show dropdown over. It cannot be done safely because parent containers have `overflow:hidden`. Also even if we open this dropdown in down direction somehow, it will be shown out of the screen bounds for some screen sizes.