### PR TITLE
#8644 Resolving race condition that was preventing mapInfo parameter to work in some cases

### DIFF
--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -193,6 +193,7 @@ GET: `#/viewer/openlayers/config?addLayers=layer1;service,layer2&layerFilters=at
 from the layerName by a `;`.
 
 In the example above:
+
 - `layer1` and `layer2` are layer names;
 - `service` is the service identifier of the catalog.
 If no service is provided, the default service will be used.
@@ -228,6 +229,7 @@ as other layers:
 `#/viewer/openlayers/new?background=layer1;service`
 
 Where:
+
 - `Sentinel` & `layer1` are layer names,
 - `service` is the service name providing layer data. Service name is optional,
 `default_map_backgrounds` will be used if it is omitted.

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -335,5 +335,5 @@ export const delayedSearchEpic = (action$) =>
                 .switchMap(() => {
                     return Rx.Observable.of(searchLayerWithFilter({layer: name, "cql_filter": cqlFilter}));
                 })
-                .takeUntil(action$.ofType(LAYER_LOAD));
+                .takeUntil(action$.ofType(LAYER_LOAD).filter(({ layerId }) => layerId.startsWith(name)));
         });

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -10,41 +10,48 @@ import * as Rx from 'rxjs';
 import toBbox from 'turf-bbox';
 import pointOnSurface from '@turf/point-on-surface';
 import assign from 'object-assign';
-import { sortBy, isNil } from 'lodash';
+import {isNil, sortBy} from 'lodash';
 
-import { queryableLayersSelector, getLayerFromName, centerToMarkerSelector } from '../selectors/layers';
+import {centerToMarkerSelector, getLayerFromName, queryableLayersSelector} from '../selectors/layers';
 
-import { updateAdditionalLayer } from '../actions/additionallayers';
-import { showMapinfoMarker, featureInfoClick, updateCenterToMarker, LOAD_FEATURE_INFO, ERROR_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO  } from '../actions/mapInfo';
-import { zoomToExtent, zoomToPoint } from '../actions/map';
-import { ADD_LAYER, LAYER_LOAD, changeLayerProperties } from '../actions/layers';
+import {updateAdditionalLayer} from '../actions/additionallayers';
 import {
-    SEARCH_LAYER_WITH_FILTER,
-    TEXT_SEARCH_STARTED,
-    TEXT_SEARCH_RESULTS_PURGE,
-    TEXT_SEARCH_RESET,
-    TEXT_SEARCH_ITEM_SELECTED,
-    TEXT_SEARCH_SHOW_GFI,
-    ZOOM_ADD_POINT,
+    ERROR_FEATURE_INFO,
+    EXCEPTIONS_FEATURE_INFO,
+    featureInfoClick,
+    LOAD_FEATURE_INFO,
+    showMapinfoMarker,
+    updateCenterToMarker
+} from '../actions/mapInfo';
+import {zoomToExtent, zoomToPoint} from '../actions/map';
+import {ADD_LAYER, changeLayerProperties} from '../actions/layers';
+import {
     addMarker,
     nonQueriableLayerError,
-    serverError,
-    resultsPurge,
-    searchTextLoading,
-    searchResultLoaded,
+    resultsPurge, SCHEDULE_SEARCH_LAYER_WITH_FILTER,
+    SEARCH_LAYER_WITH_FILTER, searchLayerWithFilter,
     searchResultError,
+    searchResultLoaded,
+    searchTextChanged,
+    searchTextLoading,
     selectNestedService,
-    searchTextChanged, SCHEDULE_SEARCH_LAYER_WITH_FILTER, searchLayerWithFilter
+    serverError,
+    TEXT_SEARCH_ITEM_SELECTED,
+    TEXT_SEARCH_RESET,
+    TEXT_SEARCH_RESULTS_PURGE,
+    TEXT_SEARCH_SHOW_GFI,
+    TEXT_SEARCH_STARTED,
+    ZOOM_ADD_POINT
 } from '../actions/search';
 
 import CoordinatesUtils from '../utils/CoordinatesUtils';
-import {defaultIconStyle, showGFIForService, layerIsVisibleForGFI} from '../utils/SearchUtils';
+import {defaultIconStyle, layerIsVisibleForGFI, showGFIForService} from '../utils/SearchUtils';
 import {generateTemplateString} from '../utils/TemplateUtils';
 
 import {API} from '../api/searchText';
 import {getFeatureSimple} from '../api/WFS';
-import { getDefaultInfoFormatValueFromLayer } from '../utils/MapInfoUtils';
-import { identifyOptionsSelector } from '../selectors/mapInfo';
+import {getDefaultInfoFormatValueFromLayer} from '../utils/MapInfoUtils';
+import {identifyOptionsSelector} from '../selectors/mapInfo';
 
 const getInfoFormat = (layerObj, state) => getDefaultInfoFormatValueFromLayer(layerObj, {...identifyOptionsSelector(state)});
 
@@ -326,14 +333,17 @@ export const searchOnStartEpic = (action$, store) =>
             return Rx.Observable.empty();
         });
 
-
+/**
+ * Gets every `SCHEDULE_SEARCH_LAYER_WITH_FILTER` event.
+ * Triggers a GetFeature with a subsequent getFeatureInfo with a point taken from geometry of first feature retrieved after layer is added to the map
+ */
 export const delayedSearchEpic = (action$) =>
     action$.ofType(SCHEDULE_SEARCH_LAYER_WITH_FILTER)
         .switchMap(({layer: name, "cql_filter": cqlFilter}) => {
             return action$.ofType(ADD_LAYER)
-                .filter(({ layer }) => layer.name === name)
+                .filter(({layer}) => layer.name === name)
+                .take(1)
                 .switchMap(() => {
                     return Rx.Observable.of(searchLayerWithFilter({layer: name, "cql_filter": cqlFilter}));
-                })
-                .takeUntil(action$.ofType(LAYER_LOAD).filter(({ layerId }) => layerId.startsWith(name)));
+                });
         });


### PR DESCRIPTION
## Description
This PR solves the issue with `mapInfo` query parameter described here https://github.com/geosolutions-it/MapStore2/issues/8644

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8644 
`mapInfo` parameter wasn't working under some conditions that led to `LAYER_LOAD` action appear before `ADD_LAYER` we need.

**What is the new behavior?**
`takeUntil` now checks for a `layerId` passed into `LAYER_LOAD` action to make a match with the layer name.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
