### PR TITLE
[Backport 2022.02.xx-c040] #8523 Add alwaysRender property (#8754)

### DIFF
--- a/docs/developer-guide/plugins-howto.md
+++ b/docs/developer-guide/plugins-howto.md
@@ -614,6 +614,7 @@ There is also a set of options to (dynamically) add/exclude containers:
 - **showIn**: can be used to add a plugin to a container or more than one, in addition to the default one (it is an array of container plugin names)
 - **hideFrom**: can be used to exclude a plugin from a given container or more than one (it is an array of container plugin names)
 - **doNotHide**: can be used to show a plugin in the root container, in addition to the default one
+- **alwaysRender**: can be used to always renders the component in the given container, regardless the priority
 
 Note that also these properties accept dynamic expressions.
 

--- a/web/client/plugins/Measure.jsx
+++ b/web/client/plugins/Measure.jsx
@@ -178,7 +178,8 @@ export default createPlugin('Measure', {
             text: <Message msgId="measureComponent.Measure"/>,
             icon: <Glyphicon glyph="1-ruler"/>,
             action: () => setControlProperty("measure", "enabled", true),
-            doNotHide: true
+            doNotHide: true,
+            priority: 2
         },
         SidebarMenu: {
             name: 'measurement',
@@ -192,12 +193,14 @@ export default createPlugin('Measure', {
             toggle: true,
             toggleControl: 'measure',
             toggleProperty: 'enabled',
-            doNotHide: true
+            doNotHide: true,
+            priority: 1
         },
         Map: {
             name: 'Measure',
             Tool: MeasureSupport,
-            doNotHide: true
+            doNotHide: true,
+            alwaysRender: true
         }
     },
     reducers: {

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -242,6 +242,15 @@ const executeDeferredProp = (pluginImpl, pluginConfig, name) => pluginImpl && is
     ({...pluginImpl, [name]: pluginImpl[name](pluginConfig)}) :
     pluginImpl;
 
+const alwaysRender = (plugin, override = {}, container) => {
+    const pluginImpl = executeDeferredProp(plugin.impl, plugin.config, container);
+    return (
+        get(override, container + ".alwaysRender") ||
+        get(pluginImpl, container + ".alwaysRender") ||
+        false
+    );
+};
+
 const getPriority = (plugin, override = {}, container) => {
     const pluginImpl = executeDeferredProp(plugin.impl, plugin.config, container);
     return (
@@ -333,9 +342,13 @@ export const getPluginItems = (state, plugins = {}, pluginsConfig = {}, containe
             }
             return [...acc, curr];
         }, [])
-    // include only plugins for which container is the preferred container
-        .filter((plugin) => isMorePrioritizedContainer(plugin, plugin.config.override, pluginsConfig,
-            getPriority(plugin, plugin.config.override, containerName)))
+        // include only plugins for which container is the preferred container
+        .filter((plugin) =>
+            alwaysRender(plugin, plugin.config.override, containerName)
+            || isMorePrioritizedContainer(plugin, plugin.config.override, pluginsConfig,
+                getPriority(plugin, plugin.config.override, containerName)
+            )
+        )
         .map((plugin) => {
             const pluginName = getPluginSimpleName(plugin.name);
             const pluginImpl = includeLoaded(pluginName, loadedPlugins, plugin.impl);

--- a/web/client/utils/__tests__/PluginsUtils-test.js
+++ b/web/client/utils/__tests__/PluginsUtils-test.js
@@ -604,4 +604,34 @@ describe('PluginsUtils', () => {
         expect(result.loaded).toBe(true);
 
     });
+    it('getPluginItems with alwaysRender', () => {
+        const plugins = {
+            Test1Plugin: {
+                Container1: {
+                    priority: 1
+                },
+                Container2: {
+                    priority: 2
+                },
+                Container3: {
+                    alwaysRender: true
+                }
+            },
+            Container1Plugin: {},
+            Container2Plugin: {}
+        };
+
+        const pluginsConfig = [
+            { name: "Test1" },
+            { name: "Container1" },
+            { name: "Container2" },
+            { name: "Container3" }
+        ];
+        const items1 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container1", "Container1", true, []);
+        expect(items1.length).toBe(0);
+        const items2 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container2", "Container2", true, []);
+        expect(items2.length).toBe(1);
+        const items3 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container3", "Container3", true, []);
+        expect(items3.length).toBe(1);
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces a new property for the Plugins API to make a contained plugin always rendered skipping the priority property

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8523

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

This PR introduces a new `alwaysRender` property for the Plugins API 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
