### PR TITLE
#8465 Imrpoving API and preventing issues from geostore

### DIFF
--- a/build/devServer.js
+++ b/build/devServer.js
@@ -3,40 +3,41 @@ const protocol = process.env.MAPSTORE_BACKEND_PROTOCOL || "http";
 const host = process.env.MAPSTORE_BACKEND_HOST || "localhost";
 const MAPSTORE_BACKEND_BASE_URL = process.env.MAPSTORE_BACKEND_BASE_URL || (protocol + "://" + host + ":" + port);
 const MAPSTORE_BACKEND_BASE_PATH = process.env.MAPSTORE_BACKEND_BASE_PATH || "/mapstore";
-var matches = MAPSTORE_BACKEND_BASE_URL.match(/^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i);
+const MAPSTORE_BACKEND_URL = process.env.MAPSTORE_BACKEND_URL || MAPSTORE_BACKEND_BASE_URL + MAPSTORE_BACKEND_BASE_PATH;
+var matches = MAPSTORE_BACKEND_URL.match(/^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i);
 var domain = matches && matches[1];
 // configuration for local dev server. This is used by webpack-dev-server
 // to proxy requests to the backend.
 const devServer = {
     proxy: {
         '/rest': {
-            target: `${MAPSTORE_BACKEND_BASE_URL}${MAPSTORE_BACKEND_BASE_PATH}`,
+            target: MAPSTORE_BACKEND_URL,
             secure: false,
             logLevel: "debug"
         },
         '/pdf': {
-            target: `${MAPSTORE_BACKEND_BASE_URL}${MAPSTORE_BACKEND_BASE_PATH}`,
+            target: MAPSTORE_BACKEND_URL,
             secure: false,
             headers: {
                 host: domain
             }
         },
         '/proxy': {
-            target: `${MAPSTORE_BACKEND_BASE_URL}${MAPSTORE_BACKEND_BASE_PATH}`,
+            target: MAPSTORE_BACKEND_URL,
             secure: false,
             headers: {
                 host: domain
             }
         },
         '/extensions.json': {
-            target: `${MAPSTORE_BACKEND_BASE_URL}${MAPSTORE_BACKEND_BASE_PATH}`,
+            target: MAPSTORE_BACKEND_URL,
             secure: false,
             headers: {
                 host: domain
             }
         },
         '/dist/extensions': {
-            target: `${MAPSTORE_BACKEND_BASE_URL}${MAPSTORE_BACKEND_BASE_PATH}`,
+            target: MAPSTORE_BACKEND_URL,
             secure: false,
             headers: {
                 host: domain

--- a/docs/developer-guide/developing.md
+++ b/docs/developer-guide/developing.md
@@ -44,10 +44,10 @@ See the [dedicated section in this page](#backend) for more info
 You can run only the front-end running `npm run fe:start`.
 Running this script MapStore will run on port `8081` and will look for the back-end at port `8080`.
 
-If you want to use an online instance of MapStore as backend, instead of the local one, you can define the environment variable `MAPSTORE_BACKEND_BASE_URL` to the desired URL.
+If you want to use an online instance of MapStore as backend, instead of the local one, you can define the environment variable `MAPSTORE_BACKEND_URL` to the desired URL.
 
 ```sh
-export MAPSTORE_BACKEND_BASE_URL=https://demo.geo-solutions.it/mapstore
+export MAPSTORE_BACKEND_URL=https://dev-mapstore.geosolutionsgroup.com/mapstore
 npm run fe:start # this command lunches only the front-end
 ```
 

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -274,6 +274,7 @@
                     <properties>
                         <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
                         <cargo.logging>low</cargo.logging>
+<!-- setting javax.xml.parsers.SAXParserFactory is a workaround for issue https://github.com/geosolutions-it/geostore/issues/311 and can be removed when solved -->
                         <cargo.jvmargs>
                             -Djavax.xml.parsers.SAXParserFactory="com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl"
                         </cargo.jvmargs>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -274,6 +274,9 @@
                     <properties>
                         <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
                         <cargo.logging>low</cargo.logging>
+                        <cargo.jvmargs>
+                            -Djavax.xml.parsers.SAXParserFactory="com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl"
+                        </cargo.jvmargs>
                     </properties>
                 </configuration>
                 <deployables>


### PR DESCRIPTION
## Description
This PR makes easier to configure the URL. moreover it adds some arguments to prevent this issue on geostore:

https://github.com/geosolutions-it/geostore/issues/311

Waiting for a solution of it 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#8465 

**What is the current behavior?**

- Developers can not easely define the URL of mapstore. (need to use the base URL).
- randomly backend has an issue that doens't allow to start the backend


**What is the new behavior?**
- The developers can now define `MAPSTORE_BACKEND_URL=https://dev-mapstore.geosolutionsgroup.com/mapstore` to run on dev

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
