### PR TITLE
[Backport 2022.02.xx] #8706 Point and Line layers make it difficult to use Identify (#8700)

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -314,7 +314,10 @@ class CesiumMap extends React.Component {
     getIntersectedFeatures = (map, position) => {
         // we can use pick so the only first intersect feature will be returned
         // this is more intuitive for uses such as get feature info
-        const feature = map.scene.pick(position);
+        const feature = map.scene.drillPick(position).find((aFeature) => {
+            const {entityCollection: {owner: {queryable}}} = aFeature.id;
+            return queryable;
+        });
         if (feature instanceof Cesium.Cesium3DTileFeature && feature?.tileset?.msId) {
             const msId = feature.tileset.msId;
             // 3d tile feature does not contain a geometry in the Cesium3DTileFeature class
@@ -322,6 +325,10 @@ class CesiumMap extends React.Component {
             const propertyNames = feature.getPropertyNames();
             const properties = Object.fromEntries(propertyNames.map(key => [key, feature.getProperty(key)]));
             return [{ id: msId, features: [{ type: 'Feature', properties, geometry: null }] }];
+        } else if (feature?.id instanceof Cesium.Entity && feature.id.id && feature.id.properties) {
+            const {properties: {propertyNames}, entityCollection: {owner: {name}}} = feature.id;
+            const props = Object.fromEntries(propertyNames.map(key => [key, feature.id.properties[key].getValue(0)]));
+            return [{ id: name, features: [{ type: 'Feature', properties: props, id: feature?.id?.id, geometry: null }] }];
         }
         return [];
     }

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -1384,6 +1384,7 @@ describe('Cesium layer', () => {
             url: 'geoserver/wfs',
             title: 'Title',
             name: 'workspace:layer',
+            id: 'ws:layer_id',
             visibility: true,
             bbox: {
                 crs: 'EPSG:4326',
@@ -1398,7 +1399,7 @@ describe('Cesium layer', () => {
         // create layers
         const cmp = ReactDOM.render(
             <CesiumLayer
-                type="vector"
+                type="wfs"
                 options={options}
                 map={map}
             />, document.getElementById('container'));
@@ -1406,7 +1407,37 @@ describe('Cesium layer', () => {
         expect(cmp.layer).toBeTruthy();
         expect(cmp.layer.dataSource).toBeTruthy();
         expect(cmp.layer.dataSource.entities.values.length).toBe(0);
+        expect(cmp.layer.dataSource.name).toBe('ws:layer_id');
+        expect(cmp.layer.dataSource.queryable).toBe(true);
         expect(cmp.layer.detached).toBe(true);
+    });
+    it('should create a non-queriable wfs layer', () => {
+        const options = {
+            type: 'wfs',
+            url: 'geoserver/wfs',
+            title: 'Title',
+            name: 'workspace:layer',
+            id: 'ws:layer_id',
+            visibility: true,
+            queryable: false,
+            bbox: {
+                crs: 'EPSG:4326',
+                bounds: {
+                    minx: -180,
+                    miny: -90,
+                    maxx: 180,
+                    maxy: 90
+                }
+            }
+        };
+        // create layers
+        const cmp = ReactDOM.render(
+            <CesiumLayer
+                type="wfs"
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        expect(cmp.layer.dataSource.queryable).toBe(false);
     });
 
     it('should create a bil terrain provider from wms layer (deprecated)', () => {

--- a/web/client/components/map/cesium/plugins/WFSLayer.js
+++ b/web/client/components/map/cesium/plugins/WFSLayer.js
@@ -32,7 +32,7 @@ const requestFeatures = (options, params, cancelToken) => {
 
 const createLayer = (options, map) => {
 
-    let dataSource = new Cesium.GeoJsonDataSource();
+    let dataSource = new Cesium.GeoJsonDataSource(options?.id);
 
     const params = optionsToVendorParams(options);
 
@@ -70,6 +70,7 @@ const createLayer = (options, map) => {
     }
 
     dataSource.show = !!options.visibility;
+    dataSource.queryable = options.queryable === undefined || options.queryable;
 
     return {
         detached: true,

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -134,6 +134,7 @@ export const getMarkerLayer = (name, clickedMapPoint, styleName, otherParams, ma
     return {
         type: 'vector',
         visibility: true,
+        queryable: false,
         name: name || "GetFeatureInfo",
         styleName: styleName || "marker",
         label: markerLabel,

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -22,6 +22,7 @@ import {
     getLabelFromValue,
     getDefaultInfoFormatValueFromLayer,
     getLayerFeatureInfo,
+    getMarkerLayer,
     defaultQueryableFilter,
     filterRequestParams
 } from '../MapInfoUtils';
@@ -725,4 +726,56 @@ describe('MapInfoUtils', () => {
         expect(results).toEqual(false);
     });
 
+    it("getMarkerLayer should return layer config", () => {
+        let features;
+        let styleName;
+        let markerLabel;
+        let results = getMarkerLayer(
+            "GetFeatureInfoHighLight",
+            { features },
+            styleName,
+            {
+                overrideOLStyle: true,
+                style: {
+                    iconUrl:
+                        "data:image/png;base64,iVBORw...",
+                    shadowUrl:
+                        "data:image/png;base64,iVBORw...",
+                    iconSize: [25, 41],
+                    iconAnchor: [12, 41],
+                    popupAnchor: [1, -34],
+                    shadowSize: [41, 41],
+                    color: "#3388ff",
+                    weight: 4,
+                    dashArray: "",
+                    fillColor: "#3388ff",
+                    fillOpacity: 0.2
+                }
+            },
+            markerLabel
+        );
+        expect(results).toEqual({
+            type: "vector",
+            visibility: true,
+            queryable: false,
+            name: "GetFeatureInfoHighLight",
+            styleName: "marker",
+            label: undefined,
+            features: [],
+            overrideOLStyle: true,
+            style: {
+                iconUrl: "data:image/png;base64,iVBORw...",
+                shadowUrl: "data:image/png;base64,iVBORw...",
+                iconSize: [25, 41],
+                iconAnchor: [12, 41],
+                popupAnchor: [1, -34],
+                shadowSize: [41, 41],
+                color: "#3388ff",
+                weight: 4,
+                dashArray: "",
+                fillColor: "#3388ff",
+                fillOpacity: 0.2
+            }
+        });
+    });
 });

--- a/web/client/utils/cesium/ClickUtils.js
+++ b/web/client/utils/cesium/ClickUtils.js
@@ -24,10 +24,21 @@ export const getMouseXYZ = (viewer, event) => {
         return null;
     }
 
-    const feature = scene.pick(mousePosition);
+    const feature = viewer.scene.drillPick(mousePosition).find((aFeature) => {
+        const {entityCollection: {owner: {queryable}}} = aFeature.id;
+        return queryable;
+    });
     if (feature) {
+        let currentDepthTestAgainstTerrain = scene.globe.depthTestAgainstTerrain;
+        let currentPickTranslucentDepth = scene.pickTranslucentDepth;
+        scene.globe.depthTestAgainstTerrain = true;
+        scene.pickTranslucentDepth = true;
         const depthCartesian = scene.pickPosition(mousePosition);
-        return Cesium.Cartographic.fromCartesian(depthCartesian);
+        scene.globe.depthTestAgainstTerrain = currentDepthTestAgainstTerrain;
+        scene.pickTranslucentDepth = currentPickTranslucentDepth;
+        if (depthCartesian) {
+            return Cesium.Cartographic.fromCartesian(depthCartesian);
+        }
     }
 
     const ray = viewer.camera.getPickRay(mousePosition);

--- a/web/client/utils/mapinfo/__tests__/wfs-test.js
+++ b/web/client/utils/mapinfo/__tests__/wfs-test.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from "expect";
+import wfs from "../wfs";
+
+describe("mapinfo wfs utils", () => {
+    it("should create a GetFeature request", () => {
+        const layer = {
+            title: "Title",
+            url: "http://layer.url"
+        };
+        const request = wfs.buildRequest(layer);
+        expect(request).toEqual({
+            request: {
+                point: undefined,
+                service: "WFS",
+                version: "1.1.1",
+                request: "GetFeature",
+                outputFormat: "application/json",
+                exceptions: "application/json",
+                id: undefined,
+                typeName: undefined,
+                srs: "EPSG:4326",
+                feature_count: 10,
+                params: undefined
+            },
+            metadata: {
+                title: "Title",
+                regex: undefined,
+                viewer: undefined,
+                featureInfo: undefined
+            },
+            url: "http://layer.url"
+        });
+    });
+
+    it("should create a request with features retrieved from the intersected ones", () => {
+        const layer = {
+            id: "layer-id",
+            title: "Title"
+        };
+        const point = {
+            intersectedFeatures: [
+                {
+                    id: "layer-id",
+                    features: [
+                        {
+                            type: "Feature",
+                            properties: { key: "value" },
+                            geometry: null
+                        }
+                    ]
+                }
+            ]
+        };
+        const request = wfs.buildRequest(layer, { point });
+        expect(request).toEqual({
+            request: {
+                features: [
+                    {
+                        type: "Feature",
+                        properties: { key: "value" },
+                        geometry: null
+                    }
+                ],
+                outputFormat: "application/json"
+            },
+            metadata: {
+                title: "Title",
+                regex: undefined,
+                viewer: undefined,
+                featureInfo: undefined
+            },
+            url: "client"
+        });
+    });
+
+    it("should return the response object from getIdentifyFlow", (done) => {
+        wfs
+            .getIdentifyFlow(undefined, undefined, { features: [] })
+            .toPromise()
+            .then((response) => {
+                expect(response).toEqual({
+                    data: {
+                        features: []
+                    }
+                });
+                done();
+            });
+    });
+});


### PR DESCRIPTION
## Description
Get WFS feature info from pick method instead of doing get feature requests

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [X] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8706

**What is the new behavior?**
Use picking feature data in indentify plugin

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
