### PR TITLE
#8600 BIL Terrain is not visible after switching between 3D/2D/3D

### DIFF
--- a/web/client/utils/cesium/GeoServerBILTerrainProvider.js
+++ b/web/client/utils/cesium/GeoServerBILTerrainProvider.js
@@ -402,7 +402,7 @@ GeoServerBILTerrainProvider.prototype.getHeightmapTerrainDataArray = function(x,
         const hasChildren = terrainChildrenMask(x, y, level, this._options);
         if (tilesCache[urlValue]) {
             // we need .when because sampleTerrain expect to use .otherwise
-            return when(Promise.resolve(tilesCache[urlValue]));
+            return when(Promise.resolve(new HeightmapTerrainData(tilesCache[urlValue])));
         }
         const proxy = this._options.proxy || { getURL: v => v };
         requestPromise = Resource.fetchArrayBuffer({
@@ -418,7 +418,7 @@ GeoServerBILTerrainProvider.prototype.getHeightmapTerrainDataArray = function(x,
         if (defined(requestPromise)) {
             return requestPromise
                 .then((arrayBuffer) => {
-                    tilesCache[urlValue] = this.arrayToHeightmapTerrainData(
+                    tilesCache[urlValue] = this.arrayToHeightmapTerrainDataOptions(
                         arrayBuffer,
                         limitations,
                         {
@@ -430,7 +430,7 @@ GeoServerBILTerrainProvider.prototype.getHeightmapTerrainDataArray = function(x,
                         this._options.littleEndian,
                         hasChildren
                     );
-                    return tilesCache[urlValue];
+                    return new HeightmapTerrainData(tilesCache[urlValue]);
                 })
                 .otherwise(() => {
                     return new HeightmapTerrainData({
@@ -447,7 +447,7 @@ GeoServerBILTerrainProvider.prototype.getHeightmapTerrainDataArray = function(x,
     return requestPromise;
 };
 
-GeoServerBILTerrainProvider.prototype.arrayToHeightmapTerrainData = function(arrayBuffer, limitations, size, formatArray, hasWaterMask, littleEndian, childrenMask) {
+GeoServerBILTerrainProvider.prototype.arrayToHeightmapTerrainDataOptions = function(arrayBuffer, limitations, size, formatArray, hasWaterMask, littleEndian, childrenMask) {
     let sizeValue = size;
     if (typeof (sizeValue) === "number") {
         sizeValue = { width: sizeValue, height: sizeValue };
@@ -479,7 +479,7 @@ GeoServerBILTerrainProvider.prototype.arrayToHeightmapTerrainData = function(arr
         }
         optionsHeihtmapTerrainData.waterMask = waterMask;
     }
-    return new HeightmapTerrainData(optionsHeihtmapTerrainData);
+    return optionsHeihtmapTerrainData;
 };
 
 GeoServerBILTerrainProvider.prototype.requestTileGeometry = function(x, y, level) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The terrain cache was storing also the cesium classes so it was not invalid for a new instance of cesium map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8600

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The terrain is visible after the switch to 3D

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
