### PR TITLE
#8545 Layer download: WPS only case

### DIFF
--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -116,6 +116,7 @@ class DownloadDialog extends React.Component {
         const wfsFormats = validWFSFormats.length > 0 ?
             validWFSFormats.filter(f => this.props.wfsFormats.find(wfsF => wfsF.name.toLowerCase() === f.name.toLowerCase())) :
             this.props.wfsFormats;
+        const wfsAvailable = Boolean(this.props.layer.search?.url);
 
         return this.props.enabled ? (<Portal><Dialog id="mapstore-export" draggable={false} modal>
             <span role="header">
@@ -125,10 +126,11 @@ class DownloadDialog extends React.Component {
             <div role="body">
                 {this.props.checkingWPSAvailability ?
                     <Loader size={100} style={{margin: '0 auto'}}/> :
-                    this.props.service === 'wfs' && !this.props.layer.search?.url ?
+                    !this.props.wpsAvailable && !wfsAvailable ?
                         <EmptyView title={<Message msgId="layerdownload.noSupportedServiceFound"/>}/> :
                         <DownloadOptions
                             wpsAvailable={this.props.wpsAvailable}
+                            wfsAvailable={wfsAvailable}
                             service={this.props.service}
                             downloadOptions={this.props.downloadOptions}
                             setService={this.props.setService}

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -27,6 +27,7 @@ import DownloadWPSOptions from './DownloadWPSOptions';
 class DownloadOptions extends React.Component {
     static propTypes = {
         wpsAvailable: PropTypes.bool,
+        wfsAvailable: PropTypes.bool,
         service: PropTypes.string,
         downloadOptions: PropTypes.object,
         formatOptionsFetch: PropTypes.func,
@@ -46,6 +47,7 @@ class DownloadOptions extends React.Component {
 
     static defaultProps = {
         wpsAvailable: false,
+        wfsAvailable: true,
         service: 'wps',
         downloadOptions: {},
         formatsLoading: false,
@@ -74,7 +76,7 @@ class DownloadOptions extends React.Component {
 
     render() {
         return (<form>
-            {this.props.wpsAvailable &&
+            {this.props.wpsAvailable && this.props.wfsAvailable &&
                 <>
                     <label><Message msgId="layerdownload.service" /></label>
                     <Select

--- a/web/client/components/data/download/__tests__/DownloadDialog-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadDialog-test.jsx
@@ -25,7 +25,29 @@ describe('Test for DownloadDialog component', () => {
     });
 
     it('render download options', () => {
-        ReactDOM.render(<DownloadDialog enabled service="wps"/>, document.getElementById("container"));
+        const selectedLayer =
+        {
+            type: 'wfs',
+            visibility: true,
+            id: 'mapstore:states__7',
+            search: {
+                url: 'http://u.r.l'
+            }
+        };
+        ReactDOM.render(<DownloadDialog enabled service="wps" layer={selectedLayer} />, document.getElementById("container"));
+        const dialog = document.getElementById('mapstore-export');
+        expect(dialog).toBeTruthy();
+        expect(dialog.getElementsByTagName('form')[0]).toBeTruthy();
+    });
+
+    it('render download options with only "wps" available', () => {
+        const selectedLayer =
+        {
+            type: 'wms',
+            visibility: true,
+            id: 'mapstore:states__7'
+        };
+        ReactDOM.render(<DownloadDialog enabled service="wps" wpsAvailable layer={selectedLayer} />, document.getElementById("container"));
         const dialog = document.getElementById('mapstore-export');
         expect(dialog).toBeTruthy();
         expect(dialog.getElementsByTagName('form')[0]).toBeTruthy();

--- a/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
@@ -30,7 +30,7 @@ describe('Test for DownloadOptions component', () => {
     });
 
     it('render serivce selector', () => {
-        ReactDOM.render(<DownloadOptions wpsAvailable />, document.getElementById("container"));
+        ReactDOM.render(<DownloadOptions wpsAvailable wfsAvailable />, document.getElementById("container"));
         const form = document.getElementsByTagName('form')[0];
         const firstChild = form.querySelector('label');
         expect(firstChild.innerHTML).toBe('<span>layerdownload.service</span>');
@@ -39,9 +39,16 @@ describe('Test for DownloadOptions component', () => {
     });
 
     it('render service selector with WFS service', () => {
-        ReactDOM.render(<DownloadOptions wpsAvailable service="wfs" />, document.getElementById("container"));
+        ReactDOM.render(<DownloadOptions wpsAvailable wfsAvailable service="wfs" />, document.getElementById("container"));
         const form = document.getElementsByTagName('form')[0];
         const selectorValueLabel = form.querySelector('.Select .Select-value-label');
         expect(selectorValueLabel.innerText).toBe('WFS');
+    });
+
+    it('should not render service selector', () => {
+        ReactDOM.render(<DownloadOptions wpsAvailable wfsAvailable={false} service="wps" />, document.getElementById("container"));
+        const form = document.getElementsByTagName('form')[0];
+        const selectors = form.querySelectorAll('.Select');
+        expect(selectors.length).toBe(2);
     });
 });

--- a/web/client/epics/__tests__/layerdownload-test.js
+++ b/web/client/epics/__tests__/layerdownload-test.js
@@ -63,7 +63,61 @@ describe('layerdownload Epics', () => {
         };
 
         mockAxios.onGet().reply(200, xmlData);
-        const state = { controls: { layerdownload: { enabled: false, downloadOptions: {}} } };
+        const state = {
+            controls: {
+                layerdownload: { enabled: false, downloadOptions: {}}
+            },
+            layers: {
+                flat: [
+                    {
+                        type: 'wfs',
+                        visibility: true,
+                        id: 'mapstore:states__7',
+                        search: {
+                            url: 'http://u.r.l'
+                        }
+                    }
+                ],
+                selected: [
+                    'mapstore:states__7'
+                ]
+            }
+        };
+        testEpic(checkWPSAvailabilityEpic, 4, checkWPSAvailability('http://check.wps.availability.url', 'wfs'), epicResult, state);
+    });
+    it('should select WPS service', (done) => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(4);
+            actions.map((action) => {
+                switch (action.type) {
+                case SET_SERVICE:
+                    expect(action.service).toBe('wps');
+                    break;
+                default:
+                    break;
+                }
+            });
+            done();
+        };
+
+        mockAxios.onGet().reply(200, xmlData);
+        const state = {
+            controls: {
+                layerdownload: { enabled: false, downloadOptions: {}}
+            },
+            layers: {
+                flat: [
+                    {
+                        type: 'wms',
+                        visibility: true,
+                        id: 'mapstore:states__7'
+                    }
+                ],
+                selected: [
+                    'mapstore:states__7'
+                ]
+            }
+        };
         testEpic(checkWPSAvailabilityEpic, 4, checkWPSAvailability('http://check.wps.availability.url', 'wfs'), epicResult, state);
     });
     it('downloads a layer', (done) => {


### PR DESCRIPTION
## Description
The issue was posted in https://github.com/geosolutions-it/MapStore2/pull/8607#issuecomment-1268175014
This PR handle the case when only WPS service is available for download.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
 https://github.com/geosolutions-it/MapStore2/pull/8607#issuecomment-1268175014

**What is the new behavior?**
If WPS is available, DownloadDialog can be opened without service selector.
The user can download via WPS service.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
