### PR TITLE
#8808 Modifying test to make it stable

### DIFF
--- a/web/client/components/misc/datetimepicker/__tests__/DateTimePicker-test.js
+++ b/web/client/components/misc/datetimepicker/__tests__/DateTimePicker-test.js
@@ -142,13 +142,14 @@ describe('DateTimePicker component', () => {
     });
 
     it('DateTimePicker test calendarSetHours disabled option', function(done) {
-        const date = '2010-01-01';
+        const date = '2010-01-01T00:00:00Z';
         const handleChange = (value) => {
             const hours = getUTCTimePart(value);
             expect(hours).toEqual('00:00:00');
             done();
         };
-        ReactDOM.render(<DateTimePicker format="'YYYY-MM-DDTHH:mm:ss[Z]'" options={{ shouldCalendarSetHours: false }} value={moment.utc(date, 'YYYY-MM-DD').toDate()} onChange={handleChange} />, document.getElementById("container"));
+        const dateObj = moment.utc(date, 'YYYY-MM-DDTHH:mm:ss[Z]').toDate();
+        ReactDOM.render(<DateTimePicker format="YYYY-MM-DDTHH:mm:ss[Z]" options={{ shouldCalendarSetHours: false }} value={dateObj} currentDate={dateObj} onChange={handleChange} />, document.getElementById("container"));
         const container = document.getElementById('container');
         const calendar = container.querySelector('.rw-btn-calendar');
         TestUtils.Simulate.click(calendar);


### PR DESCRIPTION
## Description
One of the test related to `DateTimePicker` is failing.
This happens because date picker always uses today as default value whenever calendar popup is rendered.
Specifically in this test this led to unstable behavior when date value in test and date clicked in the calendar have winter/summer time in environment using timezone with these corrections.
This PR applies minor change to the `DateTimePicker` configuration in test to make sure that clicked date and initially selected date are both in winter time.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8808

**What is the new behavior?**
Test is passed in any environment

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
