### PR TITLE
#8821 Add tooltip for layer titles in legend widgets and make them responsive

### DIFF
--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -50,6 +50,7 @@ export default pure(({
     editWidget = () => { },
     onLayoutChange = () => { },
     language,
+    currentLocale,
     env,
     ...actions
 } = {}) => {
@@ -122,6 +123,7 @@ export default pure(({
                 onDelete={() => deleteWidget(w)}
                 onEdit={() => editWidget(w)}
                 language={language}
+                currentLocale={currentLocale}
                 env={env} /></div>))
         }
     </ResponsiveReactGridLayout>);

--- a/web/client/components/widgets/widget/LegendView.jsx
+++ b/web/client/components/widgets/widget/LegendView.jsx
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
-
-import { Grid, Row, Col } from 'react-bootstrap';
 import WMSLegend from '../../TOC/fragments/WMSLegend';
 import OpacitySlider from "../../TOC/fragments/OpacitySlider";
 import Title from "../../TOC/fragments/Title";
@@ -39,7 +37,7 @@ export default ({
     );
 
     return (<div className={"legend-widget"}>
-        {layers.map((layer, index) => (<div key={index} className="widget-legend-toc">
+        {layers.map((layer, index) => (<div key={index} className={`widget-legend-toc${(layer.expanded || legendExpanded) ? ' expanded' : ''}`}>
             <div className="toc-default-layer-head">
                 {!disableVisibility && <LayersTool
                     tooltip={'toc.toggleLayerVisibility'}
@@ -48,7 +46,7 @@ export default ({
                     glyph={layer.visibility ? "eye-open" : "eye-close"}
                     onClick={()=> updateProperty('visibility', !layer.visibility, layer.id)}
                 />}
-                <Title node={layer} currentLocale={currentLocale}/>
+                <Title node={layer} currentLocale={currentLocale} tooltip/>
                 {!legendExpanded && layer.type === "wms" && <LayersTool
                     node={layer}
                     tooltip="toc.displayLegendAndTools"
@@ -56,23 +54,20 @@ export default ({
                     className={`toc-legend-icon ${layer.expanded ? 'expanded' : ''}`}
                     glyph="chevron-left"
                     onClick={()=> updateProperty('expanded', !layer.expanded, layer.id)} />}
-                {!layer.expanded && renderOpacitySlider(layer)}
             </div>
-            {(layer.expanded || legendExpanded) ? <div key="legend" className="expanded-legend-view">
-                <Grid fluid>
-                    <Row>
-                        <Col xs={12}>
-                            <WMSLegend
-                                node={{ ...layer }}
-                                currentZoomLvl={currentZoomLvl}
-                                scales={scales}
-                                language={language}
-                                {...legendProps} />
-                        </Col>
-                    </Row>
-                </Grid>
+            <div>
+                {(layer.expanded || legendExpanded)
+                    ? <div key="legend" className="expanded-legend-view">
+                        <WMSLegend
+                            node={{ ...layer }}
+                            currentZoomLvl={currentZoomLvl}
+                            scales={scales}
+                            language={language}
+                            {...legendProps} />
+                    </div>
+                    : null}
                 {renderOpacitySlider(layer)}
-            </div> : null}
+            </div>
         </div>))}
     </div>);
 };

--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -32,7 +32,7 @@ import {
     isDashboardLoading,
     showConnectionsSelector
 } from '../selectors/dashboard';
-import { currentLocaleLanguageSelector } from '../selectors/locale';
+import { currentLocaleLanguageSelector, currentLocaleSelector } from '../selectors/locale';
 import { isLocalizedLayerStylesEnabledSelector, localizedLayerStylesEnvSelector } from '../selectors/localizedLayerStyles';
 import {
     dependenciesSelector,
@@ -64,8 +64,9 @@ const WidgetsView = compose(
             isLocalizedLayerStylesEnabledSelector,
             localizedLayerStylesEnvSelector,
             getMaximizedState,
+            currentLocaleSelector,
             (resource, widgets, layouts, dependencies, selectionActive, editingWidget, groups, showGroupColor, loading, isMobile, currentLocaleLanguage, isLocalizedLayerStylesEnabled,
-                env, maximized) => ({
+                env, maximized, currentLocale) => ({
                 resource,
                 loading,
                 canEdit: isMobile ? !isMobile : resource && !!resource.canEdit,
@@ -78,7 +79,8 @@ const WidgetsView = compose(
                 showGroupColor,
                 language: isLocalizedLayerStylesEnabled ? currentLocaleLanguage : null,
                 env,
-                maximized
+                maximized,
+                currentLocale
             })
         ), {
             editWidget,

--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -51,16 +51,6 @@
             .mapstore-widget-options {
                 .color-var(@theme-vars[primary]);
             }
-
-            .legend-widget {
-                .widget-legend-toc {
-                    .toc-default-layer-head {
-                        .color-var(@theme-vars[main-color]);
-                        .background-color-var(@theme-vars[main-bg]);
-                        .border-bottom-color-var(@theme-vars[main-border-color]);
-                    }
-                }
-            }
         }
     }
 
@@ -95,6 +85,16 @@
 
     .ms-widget-empty-message {
         .background-color-var(@theme-vars[main-bg]);
+    }
+
+    .legend-widget {
+        .widget-legend-toc {
+            .toc-default-layer-head {
+                .color-var(@theme-vars[main-color]);
+                .background-color-var(@theme-vars[main-bg]);
+                .border-bottom-color-var(@theme-vars[main-border-color]);
+            }
+        }
     }
 }
 
@@ -327,68 +327,6 @@
         .counter-widget .ms2-border-layout-body {
             position: relative;
         }
-        .legend-widget {
-            .setFontSize(@font-size-small);
-            font-size: @fSize;
-            padding-top: 0;
-            .em(padding-right, 15);
-            .em(padding-bottom, 15);
-            .em(padding-left, 15);
-            .widget-legend-toc {
-                -webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.06), 0 4px 8px rgba(0, 0, 0, 0.12), 2px -2px 6px rgba(0, 0, 0, 0.06);
-                -moz-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.06), 0 4px 8px rgba(0, 0, 0, 0.12), 2px -2px 6px rgba(0, 0, 0, 0.06);
-                box-shadow: 0 3px 6px rgba(0, 0, 0, 0.06), 0 4px 8px rgba(0, 0, 0, 0.12), 2px -2px 6px rgba(0, 0, 0, 0.06);
-                padding: 0;
-                .em(margin-top, 10);
-                .toc-default-layer-head {
-                    .em(height, 44);
-                    width: 100%;
-                    margin-bottom: 0;
-                    .em(padding-top, 14);
-                    .em(padding-right, 14);
-                    padding-bottom: 0;
-                    padding-left: 0;
-                    .em(border-bottom-width, 1);
-                    border-bottom-style: solid;
-                    .visibility-check{
-                        &.glyphicon {
-                            cursor: pointer;
-                            float: left;
-                            margin-top: 0;
-                            margin-right: 0;
-                            .em(margin-bottom, 10);
-                            .em(margin-left, 10);
-                        }
-                    }
-                    .toc-title {
-                        overflow: hidden;
-                        .em(height, 15);
-                        margin-top: 0;
-                        margin-right: 0;
-                        .em(margin-bottom, 5);
-                        .em(margin-left, 5);
-                        .em(width, 140);
-                        line-height: 1;
-                    }
-                    .toc-legend-icon {
-                        &.expanded {
-                            transform: rotate(-90deg);
-                        }
-                        &.glyphicon {
-                            cursor: pointer;
-                            float: right;
-                            .em(margin-right, 10);
-                        }
-                    }
-                    .mapstore-slider {
-                        .em(margin-top, -8);
-                    }
-                }
-                .expanded-legend-view {
-                    .em(margin-top, 15);
-                }
-            }
-        }
         .map-widget-view, .chart-widget-view {
             .widget-icons, .widget-title {
                 .em(margin-bottom, 6);
@@ -418,6 +356,55 @@
         }
         .mapstore-widget-header {
             height: auto;
+        }
+    }
+}
+
+.legend-widget {
+    .setFontSize(@font-size-small);
+    font-size: @fSize;
+    padding-top: 0;
+    .em(padding-right, 15);
+    .em(padding-bottom, 15);
+    .em(padding-left, 15);
+    .widget-legend-toc {
+        .shadow-soft();
+        .em(margin-top, 10);
+        .toc-default-layer-head {
+            .em(padding, 8);
+            padding-bottom: 0;
+            display: flex;
+            align-items: center;
+            width: 100%;
+            .toc-title {
+                flex: 1;
+                max-width: none;
+                .em(padding-right, 8);
+                white-space: nowrap;
+                text-overflow: ellipsis;
+                overflow: hidden;
+            }
+            .visibility-check + .toc-title {
+                .em(padding-left, 8);
+            }
+            .toc-legend-icon {
+                &.expanded {
+                    transform: rotate(-90deg);
+                }
+            }
+            .toc-layer-tool {
+                cursor: pointer;
+            }
+        }
+        .expanded-legend-view {
+            .em(padding, 8);
+        }
+        &.expanded {
+            .toc-default-layer-head {
+                .em(border-bottom-width, 1);
+                border-bottom-style: solid;
+                .em(padding-bottom, 8);
+            }
         }
     }
 }

--- a/web/client/themes/default/less/wizard.less
+++ b/web/client/themes/default/less/wizard.less
@@ -15,19 +15,6 @@
 // **************
 // Layout
 // **************
-#ms-components-theme(@theme-vars) {
-    .ms-wizard.map-options {
-        .legend-widget{
-            .widget-legend-toc {
-                .toc-default-layer-head {
-                    .color-var(@theme-vars[main-color]);
-                    .background-color-var(@theme-vars[main-bg]);
-                }
-            }
-        }
-    }
-}
-
 
 .ms-wizard {
     position: absolute;
@@ -120,32 +107,6 @@
             width: 200px;
             .Select-option {
                 word-break: break-all;
-            }
-        }
-    }
-    .legend-widget {
-        .widget-legend-toc {
-            -webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.06), 0 4px 8px rgba(0, 0, 0, 0.12), 2px -2px 6px rgba(0, 0, 0, 0.06);
-            -moz-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.06), 0 4px 8px rgba(0, 0, 0, 0.12), 2px -2px 6px rgba(0, 0, 0, 0.06);
-            box-shadow: 0 3px 6px rgba(0, 0, 0, 0.06), 0 4px 8px rgba(0, 0, 0, 0.12), 2px -2px 6px rgba(0, 0, 0, 0.06);
-            padding: 0;
-            margin-top: 10px;
-            .toc-default-layer-head {
-                height: 52px;
-                width: 100%;
-                margin-bottom: 0;
-                padding: 18px 0;
-                .toc-title {
-                    overflow: hidden;
-                    font-weight: 600;
-                    height: 15px;
-                    margin: 0 10px;
-                    width: 140px;
-                    line-height: 1;
-                }
-            }
-            .expanded-legend-view {
-                padding-bottom: 15px;
             }
         }
     }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces following changes:

- improve layout of legend widget in dashboard
- enable tooltip options for legend widget title

![image](https://user-images.githubusercontent.com/19175505/202172490-4cc789be-ede6-47ca-a4f1-ee208b7bfd2b.png)
![image](https://user-images.githubusercontent.com/19175505/202172413-029d0c62-6bec-433e-bd3f-1b0d508808fb.png)


Now the tooltip of layer title in legend widget will follow the properties configurable in the settings of the map layer

![image](https://user-images.githubusercontent.com/19175505/202172239-e8580ce8-d4ec-4fb2-8c6b-efbc0bf9af3d.png)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8821

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
This PR improve the layout of legend widgets in dashboards

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
