### PR TITLE
8675 Query parameters documentation and `lon,lat` order unification

### DIFF
--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -153,7 +153,7 @@ GET: `#/viewer/openlayers/config?featureinfo={"lat": 43.077, "lng": 12.656, "fil
 
 GET: `#/viewer/openlayers/config?featureInfo=38.72,-95.625`
 
-Where lat,lng values are comma-separated respecting order.
+Where lon,lat values are comma-separated respecting order.
 
 ### Map
 
@@ -175,13 +175,20 @@ Following example will override "catalogServices" and "mapInfoConfiguration":
 
 GET: `#/viewer/openlayers/config?center=0,0&zoom=5`
 
+Where lon,lat values are comma-separated respecting order.
+
+
 ### Marker / Zoom
 
 GET: `#/viewer/openlayers/config?marker=0,0&zoom=5`
 
+Where lon,lat values are comma-separated respecting order.
+
 ### Bbox
 
 GET: `#/viewer/openlayers/config?bbox=8,8,53,53`
+
+Where values are `minLongitude, minLatitude, maxLongitude, maxLatitude` respecting order.
 
 ### AddLayers
 

--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -774,7 +774,7 @@ describe('queryparam epics', () => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 try {
                     expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
-                    expect(actions[0].point.latlng).toEqual({lat: '38.72', lng: '-95.625'});
+                    expect(actions[0].point.latlng).toEqual({lng: '38.72', lat: '-95.625'});
                     expect(actions[0].point.pixel).toBe(undefined);
                     expect(actions[0].point.geometricFilter).toExist();
                 } catch (e) {

--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -761,7 +761,7 @@ describe('queryparam epics', () => {
             },
             router: {
                 location: {
-                    search: "?featureInfo=38.72,-95.625"
+                    search: "?featureInfo=-95.625,38.72"
                 }
             }
         };
@@ -774,7 +774,7 @@ describe('queryparam epics', () => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 try {
                     expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
-                    expect(actions[0].point.latlng).toEqual({lng: '38.72', lat: '-95.625'});
+                    expect(actions[0].point.latlng).toEqual({lng: '-95.625', lat: '38.72'});
                     expect(actions[0].point.pixel).toBe(undefined);
                     expect(actions[0].point.geometricFilter).toExist();
                 } catch (e) {

--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -244,7 +244,7 @@ export const paramActions = {
                 }
             }, projection), false, filterNameList ?? [])];
         } else if (typeof value === 'string') {
-            const [latitude, longitude] = value.split(',');
+            const [longitude, latitude] = value.split(',');
             if (typeof latitude !== 'undefined' && typeof longitude !== 'undefined') {
                 return [featureInfoClick(updatePointWithGeometricFilter({
                     latlng: {


### PR DESCRIPTION
## Description
This PR updates documentation for query parameters that specify coordinates with unnamed, comma-separated format.
It also changes order to `lng,lat` for `featureInfo` parameter to match all other parameters.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Documentation update

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8675 

**What is the new behavior?**
As per description

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
