### PR TITLE
#8723 Fix for WMTS background issues due to `attribution` parameter; #8724 WMTS request identify flow fixes

### DIFF
--- a/web/client/components/data/identify/viewers/row/RowViewer.jsx
+++ b/web/client/components/data/identify/viewers/row/RowViewer.jsx
@@ -12,6 +12,7 @@ import PropertiesViewer from './PropertiesViewer';
 import { getRowViewer } from '../../../../../utils/MapInfoUtils';
 import { ANNOTATIONS } from '../../../../../utils/AnnotationsUtils';
 import PropTypes from 'prop-types';
+import {omit} from "lodash/object";
 
 const defaultRowViewerOptions = {
     // we need some default options for annotations
@@ -41,7 +42,7 @@ function RowViewer({
     const Row = layerRowViewer || component || PropertiesViewer;
     return (
         <Row
-            {...feature.properties}
+            {...omit(feature.properties, ['ref'])}
             feature={feature}
             labelIds={labelIds}
             exclude={excludeProperties}

--- a/web/client/utils/leaflet/WMTS.js
+++ b/web/client/utils/leaflet/WMTS.js
@@ -42,8 +42,9 @@ var WMTS = L.TileLayer.extend({
             wmtsParams.width = wmtsParams.height = tileSize;
         }
         for (let i in options) {
-            // all keys that are not TileLayer options go to WMS params
-            if (!this.options.hasOwnProperty(i) && i !== 'crs') {
+            // all keys that are not TileLayer options go to WMTS params
+            // skip attribution parameter, html content of it make requests fail
+            if (!this.options.hasOwnProperty(i) && i !== 'crs' && i !== 'attribution') {
                 wmtsParams[i] = options[i];
             }
         }

--- a/web/client/utils/mapinfo/__tests__/wmts-test.js
+++ b/web/client/utils/mapinfo/__tests__/wmts-test.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+
+import axios from '../../../libs/ajax';
+import MockAdapter from "axios-mock-adapter";
+import {INFO_FORMATS} from "../../FeatureInfoUtils";
+import {getFeatureInfo} from "../../../api/identify";
+
+describe('mapinfo wmts utils', () => {
+    let mockAxios;
+    beforeEach((done) => {
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        if (mockAxios) {
+            mockAxios.restore();
+        }
+        mockAxios = null;
+        setTimeout(done);
+    });
+
+    it('should return the response object from getIdentifyFlow in case of 400 error, TileOutOfRange', (done) => {
+        const SAMPLE_LAYER = {
+            type: "wmts",
+            name: "test_layer"
+        };
+        mockAxios.onGet().reply(() => {
+            return [400, '<?xml version="1.0" encoding="UTF-8"?><ExceptionReport version="1.1.0" xmlns="http://www.opengis.net/ows/1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://geowebcache.org/schema/ows/1.1.0/owsExceptionReport.xsd">  <Exception exceptionCode="TileOutOfRange" locator="TILEROW">    <ExceptionText>Row 84 is out of range, min: 85 max:87</ExceptionText>  </Exception></ExceptionReport>'];
+        });
+        getFeatureInfo(
+            "TEST_URL", {
+                info_format: INFO_FORMATS.PROPERTIES
+            }, SAMPLE_LAYER
+        ).subscribe(
+            n => {
+                expect(n.data.features).toEqual([]);
+                expect(n.features).toEqual([]);
+                done();
+            },
+            error => {
+                return done(error);
+            }
+        );
+    });
+});

--- a/web/client/utils/mapinfo/wmts.js
+++ b/web/client/utils/mapinfo/wmts.js
@@ -96,11 +96,11 @@ export default {
                         if (code === 'TileOutOfRange') {
                             return { data: { features: []}};
                         }
-                        return e;
+                        throw e;
                     });
 
                 }
-                return e;
+                throw e;
             })
 
 };

--- a/web/client/utils/mapinfo/wmts.js
+++ b/web/client/utils/mapinfo/wmts.js
@@ -17,9 +17,13 @@ import {
 import {getLayerUrl} from '../LayersUtils';
 import {optionsToVendorParams} from '../VendorParamsUtils';
 
-import {isObject, isNil} from 'lodash';
+import {isObject, isNil, get} from 'lodash';
 
 import assign from 'object-assign';
+import Rx, {Observable} from "rxjs";
+import axios from "../../libs/ajax";
+import {parseString} from "xml2js";
+import {stripPrefix} from "xml2js/lib/processors";
 
 export default {
     buildRequest: (layer, props) => {
@@ -78,5 +82,25 @@ export default {
             },
             url: getLayerUrl(layer).replace(/[?].*$/g, '')
         };
-    }
+    },
+    getIdentifyFlow: (layer, basePath, params) =>
+        Observable.defer(() => axios.get(basePath, { params }))
+            .catch((e) => {
+                if (e.data.indexOf("ExceptionReport") > 0) {
+                    return Rx.Observable.bindNodeCallback( (data, callback) => parseString(data, {
+                        tagNameProcessors: [stripPrefix],
+                        explicitArray: false,
+                        mergeAttrs: true
+                    }, callback))(e.data).map(data => {
+                        const code = get(data, "ExceptionReport.Exception.exceptionCode");
+                        if (code === 'TileOutOfRange') {
+                            return { data: { features: []}};
+                        }
+                        return e;
+                    });
+
+                }
+                return e;
+            })
+
 };

--- a/web/client/utils/mapinfo/wmts.js
+++ b/web/client/utils/mapinfo/wmts.js
@@ -94,13 +94,13 @@ export default {
                     }, callback))(e.data).map(data => {
                         const code = get(data, "ExceptionReport.Exception.exceptionCode");
                         if (code === 'TileOutOfRange') {
-                            return { data: { features: []}};
+                            return params.infoformat === 'text/plain' ? {data: 'no features were found'} : { data: { features: []}};
                         }
-                        throw e;
+                        return e;
                     });
 
                 }
-                throw e;
+                return e;
             })
 
 };


### PR DESCRIPTION
## Description
This PR applies minor changes to resolve following issues:
[8723](https://github.com/geosolutions-it/MapStore2/issues/8723)
[8724](https://github.com/geosolutions-it/MapStore2/issues/8724)

- WMTS background requests were failing due to `attribution` parameter passed to the requests. While parameter itself doesn't break anything, having html tags in it makes tile requests fail. Applied changes just making sure that attribution is used by MapStore, but not being added to the request.
- Features set displayed in identify results panels could possibly have feature with `ref` property. Such feature can potentially cause React exception because of props spreading in `RowViewer` component. With the applied changes `ref` property is omitted prior to spreading.
- Click outside of the tile matrix is causing `GetFeatureInfo` request fail with 400 error. This error was not handled properly on the side of identify flow for WMTS layer. It resulted into epic error and complete outage of side-effects processing. Applied changes adding extra check to the identify flow for WMTS layers to make sure that error is processed properly if request fails because row/column is out of range.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
[8723](https://github.com/geosolutions-it/MapStore2/issues/8723)
[8724](https://github.com/geosolutions-it/MapStore2/issues/8724)

**What is the new behavior?**
According to the description. Please refer to the example map/geoStory in referenced issues for testing.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
