### PR TITLE
#8752 Single widget layout - make sure that chart widget properly merge options passed from enhancer and from widget configuration itself

### DIFF
--- a/web/client/components/widgets/enhancers/__tests__/chartWidget-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/chartWidget-test.jsx
@@ -33,7 +33,7 @@ describe('chartWidget enhancer', () => {
     it('chartWidgetProps default', (done) => {
         const Sink = chartWidgetProps(createSink(props => {
             expect(props).toBeTruthy();
-            expect(props).toEqual({charts: [], selectedChartId: undefined});
+            expect(props).toEqual({charts: [], selectedChartId: undefined, options: {}});
             done();
         }));
         ReactDOM.render(<Sink/>, document.getElementById("container"));

--- a/web/client/components/widgets/enhancers/chartWidget.js
+++ b/web/client/components/widgets/enhancers/chartWidget.js
@@ -44,8 +44,8 @@ export default compose(
 );
 
 export const chartWidgetProps = compose(
-    withProps(({charts = [], selectedChartId})=> {
+    withProps(({charts = [], selectedChartId, options = {}})=> {
         const chartData = charts?.find(c => c.chartId === selectedChartId) || {};
-        return { ...chartData, charts, selectedChartId };
+        return { ...chartData, options: {...options, ...(chartData?.options ?? {})}, charts, selectedChartId };
     })
 );


### PR DESCRIPTION
## Description
#8752 
Issue appears after changes applied to the chart widget (#8588), with the approach of having multiple charts to be available as a single switchable widget on dashboard.
Even though this feature is not relevant to Map widgets, it still affects it because widget component is shared.

This PR applies minor change to the recently added enhancer to make sure that options related to the single widget layout are properly merged with widget options (grouping, color settings etc) and passed down to the WidgetContainer where they are used to render single widget controls: dropdown and arrows.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8752 

**What is the new behavior?**
As per description. Options being merged correctly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
