### PR TITLE
#8238 Save dialog is not properly displayed in certain cases

### DIFF
--- a/web/client/components/home/Home.jsx
+++ b/web/client/components/home/Home.jsx
@@ -15,6 +15,7 @@ import Message from '../../components/I18N/Message';
 import ConfirmModal from '../../components/misc/ResizableModal';
 import { get, pick } from "lodash";
 import ConfigUtils from "../../utils/ConfigUtils";
+import Portal from '../../components/misc/Portal';
 export const getPath = () => {
     const miscSettings = ConfigUtils.getConfigProp('miscSettings');
     return get(miscSettings, ['homePath'], '/');
@@ -61,25 +62,27 @@ class Home extends React.Component {
                         {...pick(restProps, ['disabled', 'active', 'block', 'componentClass', 'href', 'children', 'icon', 'bsStyle', 'className'])}
                     ><Glyphicon glyph={this.props.icon}/></Button>
                 </OverlayTrigger>
-                <ConfirmModal
-                    ref="unsavedMapModal"
-                    show={this.props.displayUnsavedDialog || false}
-                    onClose={this.props.onCloseUnsavedDialog}
-                    title={<Message msgId="resources.maps.unsavedMapConfirmTitle" />}
-                    buttons={[{
-                        bsStyle: "primary",
-                        text: <Message msgId="resources.maps.unsavedMapConfirmButtonText" />,
-                        onClick: this.goHome
-                    }, {
-                        text: <Message msgId="resources.maps.unsavedMapCancelButtonText" />,
-                        onClick: this.props.onCloseUnsavedDialog
-                    }]}
-                    fitContent
-                >
-                    <div className="ms-detail-body">
-                        <Message msgId="resources.maps.unsavedMapConfirmMessage" />
-                    </div>
-                </ConfirmModal>
+                <Portal>
+                    <ConfirmModal
+                        ref="unsavedMapModal"
+                        show={this.props.displayUnsavedDialog || false}
+                        onClose={this.props.onCloseUnsavedDialog}
+                        title={<Message msgId="resources.maps.unsavedMapConfirmTitle" />}
+                        buttons={[{
+                            bsStyle: "primary",
+                            text: <Message msgId="resources.maps.unsavedMapConfirmButtonText" />,
+                            onClick: this.goHome
+                        }, {
+                            text: <Message msgId="resources.maps.unsavedMapCancelButtonText" />,
+                            onClick: this.props.onCloseUnsavedDialog
+                        }]}
+                        fitContent
+                    >
+                        <div className="ms-detail-body">
+                            <Message msgId="resources.maps.unsavedMapConfirmMessage" />
+                        </div>
+                    </ConfirmModal>
+                </Portal>
             </React.Fragment>
         );
     }


### PR DESCRIPTION
## Description
Fix zIndex value for unsaved map confirmation dialog.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

#8238 

**What is the new behavior?**
Works as expected

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information

Reproducible only on https://qa-mapstore.geosolutionsgroup.com/mapstore/#/ 