### PR TITLE
#8588: Fix - Map config load on no widget config

### DIFF
--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -176,6 +176,10 @@ describe('Test the widgets reducer', () => {
         const state = widgets(undefined, configureMap({widgetsConfig: {widgets: [{id: "1"}]}}));
         expect(state.containers[DEFAULT_TARGET].widgets.length).toBe(1);
     });
+    it('configureMap with no widget', () => {
+        const state = widgets(undefined, configureMap({}));
+        expect(state.containers[DEFAULT_TARGET].widgets).toBeFalsy();
+    });
     it('changeLayout', () => {
         const L = {lg: []};
         const AL = {md: []};

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -169,10 +169,12 @@ function widgetsReducer(state = emptyState, action) {
             ...data
         }, state);
     case MAP_CONFIG_LOADED:
-        const { widgetsConfig } = (action.config || {});
-        const updatedWidgetsConfig = convertToCompatibleWidgets(widgetsConfig);
+        let { widgetsConfig } = (action.config || {});
+        if (widgetsConfig) {
+            widgetsConfig = convertToCompatibleWidgets(widgetsConfig);
+        }
         return set(`containers[${DEFAULT_TARGET}]`, {
-            ...updatedWidgetsConfig
+            ...widgetsConfig
         }, state);
     case CHANGE_LAYOUT: {
         return set(`containers[${action.target}].layout`, action.layout)(set(`containers[${action.target}].layouts`, action.allLayouts, state));


### PR DESCRIPTION
## Description
This PR fixes the issue when on map config load with no widget config, the map fails to load

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#8588 

**What is the new behavior?**
Map loads find with and without widget data

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
