### PR TITLE
#8520: Widget title ellipsis

### DIFF
--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -162,6 +162,8 @@
             flex-direction: row;
             align-items: center;
             .widget-title {
+                white-space: nowrap;
+                overflow: hidden;
                 text-overflow: ellipsis;
                 width: calc(100% - 30px);
                 .setFontSize(@font-size-base);


### PR DESCRIPTION
## Description
Widget title forms ellipsis when title is lengthy

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
[#8520](https://github.com/geosolutions-it/MapStore2/issues/8520#issuecomment-1253534172)

**What is the new behavior?**
![image](https://user-images.githubusercontent.com/26929983/191491958-4c37eb2c-1163-4513-8b97-af760e0b0cdb.png)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
