### PR TITLE
#8726 Widgets: set correct init position

### DIFF
--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -84,7 +84,7 @@ compose(
         widthProvider({ overrideWidthProvider: false }),
         withProps(({ isMobileAgent, width, mapLayout, singleWidgetLayoutBreakpoint = 600 }) => {
             const rightOffset = mapLayout?.right ?? 0;
-            const leftOffset = 0;
+            const leftOffset = (width && width > 800) ? 500 : 0;
             const viewWidth = width - (leftOffset + rightOffset + RIGHT_MARGIN);
             const isSingleWidgetLayout = isMobileAgent || viewWidth <= singleWidgetLayoutBreakpoint;
             const backgroundSelectorOffset = isSingleWidgetLayout ? (isMobileAgent ? 40 : 60) : 0;


### PR DESCRIPTION
## Description
Return back `leftOffset` calculation for the widget.
Regression was commited in
https://github.com/geosolutions-it/MapStore2/commit/70322da2630492bc419f209acf1ebaf42c716eba

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8726 

**What is the new behavior?**
The widget initially located to the left of the TOC.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

