### PR TITLE
[Backport 2022.01.xx] Error downloading filtered dataset, where filter is based on another layer (#8603)

### DIFF
--- a/web/client/observables/wps/__tests__/common-test.js
+++ b/web/client/observables/wps/__tests__/common-test.js
@@ -9,7 +9,8 @@
 import expect from 'expect';
 
 import {
-    getWPSURL
+    getWPSURL,
+    cdata
 } from '../common';
 
 
@@ -40,5 +41,63 @@ describe('common WPS utils', () => {
         expect(/https:\/\/host.?\/service\/wps\?service=WPS&IDENTIFIER=gs%3AAggregate&REQUEST=DescribeProcess&version=1\.0\.0/.test(getWPSURL(url, options))).toEqual(true);
 
     });
-
+    it('test cdata wrapper on xml with no cdata', () => {
+        const filterString = `<wps:ComplexData mimeType="text/xml; subtype=filter/1.1">
+					<ogc:Filter
+						xmlns:ogc="http://www.test.net/ogc"
+						xmlns:gml="http://www.test.net/gml">
+						<ogc:And>
+							<ogc:Intersects>
+								<ogc:PropertyName>the_geom</ogc:PropertyName>
+								<ogc:Function name="collectGeometries">
+									<ogc:Function name="queryCollection">
+										<ogc:Literal>geonode:test_export_filter0</ogc:Literal>
+										<ogc:Literal>the_geom</ogc:Literal>
+									</ogc:Function>
+								</ogc:Function>
+							</ogc:Intersects>
+						</ogc:And>
+					</ogc:Filter>
+				</wps:ComplexData>`;
+        expect(cdata(filterString)).toEqual(`<![CDATA[<wps:ComplexData mimeType="text/xml; subtype=filter/1.1">
+					<ogc:Filter
+						xmlns:ogc="http://www.test.net/ogc"
+						xmlns:gml="http://www.test.net/gml">
+						<ogc:And>
+							<ogc:Intersects>
+								<ogc:PropertyName>the_geom</ogc:PropertyName>
+								<ogc:Function name="collectGeometries">
+									<ogc:Function name="queryCollection">
+										<ogc:Literal>geonode:test_export_filter0</ogc:Literal>
+										<ogc:Literal>the_geom</ogc:Literal>
+									</ogc:Function>
+								</ogc:Function>
+							</ogc:Intersects>
+						</ogc:And>
+					</ogc:Filter>
+				</wps:ComplexData>]]>`);
+    });
+    it('test cdata wrapper on xml with cdata', () => {
+        const filterString = `<wps:ComplexData mimeType="text/xml; subtype=filter/1.1">
+					<ogc:Filter
+						xmlns:ogc="http://www.test.net/ogc"
+						xmlns:gml="http://www.test.net/gml">
+						<ogc:And>
+							<ogc:Intersects>
+								<ogc:PropertyName>the_geom</ogc:PropertyName>
+								<ogc:Function name="collectGeometries">
+									<ogc:Function name="queryCollection">
+										<ogc:Literal>geonode:test_export_filter0</ogc:Literal>
+										<ogc:Literal>the_geom</ogc:Literal>
+                                        <ogc:Literal>
+											<![CDATA[INCLUDE]]>
+										</ogc:Literal>
+									</ogc:Function>
+								</ogc:Function>
+							</ogc:Intersects>
+						</ogc:And>
+					</ogc:Filter>
+				</wps:ComplexData>`;
+        expect(cdata(filterString)).toEqual(filterString);
+    });
 });

--- a/web/client/observables/wps/common.js
+++ b/web/client/observables/wps/common.js
@@ -63,11 +63,17 @@ export const literalData = (literal) => `<wps:LiteralData>${literal}</wps:Litera
 export const complexData = (data, mimeType, encoding) => `<wps:ComplexData${mimeType ? ` mimeType="${mimeType}"` : ''}${encoding ? ` encoding="${encoding}"` : ''}>${data}</wps:ComplexData>`;
 /**
  * Wrap data in CDATA
+ * Avoids wrapping data if it already contains CDATA
  * @memberof observables.wps.common
  * @param {string} data data to wrap
  * @returns {string}
  */
-export const cdata = (data) => `<![CDATA[${data}]]>`;
+export const cdata = (data) => {
+    const regex = /\bCDATA\b/;
+    const isCdataIncluded = regex.test(data);
+    if (isCdataIncluded) return data;
+    return `<![CDATA[${data}]]>`;
+};
 
 /**
  * Wrap XML in wps:ResponseForm


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes a problem with the cdata wrapper where syntax gets broken because the xml already contains cdata when it's passed to the wrapper

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8603 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Can now download filtered dataset where filter is based on another layer

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
