### PR TITLE
MapStore2-C040#638 get WFS feature from pick

### DIFF
--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -33,6 +33,7 @@ export const TOGGLE_SHOW_COORD_EDITOR = 'IDENTIFY:TOGGLE_SHOW_COORD_EDITOR';
 export const EDIT_LAYER_FEATURES = 'IDENTIFY:EDIT_LAYER_FEATURES';
 export const SET_CURRENT_EDIT_FEATURE_QUERY = 'IDENTIFY:CURRENT_EDIT_FEATURE_QUERY';
 export const SET_MAP_TRIGGER = 'IDENTIFY:SET_MAP_TRIGGER';
+export const SET_INTERSECTED_FEATURES = 'IDENTIFY:SET_INTERSECTED_FEATURES';
 
 export const TOGGLE_EMPTY_MESSAGE_GFI = "IDENTIFY:TOGGLE_EMPTY_MESSAGE_GFI";
 
@@ -83,6 +84,17 @@ export function exceptionsFeatureInfo(reqId, exceptions, rParams, lMetaData) {
         exceptions: exceptions,
         requestParams: rParams,
         layerMetadata: lMetaData
+    };
+}
+
+/**
+ * Private
+ * @return a SET_INTERSECTED_FEATURES action with the actual intersected features captured with picking
+ */
+export function setIntersectedFeature(intersectedFeatures) {
+    return {
+        type: SET_INTERSECTED_FEATURES,
+        intersectedFeatures
     };
 }
 

