### PR TITLE
#8621 Mobile widgets view minor improvements

### DIFF
--- a/web/client/components/widgets/widget/ChartWidget.jsx
+++ b/web/client/components/widgets/widget/ChartWidget.jsx
@@ -32,7 +32,6 @@ const ChartWidget = ({
     icons,
     showTable,
     topRightItems,
-    options = {},
     confirmDelete = false,
     dataGrid = {},
     onDelete = () => {},
@@ -50,7 +49,7 @@ const ChartWidget = ({
         onDelete={onDelete}
         toggleDeleteConfirm = {toggleDeleteConfirm}
         topRightItems={topRightItems}
-        options={options}
+        options={props?.options}
     >
         {showTable
             ? <TableView data={data} {...props}/>

--- a/web/client/components/widgets/widget/CounterWidget.jsx
+++ b/web/client/components/widgets/widget/CounterWidget.jsx
@@ -31,7 +31,6 @@ export default ({
     headerStyle,
     icons,
     topRightItems,
-    options = {},
     dataGrid = {},
     toggleTableView = () => {},
     toggleDeleteConfirm = () => {},
@@ -49,7 +48,7 @@ export default ({
         toggleDeleteConfirm = {toggleDeleteConfirm}
         headerStyle={headerStyle}
         topRightItems={topRightItems}
-        options={options}
+        options={props?.options}
     >
         <CounterView id={id} isAnimationActive={!loading} loading={loading} data={data} series={series} iconFit {...props} />
     </WidgetContainer>);

--- a/web/client/components/widgets/widget/LegendWidget.jsx
+++ b/web/client/components/widgets/widget/LegendWidget.jsx
@@ -20,7 +20,6 @@ export default ({
     headerStyle,
     confirmDelete = false,
     topRightItems,
-    options = {},
     dataGrid = {},
     onDelete = () => {},
     ...props
@@ -29,7 +28,7 @@ export default ({
         icons={icons}
         topRightItems={topRightItems}
         isDraggable={dataGrid.isDraggable}
-        options={options}
+        options={props?.options}
     >
         <LegendView {...props} />
     </WidgetContainer>

--- a/web/client/components/widgets/widget/SingleWidgetControls.jsx
+++ b/web/client/components/widgets/widget/SingleWidgetControls.jsx
@@ -6,27 +6,30 @@ import classnames from 'classnames';
 import Button from "../../../components/misc/Button";
 
 const SingleWidgetControls = ({ options }) => {
+    const showButtons = options.dropdownWidgets.length > 1;
     const maxIndex = options.dropdownWidgets.length - 1;
     const activeIndex = options.dropdownWidgets.findIndex(el => el.id === options.activeWidget.id);
     const nextIndex = activeIndex === maxIndex ? 0 : activeIndex + 1;
     const prevIndex = activeIndex === 0 ? maxIndex : activeIndex - 1;
     return (
         <div className="widget-selector">
-            <Button
-                className="previous-widget btn-sm no-border"
-                onPointerDown={() => options.setActiveWidget(options.dropdownWidgets[prevIndex])}
-            >
-                <Glyphicon
-                    glyph="arrow-left"/>
-            </Button>
+            {
+                showButtons ?
+                    <Button
+                        className="previous-widget btn-sm no-border"
+                        onPointerDown={() => options.setActiveWidget(options.dropdownWidgets[prevIndex])}
+                    >
+                        <Glyphicon glyph="arrow-left"/>
+                    </Button> : null
+            }
             <Select
                 openOnFocus
                 clearable={false}
                 searchable={false}
-                value={{ id: options.activeWidget.id, label: options.activeWidget.title}}
+                value={{ id: options.activeWidget.id, label: options.activeWidget.title ?? options.activeWidget?.layer?.title}}
                 onChange={(w) => options.setActiveWidget(options.dropdownWidgets.find(el => el.id === w.value))}
                 options={useMemo(() =>
-                    options.dropdownWidgets.map(w => ({value: w.id, label: w.title, active: w.id === options.activeWidget.id})),
+                    options.dropdownWidgets.map(w => ({value: w.id, label: w.title ?? w?.layer?.title, active: w.id === options.activeWidget.id})),
                 [options.dropdownWidgets])}
                 optionComponent={({option, onSelect}) => <div
                     className={classnames({
@@ -38,13 +41,16 @@ const SingleWidgetControls = ({ options }) => {
                     {option.label}
                 </div>}
             />
-            <Button
-                className="next-widget btn-sm no-border"
-                onPointerDown={() => options.setActiveWidget(options.dropdownWidgets[nextIndex])}
-            >
-                <Glyphicon
-                    glyph="arrow-right"/>
-            </Button>
+            {
+                showButtons ?
+                    <Button
+                        className="next-widget btn-sm no-border"
+                        onPointerDown={() => options.setActiveWidget(options.dropdownWidgets[nextIndex])}
+                    >
+                        <Glyphicon glyph="arrow-right"/>
+                    </Button> : null
+            }
+
         </div>
     );
 };

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -31,6 +31,7 @@ import {
     exportCSV,
     exportImage,
     toggleCollapse,
+    toggleCollapseAll,
     toggleMaximize,
     updateWidgetProperty
 } from '../actions/widgets';
@@ -70,6 +71,7 @@ compose(
             updateWidgetProperty,
             exportCSV,
             toggleCollapse,
+            toggleCollapseAll,
             toggleMaximize,
             exportImage,
             deleteWidget,
@@ -217,8 +219,23 @@ compose(
             ),
             withPropsOnChange(
                 ['activeWidget', 'isSingleWidgetLayout', 'widgets'],
-                ({activeWidget, dropdownWidgets, setActiveWidget, isSingleWidgetLayout, widgets, toolsOptions, layouts}) => {
+                ({
+                    activeWidget,
+                    dropdownWidgets,
+                    isSingleWidgetLayout,
+                    widgets,
+                    toolsOptions,
+                    layouts,
+                    setActiveWidget,
+                    toggleCollapseAll: collapseAll
+                }) => {
                     if (activeWidget && isSingleWidgetLayout && widgets.length) {
+                        const showWidget = widgets.find(el => el.id === activeWidget.id);
+                        if (!showWidget) {
+                            // If single widget should not be displayed - hide all other widgets to make widgets tray
+                            // update its state properly (show "Expand all widgets" button)
+                            collapseAll();
+                        }
                         const widget = {
                             ...activeWidget,
                             options: {

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
-import {compose, defaultProps, lifecycle, withProps, withPropsOnChange, withState} from 'recompose';
+import {compose, defaultProps, withHandlers, withProps, withPropsOnChange, withState} from 'recompose';
 
 
 import {createPlugin} from '../utils/PluginsUtils';
@@ -201,6 +201,16 @@ compose(
         compose(
             // add state to store currently selected widget
             withState('activeWidget', 'setActiveWidget', false),
+            withHandlers({
+                toggleCollapse: props => (w) => {
+                    const showWidget = props.widgets?.find(el => el.id === props.activeWidget?.id);
+                    if (props.isSingleWidgetLayout && showWidget) {
+                        props.toggleCollapseAll();
+                    } else {
+                        props.toggleCollapse(w);
+                    }
+                }
+            }),
             // adjust dropdown options according to the widgets visibility for the user
             withPropsOnChange(
                 ["dropdownWidgets", "toolsOptions"],
@@ -217,21 +227,6 @@ compose(
                     }
                 }
             ),
-            // If single widget should not be displayed - hide all other widgets to make widgets tray
-            // update its state properly (show "Expand all widgets" button)
-            lifecycle({
-                componentDidUpdate(prevProps) {
-                    const { widgets, activeWidget, isSingleWidgetLayout, toggleCollapseAll: collapseAll } = this.props;
-                    if (activeWidget && isSingleWidgetLayout && widgets.length && widgets !== prevProps.widgets) {
-                        const showWidget = widgets.find(el => el.id === activeWidget.id);
-                        if (!showWidget) {
-                            // If single widget should not be displayed - hide all other widgets to make widgets tray
-                            // update its state properly (show "Expand all widgets" button)
-                            collapseAll();
-                        }
-                    }
-                }
-            }),
             withPropsOnChange(
                 ['activeWidget', 'isSingleWidgetLayout', 'widgets'],
                 ({


### PR DESCRIPTION
## Description
This PR improves UX of mobile widgets as well as resolves minor bugs:
- Hide widget toggle arrows if only one widget is available;
- Use layer title in dropdown if widget title was not set to prevent options with empty name;
- Properly update visibility status of all widgets whenever collapse button of single widget used.
- Fixes regression introduced by #8622 when custom colors classification was not applied to the charts. This issue was mentioned in #8679 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8621
https://github.com/geosolutions-it/MapStore2/pull/8622#issuecomment-1271594893

**What is the new behavior?**
Referenced issues are covered with the changes

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
