### PR TITLE
#7934 fix some remaining zombie config and improved migration guideline

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -148,7 +148,7 @@ We suggest you to clean up your project as well:
   - dashboard
   - geostory
   - mobile
-- remove Define plugins in webpack-config.js or prod.webpack-config.js containing version info retrieved with git-revision-webpack-plugin, because we have moved these definitions to a more general file *build/BuildUtils.js*
+- remove `DefinePlugin` entries dedicated to git revision retrieved by `git-revision-webpack-plugin`, if any, from `webpack-config.js` or `prod.webpack-config.js`, because they have been moved to the file `build/BuildUtils.js`
 - check that in your package.json you have this extends rule
 
 ```js

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -142,12 +142,13 @@ We no longer maintain the Version plugin since we have moved its content inside 
 We suggest you to clean up your project as well:
 
 - remove Version entry it from a local list of plugins.js
-- remove Version entries it from a localConfig
-- add About entry into other pages of mapstore plugins array, suggest list is:
+- remove Version entries it from a localConfig.json and pluginConfig.json
+- add About entry into other pages of mapstore plugins array:
+
   - dashboard
   - geostory
   - mobile
-- remove Define plugins in webpack-config.js or prod.webpack-config.js, since we have moved these definition to a more general *build/buildConfig.js* file
+- remove Define plugins in webpack-config.js or prod.webpack-config.js containing version info retrieved with git-revision-webpack-plugin, because we have moved these definitions to a more general file *build/BuildUtils.js*
 - check that in your package.json you have this extends rule
 
 ```js

--- a/project/standard/templates/configs/pluginsConfig.json
+++ b/project/standard/templates/configs/pluginsConfig.json
@@ -155,12 +155,6 @@
       ]
     },
     {
-      "name": "Version",
-      "glyph": "info-sign",
-      "title": "plugins.Version.title",
-      "description": "plugins.Version.description"
-    },
-    {
       "name": "BackgroundSelector",
       "title": "plugins.BackgroundSelector.title",
       "description": "plugins.BackgroundSelector.description"
@@ -321,9 +315,6 @@
       "glyph": "cog",
       "title": "plugins.Settings.title",
       "description": "plugins.Settings.description",
-      "children": [
-        "Version"
-      ],
       "dependencies": [
         "SidebarMenu"
       ],

--- a/web/client/configs/pluginsConfig.json
+++ b/web/client/configs/pluginsConfig.json
@@ -315,9 +315,6 @@
       "glyph": "cog",
       "title": "plugins.Settings.title",
       "description": "plugins.Settings.description",
-      "children": [
-        "Version"
-      ],
       "dependencies": [
         "SidebarMenu"
       ],


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

While checking other things I noticed that in a previous PR #8504 we missed to clean up the config of standard project when removing the version plugin

this pr improves also the migration guideline

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: clean up

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7934 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
when creating a new project standard the pluginConfig.json does not contain version plugin definition
migration guideline is updated by specifying some info

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
