### PR TITLE
[Backport 2022.02.xx] #8781 Attribute table does not draw new features on layers with point geometries (#8789)

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -706,19 +706,21 @@ export default class DrawSupport extends React.Component {
                 this.props.onEndDrawing(feature, this.props.drawOwner);
                 feature = reprojectGeoJson(feature, this.getMapCrs(), "EPSG:4326");
 
-                const newFeatures = isSimpleGeomType(this.props.drawMethod) && this.props.features[0].geometry.type !== "GeometryCollection" ?
-                    this.props.features.map(feat => ({
-                        ...feat,
-                        featureProjection: this.getMapCrs() // useful for reprojecting it after in replace method flow
-                    })).concat([{
-                        ...feature,
-                        type: "Feature",
-                        geometry: {
-                            type: feature.type,
-                            coordinates: feature.coordinates
-                        },
-                        featureProjection: this.getMapCrs(), // useful for reprojecting it after in replace method flow
-                        properties}]) :
+                const newFeatures = isSimpleGeomType(this.props.drawMethod) && this.props.features[0].geometry?.type !== "GeometryCollection" ?
+                    this.props.features
+                        .filter(feat => feat.geometry !== null)
+                        .map(feat => ({
+                            ...feat,
+                            featureProjection: this.getMapCrs() // useful for reprojecting it after in replace method flow
+                        })).concat([{
+                            ...feature,
+                            type: "Feature",
+                            geometry: {
+                                type: feature.type,
+                                coordinates: feature.coordinates
+                            },
+                            featureProjection: this.getMapCrs(), // useful for reprojecting it after in replace method flow
+                            properties}]) :
                     [{...feature, properties}];
                 if (this.props.options.stopAfterDrawing) {
                     this.props.onChangeDrawingStatus('stop', this.props.drawMethod, this.props.drawOwner, newFeatures);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds an additional check for null geometries on draw/edit events for OpenLayers supports

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8781

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The feature editor does not throw an error while drawing point geometries

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
