### PR TITLE
#8588: Fix - Effective handle of widget conversion

### DIFF
--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -176,9 +176,17 @@ describe('Test the widgets reducer', () => {
         const state = widgets(undefined, configureMap({widgetsConfig: {widgets: [{id: "1"}]}}));
         expect(state.containers[DEFAULT_TARGET].widgets.length).toBe(1);
     });
-    it('configureMap with no widget', () => {
+    it('configureMap with no widgetsConfig', () => {
         const state = widgets(undefined, configureMap({}));
         expect(state.containers[DEFAULT_TARGET].widgets).toBeFalsy();
+    });
+    it('configureMap with empty object widgetsConfig', () => {
+        const state = widgets(undefined, configureMap({widgetsConfig: {}}));
+        expect(state.containers[DEFAULT_TARGET].widgets).toBeFalsy({});
+    });
+    it('configureMap with empty widgets in widgetsConfig', () => {
+        const state = widgets(undefined, configureMap({widgetsConfig: { widgets: []}}));
+        expect(state.containers[DEFAULT_TARGET].widgets).toEqual([]);
     });
     it('changeLayout', () => {
         const L = {lg: []};

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -35,7 +35,7 @@ import { MAP_CONFIG_LOADED } from '../actions/config';
 import { DASHBOARD_LOADED, DASHBOARD_RESET } from '../actions/dashboard';
 import assign from 'object-assign';
 import set from 'lodash/fp/set';
-import { get, find, omit, mapValues, castArray } from 'lodash';
+import { get, find, omit, mapValues, castArray, isEmpty } from 'lodash';
 import { arrayUpsert, compose, arrayDelete } from '../utils/ImmutableUtils';
 import {
     convertDependenciesMappingForCompatibility as convertToCompatibleWidgets,
@@ -170,7 +170,7 @@ function widgetsReducer(state = emptyState, action) {
         }, state);
     case MAP_CONFIG_LOADED:
         let { widgetsConfig } = (action.config || {});
-        if (widgetsConfig) {
+        if (!isEmpty(widgetsConfig)) {
             widgetsConfig = convertToCompatibleWidgets(widgetsConfig);
         }
         return set(`containers[${DEFAULT_TARGET}]`, {

--- a/web/client/utils/WidgetsUtils.js
+++ b/web/client/utils/WidgetsUtils.js
@@ -151,7 +151,7 @@ export const CHART_PROPS = ["selectedChartId", "id", "mapSync", "widgetType", "c
 export const convertDependenciesMappingForCompatibility = (data) => {
     const mapDependencies = ["layers", "viewport", "zoom", "center"];
     const _data = cloneDeep(data);
-    const widgets = _data.widgets || {};
+    const widgets = _data?.widgets || [];
     const tempWidgetMapDependency = [];
     return {
         ..._data,


### PR DESCRIPTION
## Description
This PR fixes initiation of widget conversion based on widgetconfig data from some old and empty maps 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#8588 

**What is the new behavior?**
All these maps loads fine
https://dev-mapstore.geosolutionsgroup.com/mapstore/#/viewer/openlayers/10358 (With widget)
https://dev-mapstore.geosolutionsgroup.com/mapstore/#/viewer/openlayers/new (No widgetconfig)
https://dev-mapstore.geosolutionsgroup.com/mapstore/#/viewer/openlayers/40249 (Widgetconfig with empty obj)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Should fix also https://github.com/geosolutions-it/MapStore2/issues/8722