### PR TITLE
[Backport 2022.01.xx] #8761 Geostory Advanced Map Editor button should be provided properly

### DIFF
--- a/web/client/components/geostory/common/MapEditor.jsx
+++ b/web/client/components/geostory/common/MapEditor.jsx
@@ -17,8 +17,8 @@ import connectMap, {withFocusedContentMap,
     handleToolbar,
     withToolbar,
     withSaveChanges,
-    withConfirmClose,
-    handleAdvancedMapEditor} from './enhancers/map';
+    withConfirmClose
+} from './enhancers/map';
 
 import localizeStringMap from '../../misc/enhancers/localizeStringMap';
 import BorderLayout from '../../layout/BorderLayout';
@@ -91,7 +91,7 @@ const MapEditor = ({
                             bsStyle: "primary",
                             noTooltipWhenDisabled: true
                         }}
-                        buttons={buttons}/>
+                        buttons={buttons} />
                 </div>
             }>
             {!!editNode &&
@@ -130,7 +130,6 @@ export default branch(
         withSaveChanges,
         handleMapUpdate,
         handleToolbar,
-        handleAdvancedMapEditor,
         withToolbar,
         withConfirmClose
     )

--- a/web/client/components/geostory/common/enhancers/__tests__/map-test.jsx
+++ b/web/client/components/geostory/common/enhancers/__tests__/map-test.jsx
@@ -102,7 +102,11 @@ describe("geostory media map component enhancers", () => {
 
         const Component = withToolbar(Toolbar);
 
-        ReactDOM.render(<Component pendingChanges disableReset={false} {...actions}/>, document.getElementById("container"));
+        ReactDOM.render(<Component buttonItems={[{
+            name: 'MapEditor',
+            target: 'mapEditorToolbar',
+            Component: () => <button onClick={actions.toggleAdvancedEditing} />
+        }]} pendingChanges disableReset={false} {...actions}/>, document.getElementById("container"));
 
         const buttons = document.querySelectorAll("button");
         expect(buttons).toExist();

--- a/web/client/components/geostory/common/enhancers/map.jsx
+++ b/web/client/components/geostory/common/enhancers/map.jsx
@@ -13,7 +13,6 @@ import {branch, compose, createEventHandler, mapPropsStream, withHandlers, withP
 import {createSelector} from 'reselect';
 import uuid from "uuid";
 
-import {show} from '../../../../actions/mapEditor';
 import {getCurrentFocusedContentEl, isFocusOnContentSelector, resourcesSelector} from '../../../../selectors/geostory';
 import {createMapObject} from '../../../../utils/GeoStoryUtils';
 import Message from '../../../I18N/Message';
@@ -65,19 +64,9 @@ export const handleMapUpdate = withHandlers({
     onChange: ({update, focusedContent = {}}) =>
         (path, value) => {
             update(focusedContent.path + `.${path}`, value, "merge");
-        }});
-/**
- * Connect and toggle advanced Editor
- */
-export const handleAdvancedMapEditor = compose(
-    connect(null, {toggleAdvancedEditing: show}),
-    withHandlers({
-        toggleAdvancedEditing: ({toggleAdvancedEditing = () => {}, map = {}}) => () => {
-            const {id, ...data} = map;
-            toggleAdvancedEditing('inlineEditor', {data, id});
         }
-    })
-);
+});
+
 /**
  * Handle edit map toggle, map rest and open AdvancedMapEditor.
  * Map reset restores the original resource map configuration by removing all content map configs
@@ -103,15 +92,11 @@ const ResetButton = (props) => (<ConfirmButton
 />);
 
 export const withToolbar = compose(
-    withProps(({disableReset, onReset, toggleAdvancedEditing = () => {}}) => ({
+    withProps(({disableReset, onReset, buttonItems = [], map}) => ({
         buttons: [{
             renderButton: <ResetButton disabled={disableReset} onClick={onReset}/>
         },
-        {
-            glyph: "pencil",
-            tooltipId: "geostory.contentToolbar.advancedMapEditor",
-            onClick: toggleAdvancedEditing
-        }]
+        ...buttonItems.map(({Component}) => ({renderButton: <Component map={map} />}))]
     })),
     withNodeSelection,      // Node selection
     withStateHandlers(() => ({'editNode': undefined}), { // Node enable editing

--- a/web/client/plugins/GeoStory.jsx
+++ b/web/client/plugins/GeoStory.jsx
@@ -94,7 +94,7 @@ const GeoStory = ({
 
     return (<BorderLayout
         className="ms-geostory"
-        columns={[<MapEditor {...props} add={addFunc} update={onUpdate} mode={mode} />]}>
+        columns={[<MapEditor {...props} buttonItems={props.items?.filter(item => item.target === 'mapEditorToolbar')} add={addFunc} update={onUpdate} mode={mode} />]}>
         <Story
             {...story}
             {...props} // add actions

--- a/web/client/plugins/MapEditor.jsx
+++ b/web/client/plugins/MapEditor.jsx
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import React from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { createPlugin } from '../utils/PluginsUtils';
@@ -13,10 +14,29 @@ import { createPlugin } from '../utils/PluginsUtils';
 import * as epics from '../epics/mapEditor';
 import mapEditor from '../reducers/mapEditor';
 
-import { hide, save } from '../actions/mapEditor';
+import { hide, save, show } from '../actions/mapEditor';
 import MapEditorModal from './mapEditor/MapEditorModal';
+import ToolbarButton from '../components/misc/toolbar/ToolbarButton';
 
 import {openSelector, ownerSelector} from '../selectors/mapEditor';
+
+/**
+ * Connect and toggle advanced Editor
+ */
+const mapEditorButton = ({ toggleAdvancedEditing = () => { }, map = {} }) => {
+    return (<ToolbarButton
+        bsStyle="primary"
+        glyph="pencil"
+        tooltipId="geostory.contentToolbar.advancedMapEditor"
+        onClick={() => {
+            const {id, ...data} = map;
+            toggleAdvancedEditing('inlineEditor', {data, id});
+        }} />);
+};
+
+const ConnectedMapEditorButton = connect(null, { toggleAdvancedEditing: show }
+)(mapEditorButton);
+
 
 /**
  * Wraps the MapViewer in a modal to allow to edit a map with the usual plugins.
@@ -25,6 +45,7 @@ import {openSelector, ownerSelector} from '../selectors/mapEditor';
  * @class
  * @memberof plugins
  */
+
 export default createPlugin('MapEditor', {
     component: connect(
         createStructuredSelector({
@@ -35,6 +56,13 @@ export default createPlugin('MapEditor', {
             save
         }
     )(MapEditorModal),
+    containers: {
+        GeoStory: {
+            name: 'MapEditor',
+            target: 'mapEditorToolbar',
+            Component: ConnectedMapEditorButton
+        }
+    },
     reducers: {
         mapEditor
     },


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The advanced map editor button inside Geostory map editor panel has been provided to the panel in the approapiate place. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8761 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
