### PR TITLE
8536 Resolving measure plugin draw conflicts

### DIFF
--- a/web/client/components/map/leaflet/MeasurementSupport.jsx
+++ b/web/client/components/map/leaflet/MeasurementSupport.jsx
@@ -199,7 +199,7 @@ class MeasurementSupport extends React.Component {
     };
 
     UNSAFE_componentWillMount() {
-        if (this.props.measurement.geomType && (this.props.measurement.lineMeasureEnabled || this.props.measurement.areaMeasureEnabled || this.props.measurement.bearingMeasureEnabled) && isNil(this.drawControl) && this.props.enabled) {
+        if (this.props.measurement?.geomType && (this.props.measurement?.lineMeasureEnabled || this.props.measurement?.areaMeasureEnabled || this.props.measurement?.bearingMeasureEnabled) && isNil(this.drawControl) && this.props.enabled) {
             this.addDrawInteraction(this.props);
         }
     }

--- a/web/client/components/map/leaflet/MeasurementSupport.jsx
+++ b/web/client/components/map/leaflet/MeasurementSupport.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import assign from 'object-assign';
 import L from 'leaflet';
 import {
+    isNil,
     slice
 } from 'lodash';
 import {
@@ -197,6 +198,11 @@ class MeasurementSupport extends React.Component {
         feet: false
     };
 
+    UNSAFE_componentWillMount() {
+        if (this.props.measurement.geomType && (this.props.measurement.lineMeasureEnabled || this.props.measurement.areaMeasureEnabled || this.props.measurement.bearingMeasureEnabled) && isNil(this.drawControl) && this.props.enabled) {
+            this.addDrawInteraction(this.props);
+        }
+    }
 
     UNSAFE_componentWillReceiveProps(newProps) {
         if ((newProps && newProps.uom && newProps.uom.length && newProps.uom.length.unit) !== (this.props && this.props.uom && this.props.uom.length && this.props.uom.length.unit) && this.drawControl) {
@@ -220,6 +226,11 @@ class MeasurementSupport extends React.Component {
             this.removeDrawInteraction();
         }
     }
+
+    componentWillUnmount() {
+        this.removeDrawInteraction();
+    }
+
     onDrawStart = () => {
         this.props.map.off('click', this.restartDrawing, this);
         this.removeArcLayer();


### PR DESCRIPTION
## Description
Measure tool recently was extended to support Cesium viewer and refactored to take advantage of lazy-loading of the components. This led to side effects when Openlayers/Leaflet measure did not enable properly upon tool activation and was not disabled when measure tool is deactivated.
This PR provides minor changes to properly initialize draw mode and deactivate it whenever components are mounted or unmounted.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8536 

**What is the new behavior?**
Tool is properly activated and deactivated for Openlayers and Leaflet viewers.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
