### PR TITLE
Produce build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - run : "npm install"
       - run: "npm run fe:build"
       - run: "npm run jsdoc:build"
-      - run: "mvn clean install -Dmapstore2.version=$GITHUB_REF_NAME printingbundle"
+      - run: "mvn clean install -Dmapstore2.version=$GITHUB_REF_NAME -Pprintingbundle"
       ############
       # Publish
       ##########

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build-mapstore:
+    runs-on: ubuntu-latest
     steps:
       - name: "checking out"
         uses: actions/checkout@v2
@@ -60,5 +61,4 @@ jobs:
                 product/target/mapstore.war
                 printing/target/mapstore-printing.zip
                 binary/target/mapstore2*-bin.zip
-                
                 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,15 +48,16 @@ jobs:
       ############
       # Build
       ##########
-      - run: "./build.sh $GITHUB_REF_NAME printing-bundle,binary"
+      - run : "npm install"
+      - run: "npm run fe:build"
+      - run: "npm run jsdoc:build"
+      - run: "mvn clean install -Dmapstore2.version=$GITHUB_REF_NAME printingbundle"
       ############
       # Publish
       ##########
       - uses: actions/upload-artifact@v3.1.0
         with:
-            name: MapStore-${{ github.sha }}
+            name: MapStore-Artifacts${{ github.sha }}
             path: |
                 product/target/mapstore.war
-                printing/target/mapstore-printing.zip
-                binary/target/mapstore2*-bin.zip
-                
+                printing/target/mapstore-printing.zip                

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,9 @@ on:
     # using filter pattern: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
     - '[cC][0-9][0-9][0-9]-+**' # c123 or c123-something for custom branch
     - '[0-9][0-9][0-9][0-9].[0-9][0-9].xx' # stable brances. E.g. 2021.01.xx
-  pull_request:
-    branches:
-    - master # only to test the current PR
 
 jobs:
-  build-mapstore:
+  build-publish:
     runs-on: ubuntu-latest
     steps:
       - name: "checking out"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,13 +48,11 @@ jobs:
       ############
       # Build
       ##########
-      - name: "build"
-        run: "./build.sh $GITHUB_REF_NAME printing-bundle,binary"
+      - run: "./build.sh $GITHUB_REF_NAME printing-bundle,binary"
       ############
       # Publish
       ##########
-      - name: "publish zip as artifact"
-        uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3.1.0
         with:
             name: MapStore-${{ github.sha }}
             path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,28 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-       - name: "cache maven dependencies"
+      - name: "cache maven dependencies"
         uses: actions/cache@v1
         with:
           path: ~/.m2/repository
           key: mapstore-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             mapstore-${{ runner.os }}-maven-
+      ############
+      # Build
+      ##########
+      - name: "build"
+        run: "build.sh ${{GITHUB_REF_NAME}} printing-bundle,binary"
+      ############
+      # Publish
+      ##########
+      - name: "publish zip as artifact"
+        uses: actions/upload-artifact@v1
+        with:
+            name: MapStore-${{ github.sha }}
+            path: |
+                product/target/mapstore.war
+                printing/target/mapstore-printing.zip
+                binary/target/mapstore2*-bin.zip
+                
+                

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: checks
+on:
+  push:
+    branches:
+    - master
+    # using filter pattern: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+    - '[cC][0-9][0-9][0-9]-+**' # c123 or c123-something for custom branch
+    - '[0-9][0-9][0-9][0-9].[0-9][0-9].xx' # stable brances. E.g. 2021.01.xx
+  pull_request:
+    branches:
+    - master # only to test the current PR
+
+jobs:
+  build-mapstore:
+    steps:
+      - name: "checking out"
+        uses: actions/checkout@v2
+      - name: "setting up npm"
+        uses: actions/setup-node@v2
+        with:
+            node-version: '12.x'
+      - name: "setting up Java"
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8.x'
+      ############
+      # CACHING
+      ##########
+      - name: "cache node modules"
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+       - name: "cache maven dependencies"
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: mapstore-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            mapstore-${{ runner.os }}-maven-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: checks
+name: build artifacts
 on:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       # Build
       ##########
       - name: "build"
-        run: "build.sh ${{GITHUB_REF_NAME}} printing-bundle,binary"
+        run: "./build.sh $GITHUB_REF_NAME printing-bundle,binary"
       ############
       # Publish
       ##########


### PR DESCRIPTION

## Description
Produce mapstore.war of the latest master (and other artifacts) for download and install.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
We were not able to get the current mapster war without accessing to jenkins. 

I didn't create an issue for this yet. Experimenting first.


**What is the new behavior?**
We should be able to download the main artifacts (mapstore.war, printing-bundle and binary).

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
