### PR TITLE
#8693 Register background selector epics with the map

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -31,6 +31,7 @@ import withScalesDenominators from "../components/map/enhancers/withScalesDenomi
 import { createFeatureFilter } from '../utils/FilterUtils';
 import ErrorPanel from '../components/map/ErrorPanel';
 import catalog from "../epics/catalog";
+import backgroundSelector from "../epics/backgroundselector";
 import API from '../api/catalog';
 
 /**
@@ -474,6 +475,7 @@ export default createPlugin('Map', {
     },
     epics: {
         ...mapEpics,
+        ...backgroundSelector,
         ...catalog(API)
     },
     containers: {


### PR DESCRIPTION
## Description
To make it always possible to update background of the map using query parameters one should register `backgroundSelector` epics along with `catalog` epics.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8693 

**What is the new behavior?**
Background can be changed using query parameters on a context where only map is active in plugins list.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
