### PR TITLE
#8695 Move Identify plugin into main bundle

### DIFF
--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -22,6 +22,7 @@ import RulesManagerFooter from "../plugins/RulesManagerFooter";
 import Print from "../plugins/Print";
 import UserSession from "../plugins/UserSession";
 import Login from '../plugins/Login';
+import Identify from '../plugins/Identify';
 
 
 /**
@@ -43,6 +44,7 @@ export const plugins = {
     RulesManagerFooter: RulesManagerFooter,
     UserSessionPlugin: UserSession,
     LoginPlugin: Login,
+    IdentifyPlugin: Identify,
 
     // ### DYNAMIC PLUGINS ### //
     // product plugins
@@ -96,7 +98,6 @@ export const plugins = {
     HelpLinkPlugin: toModulePlugin('HelpLink', () => import(/* webpackChunkName: 'plugins/helpLink' */ '../plugins/HelpLink')),
     HelpPlugin: toModulePlugin('Help', () => import(/* webpackChunkName: 'plugins/helpPlugin' */ '../plugins/Help')),
     HomePlugin: toModulePlugin('Home', () => import(/* webpackChunkName: 'plugins/home' */ '../plugins/Home')),
-    IdentifyPlugin: toModulePlugin('Identify', () => import(/* webpackChunkName: 'plugins/identify' */ '../plugins/Identify')),
     LanguagePlugin: toModulePlugin('Language', () => import(/* webpackChunkName: 'plugins/language' */ '../plugins/Language')),
     LayerDownload: toModulePlugin('LayerDownload', () => import(/* webpackChunkName: 'plugins/layerDownload' */ '../plugins/LayerDownload')),
     LayerInfoPlugin: toModulePlugin('LayerInfo', () => import(/* webpackChunkName: 'plugins/layerInfo' */ '../plugins/LayerInfo')),


### PR DESCRIPTION
## Description
`Identify` is one of the plugins which configuration can be defined by object passed in `localConfig` in `initialState.defaultState.mapInfo`. Reducers of module plugins are registered once plugin should be rendered on the page for the first time. At the same time, Redux denies to use state values added prior to the reducer registration, which makes this approach of configuration definition not possible when plugin is a module.
This PR adds `Identify` back to the main bundle to fix the regression

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8695 

**What is the new behavior?**
 Plugin is static, therefore configuration applied this way works as expected.
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
