### PR TITLE
#8597 Simplifying query params

### DIFF
--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -205,9 +205,13 @@ If so, it will postpone search to ensure that layer is added to the map. Otherwi
 immediately.
 
 GET: `#/viewer/openlayers/new?addLayers=layer1|service&mapinfo=layer1&mapInfoFilter="BB='cc'"`
-Where `layer1` is layer name. `service` is the service name providing layer data. Service name is optional,
-service selected by default will be used if it is omitted.
-`mapInfoFilter` is a cql filter applied to the layer.
+
+Where : 
+
+- `layer1` is layer name. 
+- `service` is the service name providing layer data. Service name is optional. If missing the default.
+- `mapInfoFilter` is a cql filter applied to the layer.
+
 
 ### Background
 
@@ -216,6 +220,7 @@ Supports default backgrounds provided by static service defined in `localConfig.
 as other layers:
 
 `#/viewer/openlayers/new?background=Sentinel`
+
 `#/viewer/openlayers/new?background=layer1|service`
 
 Where `Sentinel` & `layer1` are layer names, `service` is the service name providing layer data. Service name is optional,

--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -196,7 +196,7 @@ In the example above:
 - `layer1` and `layer2` are layer names;
 - `service` is the service identifier of the catalog.
 If no service is provided, the default service will be used.
-- `layerFilters` is a list of cql filters delimited by a semicolon (`;`) to apply to the corresponding layer in the same position of the `addLayers` parameter
+- `layerFilters` is a list of cql filters to apply to the corresponding layer in the same position of the `addLayers` parameter, separated by `;`
 
 ### MapInfo
 

--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -187,12 +187,16 @@ GET: `#/viewer/openlayers/config?bbox=8,8,53,53`
 
 This is a shortened syntax for `CATALOG:ADD_LAYERS_FROM_CATALOGS` action described down below.
 
-GET: `#/viewer/openlayers/config?addLayers=tiger:layer1|service,layer2&layerFilters="MM='nn'"`
+GET: `#/viewer/openlayers/config?addLayers=layer1;service,layer2&layerFilters=MM='nn'`
 
