### PR TITLE
#8726 The new widgets on the map are under the TOC

### DIFF
--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -287,7 +287,9 @@
                 "declineUrl" : "http://www.google.com"
               }
             },
-            "FeedbackMask"
+            "FeedbackMask",
+            { "name": "Widgets" },
+            { "name": "WidgetsTray" }
         ],
         "desktop": ["Details",
           {

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -53,7 +53,7 @@ compose(
             getFloatingWidgetsLayout,
             getMaximizedState,
             dependenciesSelector,
-            (state) => mapLayoutValuesSelector(state, { right: true, left: true }),
+            (state) => mapLayoutValuesSelector(state, { right: true}),
             state => state.browser && state.browser.mobile,
             getFloatingWidgets,
             (id, widgets, layouts, maximized, dependencies, mapLayout, isMobileAgent, dropdownWidgets) => ({

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -53,7 +53,7 @@ compose(
             getFloatingWidgetsLayout,
             getMaximizedState,
             dependenciesSelector,
-            (state) => mapLayoutValuesSelector(state, { right: true}),
+            (state) => mapLayoutValuesSelector(state, { right: true, left: true }),
             state => state.browser && state.browser.mobile,
             getFloatingWidgets,
             (id, widgets, layouts, maximized, dependencies, mapLayout, isMobileAgent, dropdownWidgets) => ({
@@ -82,11 +82,11 @@ compose(
     compose(
         heightProvider({ debounceTime: 20, closest: true, querySelector: '.fill' }),
         widthProvider({ overrideWidthProvider: false }),
-        withProps(({ isMobileAgent, width, mapLayout, singleWidgetLayoutBreakpoint = 600 }) => {
+        withProps(({ isMobileAgent, width, mapLayout, singleWidgetLayoutBreakpoint = 1024 }) => {
             const rightOffset = mapLayout?.right ?? 0;
-            const leftOffset = 0;
-            const viewWidth = width - (leftOffset + rightOffset + RIGHT_MARGIN);
-            const isSingleWidgetLayout = isMobileAgent || viewWidth <= singleWidgetLayoutBreakpoint;
+            const isSingleWidgetLayout = isMobileAgent || width <= singleWidgetLayoutBreakpoint;
+            const leftOffset = isSingleWidgetLayout ? 0 : 500;
+            const viewWidth = width - (rightOffset + RIGHT_MARGIN + leftOffset);
             const backgroundSelectorOffset = isSingleWidgetLayout ? (isMobileAgent ? 40 : 60) : 0;
             return {
                 backgroundSelectorOffset,
@@ -104,7 +104,6 @@ compose(
             leftOffset,
             viewWidth,
             isSingleWidgetLayout,
-            singleWidgetLayoutBreakpoint,
             singleWidgetLayoutMaxHeight = 300,
             singleWidgetLayoutMinHeight = 200,
             backgroundSelectorOffset
@@ -145,7 +144,7 @@ compose(
             return ({
                 rowHeight,
                 className: "on-map",
-                breakpoints: isSingleWidgetLayout ? { xxs: 0 } : { md: singleWidgetLayoutBreakpoint, xxs: 0 },
+                breakpoints: isSingleWidgetLayout ? { xxs: 0 } : { md: 0 },
                 cols: { md: 6, xxs: 1 },
                 ...widthOptions,
                 useDefaultWidthProvider: false,

--- a/web/client/plugins/widgets/WidgetsTray.jsx
+++ b/web/client/plugins/widgets/WidgetsTray.jsx
@@ -133,7 +133,7 @@ export default compose(
         hasCollapsedWidgets: widgets.filter(({ collapsed } = {}) => collapsed).length > 0,
         hasTrayWidgets: widgets.length > 0
     })),
-    withProps(({ isMobileAgent, width, singleWidgetLayoutBreakpoint = 600 }) => {
+    withProps(({ isMobileAgent, width, singleWidgetLayoutBreakpoint = 1024 }) => {
         return {
             isSingleWidgetLayout: isMobileAgent || width <= singleWidgetLayoutBreakpoint
         };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Restore left offset of map widgets

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8726

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The widgets on map have a left offset of 500px to keep them always visible on desktop

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