--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -21,6 +21,7 @@ class DefaultViewer extends React.Component {
     static propTypes = {
         format: PropTypes.string,
         collapsible: PropTypes.bool,
+        intersectedFeatures: PropTypes.array,
         requests: PropTypes.array,
         responses: PropTypes.array,
         missingResponses: PropTypes.number,
@@ -45,6 +46,7 @@ class DefaultViewer extends React.Component {
 
     static defaultProps = {
         format: getDefaultInfoFormatValue(),
+        intersectedFeatures: [],
         responses: [],
         requests: [],
         missingResponses: 0,
@@ -68,7 +70,10 @@ class DefaultViewer extends React.Component {
     };
 
     shouldComponentUpdate(nextProps) {
-        return nextProps.responses !== this.props.responses || nextProps.missingResponses !== this.props.missingResponses || nextProps.index !== this.props.index;
+        return nextProps.responses !== this.props.responses
+            || nextProps.missingResponses !== this.props.missingResponses
+            || nextProps.index !== this.props.index
+            || nextProps.intersectedFeatures !== this.props.intersectedFeatures;
     }
 
     /**
@@ -142,6 +147,20 @@ class DefaultViewer extends React.Component {
     }
 
     renderPages = () => {
+        if (this.props.intersectedFeatures.length) {
+            return this.props.intersectedFeatures.map(featureSet => (<Panel
+                eventKey={0}
+                key={0}
+                collapsible={this.props.collapsible}
+                header={ null }
+                style={this.props.style}>
+                <ViewerPage
+                    response={{features: featureSet.features}}
+                    format="application/json"
+                    viewers={this.props.viewers}
+                    layer={{title: 'Unknown'}}/>
+            </Panel>));
+        }
         const {validResponses: responses} = this.getResponseProperties();
         return responses.map((res, i) => {
             const {response, layerMetadata} = res;
@@ -194,7 +213,7 @@ class DefaultViewer extends React.Component {
         componentOrder = this.props.isMobile ? componentOrder : reverse(componentOrder);
         return (
             <div className="mapstore-identify-viewer">
-                {!emptyResponses ? componentOrder.map((c)=> c) : this.renderEmptyPages()}
+                {!emptyResponses || this.props.intersectedFeatures.length ? componentOrder.map((c)=> c) : this.renderEmptyPages()}
             </div>
         );
     }
@@ -203,7 +222,7 @@ class DefaultViewer extends React.Component {
         if (isEmpty(currResponse) && this.props.isMobile) {
             return {height: "100%"};
         }
-        return {display: isEmpty(currResponse) ? 'none' : 'block'};
+        return {display: (isEmpty(currResponse) && !this.props.intersectedFeatures.length) ? 'none' : 'block'};
     }
 }
 

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -34,6 +34,7 @@ import ResponsivePanel from "../../misc/panels/ResponsivePanel";
 export default props => {
     const {
         enabled,
+        intersectedFeatures = [],
         requests = [],
         onClose = () => {},
         responses = [],
@@ -114,7 +115,7 @@ export default props => {
             containerClassName={enabled && requests.length !== 0 ? "identify-active" : ""}
             bsStyle="primary"
             glyph="map-marker"
-            open={enabled && requests.length !== 0}
+            open={enabled && (requests.length !== 0 || intersectedFeatures.length)}
             size={size}
             fluid={fluid}
             position={position}
@@ -203,6 +204,7 @@ export default props => {
                 setIndex={setIndex}
                 format={format}
                 missingResponses={missingResponses}
+                intersectedFeatures={intersectedFeatures}
                 responses={responses}
                 requests={requests}
                 showEmptyMessageGFI={showEmptyMessageGFI}

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -322,6 +322,10 @@ class CesiumMap extends React.Component {
             const propertyNames = feature.getPropertyNames();
             const properties = Object.fromEntries(propertyNames.map(key => [key, feature.getProperty(key)]));
             return [{ id: msId, features: [{ type: 'Feature', properties, geometry: null }] }];
+        } else if (feature?.id instanceof Cesium.Entity && feature.id.id && feature.id.properties) {
+            const {propertyNames} = feature.id.properties;
+            const properties = Object.fromEntries(propertyNames.map(key => [key, feature.id.properties[key].getValue(0)]));
+            return [{ features: [{ type: 'Feature', properties, id: feature?.id?.id, geometry: null }] }];
         }
         return [];
     }

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -19,7 +19,7 @@ import {
     exceptionsFeatureInfo, loadFeatureInfo, errorFeatureInfo,
     noQueryableLayers, newMapInfoRequest, getVectorInfo,
     showMapinfoMarker, hideMapinfoMarker, setCurrentEditFeatureQuery,
-    SET_MAP_TRIGGER, CLEAR_WARNING
+    SET_MAP_TRIGGER, CLEAR_WARNING, setIntersectedFeature
 } from '../actions/mapInfo';
 
 import { SET_CONTROL_PROPERTIES, SET_CONTROL_PROPERTY, TOGGLE_CONTROL } from '../actions/controls';
@@ -75,6 +75,10 @@ import {updatePointWithGeometricFilter} from "../utils/IdentifyUtils";
 export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { } }) =>
     action$.ofType(FEATURE_INFO_CLICK)
         .switchMap(({ point, filterNameList = [], overrideParams = {} }) => {
+            if (point.intersectedFeatures?.length) {
+                return Rx.Observable.of(setIntersectedFeature(point.intersectedFeatures));
+            }
+
             // Reverse - To query layer in same order as in TOC
             let queryableLayers = reverse(queryableLayersSelector(getState()));
             const queryableSelectedLayers = queryableSelectedLayersSelector(getState());
@@ -151,7 +155,7 @@ export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { }
             // NOTE: multiSelection is inside the event
             // TODO: move this flag in the application state
             if (point && point.modifiers && point.modifiers.ctrl === true && point.multiSelection) {
-                return out$;
+                return out$.startWith(setIntersectedFeature([]));
             }
             return out$.startWith(purgeMapInfoResults());
         });

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -66,7 +66,8 @@ import {
     showEmptyMessageGFISelector,
     validResponsesSelector,
     hoverEnabledSelector,
-    mapInfoEnabledSelector
+    mapInfoEnabledSelector,
+    intersectedFeaturesSelector
 } from '../selectors/mapInfo';
 import { mapLayoutValuesSelector } from '../selectors/maplayout';
 import { isCesium, mapTypeSelector } from '../selectors/maptype';
@@ -78,6 +79,7 @@ import Message from './locale/Message';
 
 const selector = createStructuredSelector({
     enabled: (state) => mapInfoEnabledSelector(state) || state.controls && state.controls.info && state.controls.info.enabled || false,
+    intersectedFeatures: intersectedFeaturesSelector,
     responses: responsesSelector,
     validResponses: validResponsesSelector,
     requests: requestsSelector,
@@ -104,7 +106,7 @@ const selector = createStructuredSelector({
  */
 const identifyIndex = compose(
     connect(
-        createSelector(indexSelector, isLoadedResponseSelector, (state) => state.browser && state.browser.mobile,  (index, loaded, isMobile) => ({ index, loaded, isMobile })),
+        createSelector(indexSelector, isLoadedResponseSelector, intersectedFeaturesSelector, (state) => state.browser && state.browser.mobile,  (index, loaded, intersectedFeatures, isMobile) => ({ index, loaded: loaded || intersectedFeatures, isMobile })),
         {
             setIndex: changePage
         }
@@ -124,6 +126,7 @@ const identifyDefaultProps = defaultProps({
     draggable: true,
     collapsible: false,
     format: getDefaultInfoFormatValue(),
+    intersectedFeatures: [],
     requests: [],
     responses: [],
     viewerOptions: {},

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -37,7 +37,8 @@ import {
     SET_CURRENT_EDIT_FEATURE_QUERY,
     SET_MAP_TRIGGER,
     SET_SHOW_IN_MAP_POPUP,
-    INIT_PLUGIN
+    INIT_PLUGIN,
+    SET_INTERSECTED_FEATURES
 } from '../actions/mapInfo';
 
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -282,7 +283,11 @@ function mapInfo(state = initState, action) {
     }
     case PURGE_MAPINFO_RESULTS:
         const {index, loaded, ...others} = state;
-        return {...others, queryableLayers: [], responses: [], requests: [] };
+        return {...others, queryableLayers: [], responses: [], requests: [], intersectedFeatures: [] };
+    case SET_INTERSECTED_FEATURES: {
+        const {intersectedFeatures} = action;
+        return {...state, intersectedFeatures};
+    }
     case LOAD_FEATURE_INFO: {
         return receiveResponse(state, action, 'data');
     }

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -109,6 +109,8 @@ export const isHighlightEnabledSelector = (state = {}) => state.mapInfo && state
 
 export const indexSelector = (state = {}) => state && state.mapInfo && state.mapInfo.index;
 
+export const intersectedFeaturesSelector = state => state?.mapInfo?.intersectedFeatures;
+
 export const responsesSelector = state => state.mapInfo && state.mapInfo.responses || [];
 
 export const requestsSelector = state => state?.mapInfo?.requests || [];

--- a/web/client/utils/cesium/ClickUtils.js
+++ b/web/client/utils/cesium/ClickUtils.js
@@ -26,8 +26,16 @@ export const getMouseXYZ = (viewer, event) => {
 
     const feature = scene.pick(mousePosition);
     if (feature) {
+        let currentDepthTestAgainstTerrain = scene.globe.depthTestAgainstTerrain;
+        let currentPickTranslucentDepth = scene.pickTranslucentDepth;
+        scene.globe.depthTestAgainstTerrain = true;
+        scene.pickTranslucentDepth = true;
         const depthCartesian = scene.pickPosition(mousePosition);
-        return Cesium.Cartographic.fromCartesian(depthCartesian);
+        scene.globe.depthTestAgainstTerrain = currentDepthTestAgainstTerrain;
+        scene.pickTranslucentDepth = currentPickTranslucentDepth;
+        if (depthCartesian) {
+            return Cesium.Cartographic.fromCartesian(depthCartesian);
+        }
     }
 
     const ray = viewer.camera.getPickRay(mousePosition);


### PR DESCRIPTION
## Description
Get WFS feature info from pick method instead of doing get feature requests

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [X] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
https://github.com/geosolutions-it/mapstore2-c040/issues/638

**What is the new behavior?**
Use picking feature data in `indentify` plugin

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
