### PR TITLE
#8578 SEARCH_WITH_FILTER action: add popup support

### DIFF
--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -52,6 +52,7 @@ const STATE_NAME = 'STATE_NAME';
 
 import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
 import {addLayer} from "../../actions/layers";
+import { ADD_MAP_POPUP } from '../../actions/mapPopups';
 
 const nestedService = {
     nestedPlaceholder: TEST_NESTED_PLACEHOLDER
@@ -608,6 +609,35 @@ describe('search Epics', () => {
             expect(actions[1].type).toBe(SHOW_MAPINFO_MARKER);
             done();
         }, {layers: {flat: [{name: "layerName", url: "base/web/client/test-resources/wms/GetFeature.json", visibility: true, queryable: true, type: "wms"}]}});
+    });
+    it('searchOnStartEpic, that adds popup', (done) => {
+        const testStore = {
+            mapInfo: {showInMapPopup: true},
+            layers: {
+                flat: [
+                    {
+                        name: "layerName",
+                        url: "base/web/client/test-resources/wms/GetFeature.json",
+                        visibility: true,
+                        queryable: true,
+                        type: "wms"
+                    }
+                ]
+            }
+        };
+        let action = searchLayerWithFilter({layer: "layerName", cql_filter: "cql"});
+        const NUM_ACTIONS = 3;
+        testEpic(searchOnStartEpic, NUM_ACTIONS, action, (actions) => {
+            expect(actions).toExist();
+            expect(actions.length).toBe(NUM_ACTIONS);
+            expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
+            expect(actions[1].type).toBe(SHOW_MAPINFO_MARKER);
+            const popupAction = actions[2];
+            expect(popupAction.type).toBe(ADD_MAP_POPUP);
+            expect(popupAction.popup?.position?.coordinates?.[0]).toBe(968346.2286324208);
+            expect(popupAction.popup?.position?.coordinates?.[1]).toBe(5538315.133325616);
+            done();
+        }, testStore);
     });
     it('textSearchShowGFIEpic, it sends info format taken from layer', (done) => {
         let action = showGFI(

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -600,19 +600,10 @@ describe('search Epics', () => {
         }, {layers: {flat: [{name: "layerName", url: "clearlyNotAUrl", visibility: true, queryable: true, type: "wms"}]}});
     });
     it('searchOnStartEpic, that sends a Getfeature and a GFI requests', (done) => {
-        let action = searchLayerWithFilter({layer: "layerName", cql_filter: "cql"});
-        const NUM_ACTIONS = 2;
-        testEpic(searchOnStartEpic, NUM_ACTIONS, action, (actions) => {
-            expect(actions).toExist();
-            expect(actions.length).toBe(NUM_ACTIONS);
-            expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
-            expect(actions[1].type).toBe(SHOW_MAPINFO_MARKER);
-            done();
-        }, {layers: {flat: [{name: "layerName", url: "base/web/client/test-resources/wms/GetFeature.json", visibility: true, queryable: true, type: "wms"}]}});
-    });
-    it('searchOnStartEpic, that adds popup', (done) => {
         const testStore = {
-            mapInfo: {showInMapPopup: true},
+            map: {
+                projection: "EPSG:3857"
+            },
             layers: {
                 flat: [
                     {
@@ -626,18 +617,55 @@ describe('search Epics', () => {
             }
         };
         let action = searchLayerWithFilter({layer: "layerName", cql_filter: "cql"});
-        const NUM_ACTIONS = 3;
+        const NUM_ACTIONS = 2;
         testEpic(searchOnStartEpic, NUM_ACTIONS, action, (actions) => {
             expect(actions).toExist();
             expect(actions.length).toBe(NUM_ACTIONS);
             expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
             expect(actions[1].type).toBe(SHOW_MAPINFO_MARKER);
-            const popupAction = actions[2];
-            expect(popupAction.type).toBe(ADD_MAP_POPUP);
-            expect(popupAction.popup?.position?.coordinates?.[0]).toBe(968346.2286324208);
-            expect(popupAction.popup?.position?.coordinates?.[1]).toBe(5538315.133325616);
             done();
         }, testStore);
+    });
+    it('searchOnStartEpic, that adds popup', (done) => {
+        const testStore = {
+            mapInfo: { showInMapPopup: true },
+            map: {
+                projection: "EPSG:3857"
+            },
+            layers: {
+                flat: [
+                    {
+                        name: "layerName",
+                        url: "base/web/client/test-resources/wms/GetFeature.json",
+                        visibility: true,
+                        queryable: true,
+                        type: "wms"
+                    }
+                ]
+            }
+        };
+        let action = searchLayerWithFilter({layer: "layerName", cql_filter: "cql"});
+        const NUM_ACTIONS = 2;
+        testEpic(
+            searchOnStartEpic,
+            NUM_ACTIONS,
+            action,
+            (actions) => {
+                expect(actions).toExist();
+                expect(actions.length).toBe(NUM_ACTIONS);
+                expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
+                const popupAction = actions[1];
+                expect(popupAction.type).toBe(ADD_MAP_POPUP);
+                expect(popupAction.popup?.position?.coordinates?.[0]).toBe(
+                    968346.2286324208
+                );
+                expect(popupAction.popup?.position?.coordinates?.[1]).toBe(
+                    5538315.133325616
+                );
+                done();
+            },
+            testStore
+        );
     });
     it('textSearchShowGFIEpic, it sends info format taken from layer', (done) => {
         let action = showGFI(

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -323,31 +323,31 @@ export const searchOnStartEpic = (action$, store) =>
                         .then( (response = {}) => response.features && response.features.length && {...response.features[0], typeName: name})
                 )
                     .switchMap(({ type, geometry, typeName }) => {
-                        let coord = pointOnSurface({ type, geometry }).geometry.coordinates;
-                        const latlng = {lng: coord[0], lat: coord[1] };
-                        const projection = projectionSelector(store.getState());
-                        const { x, y } = reproject(
-                            coord,
-                            "EPSG:4326",
-                            projection
-                        );
-
-                        let mapActionObservable;
-                        if (isMapPopup(store.getState())) {
-                            mapActionObservable = Rx.Observable.of(
-                                addPopup(uuid(), {
-                                    component: IDENTIFY_POPUP,
-                                    maxWidth: 600,
-                                    position: { coordinates: [x, y] }
-                                })
-                            );
-                        } else {
-                            mapActionObservable = Rx.Observable.of(
-                                showMapinfoMarker()
-                            );
-                        }
+                        const coord = pointOnSurface({ type, geometry }).geometry.coordinates;
 
                         if (coord) {
+                            const latlng = {lng: coord[0], lat: coord[1] };
+                            const projection = projectionSelector(store.getState());
+                            const { x, y } = reproject(
+                                coord,
+                                "EPSG:4326",
+                                projection
+                            );
+                            let mapActionObservable;
+                            if (isMapPopup(store.getState())) {
+                                mapActionObservable = Rx.Observable.of(
+                                    addPopup(uuid(), {
+                                        component: IDENTIFY_POPUP,
+                                        maxWidth: 600,
+                                        position: { coordinates: [x, y] }
+                                    })
+                                );
+                            } else {
+                                mapActionObservable = Rx.Observable.of(
+                                    showMapinfoMarker()
+                                );
+                            }
+
                             // trigger get feature info
                             return Rx.Observable.of(
                                 featureInfoClick(

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -303,7 +303,7 @@ export const zoomAndAddPointEpic = (action$, store) =>
 export const searchOnStartEpic = (action$, store) =>
     action$.ofType(SEARCH_LAYER_WITH_FILTER)
         .switchMap(({layer: name, "cql_filter": cqlFilter}) => {
-            const state = store.getState(store.getState());
+            const state = store.getState();
             // if layer is NOT queriable and visible then show error notification
             if (queryableLayersSelector(state).filter(l => l.name === name ).length === 0) {
                 return Rx.Observable.of(nonQueriableLayerError());


### PR DESCRIPTION
## Description
Add popup support to `searchOnStartEpic`

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8578

**What is the new behavior?**
Works as expected

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information

Steps to reproduce on local environment:
* Set `"showInMapPopup": true` in the config https://github.com/geosolutions-it/MapStore2/blob/0e3b035dc1a3928dac19b8dbf5ba45330cdd3a29/web/client/configs/localConfig.json#L335
* Create a map with "Manhattan (NY) points of interest";
* Open new map with URL: `http://localhost:8081/#/viewer/openlayers/19?actions=[{%22type%22:%22SEARCH:SEARCH_WITH_FILTER%22,%22cql_filter%22:%22NAME='art'%22,%22layer%22:%22tiger:poi2%22}]`
