### PR TITLE
[Backport 2022.02.xx] #8675 Query parameters documentation and `lon,lat` order unification (#8676)

### DIFF
--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -153,7 +153,7 @@ GET: `#/viewer/openlayers/config?featureinfo={"lat": 43.077, "lng": 12.656, "fil
 
 GET: `#/viewer/openlayers/config?featureInfo=38.72,-95.625`
 
-Where lat,lng values are comma-separated respecting order.
+Where lon,lat values are comma-separated respecting order.
 
 ### Map
 
@@ -175,13 +175,20 @@ Following example will override "catalogServices" and "mapInfoConfiguration":
 
 GET: `#/viewer/openlayers/config?center=0,0&zoom=5`
 
+Where lon,lat values are comma-separated respecting order.
+
+
 ### Marker / Zoom
 
 GET: `#/viewer/openlayers/config?marker=0,0&zoom=5`
 
+Where lon,lat values are comma-separated respecting order.
+
 ### Bbox
 
 GET: `#/viewer/openlayers/config?bbox=8,8,53,53`
+
+Where values are `minLongitude, minLatitude, maxLongitude, maxLatitude` respecting order.
 
 ### AddLayers
 

--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -761,7 +761,7 @@ describe('queryparam epics', () => {
             },
             router: {
                 location: {
-                    search: "?featureInfo=38.72,-95.625"
+                    search: "?featureInfo=-95.625,38.72"
                 }
             }
         };
@@ -774,7 +774,7 @@ describe('queryparam epics', () => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 try {
                     expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
-                    expect(actions[0].point.latlng).toEqual({lat: '38.72', lng: '-95.625'});
+                    expect(actions[0].point.latlng).toEqual({lng: '-95.625', lat: '38.72'});
                     expect(actions[0].point.pixel).toBe(undefined);
                     expect(actions[0].point.geometricFilter).toExist();
                 } catch (e) {

--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -244,7 +244,7 @@ export const paramActions = {
                 }
             }, projection), false, filterNameList ?? [])];
         } else if (typeof value === 'string') {
-            const [latitude, longitude] = value.split(',');
+            const [longitude, latitude] = value.split(',');
             if (typeof latitude !== 'undefined' && typeof longitude !== 'undefined') {
                 return [featureInfoClick(updatePointWithGeometricFilter({
                     latlng: {


### PR DESCRIPTION
8675 Query parameters documentation and `lon,lat` order unification (#8676)