### PR TITLE
#8591 Fix chart legend ordering matching colorCatagories order

### DIFF
--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -228,6 +228,7 @@ function getData({
     let colorCategories = [];
     let data = dataUnsorted;
     if (classificationAttr && classificationType === "value")  {
+        // #8591 changing order of data for matching colorCategories order
         classifications = dataUnsorted.map(d => d[classificationAttr]);
         classificationColors = getClassification(classificationType, classifications, autoColorOptions, customColorEnabled).classificationColors;
         colorCategories = getClassification(classificationType, classifications, autoColorOptions, customColorEnabled).colorCategories;

--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -143,7 +143,7 @@ const getLegendLabel = (value, colorCategories, defaultClassLabel, type) => {
  * @param {number} value the classification value to be labelled
  * @param {object[]} colorCategories mapping objects value => label [{..., min: 100, max: 200, title: "Between 100 and 200"}, ...]
  * @param {string} defaultClassLabel the default label, if specified, to be shown in case there is no mapping for the value
- * @param {string} xValue the x value in the chart, to be shown as fall back in case value is not classfied nor defaultClassLabel exists
+ * @param {string} xValue the x value in the chart, to be shown as fall back in case value is not classified nor defaultClassLabel exists
  * @param {string} rangeClassAttribute the attributed name used to color code the chart, to be used if the value falls within a classification
  * range but no label exists for such classification
  * @returns {string} the assigned label to the classified value, or empty string
@@ -227,7 +227,7 @@ function getData({
     let classificationColors = [];
     let colorCategories = [];
     let data = dataUnsorted;
-    if (classificationAttr) {
+    if (classificationAttr && classificationType === "value")  {
         classifications = dataUnsorted.map(d => d[classificationAttr]);
         classificationColors = getClassification(classificationType, classifications, autoColorOptions, customColorEnabled).classificationColors;
         colorCategories = getClassification(classificationType, classifications, autoColorOptions, customColorEnabled).colorCategories;
@@ -239,12 +239,12 @@ function getData({
         const newData = dataSplit.map(dataAggregated => {
             const dataSorted = colorCategories.map(colorCat => {
                 return find(dataAggregated, (d) => d[classificationAttr] === colorCat.value);
-            });
+            }).filter(v => v);
             return dataSorted;
         });
         data = flatten(newData);
-        classifications = classificationAttr ? data.map(d => d[classificationAttr]) : [];
     }
+    classifications = classificationAttr ? data.map(d => d[classificationAttr]) : [];
     const x = data.map(d => d[xDataKey]);
     let y = data.map(d => d[yDataKey]);
 

--- a/web/client/components/charts/__tests__/WidgetChart-test.js
+++ b/web/client/components/charts/__tests__/WidgetChart-test.js
@@ -10,16 +10,20 @@ import {
     DATASET_1,
     DATASET_2,
     DATASET_3,
+    DATASET_5_UNORDERED,
+    DATASET_5_ORDERED,
     DATASET_4,
     LABELLED_CLASSIFICATION,
     LABELLED_RANGE_CLASSIFICATION,
     UNLABELLED_CLASSIFICATION,
     UNLABELLED_CLASSIFICATION_3,
+    UNLABELLED_CLASSIFICATION_5_ORDERED,
     UNLABELLED_RANGE_CLASSIFICATION,
     PIE_CHART_TEMPLATE_LABELS_CLASSIFICATION,
     PIE_CHART_TEMPLATE_LABELS_RANGE_CLASSIFICATION,
     SPLIT_DATASET_2,
     SPLIT_DATASET_3,
+    SPLIT_DATASET_5_ORDERED,
     TEMPLATE_LABELS_CLASSIFICATION,
     TEMPLATE_LABELS_RANGE_CLASSIFICATION,
     DATASET_WITH_DATES,
@@ -275,6 +279,41 @@ describe('Widget Chart: data conversions ', () => {
             // colors are those defined by the user
             data[0].marker.colors.map((v, i) => {
                 const classColor = UNLABELLED_CLASSIFICATION.filter(item => item.value === DATASET_3.data[i][CLASSIFICATIONS.dataKey])[0]?.color ?? autoColorOptions.defaultCustomColor;
+                expect(v).toBe(classColor);
+            });
+            // LAYOUT
+            expect(layout.margin).toEqual({t: 5, b: 5, l: 2, r: 2, pad: 4}); // fixed margins
+        });
+        it('custom classified colors - using default labels and colors, wrong order', () => {
+            const classification = UNLABELLED_CLASSIFICATION_5_ORDERED;
+            const autoColorOptions = {
+                defaultCustomColor: "#00ff00",
+                defaultClassLabel: "Default",
+                classification,
+                name: 'global.colors.custom'
+            };
+            const { data, layout } = toPlotly({
+                type: 'pie',
+                autoColorOptions,
+                classificationAttr: "classValue",
+                classifications: CLASSIFICATIONS,
+                options: {
+                    classificationAttributeType: 'string'
+                },
+                ...DATASET_5_UNORDERED
+            });
+            expect(data.length).toBe(1);
+            expect(data[0].type).toBe('pie');
+            expect(data[0].textposition).toEqual('inside');
+            // data values mapped
+            data[0].values.map((v, i) => expect(v).toBe(DATASET_5_ORDERED.data[i][DATASET_5_ORDERED.series[0].dataKey]));
+            // data labels mapped
+            data[0].labels.map((v, i) => {
+                expect(v).toBe(DATASET_5_ORDERED.data[i][DATASET_5_ORDERED.xAxis.dataKey]);
+            });
+            // colors are those defined by the user
+            data[0].marker.colors.map((v, i) => {
+                const classColor = classification.filter(item => item.value === DATASET_5_ORDERED.data[i][CLASSIFICATIONS.dataKey])[0]?.color ?? autoColorOptions.defaultCustomColor;
                 expect(v).toBe(classColor);
             });
             // LAYOUT
@@ -593,6 +632,42 @@ describe('Widget Chart: data conversions ', () => {
                 expect(layout.margin).toEqual({ t: 5, b: 30, l: 5, r: 5, pad: 4 });
             });
         });
+        it('custom classified colors - using default labels and colors, wrong order', () => {
+            const classification = UNLABELLED_CLASSIFICATION_5_ORDERED;
+            const autoColorOptions = {
+                defaultCustomColor: "#00ff00",
+                defaultClassLabel: "Default",
+                classification,
+                name: 'global.colors.custom'
+            };
+            const { data, layout } = toPlotly({
+                type: 'bar',
+                autoColorOptions,
+                classificationAttr: "classValue",
+                classifications: CLASSIFICATIONS,
+                options: {
+                    classificationAttributeType: 'string'
+                },
+                ...DATASET_5_UNORDERED
+            });
+            expect(data.length).toBe(1);
+            const traces = data[0];
+            expect(traces.length).toBe(3);
+            traces.forEach((trace, i) => {
+                expect(trace.type).toBe('bar');
+                // data values mapped
+                trace.y.map((v, j) => expect(v).toBe(SPLIT_DATASET_5_ORDERED.data[i][j][SPLIT_DATASET_5_ORDERED.series[0].dataKey]));
+                trace.x.map((v, j) => expect(v).toBe(SPLIT_DATASET_5_ORDERED.data[i][j][SPLIT_DATASET_5_ORDERED.xAxis.dataKey], "here 2"));
+                // data labels mapped
+                const classLabel = classification.filter(item => item.value === SPLIT_DATASET_5_ORDERED.data[i][0][CLASSIFICATIONS.dataKey])[0]?.value ?? autoColorOptions.defaultClassLabel;
+                expect(trace.name).toBe(classLabel);
+                // colors are those defined by the user
+                const classColor = classification.filter(item => item.value === SPLIT_DATASET_5_ORDERED.data[i][0][CLASSIFICATIONS.dataKey])[0]?.color ?? autoColorOptions.defaultCustomColor;
+                trace.marker.color.forEach(item => expect(item).toBe(classColor));
+                expect(layout.margin).toEqual({ t: 5, b: 30, l: 5, r: 5, pad: 4 });
+            });
+        });
+
         it('custom classified colors - using templatized labels and custom colors only - bar charts', () => {
             const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", classification: TEMPLATE_LABELS_CLASSIFICATION, name: 'global.colors.custom' };
             const { data, layout } = toPlotly({

--- a/web/client/components/charts/__tests__/WidgetChart-test.js
+++ b/web/client/components/charts/__tests__/WidgetChart-test.js
@@ -14,6 +14,7 @@ import {
     LABELLED_CLASSIFICATION,
     LABELLED_RANGE_CLASSIFICATION,
     UNLABELLED_CLASSIFICATION,
+    UNLABELLED_CLASSIFICATION_3,
     UNLABELLED_RANGE_CLASSIFICATION,
     PIE_CHART_TEMPLATE_LABELS_CLASSIFICATION,
     PIE_CHART_TEMPLATE_LABELS_RANGE_CLASSIFICATION,
@@ -217,8 +218,8 @@ describe('Widget Chart: data conversions ', () => {
         // LAYOUT
         expect(layout.margin).toEqual({t: 5, b: 5, l: 2, r: 2, pad: 4}); // fixed margins
     });
-    describe('Pie chart - Color coded custom classifications with absolute values', () => {
-        it('custom classified colors - using custom labels and colors only', () => {
+    describe('1) Pie chart - Color coded custom classifications with absolute values', () => {
+        it('custom classified colors - using custom labels and colors only 1', () => {
             const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", classification: LABELLED_CLASSIFICATION, name: 'global.colors.custom' };
             const { data, layout } = toPlotly({
                 type: 'pie',
@@ -248,7 +249,11 @@ describe('Widget Chart: data conversions ', () => {
             expect(layout.margin).toEqual({t: 5, b: 5, l: 2, r: 2, pad: 4}); // fixed margins
         });
         it('custom classified colors - using default labels and colors', () => {
-            const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "", classification: UNLABELLED_CLASSIFICATION, name: 'global.colors.custom' };
+            const autoColorOptions = {
+                defaultCustomColor: "#00ff00",
+                defaultClassLabel: "",
+                classification: UNLABELLED_CLASSIFICATION,
+                name: 'global.colors.custom' };
             const { data, layout } = toPlotly({
                 type: 'pie',
                 autoColorOptions,
@@ -329,7 +334,7 @@ describe('Widget Chart: data conversions ', () => {
             });
         });
     });
-    describe('Pie chart - Color coded custom classifications with range values', () => {
+    describe('2) Pie chart - Color coded custom classifications with range values', () => {
         it('custom classified colors - using custom labels and colors only', () => {
             const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", rangeClassification: LABELLED_RANGE_CLASSIFICATION, name: 'global.colors.custom' };
             const { data, layout } = toPlotly({
@@ -525,7 +530,7 @@ describe('Widget Chart: data conversions ', () => {
             });
         });
     });
-    describe('color coded/custom classified Bar chart with absolute values', () => {
+    describe('3) color coded/custom classified Bar chart with absolute values', () => {
         it('custom classified colors - using custom labels and colors only', () => {
             const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", classification: LABELLED_CLASSIFICATION, name: 'global.colors.custom' };
             const { data, layout } = toPlotly({
@@ -555,7 +560,13 @@ describe('Widget Chart: data conversions ', () => {
             });
         });
         it('custom classified colors - using default labels and colors', () => {
-            const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", classification: UNLABELLED_CLASSIFICATION, name: 'global.colors.custom' };
+            const classification = UNLABELLED_CLASSIFICATION_3;
+            const autoColorOptions = {
+                defaultCustomColor: "#00ff00",
+                defaultClassLabel: "Default",
+                classification,
+                name: 'global.colors.custom'
+            };
             const { data, layout } = toPlotly({
                 type: 'bar',
                 autoColorOptions,
@@ -574,10 +585,10 @@ describe('Widget Chart: data conversions ', () => {
                 trace.y.map((v, j) => expect(v).toBe(SPLIT_DATASET_3.data[i][j][SPLIT_DATASET_3.series[0].dataKey]));
                 trace.x.map((v, j) => expect(v).toBe(SPLIT_DATASET_3.data[i][j][SPLIT_DATASET_3.xAxis.dataKey]));
                 // data labels mapped
-                const classLabel = UNLABELLED_CLASSIFICATION.filter(item => item.value === SPLIT_DATASET_3.data[i][0][CLASSIFICATIONS.dataKey])[0]?.value ?? autoColorOptions.defaultClassLabel;
+                const classLabel = classification.filter(item => item.value === SPLIT_DATASET_3.data[i][0][CLASSIFICATIONS.dataKey])[0]?.value ?? autoColorOptions.defaultClassLabel;
                 expect(trace.name).toBe(classLabel);
                 // colors are those defined by the user
-                const classColor = UNLABELLED_CLASSIFICATION.filter(item => item.value === SPLIT_DATASET_3.data[i][0][CLASSIFICATIONS.dataKey])[0]?.color ?? autoColorOptions.defaultCustomColor;
+                const classColor = classification.filter(item => item.value === SPLIT_DATASET_3.data[i][0][CLASSIFICATIONS.dataKey])[0]?.color ?? autoColorOptions.defaultCustomColor;
                 trace.marker.color.forEach(item => expect(item).toBe(classColor));
                 expect(layout.margin).toEqual({ t: 5, b: 30, l: 5, r: 5, pad: 4 });
             });
@@ -632,9 +643,13 @@ describe('Widget Chart: data conversions ', () => {
             expect(layout.colorway).toEqual([autoColorOptions.defaultCustomColor]);
         });
     });
-    describe('color coded/custom classified Bar chart with range values', () => {
+    describe('4) color coded/custom classified Bar chart with range values', () => {
         it('custom classified colors - using custom labels and colors only', () => {
-            const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", rangeClassification: LABELLED_RANGE_CLASSIFICATION, name: 'global.colors.custom' };
+            const autoColorOptions = {
+                defaultCustomColor: "#00ff00",
+                defaultClassLabel: "Default",
+                rangeClassification: LABELLED_RANGE_CLASSIFICATION,
+                name: 'global.colors.custom' };
             const { data, layout } = toPlotly({
                 type: 'bar',
                 autoColorOptions,
@@ -736,7 +751,7 @@ describe('Widget Chart: data conversions ', () => {
         });
     });
     describe('color coded/custom classified Bar chart - common features', () => {
-        it('default classfied bar chart type is stacked', () => {
+        it('default classified bar chart type is stacked', () => {
             const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", classification: LABELLED_CLASSIFICATION, name: 'global.colors.custom' };
             const { data, layout } = toPlotly({
                 type: 'bar',
@@ -752,7 +767,7 @@ describe('Widget Chart: data conversions ', () => {
             expect(traces.length).toBe(2);
             expect(layout.barmode).toBe('stack');
         });
-        it('change classfied bar chart type to grouped', () => {
+        it('change classified bar chart type to grouped', () => {
             const autoColorOptions = { defaultCustomColor: "#00ff00", defaultClassLabel: "Default", classification: LABELLED_CLASSIFICATION, name: 'global.colors.custom' };
             const { data, layout } = toPlotly({
                 type: 'bar',

--- a/web/client/components/charts/__tests__/WidgetChart-test.js
+++ b/web/client/components/charts/__tests__/WidgetChart-test.js
@@ -1,9 +1,7 @@
-
 import React from 'react';
-import ReactDOM from 'react-dom';
-import WidgetChart, { toPlotly, defaultColorGenerator, COLOR_DEFAULTS } from '../WidgetChart';
-
 import expect from 'expect';
+import ReactDOM from 'react-dom';
+
 import {
     CLASSIFICATIONS,
     RANGE_CLASSIFICATIONS,
@@ -29,6 +27,7 @@ import {
     DATASET_WITH_DATES,
     SPLIT_DATASET_4
 } from './sample_data';
+import WidgetChart, { toPlotly, defaultColorGenerator, COLOR_DEFAULTS } from '../WidgetChart';
 
 describe('WidgetChart', () => {
     beforeEach((done) => {
@@ -95,7 +94,6 @@ describe('WidgetChart', () => {
         ReactDOM.render(<WidgetChart onInitialized={check} {...DATASET_1} type="bar" />, document.getElementById("container"));
     });
 });
-
 
 const TYPES = ['pie', 'line', 'bar'];
 
@@ -257,7 +255,9 @@ describe('Widget Chart: data conversions ', () => {
                 defaultCustomColor: "#00ff00",
                 defaultClassLabel: "",
                 classification: UNLABELLED_CLASSIFICATION,
-                name: 'global.colors.custom' };
+                name: 'global.colors.custom'
+            };
+
             const { data, layout } = toPlotly({
                 type: 'pie',
                 autoColorOptions,

--- a/web/client/components/charts/__tests__/sample_data.js
+++ b/web/client/components/charts/__tests__/sample_data.js
@@ -98,10 +98,10 @@ export const DATASET_5_UNORDERED = {
 export const DATASET_5_ORDERED = {
     data: [
         { name: 'Page A', value: 1, classValue: '1'},
-        { name: 'Page A', value: 1, classValue: '2'},
-        { name: 'Page A', value: 1, classValue: '3'},
         { name: 'Page B', value: 0, classValue: '1'},
+        { name: 'Page A', value: 1, classValue: '2'},
         { name: 'Page B', value: 10, classValue: '2'},
+        { name: 'Page A', value: 1, classValue: '3'},
         { name: 'Page B', value: 100, classValue: '3'}
     ],
     xAxis: { dataKey: "name" },

--- a/web/client/components/charts/__tests__/sample_data.js
+++ b/web/client/components/charts/__tests__/sample_data.js
@@ -13,9 +13,7 @@ export const DATASET_1 = {
 export const DATASET_2 = {
     data: [
         { name: 'Page A', value: 0, classValue: 'class1'},
-        { name: 'Page B', value: 1, classValue: 'class2'},
-        { name: 'Page C', value: 2, classValue: 'class2'},
-        { name: 'Page D', value: 3, classValue: 'class1'}
+        { name: 'Page B', value: 1, classValue: 'class2'}
     ],
     xAxis: { dataKey: "name" },
     series: [{ dataKey: "value" }]
@@ -57,7 +55,6 @@ export const SPLIT_DATASET_3 = {
     xAxis: { dataKey: "name" },
     series: [{ dataKey: "value" }]
 };
-
 
 export const DATASET_4 = {
     data: [
@@ -147,7 +144,6 @@ export const UNLABELLED_CLASSIFICATION_5_ORDERED = [
         unique: '3'
     }
 ];
-
 
 export const CLASSIFICATIONS = {
     dataKey: 'classValue'

--- a/web/client/components/charts/__tests__/sample_data.js
+++ b/web/client/components/charts/__tests__/sample_data.js
@@ -58,6 +58,7 @@ export const SPLIT_DATASET_3 = {
     series: [{ dataKey: "value" }]
 };
 
+
 export const DATASET_4 = {
     data: [
         { name: 'Page A', value: 0, classValue: 'class1'},
@@ -83,6 +84,70 @@ export const SPLIT_DATASET_4 = {
     xAxis: { dataKey: "name" },
     series: [{ dataKey: "value" }]
 };
+
+export const DATASET_5_UNORDERED = {
+    data: [
+        { name: 'Page A', value: 1, classValue: '2'},
+        { name: 'Page A', value: 1, classValue: '3'},
+        { name: 'Page A', value: 1, classValue: '1'},
+        { name: 'Page B', value: 10, classValue: '2'},
+        { name: 'Page B', value: 0, classValue: '1'},
+        { name: 'Page B', value: 100, classValue: '3'}
+    ],
+    xAxis: { dataKey: "name" },
+    series: [{ dataKey: "value" }]
+};
+
+export const DATASET_5_ORDERED = {
+    data: [
+        { name: 'Page A', value: 1, classValue: '1'},
+        { name: 'Page A', value: 1, classValue: '2'},
+        { name: 'Page A', value: 1, classValue: '3'},
+        { name: 'Page B', value: 0, classValue: '1'},
+        { name: 'Page B', value: 10, classValue: '2'},
+        { name: 'Page B', value: 100, classValue: '3'}
+    ],
+    xAxis: { dataKey: "name" },
+    series: [{ dataKey: "value" }]
+};
+
+export const SPLIT_DATASET_5_ORDERED = {
+    data: [
+        [
+            { name: 'Page A', value: 1, classValue: '1'},
+            { name: 'Page B', value: 0, classValue: '1'}
+        ],
+        [
+            { name: 'Page A', value: 1, classValue: '2'},
+            { name: 'Page B', value: 10, classValue: '2'}
+        ],
+        [
+            { name: 'Page A', value: 1, classValue: '3'},
+            { name: 'Page B', value: 100, classValue: '3'}
+        ]
+    ],
+    xAxis: { dataKey: "name" },
+    series: [{ dataKey: "value" }]
+};
+
+export const UNLABELLED_CLASSIFICATION_5_ORDERED = [
+    {
+        color: '#0000ff',
+        value: '1',
+        unique: '1'
+    },
+    {
+        color: '#00FF00',
+        value: '2',
+        unique: '2'
+    },
+    {
+        color: '#ff0000',
+        value: '3',
+        unique: '3'
+    }
+];
+
 
 export const CLASSIFICATIONS = {
     dataKey: 'classValue'

--- a/web/client/components/charts/__tests__/sample_data.js
+++ b/web/client/components/charts/__tests__/sample_data.js
@@ -194,6 +194,14 @@ export const UNLABELLED_CLASSIFICATION = [
         unique: 'class2'
     }
 ];
+export const UNLABELLED_CLASSIFICATION_3 = [
+    ...UNLABELLED_CLASSIFICATION,
+    {
+        color: '#00FF00',
+        value: 'class3',
+        unique: 'class3'
+    }
+];
 
 export const UNLABELLED_RANGE_CLASSIFICATION = [
     {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1864,7 +1864,7 @@
                         "classLabel": "Class Label",
                         "classValue": "Class Value",
                         "color": "Color",
-                        "confirmModalMessage": "Close and discard unclassfied values?",
+                        "confirmModalMessage": "Close and discard unclassified values?",
                         "classificationAttribute": "Classification Attribute",
                         "customLabels": "Custom Labels",
                         "barChartCustomLabelsExample": "<div><p><code>${legendValue}</code> can be used as placeholder for the Y Attribute.</p><p></p><h5>Example</h5><dl><dt><b>Y Attribute:</b></dt><dd>POPULATION</dd><dt><b>Class Label:</b></dt><dd><code>${legendValue}</code> California</dd><dt><b>Result:</b></dt><dd>POPULATION California</dd></dl></div>",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Now charts shows unordered data based on classification label list for "value" type
dashboard with id [dev-41396](https://dev-mapstore.geosolutionsgroup.com/mapstore/#/dashboard/41396) can be a dashboard to be used for testing

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8591

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Data are now sorted based on custom classification label order

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
