### PR TITLE
[Backport 2022.02.xx] #8740 Move the mouse on 3D Tiles (#8748)

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -315,8 +315,7 @@ class CesiumMap extends React.Component {
         // we can use pick so the only first intersect feature will be returned
         // this is more intuitive for uses such as get feature info
         const feature = map.scene.drillPick(position).find((aFeature) => {
-            const {entityCollection: {owner: {queryable}}} = aFeature.id;
-            return queryable;
+            return !(aFeature?.id?.entityCollection?.owner?.queryable === false);
         });
         if (feature instanceof Cesium.Cesium3DTileFeature && feature?.tileset?.msId) {
             const msId = feature.tileset.msId;

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -1378,6 +1378,37 @@ describe('Cesium layer', () => {
         expect(cmp.layer.dataSource.entities.values.length).toBe(1);
         expect(cmp.layer.detached).toBe(true);
     });
+    it('should create a vector layer queryable', () => {
+        const options = {
+            type: 'vector',
+            features: [{ type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [0, 0] } }],
+            title: 'Title',
+            visibility: true,
+            bbox: {
+                crs: 'EPSG:4326',
+                bounds: {
+                    minx: -180,
+                    miny: -90,
+                    maxx: 180,
+                    maxy: 90
+                }
+            },
+            queryable: false
+        };
+        // create layers
+        const cmp = ReactDOM.render(
+            <CesiumLayer
+                type="vector"
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        expect(cmp).toBeTruthy();
+        expect(cmp.layer).toBeTruthy();
+        expect(cmp.layer.dataSource).toBeTruthy();
+        expect(cmp.layer.dataSource.entities.values.length).toBe(1);
+        expect(cmp.layer.detached).toBe(true);
+        expect(cmp.layer.dataSource.queryable).toBe(false);
+    });
     it('should create a wfs layer', () => {
         const options = {
             type: 'wfs',

--- a/web/client/components/map/cesium/plugins/VectorLayer.js
+++ b/web/client/components/map/cesium/plugins/VectorLayer.js
@@ -54,6 +54,7 @@ const createLayer = (options, map) => {
     }
 
     dataSource.show = !!options.visibility;
+    dataSource.queryable = options.queryable === undefined || options.queryable;
 
     return {
         detached: true,

--- a/web/client/utils/cesium/ClickUtils.js
+++ b/web/client/utils/cesium/ClickUtils.js
@@ -25,8 +25,7 @@ export const getMouseXYZ = (viewer, event) => {
     }
 
     const feature = viewer.scene.drillPick(mousePosition).find((aFeature) => {
-        const {entityCollection: {owner: {queryable}}} = aFeature.id;
-        return queryable;
+        return !(aFeature?.id?.entityCollection?.owner?.queryable === false);
     });
     if (feature) {
         let currentDepthTestAgainstTerrain = scene.globe.depthTestAgainstTerrain;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Currently queryable false is available only on WFS and for this reason if was failing on top of 3D tiles because they are not inside an entity collection. This PR adds the queryable property also on Vector layer and improve the filter of drillPick

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8740

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The application does not return an error in console and the 3D tiles are queryable again

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