-Where `layer1` and `layer2` are layer names. `service` is the service name providing layer data. Service name is optional,
-service selected by default will be used if it is omitted.
-`layerFilters` is a comma-separated list of cql filters to apply to the corresponding layer.
-E.g. `layerFilters="MM='nn'","CC='bb'"`
+`addLayers` parameter is a comma separated list of `<layerName>;<service>` (`service` is optional, and if present is separated
+from the layerName by a `;`.
+
+In the example above:
+- `layer1` and `layer2` are layer names;
+- `service` is the service identifier of the catalog.
+If no service is provided, the default service will be used.
+- `layerFilters` is a comma-separated list of cql filters to apply to the corresponding layer in the same position of the `addLayers` parameter
 
 ### MapInfo
 
@@ -204,9 +208,9 @@ In this case search execution will be postponed up to the moment when layer is a
 If so, it will postpone search to ensure that layer is added to the map. Otherwise, in case of no matches, search will execute
 immediately.
 
-GET: `#/viewer/openlayers/new?addLayers=layer1|service&mapinfo=layer1&mapInfoFilter="BB='cc'"`
+GET: `#/viewer/openlayers/new?addLayers=layer1;service&mapinfo=layer1&mapInfoFilter=BB='cc'`
 
-Where : 
+Where:
 
 - `layer1` is layer name. 
 - `service` is the service name providing layer data. Service name is optional. If missing the default.
@@ -221,10 +225,13 @@ as other layers:
 
 `#/viewer/openlayers/new?background=Sentinel`
 
-`#/viewer/openlayers/new?background=layer1|service`
+`#/viewer/openlayers/new?background=layer1;service`
 
-Where `Sentinel` & `layer1` are layer names, `service` is the service name providing layer data. Service name is optional,
+Where:
+- `Sentinel` & `layer1` are layer names,
+- `service` is the service name providing layer data. Service name is optional,
 `default_map_backgrounds` will be used if it is omitted.
+
 According to the implementation of default service, it is enough to pass desired layer name even partially, e.g. `background=Sen`, 
 it will use the closest layer name match in this case.
 

--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -187,7 +187,7 @@ GET: `#/viewer/openlayers/config?bbox=8,8,53,53`
 
 This is a shortened syntax for `CATALOG:ADD_LAYERS_FROM_CATALOGS` action described down below.
 
-GET: `#/viewer/openlayers/config?addLayers=layer1;service,layer2&layerFilters=MM='nn'`
+GET: `#/viewer/openlayers/config?addLayers=layer1;service,layer2&layerFilters=MM='nn';Aa='bb'`
 
 `addLayers` parameter is a comma separated list of `<layerName>;<service>` (`service` is optional, and if present is separated
 from the layerName by a `;`.
@@ -196,7 +196,7 @@ In the example above:
 - `layer1` and `layer2` are layer names;
 - `service` is the service identifier of the catalog.
 If no service is provided, the default service will be used.
-- `layerFilters` is a comma-separated list of cql filters to apply to the corresponding layer in the same position of the `addLayers` parameter
+- `layerFilters` is a list of cql filters delimited by a semicolon (`;`) to apply to the corresponding layer in the same position of the `addLayers` parameter
 
 ### MapInfo
 

--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -187,7 +187,7 @@ GET: `#/viewer/openlayers/config?bbox=8,8,53,53`
 
 This is a shortened syntax for `CATALOG:ADD_LAYERS_FROM_CATALOGS` action described down below.
 
-GET: `#/viewer/openlayers/config?addLayers=layer1;service,layer2&layerFilters=MM='nn';Aa='bb'`
+GET: `#/viewer/openlayers/config?addLayers=layer1;service,layer2&layerFilters=attributeLayer1='value';attributeLayer2='value2'`
 
 `addLayers` parameter is a comma separated list of `<layerName>;<service>` (`service` is optional, and if present is separated
 from the layerName by a `;`.

--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -149,6 +149,12 @@ GET: `#/viewer/openlayers/config?featureinfo={"lat": 43.077, "lng": 12.656, "fil
 
 GET: `#/viewer/openlayers/config?featureinfo={"lat": 43.077, "lng": 12.656, "filterNameList": ["layerName1", "layerName2"]}`
 
+#### Simplified syntax:
+
+GET: `#/viewer/openlayers/config?featureInfo=38.72,-95.625`
+
+Where lat,lng values are comma-separated respecting order.
+
 ### Map
 
 Allows to pass the entire map JSON definition (see the map configuration format of MapStore). 
@@ -176,6 +182,46 @@ GET: `#/viewer/openlayers/config?marker=0,0&zoom=5`
 ### Bbox
 
 GET: `#/viewer/openlayers/config?bbox=8,8,53,53`
+
+### AddLayers
+
+This is a shortened syntax for `CATALOG:ADD_LAYERS_FROM_CATALOGS` action described down below.
+
+GET: `#/viewer/openlayers/config?addLayers=tiger:layer1|service,layer2&layerFilters="MM='nn'"`
+
+Where `layer1` and `layer2` are layer names. `service` is the service name providing layer data. Service name is optional,
+service selected by default will be used if it is omitted.
+`layerFilters` is a comma-separated list of cql filters to apply to the corresponding layer.
+E.g. `layerFilters="MM='nn'","CC='bb'"`
+
+### MapInfo
+
+This is a shortened syntax for `SEARCH:SEARCH_WITH_FILTER` action described down below.
+In opposite to direct usage of action, `mapInfo` parameter can work with layers added by `addLayers` parameter.
+In this case search execution will be postponed up to the moment when layer is added to the map.
+
+`mapInfo` handler will check if `addLayers` parameter is present and if it lists layer name used in `mapInfo` parameter.
+If so, it will postpone search to ensure that layer is added to the map. Otherwise, in case of no matches, search will execute
+immediately.
+
+GET: `#/viewer/openlayers/new?addLayers=layer1|service&mapinfo=layer1&mapInfoFilter="BB='cc'"`
+Where `layer1` is layer name. `service` is the service name providing layer data. Service name is optional,
+service selected by default will be used if it is omitted.
+`mapInfoFilter` is a cql filter applied to the layer.
+
+### Background
+
+Allows to dynamically add background to the map and activate it.
+Supports default backgrounds provided by static service defined in `localConfig.json` (`default_map_backgrounds`) as well
+as other layers:
+
+`#/viewer/openlayers/new?background=Sentinel`
+`#/viewer/openlayers/new?background=layer1|service`
+
+Where `Sentinel` & `layer1` are layer names, `service` is the service name providing layer data. Service name is optional,
+`default_map_backgrounds` will be used if it is omitted.
+According to the implementation of default service, it is enough to pass desired layer name even partially, e.g. `background=Sen`, 
+it will use the closest layer name match in this case.
 
 ### Actions
 

--- a/web/client/actions/__tests__/backgroundselector-test.js
+++ b/web/client/actions/__tests__/backgroundselector-test.js
@@ -7,7 +7,8 @@
  */
 
 import expect from 'expect';
-import {CREATE_BACKGROUNDS_LIST,
+import {
+    CREATE_BACKGROUNDS_LIST,
     ADD_BACKGROUND,
     ADD_BACKGROUND_PROPERTIES,
     UPDATE_BACKGROUND_THUMBNAIL,
@@ -20,7 +21,8 @@ import {CREATE_BACKGROUNDS_LIST,
     updateThumbnail,
     clearModalParameters,
     clearBackgrounds,
-    removeBackground} from '../backgroundselector';
+    removeBackground, syncActiveBackgroundLayer, SYNC_CURRENT_BACKGROUND_LAYER
+} from '../backgroundselector';
 
 describe('Test backgroundSelector actions', () => {
     it('test accessing catalog from backgroundSelector', () => {
@@ -69,5 +71,11 @@ describe('Test backgroundSelector actions', () => {
         const action = clearModalParameters();
         expect(action).toExist();
         expect(action.type).toBe(CLEAR_MODAL_PARAMETERS);
+    });
+    it('test syncActiveBackgroundLayer', () => {
+        const action = syncActiveBackgroundLayer('id');
+        expect(action).toExist();
+        expect(action.type).toBe(SYNC_CURRENT_BACKGROUND_LAYER);
+        expect(action.id).toBe('id');
     });
 });

--- a/web/client/actions/__tests__/search-test.js
+++ b/web/client/actions/__tests__/search-test.js
@@ -17,14 +17,16 @@ import {
     TEXT_SEARCH_NESTED_SERVICES_SELECTED,
     TEXT_SEARCH_CANCEL_ITEM,
     UPDATE_RESULTS_STYLE,
-    changeActiveSearchTool,
     CHANGE_SEARCH_TOOL,
-    zoomAndAddPoint,
     ZOOM_ADD_POINT,
-    changeFormat,
     CHANGE_FORMAT,
-    changeCoord,
+    SCHEDULE_SEARCH_LAYER_WITH_FILTER,
     CHANGE_COORD,
+    HIDE_MARKER,
+    changeActiveSearchTool,
+    zoomAndAddPoint,
+    changeFormat,
+    changeCoord,
     searchResultLoaded,
     searchTextLoading,
     searchResultError,
@@ -34,7 +36,7 @@ import {
     cancelSelectedItem,
     updateResultsStyle,
     hideMarker,
-    HIDE_MARKER
+    scheduleSearchLayerWithFilter
 } from '../search';
 
 describe('Test correctness of the search actions', () => {
@@ -138,5 +140,12 @@ describe('Test correctness of the search actions', () => {
         const retval = hideMarker();
         expect(retval).toExist();
         expect(retval.type).toBe(HIDE_MARKER);
+    });
+    it('scheduleSearchLayerWithFilter', () => {
+        const retval = scheduleSearchLayerWithFilter({ layer: 'layer1', cql_filter: "mm='nn'"});
+        expect(retval).toExist();
+        expect(retval.type).toBe(SCHEDULE_SEARCH_LAYER_WITH_FILTER);
+        expect(retval.layer).toBe('layer1');
+        expect(retval.cql_filter).toBe("mm='nn'");
     });
 });

--- a/web/client/actions/backgroundselector.js
+++ b/web/client/actions/backgroundselector.js
@@ -24,6 +24,7 @@ export const CREATE_BACKGROUNDS_LIST = 'BACKGROUND_SELECTOR:CREATE_BACKGROUNDS_L
 export const CLEAR_MODAL_PARAMETERS = 'BACKGROUND_SELECTOR:CLEAR_MODAL_PARAMETERS';
 export const CONFIRM_DELETE_BACKGROUND_MODAL = 'BACKGROUND_SELECTOR:CONFIRM_DELETE_BACKGROUND_MODAL';
 export const ALLOW_BACKGROUNDS_DELETION = 'BACKGROUND_SELECTOR:ALLOW_BACKGROUNDS_DELETION';
+export const SYNC_CURRENT_BACKGROUND_LAYER = 'BACKGROUND_SELECTOR:SYNC_CURRENT_BACKGROUND_LAYER';
 
 export function createBackgroundsList(backgrounds) {
     return {
@@ -71,6 +72,14 @@ export function setCurrentBackgroundLayer(layerId) {
     return {
         type: SET_CURRENT_BACKGROUND_LAYER,
         layerId
+    };
+}
+
+
+export function syncActiveBackgroundLayer(id) {
+    return {
+        type: SYNC_CURRENT_BACKGROUND_LAYER,
+        id
     };
 }
 

--- a/web/client/actions/search.js
+++ b/web/client/actions/search.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
 */
 export const SEARCH_LAYER_WITH_FILTER = 'SEARCH:SEARCH_WITH_FILTER';
+export const SCHEDULE_SEARCH_LAYER_WITH_FILTER = 'SEARCH:SCHEDULE_SEARCH_LAYER_WITH_FILTER';
 export const TEXT_SEARCH_STARTED = 'TEXT_SEARCH_STARTED';
 export const TEXT_SEARCH_RESULTS_LOADED = 'TEXT_SEARCH_RESULTS_LOADED';
 export const TEXT_SEARCH_PERFORMED = 'TEXT_SEARCH_PERFORMED';
@@ -53,6 +54,25 @@ export function searchLayerWithFilter({layer, cql_filter} = {}) {
         cql_filter: cql_filter
     };
 }
+
+/**
+ * used to trigger two wfs requests GetFeature and then GetFeatureInfo
+ * does not execute requests immediately, rely on epic to await for the time when layer is added to the map
+ * and only then actual 'searchLayerWithFilter' action is dispatched
+ * @memberof actions.search
+ * @prop {object} options {layer, cql_filter}
+ * @prop {string} options.cql_filter optional filter to apply for both requests
+ * @prop {string} options.layer name of the layer with workspace
+ */
+// eslint-disable-next-line camelcase
+export function scheduleSearchLayerWithFilter({layer, cql_filter} = {}) {
+    return {
+        type: SCHEDULE_SEARCH_LAYER_WITH_FILTER,
+        layer,
+        cql_filter: cql_filter
+    };
+}
+
 /**
  * zoom to a specific point
  * @memberof actions.search

--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -20,6 +20,9 @@ import { onLocationChanged } from 'connected-react-router';
 import {toggleControl} from "../../actions/controls";
 import {layerLoad} from "../../actions/layers";
 import {FEATURE_INFO_CLICK} from "../../actions/mapInfo";
+import {SEARCH_LAYER_WITH_FILTER} from "../../actions/search";
+import {ADD_LAYERS_FROM_CATALOGS} from "../../actions/catalog";
+import {SYNC_CURRENT_BACKGROUND_LAYER} from "../../actions/backgroundselector";
 
 const center = {
     x: -74.2,
@@ -397,7 +400,7 @@ describe('queryparam epics', () => {
                 done();
             }, state);
     });
-    it('test readQueryParamsOnMapEpic with featureinfo and zoom in sessionStorage', (done) => {
+    it('test readQueryParamsOnMapEpic with featureinfo in sessionStorage', (done) => {
         sessionStorage.setItem('queryParams', JSON.stringify({featureinfo: {lat: 0, lng: 0, filterNameList: []}}));
         const state = {
             router: {
@@ -749,5 +752,179 @@ describe('queryparam epics', () => {
                 done(e);
             }
         }, state);
+    });
+    it('simplified featureinfo request', (done)=>{
+        const NUMBER_OF_ACTIONS = 1;
+        const state = {
+            maptype: {
+                mapType: 'openlayers'
+            },
+            router: {
+                location: {
+                    search: "?featureInfo=38.72,-95.625"
+                }
+            }
+        };
+        testEpic(
+            addTimeoutEpic(readQueryParamsOnMapEpic, 10),
+            NUMBER_OF_ACTIONS, [
+                onLocationChanged({}),
+                layerLoad()
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                try {
+                    expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
+                    expect(actions[0].point.latlng).toEqual({lat: '38.72', lng: '-95.625'});
+                    expect(actions[0].point.pixel).toBe(undefined);
+                    expect(actions[0].point.geometricFilter).toExist();
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }, state);
+    });
+    it('simplified mapInfo request', (done)=>{
+        const NUMBER_OF_ACTIONS = 1;
+        const state = {
+            maptype: {
+                mapType: 'openlayers'
+            },
+            router: {
+                location: {
+                    search: "?mapinfo=tiger:poly_landmarks&mapInfoFilter=\"CFCC='H41'\""
+                }
+            }
+        };
+        testEpic(
+            addTimeoutEpic(readQueryParamsOnMapEpic, 10),
+            NUMBER_OF_ACTIONS, [
+                onLocationChanged({}),
+                layerLoad()
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                try {
+                    expect(actions[0].type).toBe(SEARCH_LAYER_WITH_FILTER);
+                    expect(actions[0].layer).toBe("tiger:poly_landmarks");
+                    expect(actions[0].cql_filter).toBe("CFCC='H41'");
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }, state);
+    });
+    it('simplified addLayers request', (done)=>{
+        const NUMBER_OF_ACTIONS = 1;
+        const state = {
+            maptype: {
+                mapType: 'openlayers'
+            },
+            router: {
+                location: {
+                    search: "?addLayers=tiger:poly_landmarks|gs_stable_wms,anotherLayer&layerFilters=\"CFCC='H41'\""
+                }
+            },
+            catalog: {
+                selectedService: 'service'
+            }
+        };
+        testEpic(
+            addTimeoutEpic(readQueryParamsOnMapEpic, 10),
+            NUMBER_OF_ACTIONS, [
+                onLocationChanged({}),
+                layerLoad()
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                try {
+                    expect(actions[0].type).toBe(ADD_LAYERS_FROM_CATALOGS);
+                    expect(actions[0].layers[0]).toBe("tiger:poly_landmarks");
+                    expect(actions[0].sources[0]).toBe("gs_stable_wms");
+                    expect(actions[0].layers[1]).toBe("anotherLayer");
+                    expect(actions[0].sources[1]).toBe("service");
+                    expect(actions[0].options[0].params.CQL_FILTER).toBe("CFCC='H41'");
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }, state);
+    });
+    it('add background', (done)=>{
+        const NUMBER_OF_ACTIONS = 2;
+        const state = {
+            maptype: {
+                mapType: 'openlayers'
+            },
+            router: {
+                location: {
+                    search: "?background=Sentinel"
+                }
+            },
+            catalog: {
+                selectedService: 'service',
+                "staticServices": {
+                    "default_map_backgrounds": {
+                        "type": "backgrounds",
+                        "title": "Default Backgrounds",
+                        "titleMsgId": "defaultMapBackgroundsServiceTitle",
+                        "autoload": true,
+                        "backgrounds": [{
+                            "type": "osm",
+                            "title": "Open Street Map",
+                            "name": "mapnik",
+                            "source": "osm",
+                            "group": "background"
+                        }, {
+                            "type": "tileprovider",
+                            "title": "NASAGIBS Night 2012",
+                            "provider": "NASAGIBS.ViirsEarthAtNight2012",
+                            "name": "Night2012",
+                            "source": "nasagibs",
+                            "group": "background"
+                        }, {
+                            "type": "tileprovider",
+                            "title": "OpenTopoMap",
+                            "provider": "OpenTopoMap",
+                            "name": "OpenTopoMap",
+                            "source": "OpenTopoMap",
+                            "group": "background"
+                        }, {
+                            "format": "image/jpeg",
+                            "group": "background",
+                            "name": "s2cloudless:s2cloudless",
+                            "opacity": 1,
+                            "title": "Sentinel 2 Cloudless",
+                            "type": "wms",
+                            "url": "https://1maps.geo-solutions.it/geoserver/wms",
+                            "source": "s2cloudless",
+                            "singleTile": false
+                        }, {
+                            "source": "ol",
+                            "group": "background",
+                            "title": "Empty Background",
+                            "fixed": true,
+                            "type": "empty"
+                        }]
+                    }
+                }
+            }
+        };
+        testEpic(
+            addTimeoutEpic(readQueryParamsOnMapEpic, 10),
+            NUMBER_OF_ACTIONS, [
+                onLocationChanged({}),
+                layerLoad()
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                try {
+                    expect(actions[0].type).toBe(ADD_LAYERS_FROM_CATALOGS);
+                    expect(actions[0].layers[0]).toBe("Sentinel");
+                    expect(actions[0].sources[0]).toBe("default_map_backgrounds");
+                    expect(actions[0].options[0].group).toBe("background");
+                    expect(actions[0].options[0].visibility).toBe(true);
+                    expect(actions[1].type).toBe(SYNC_CURRENT_BACKGROUND_LAYER);
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }, state);
     });
 });

--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -791,7 +791,7 @@ describe('queryparam epics', () => {
             },
             router: {
                 location: {
-                    search: "?mapinfo=tiger:poly_landmarks&mapInfoFilter=\"CFCC='H41'\""
+                    search: "?mapinfo=tiger:poly_landmarks&mapInfoFilter=CFCC='H41'"
                 }
             }
         };
@@ -820,7 +820,7 @@ describe('queryparam epics', () => {
             },
             router: {
                 location: {
-                    search: "?addLayers=tiger:poly_landmarks|gs_stable_wms,anotherLayer&layerFilters=\"CFCC='H41'\""
+                    search: "?addLayers=tiger:poly_landmarks;gs_stable_wms,anotherLayer&layerFilters=CFCC='H41'"
                 }
             },
             catalog: {

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -54,7 +54,7 @@ import {
     searchOptionsSelector,
     catalogSearchInfoSelector,
     getFormatUrlUsedSelector,
-    isActiveSelector
+    isActiveSelector, servicesSelectorWithBackgrounds
 } from '../selectors/catalog';
 import { metadataSourceSelector } from '../selectors/backgroundselector';
 import { currentMessagesSelector } from "../selectors/locale";
@@ -147,9 +147,9 @@ export default (API) => ({
             .filter(({ layers, sources }) => isArray(layers) && isArray(sources) && layers.length && layers.length === sources.length)
             // maxRecords is 4 (by default), but there can be a possibility that the record desired is not among
             // the results. In that case a more detailed search with full record name can be helpful
-            .switchMap(({ layers, sources, options, startPosition = 1, maxRecords = 4 }) => {
+            .mergeMap(({ layers, sources, options, startPosition = 1, maxRecords = 4 }) => {
                 const state = store.getState();
-                const services = servicesSelector(state);
+                const services = servicesSelectorWithBackgrounds(state);
                 const actions = layers
                     .filter((l, i) => !!services[sources[i]] || typeof sources[i] === 'object') // check for catalog name or object definition
                     .map((l, i) => {

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -40,7 +40,8 @@ import {
     searchItemSelected,
     searchOnStartEpic,
     textSearchShowGFIEpic,
-    zoomAndAddPointEpic
+    zoomAndAddPointEpic,
+    delayedSearchEpic
 } from '../epics/search';
 import mapInfoReducers from '../reducers/mapInfo';
 import searchReducers from '../reducers/search';
@@ -417,7 +418,7 @@ export default {
                 priority: 1
             }
         }),
-    epics: {searchEpic, searchOnStartEpic, searchItemSelected, zoomAndAddPointEpic, textSearchShowGFIEpic},
+    epics: {searchEpic, searchOnStartEpic, searchItemSelected, zoomAndAddPointEpic, textSearchShowGFIEpic, delayedSearchEpic},
     reducers: {
         search: searchReducers,
         mapInfo: mapInfoReducers

--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -14,12 +14,20 @@ import {isValidExtent} from "./CoordinatesUtils";
 import {getCenter, getConfigProp} from "./ConfigUtils";
 import {updatePointWithGeometricFilter} from "./IdentifyUtils";
 import {mapProjectionSelector} from "./PrintUtils";
-import {ADD_LAYERS_FROM_CATALOGS} from "../actions/catalog";
+import {ADD_LAYERS_FROM_CATALOGS, addLayersMapViewerUrl} from "../actions/catalog";
 import {changeMapView, ZOOM_TO_EXTENT, zoomToExtent} from "../actions/map";
 import {mapSelector} from "../selectors/map";
 import {featureInfoClick} from "../actions/mapInfo";
 import {warning} from "../actions/notifications";
-import {addMarker, SEARCH_LAYER_WITH_FILTER} from "../actions/search";
+import {
+    addMarker,
+    scheduleSearchLayerWithFilter,
+    SEARCH_LAYER_WITH_FILTER,
+    searchLayerWithFilter
+} from "../actions/search";
+import uuid from "uuid/v1";
+import {syncActiveBackgroundLayer} from "../actions/backgroundselector";
+import {selectedServiceSelector} from "../selectors/catalog";
 
 /**
  * Retrieves parameters from hash "query string" of react router
@@ -111,7 +119,8 @@ export const getRequestParameterValue = (name, state, storage = sessionStorage) 
 export const getParametersValues = (paramActions, state) => (
     Object.keys(paramActions)
         .reduce((params, parameter) => {
-            const value = getRequestParameterValue(parameter, state, sessionStorage);
+            const lowercase = parameter.toLowerCase();
+            const value = getRequestParameterValue(parameter, state, sessionStorage) ?? getRequestParameterValue(lowercase, state, sessionStorage);
             return {
                 ...params,
                 ...(!isNil(value) ? { [parameter]: value } : {})
@@ -222,28 +231,97 @@ export const paramActions = {
             })
         ];
     },
-    featureinfo: (parameters, state) => {
-        const value = parameters.featureinfo;
+    featureInfo: (parameters, state) => {
+        const value = parameters.featureInfo;
         const {lat, lng, filterNameList} = value;
+        const projection = mapProjectionSelector(state);
         if (typeof lat !== 'undefined' && typeof lng !== 'undefined') {
-            const projection = mapProjectionSelector(state);
             return [featureInfoClick(updatePointWithGeometricFilter({
                 latlng: {
                     lat,
                     lng
                 }
             }, projection), false, filterNameList ?? [])];
+        } else if (typeof value === 'string') {
+            const [latitude, longitude] = value.split(',');
+            if (typeof latitude !== 'undefined' && typeof longitude !== 'undefined') {
+                return [featureInfoClick(updatePointWithGeometricFilter({
+                    latlng: {
+                        lat: latitude,
+                        lng: longitude
+                    }
+                }, projection), false, [])];
+            }
         }
         return [];
     },
-    zoom: () => {
+    mapInfo: (parameters) => {
+        const value = parameters.mapInfo;
+        const filterValue = parameters.mapInfoFilter;
+        if (typeof value === 'string') {
+            // use delayed action dispatching if we have same layer name for mapInfo parameter and addLayers parameter
+            const layers = parameters.addLayers;
+            if (typeof layers === 'string') {
+                const parsed = layers.split(',');
+                const pairs = parsed.map(el => el.split(/[;|]/));
+                if (pairs.find(el => el[0] === value)) {
+                    return [
+                        scheduleSearchLayerWithFilter({layer: value, cql_filter: filterValue ?? ''})
+                    ];
+                }
+            }
+            return [
+                searchLayerWithFilter({layer: value, cql_filter: filterValue ?? ''})
+            ];
+        }
+        return [];
     },
-    heading: () => {
+    addLayers: (parameters, state) => {
+        const layers = parameters.addLayers;
+        if (typeof layers === 'string') {
+            const parsed = layers.split(',');
+            if (parsed.length) {
+                const defaultSource = selectedServiceSelector(state);
+                const pairs = parsed.map(el => el.split(/[;|]/));
+                const layerFilters = (parameters.layerFilters ?? '').split(',') ?? [];
+                return [
+                    addLayersMapViewerUrl(
+                        pairs.map(el => el[0]),
+                        pairs.map(el => el[1] ?? defaultSource),
+                        layerFilters.map(filter => {
+                            return filter.length ? ({
+                                params: {
+                                    CQL_FILTER: filter
+                                }
+                            }) : {};
+                        })
+                    )
+                ];
+            }
+        }
+        return [];
     },
-    pitch: () => {
+    background: (parameters) => {
+        const background = parameters.background;
+        if (typeof background === 'string') {
+            const defaultSource = 'default_map_backgrounds';
+            const pair = background.split(/[;|]/);
+            const id = uuid();
+            return [
+                addLayersMapViewerUrl(
+                    [pair[0]],
+                    [pair[1] ?? defaultSource],
+                    [{
+                        id,
+                        'group': 'background',
+                        visibility: true
+                    }]
+                ),
+                syncActiveBackgroundLayer(id)
+            ];
+        }
+        return [];
     },
-    roll: () => {
-    }, // roll is currently not supported, we return standard 0 roll
     actions: (parameters) => {
         const whiteList = (getConfigProp("initialActionsWhiteList") || []).concat([
             SEARCH_LAYER_WITH_FILTER,
@@ -254,5 +332,12 @@ export const paramActions = {
             return parameters.actions.filter(a => includes(whiteList, a.type));
         }
         return [];
-    }
+    },
+    ...([
+        // supplementary parameter types with no processing callback
+        'zoom', 'heading', 'pitch', 'roll',
+        'layerFilters', 'mapInfoFilter'
+    ]
+        .reduce((prev, cur) => ({...prev, [cur]: () => {}}), {})
+    )
 };

--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -283,7 +283,7 @@ export const paramActions = {
             if (parsed.length) {
                 const defaultSource = selectedServiceSelector(state);
                 const pairs = parsed.map(el => el.split(";"));
-                const layerFilters = (parameters.layerFilters ?? '').split(',') ?? [];
+                const layerFilters = (parameters.layerFilters ?? '').split(';') ?? [];
                 return [
                     addLayersMapViewerUrl(
                         pairs.map(el => el[0]),

--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -263,7 +263,7 @@ export const paramActions = {
             const layers = parameters.addLayers;
             if (typeof layers === 'string') {
                 const parsed = layers.split(',');
-                const pairs = parsed.map(el => el.split(/[;|]/));
+                const pairs = parsed.map(el => el.split(";"));
                 if (pairs.find(el => el[0] === value)) {
                     return [
                         scheduleSearchLayerWithFilter({layer: value, cql_filter: filterValue ?? ''})
@@ -282,7 +282,7 @@ export const paramActions = {
             const parsed = layers.split(',');
             if (parsed.length) {
                 const defaultSource = selectedServiceSelector(state);
-                const pairs = parsed.map(el => el.split(/[;|]/));
+                const pairs = parsed.map(el => el.split(";"));
                 const layerFilters = (parameters.layerFilters ?? '').split(',') ?? [];
                 return [
                     addLayersMapViewerUrl(
@@ -305,7 +305,7 @@ export const paramActions = {
         const background = parameters.background;
         if (typeof background === 'string') {
             const defaultSource = 'default_map_backgrounds';
-            const pair = background.split(/[;|]/);
+            const pair = background.split(";");
             const id = uuid();
             return [
                 addLayersMapViewerUrl(


### PR DESCRIPTION
## Description
Part of the query parameters have a complex syntax and may be hard to use by end-user.
This PR updates existing and add new query parameters with simple syntax.



- `featureInfo` parameter got a simple syntax: `#/viewer/openlayers/new?featureInfo=38.72,-95.625` where lat and lng are comma-separated values.

- `mapInfo` parameter allows to use `SEARCH_LAYER_WITH_FILTER` action upon specific layet to get feature info based on filter criteria:
 `#/viewer/openlayers/new?addLayers=tiger:poly_landmarks;gs_stable_wms&mapinfo=tiger:poly_landmarks&mapInfoFilter=CFCC='H41'`
`mapInfoFilter` in this case is a supplementary parameter to pass cql filter in it.
Previously it was not possible to trigger `SEARCH_LAYER_WITH_FILTER` on a layer that is added via query parameters. Now if both `addLayers` and `mapInfo` parameters present in a query string, app will compare name of layer in `mapInfo` and will delay search execution whenever layers is also listed in `addLayers`. Example above will delay search execution because `tiger:poly_landmarks` is in both parameters.

- `addLayers` is equivalent of `ADD_LAYERS_FROM_CATALOGS` action: `#/viewer/openlayers/new?addLayers=tiger:poly_landmarks;gs_stable_wms,tiger-ny;gs_stable_wms&layerFilters=CFCC='H41'`
`layerFilters` is a supplementary parameter to pass cql filter applied upon layer addition.

- `background` allows to dynamically add background to the map and activate it. Supports default backgrounds provided by static service defined in `localConfig.json` (`default_map_backgrounds`) as well as other layers:
`#/viewer/openlayers/new?background=Sentinel`
`#/viewer/openlayers/new?background=tiger-ny;gs_stable_wms`
Please note that default service for `background` is `default_map_backgrounds`. Based on the selection criteria for this service it is enough to pass desired layer name even partially, e.g. `background=Sen`, it will use first layer matching search criteria.

All parameters from now on support both `camelCase` and `lowercase`, e.g. `addLayers` and `addlayers`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8597 

**What is the new behavior?**
Existing parameters syntax is updated according to proposal.
New parameters are added (`mapInfo`, `background`, `addLayers`).
Added support of having `mapInfo` processor applied to the dynamically loaded layer (via `addLayers`)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
