### PR TITLE
#8745 Date-time picker for date-time/date/time attributes on feature editor

### DIFF
--- a/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
@@ -55,16 +55,37 @@ class DateTimeEditor extends AttributeEditor {
         shouldCalendarSetHours: false
     };
 
-    componentDidMount() {
-        this.props.onTemporaryChanges?.(true);
+    constructor() {
+        super();
+        this.state = {
+            date: new Date()
+        };
     }
+
+    componentDidMount() {
+        const {dataType, value} = this.props;
+        this.props.onTemporaryChanges?.(true);
+        const convertedDate = moment.utc(value, formats[dataType]);
+        this.setState({ date: convertedDate.isValid() ? convertedDate.toDate() : new Date()});
+    }
+
+    componentDidUpdate(prevProps) {
+        const { value: prevValue, dataType: prevDataType } = prevProps;
+        const { value, dataType } = this.props;
+
+        if (prevValue !== value || prevDataType !== dataType) {
+            const convertedDate = moment.utc(value, formats[dataType]);
+            this.setState({ date: convertedDate.isValid() ? convertedDate.toDate() : new Date()});
+        }
+    }
+
     componentWillUnmount() {
         this.props.onTemporaryChanges?.(false);
     }
 
     render() {
-        const {shouldCalendarSetHours, dataType, value, calendar, time} = this.props;
-        const date = moment.utc(value, formats[dataType]).toDate();
+        const {shouldCalendarSetHours, dataType, calendar, time} = this.props;
+        const { date } = this.state;
         return (<UTCDateTimePicker
             {...this.props}
             type={dataType}

--- a/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
@@ -52,7 +52,9 @@ class DateTimeEditor extends AttributeEditor {
         column: {},
         calendar: true,
         time: false,
-        shouldCalendarSetHours: false
+        shouldCalendarSetHours: false,
+        min: new Date(1500, 0, 1),
+        max: new Date(2099, 0, 1)
     };
 
     constructor() {

--- a/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
@@ -1,0 +1,85 @@
+import PropTypes from 'prop-types';
+// import { editors } from 'react-data-grid';
+import AttributeEditor from "./AttributeEditor";
+// import IntlNumberFormControl from "../../../I18N/IntlNumberFormControl";
+import React from "react";
+import DateTimePicker from "../../../misc/datetimepicker";
+import utcDateWrapper from "../../../misc/enhancers/utcDateWrapper";
+import moment from "moment";
+import "moment-timezone";
+
+/**
+ * Date time picker enhanced with UTC and timezone offset
+ * it takes the localized date in input and it translates to UTC
+ * for the DateTimePicker tool
+ */
+const UTCDateTimePicker = utcDateWrapper({
+    dateProp: "value",
+    dateTypeProp: "dataType",
+    setDateProp: "onBlur"
+})(DateTimePicker);
+
+const formats = {
+    'date-time': 'YYYY-MM-DDTHH:mm:ss[Z]',
+    'time': 'HH:mm:ss',
+    'date': 'YYYY-MM-DD[Z]'
+};
+
+/**
+ * date, date-time, time editor for FeatureGrid
+ *
+ * @name DateTimeEditor
+ * @memberof components.data.featuregrid.editors
+ * @type {Object}
+ */
+class DateTimeEditor extends AttributeEditor {
+    static propTypes = {
+        value: PropTypes.string,
+        inputProps: PropTypes.object,
+        dataType: PropTypes.string,
+        minValue: PropTypes.number,
+        maxValue: PropTypes.number,
+        column: PropTypes.object,
+        onTemporaryChanges: PropTypes.func,
+        calendar: PropTypes.bool,
+        time: PropTypes.bool,
+        shouldCalendarSetHours: PropTypes.bool
+    };
+
+    static contextTypes = {
+        locale: PropTypes.string
+    };
+
+    static defaultProps = {
+        dataType: "date-time",
+        column: {},
+        calendar: true,
+        time: false,
+        shouldCalendarSetHours: false
+    };
+
+    componentDidMount() {
+        this.props.onTemporaryChanges?.(true);
+    }
+    componentWillUnmount() {
+        this.props.onTemporaryChanges?.(false);
+    }
+
+    render() {
+        const {shouldCalendarSetHours, dataType, value, calendar, time} = this.props;
+        const date = moment.utc(value, formats[dataType]).toDate();
+        return (<UTCDateTimePicker
+            {...this.props}
+            type={dataType}
+            defaultValue={date}
+            value={date}
+            calendar={calendar}
+            time={time}
+            format={formats[dataType]}
+            options={{
+                shouldCalendarSetHours
+            }}
+        />);
+    }
+}
+export default DateTimeEditor;

--- a/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
@@ -58,7 +58,7 @@ class DateTimeEditor extends AttributeEditor {
     constructor() {
         super();
         this.state = {
-            date: new Date()
+            date: null
         };
     }
 
@@ -66,7 +66,9 @@ class DateTimeEditor extends AttributeEditor {
         const {dataType, value} = this.props;
         this.props.onTemporaryChanges?.(true);
         const convertedDate = moment.utc(value, formats[dataType]);
-        this.setState({ date: convertedDate.isValid() ? convertedDate.toDate() : new Date()});
+        if (value) {
+            this.setState({ date: convertedDate.isValid() ? convertedDate.toDate() : null});
+        }
     }
 
     componentDidUpdate(prevProps) {
@@ -75,7 +77,7 @@ class DateTimeEditor extends AttributeEditor {
 
         if (prevValue !== value || prevDataType !== dataType) {
             const convertedDate = moment.utc(value, formats[dataType]);
-            this.setState({ date: convertedDate.isValid() ? convertedDate.toDate() : new Date()});
+            this.setState({ date: convertedDate.isValid() ? convertedDate.toDate() : null});
         }
     }
 

--- a/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
@@ -1,12 +1,9 @@
 import PropTypes from 'prop-types';
-// import { editors } from 'react-data-grid';
 import AttributeEditor from "./AttributeEditor";
-// import IntlNumberFormControl from "../../../I18N/IntlNumberFormControl";
 import React from "react";
 import DateTimePicker from "../../../misc/datetimepicker";
 import utcDateWrapper from "../../../misc/enhancers/utcDateWrapper";
 import moment from "moment";
-import "moment-timezone";
 
 /**
  * Date time picker enhanced with UTC and timezone offset

--- a/web/client/components/data/featuregrid/editors/__tests__/DateTimeEditor-test.jsx
+++ b/web/client/components/data/featuregrid/editors/__tests__/DateTimeEditor-test.jsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import DateTimeEditor from "../DateTimeEditor";
+import moment from "moment";
+
+let testColumn = {
+    key: 'columnKey'
+};
+
+
+describe('FeatureGrid DateTimeEditor component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('DateTimeEditor Editor', () => {
+        const date = moment.utc('2010-01-01').toDate();
+        const cmp = ReactDOM.render(<DateTimeEditor
+            value={date}
+            rowIdx={1}
+            column={testColumn}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        expect(moment.utc(cmp.getValue().columnKey).toISOString()).toBe(date.toISOString());
+    });
+});

--- a/web/client/components/data/featuregrid/editors/index.jsx
+++ b/web/client/components/data/featuregrid/editors/index.jsx
@@ -3,6 +3,7 @@ import Editor from './AttributeEditor';
 import NumberEditor from './NumberEditor';
 import AutocompleteEditor from './AutocompleteEditor';
 import DropDownEditor from './DropDownEditor';
+import DateTimeEditor from "./DateTimeEditor";
 
 const types = {
     "defaultEditor": (props) => <Editor {...props}/>,
@@ -11,6 +12,9 @@ const types = {
     "string": (props) => props.autocompleteEnabled ?
         <AutocompleteEditor dataType="string" {...props}/> :
         <Editor dataType="string" {...props}/>,
-    "boolean": (props) => <DropDownEditor dataType="string" {...props} value={props.value && props.value.toString()} filter={false} values={["true", "false"]}/>
+    "boolean": (props) => <DropDownEditor dataType="string" {...props} value={props.value && props.value.toString()} filter={false} values={["true", "false"]}/>,
+    "date-time": (props) => <DateTimeEditor dataType="date-time" time popupPosition="top" {...props} />,
+    "date": (props) => <DateTimeEditor dataType="date" popupPosition="top" {...props} />,
+    "time": (props) => <DateTimeEditor dataType="time" calendar={false} time popupPosition="top" {...props} />
 };
 export default (type, props) => types[type] ? types[type](props) : types.defaultEditor(props);

--- a/web/client/components/misc/datetimepicker/DateTimePicker.js
+++ b/web/client/components/misc/datetimepicker/DateTimePicker.js
@@ -80,6 +80,14 @@ class DateTimePicker extends Component {
         }
     }
 
+    constructor() {
+        super();
+        this.fallbackDate = new Date();
+        this.fallbackDate.setHours(0);
+        this.fallbackDate.setMinutes(0);
+        this.fallbackDate.setSeconds(0);
+    }
+
     state = {
         open: '',
         focused: false,
@@ -155,7 +163,7 @@ class DateTimePicker extends Component {
                 </div>
                 <div className={`rw-calendar-popup rw-popup-container ${popupPosition === 'top' ? 'rw-dropup' : ''} ${!calendarVisible ? 'rw-popup-animating' : ''}`} style={{ display: calendarVisible ? 'block' : 'none', overflow: calendarVisible ? 'visible' : 'hidden', height: '285px' }}>
                     <div className={`rw-popup`} style={{ transform: calendarVisible ? 'translateY(0)' : 'translateY(-100%)', padding: '0', borderRadius: '4px', position: calendarVisible ? '' : 'absolute' }}>
-                        <Calendar tabIndex="-1" ref={this.attachCalRef} onMouseDown={this.handleMouseDown} onChange={this.handleCalendarChange} {...props} />
+                        <Calendar tabIndex="-1" ref={this.attachCalRef} min={new Date(1500, 0, 1)} onMouseDown={this.handleMouseDown} onChange={this.handleCalendarChange} {...props} />
                     </div>
                 </div>
             </div>
@@ -303,7 +311,7 @@ class DateTimePicker extends Component {
             date = setTime(value, new Date());
         } else {
             // keep hours value defined by value in state or default date
-            date = setTime(value, this.state.date ?? this.props.value);
+            date = setTime(value, this.state.date ?? this.props.value ?? this.fallbackDate);
         }
         const inputValue = this.format(date);
         this.setState({ date, inputValue, open: '' });

--- a/web/client/components/misc/datetimepicker/DateTimePicker.js
+++ b/web/client/components/misc/datetimepicker/DateTimePicker.js
@@ -163,7 +163,7 @@ class DateTimePicker extends Component {
                 </div>
                 <div className={`rw-calendar-popup rw-popup-container ${popupPosition === 'top' ? 'rw-dropup' : ''} ${!calendarVisible ? 'rw-popup-animating' : ''}`} style={{ display: calendarVisible ? 'block' : 'none', overflow: calendarVisible ? 'visible' : 'hidden', height: '285px' }}>
                     <div className={`rw-popup`} style={{ transform: calendarVisible ? 'translateY(0)' : 'translateY(-100%)', padding: '0', borderRadius: '4px', position: calendarVisible ? '' : 'absolute' }}>
-                        <Calendar tabIndex="-1" ref={this.attachCalRef} min={new Date(1500, 0, 1)} onMouseDown={this.handleMouseDown} onChange={this.handleCalendarChange} {...props} />
+                        <Calendar tabIndex="-1" ref={this.attachCalRef} onMouseDown={this.handleMouseDown} onChange={this.handleCalendarChange} {...props} />
                     </div>
                 </div>
             </div>

--- a/web/client/components/misc/datetimepicker/DateTimePicker.js
+++ b/web/client/components/misc/datetimepicker/DateTimePicker.js
@@ -58,12 +58,14 @@ class DateTimePicker extends Component {
         placeholder: PropTypes.string,
         onChange: PropTypes.func,
         calendar: PropTypes.bool,
+        popupPosition: PropTypes.oneOf(['top', 'bottom']),
         time: PropTypes.bool,
         value: PropTypes.any,
         operator: PropTypes.string,
         culture: PropTypes.string,
         toolTip: PropTypes.string,
-        tabIndex: PropTypes.string
+        tabIndex: PropTypes.string,
+        options: PropTypes.object
     }
 
     static defaultProps = {
@@ -71,7 +73,11 @@ class DateTimePicker extends Component {
         calendar: true,
         time: true,
         onChange: () => { },
-        value: null
+        value: null,
+        popupPosition: 'bottom',
+        options: {
+            shouldCalendarSetHours: true
+        }
     }
 
     state = {
@@ -111,7 +117,7 @@ class DateTimePicker extends Component {
 
     render() {
         const { open, inputValue, operator, focused } = this.state;
-        const { calendar, time, toolTip, placeholder, tabIndex } = this.props;
+        const { calendar, time, toolTip, placeholder, tabIndex, popupPosition } = this.props;
         const props = Object.keys(this.props).reduce((acc, key) => {
             if (['placeholder', 'calendar', 'time', 'onChange', 'value'].includes(key)) {
                 // remove these props because they might have undesired effects to the subsequent components
@@ -142,12 +148,12 @@ class DateTimePicker extends Component {
                     </span>
                     : ''
                 }
-                <div className={`rw-popup-container rw-popup-animating`} style={{ display: timeVisible ? "block" : "none", overflow: timeVisible ? "visible" : "hidden", height: "216px" }}>
+                <div className={`rw-popup-container rw-popup-animating ${popupPosition === 'top' ? 'rw-dropup' : ''}`} style={{ display: timeVisible ? "block" : "none", overflow: timeVisible ? "visible" : "hidden", height: "216px" }}>
                     <div className={`rw-popup rw-widget`} style={{ transform: timeVisible ? 'translateY(0)' : 'translateY(-100%)', position: timeVisible ? '' : 'absolute' }}>
                         <Hours ref={this.attachTimeRef} onMouseDown={this.handleMouseDown} {...props} onClose={this.close} onSelect={this.handleTimeSelect} />
                     </div>
                 </div>
-                <div className={`rw-calendar-popup rw-popup-container ${!calendarVisible ? 'rw-popup-animating' : ''}`} style={{ display: calendarVisible ? 'block' : 'none', overflow: calendarVisible ? 'visible' : 'hidden', height: '375px' }}>
+                <div className={`rw-calendar-popup rw-popup-container ${popupPosition === 'top' ? 'rw-dropup' : ''} ${!calendarVisible ? 'rw-popup-animating' : ''}`} style={{ display: calendarVisible ? 'block' : 'none', overflow: calendarVisible ? 'visible' : 'hidden', height: '285px' }}>
                     <div className={`rw-popup`} style={{ transform: calendarVisible ? 'translateY(0)' : 'translateY(-100%)', padding: '0', borderRadius: '4px', position: calendarVisible ? '' : 'absolute' }}>
                         <Calendar tabIndex="-1" ref={this.attachCalRef} onMouseDown={this.handleMouseDown} onChange={this.handleCalendarChange} {...props} />
                     </div>
@@ -292,7 +298,13 @@ class DateTimePicker extends Component {
     }
 
     handleCalendarChange = value => {
-        const date = setTime(value, new Date());
+        let date;
+        if (this.props.options?.shouldCalendarSetHours) {
+            date = setTime(value, new Date());
+        } else {
+            // keep hours value defined by value in state or default date
+            date = setTime(value, this.state.date ?? this.props.value);
+        }
         const inputValue = this.format(date);
         this.setState({ date, inputValue, open: '' });
         this.props.onChange(date, `${this.state.operator}${inputValue}`);

--- a/web/client/components/misc/datetimepicker/Hours.js
+++ b/web/client/components/misc/datetimepicker/Hours.js
@@ -22,11 +22,13 @@ class Hours extends Component {
 
     static propTypes = {
         onSelect: PropTypes.func,
-        onMouseDown: PropTypes.func
+        onMouseDown: PropTypes.func,
+        disabled: PropTypes.bool
     }
     static defaultProps = {
         onSelect: () => { },
-        onMouseDown: () => {}
+        onMouseDown: () => {},
+        disabled: false
     }
 
     state = { focusedItemIndex: 0, times: [] };
@@ -37,9 +39,10 @@ class Hours extends Component {
 
     render() {
         const { focusedItemIndex, times } = this.state;
+        const { onMouseDown, onSelect, disabled } = this.props;
         return (
             <ul id="rw_1_time_listbox" style={{ position: 'relative' }} ref={this.attachListRef} tabIndex="0" className="rw-list" role="listbox" aria-labelledby="rw_1_input" aria-live="false" aria-hidden="true" aria-activedescendant="rw_1_time_listbox__option__11">
-                {times.map((time, index) => <li key={time.label} onMouseDown={this.props.onMouseDown} onClick={() => this.props.onSelect(time)} ref={instance => {this.itemsRef[index] = instance;}} role="option" tabIndex="0" aria-selected="false" className={`rw-list-option ${focusedItemIndex === index ? 'rw-state-focus' : ''}`} id="rw_1_time_listbox__option__0">{time.label}</li>)}
+                {times.map((time, index) => <li key={time.label} onMouseDown={disabled ? () => {} : onMouseDown} onClick={disabled ? () => {} : () => onSelect(time)} ref={instance => {this.itemsRef[index] = instance;}} role="option" tabIndex="0" aria-selected="false" className={`rw-list-option ${focusedItemIndex === index && !disabled ? 'rw-state-focus' : ''} ${disabled ? 'rw-state-disabled' : ''}`} id="rw_1_time_listbox__option__0">{time.label}</li>)}
             </ul>
         );
     }

--- a/web/client/components/misc/datetimepicker/__tests__/DateTimePicker-test.js
+++ b/web/client/components/misc/datetimepicker/__tests__/DateTimePicker-test.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 import expect from 'expect';
 import TestUtils from 'react-dom/test-utils';
 import DateTimePicker from '../index';
+import {getUTCTimePart} from "../../../../utils/TimeUtils";
 
 describe('DateTimePicker component', () => {
     beforeEach((done) => {
@@ -130,5 +131,28 @@ describe('DateTimePicker component', () => {
         TestUtils.Simulate.change(input, { target: { value: `!== ${date}` } });
         TestUtils.Simulate.keyDown(input, {key: 'Enter'});
     });
+    it('DateTimePicker test popup position', function(done) {
+        ReactDOM.render(<DateTimePicker popupPosition="top" />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const calendar = container.querySelector('.rw-btn-calendar');
+        TestUtils.Simulate.click(calendar);
+        const dropUp = container.querySelector('.rw-dropup');
+        expect(dropUp).toExist();
+        done();
+    });
 
+    it('DateTimePicker test calendarSetHours disabled option', function(done) {
+        const date = '2010-01-01';
+        const handleChange = (value) => {
+            const hours = getUTCTimePart(value);
+            expect(hours).toEqual('00:00:00');
+            done();
+        };
+        ReactDOM.render(<DateTimePicker format="'YYYY-MM-DDTHH:mm:ss[Z]'" options={{ shouldCalendarSetHours: false }} value={moment.utc(date, 'YYYY-MM-DD').toDate()} onChange={handleChange} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const calendar = container.querySelector('.rw-btn-calendar');
+        TestUtils.Simulate.click(calendar);
+        const day = container.querySelector('.rw-calendar-grid tbody tr td:first-child .rw-btn');
+        TestUtils.Simulate.click(day);
+    });
 });


### PR DESCRIPTION
## Description
This PR adds date-time picker for date-time/date/time attributes on feature editor.
It also provides a few handy options to existing DateTimePicker component to make it usable not only for filters, but also for data editing:
- Control over popup position with dates and time.
- Ability to skip hours change upon date selection. By default it picks current time upon date change, but if this behavior is disabled via option - existing time will be kept upon date selection.

DateTimeEditor for featuregrid supports three possible data types: date-time, date, time. In all the cases it expects data to be ISO 8601 formatted (https://www.w3.org/TR/NOTE-datetime)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8745 

**What is the new behavior?**
Date-time picker is available for date, time and date-time attribute types.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
![image](https://user-images.githubusercontent.com/113525996/199675932-0e8f108f-9ef1-432a-b4cd-e2aad31a0670.png)
