### PR TITLE
#8693 Register catalog epics app-wide

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -30,6 +30,8 @@ import pluginsCreator from "./map/index";
 import withScalesDenominators from "../components/map/enhancers/withScalesDenominators";
 import { createFeatureFilter } from '../utils/FilterUtils';
 import ErrorPanel from '../components/map/ErrorPanel';
+import catalog from "../epics/catalog";
+import API from '../api/catalog';
 
 /**
  * The Map plugin allows adding mapping library dependent functionality using support tools.
@@ -470,7 +472,10 @@ export default createPlugin('Map', {
         maptype: mapTypeReducer,
         additionallayers: additionalLayersReducer
     },
-    epics: mapEpics,
+    epics: {
+        ...mapEpics,
+        ...catalog(API)
+    },
     containers: {
         Settings: () => ({
             tool: <MapSettings />,


### PR DESCRIPTION
## Description
With the module plugin approach it is impossible to use query parameters to dynamically add layers to the map in case if `TOC` or `Catalog` (MetadataExplorer) plugins are not rendered on the current page. In this case epics are either not registered or muted, which makes action run with no effect on the loaded layers.
This PR adds catalog epics to the `Map` plugin to ensure functionality is available for any map viewer.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
