### PR TITLE
#8820 Remove image constraints in geostory carousel upload

### DIFF
--- a/web/client/components/geostory/contents/carousel/carouselItem/ItemThumbnail.jsx
+++ b/web/client/components/geostory/contents/carousel/carouselItem/ItemThumbnail.jsx
@@ -60,10 +60,17 @@ export default (props) => {
                 <Thumbnail
                     onUpdate={(data, url) => setThumbnail({data, url})}
                     onError={(errors) => setThumbnailErrors(errors)}
-                    message={<Message msgId="backgroundDialog.thumbnailMessage"/>}
+                    message={<Message msgId="backgroundDialog.imageUploadMessage"/>}
                     suggestion=""
                     map={{
                         newThumbnail: get(thumbnail, 'url') || props.thumbnail?.image || "NODATA"
+                    }}
+                    thumbnailOptions={{
+                        contain: false,
+                        width: 128,
+                        height: 128,
+                        quality: 1,
+                        type: 'image/jpeg'
                     }}
                 />
                 <FormGroup>

--- a/web/client/components/maps/forms/Thumbnail.jsx
+++ b/web/client/components/maps/forms/Thumbnail.jsx
@@ -30,6 +30,7 @@ class MapThumbnail extends React.Component {
         withLabel: PropTypes.bool,
         map: PropTypes.object,
         maxFileSize: PropTypes.number,
+        thumbnailOptions: PropTypes.object,
         // CALLBACKS
         onDrop: PropTypes.func,
         onError: PropTypes.func,
@@ -64,7 +65,8 @@ class MapThumbnail extends React.Component {
         message: <Message msgId="map.message"/>,
         suggestion: <Message msgId="map.suggestion"/>,
         map: {},
-        thumbnailErrors: []
+        thumbnailErrors: [],
+        thumbnailOptions: null
     };
 
     state = {};
@@ -141,6 +143,7 @@ class MapThumbnail extends React.Component {
                     this.props.onRemoveThumbnail();
                     this.props.onError([], this.props.map.id);
                 }}
+                {...(this.props.thumbnailOptions && {thumbnailOptions: this.props.thumbnailOptions})}
             />
         );
     }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2894,6 +2894,7 @@
             "titlePlaceholder": "Den angezeigten Namen eingeben",
             "add": "Hinzufügen",
             "thumbnailMessage": "Die Größe der Bilder sollte ein Quadrat von 98 x 98 Pixel oder 128 x 128 Pixel sein, maximal 500kb",
+            "imageUploadMessage": "Klicken Sie auf oder ziehen Sie sie ab, um ein Bild hinzuzufügen",
             "additionalParameters": "Zusätzliche Parameter",
             "addAdditionalParameterTooltip": "Parameter hinzufügen",
             "removeAdditionalParameterTooltip": "Parameter entfernen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2868,6 +2868,7 @@
             "titlePlaceholder": "Enter displayed name",
             "add": "Add",
             "thumbnailMessage": "Size of images should be a square of 98px x 98px or 128px x 128px, max 500kb",
+            "imageUploadMessage": "Click, or drag and drop to add an image",
             "additionalParameters": "Additional Parameters",
             "addAdditionalParameterTooltip": "Add parameter",
             "removeAdditionalParameterTooltip": "Remove parameter",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2856,6 +2856,7 @@
             "titlePlaceholder": "Ingrese el nombre que se muestra",
             "add": "Añadir",
             "thumbnailMessage": "El tamaño de las imágenes debe ser un cuadrado de 98 px x 98 px o 128 px x 128 px, máximo 500kb",
+            "imageUploadMessage": "Haga clic, o arrastre y suelte para agregar una imagen",
             "additionalParameters": "Parámetros adicionales",
             "addAdditionalParameterTooltip": "Agregar parámetro",
             "removeAdditionalParameterTooltip": "Eliminar parámetro",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2858,6 +2858,7 @@
             "titlePlaceholder": "Entrez le nom affiché",
             "add": "Ajouter",
             "thumbnailMessage": "La taille des images doit être un carré de 98px x 98px ou 128px x 128px, maximum 500kb",
+            "imageUploadMessage": "Cliquez ou faites glisser et déposez pour ajouter une image",
             "additionalParameters": "Paramètres additionnels",
             "addAdditionalParameterTooltip": "Ajouter un paramètre",
             "removeAdditionalParameterTooltip": "Supprimer le paramètre",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2858,6 +2858,7 @@
             "titlePlaceholder": "Inserisci il nome visualizzato",
             "add": "Inserisci",
             "thumbnailMessage": "Le dimensioni delle immagini devono essere quadrate di 98 px x 98 px o 128 px x 128 px, max 500kb",
+            "imageUploadMessage": "Fare clic o trascinare e rilasciare per aggiungere un'immagine",
             "additionalParameters": "Parametri aggiuntivi",
             "addAdditionalParameterTooltip": "Aggiungi parametro",
             "removeAdditionalParameterTooltip": "Rimuovi parametro",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -2660,6 +2660,7 @@
             "titlePlaceholder": "Voer de weergavenaam naam in",
             "add": "Toevoegen",
             "thumbnailMessage": "De grootte van de afbeeldingen moet een vierkant zijn van 98px x 98px of 128px x 128px, max. 500kb",
+            "imageUploadMessage": "Klik of sleep en drop om een ​​afbeelding toe te voegen",
             "additionalParameters": "Aanvullende parameters",
             "addAdditionalParameterTooltip": "Parameter toevoegen",
             "removeAdditionalParameterTooltip": "Verwijder parameter",

--- a/web/client/translations/data.sk-SK.json
+++ b/web/client/translations/data.sk-SK.json
@@ -2676,6 +2676,7 @@
             "titlePlaceholder": "Zadať zobrazované meno",
             "add": "Pridať",
             "thumbnailMessage": "Veľkosti obrázkov by mali tvoriť štvorec o veľkosti 98px x 98px alebo 128px x 128px, s maximálnou veľkosťou 500kb",
+            "imageUploadMessage": "Kliknite alebo drakate a pridajte obrázok",
             "additionalParameters": "Ďalšie parametre",
             "addAdditionalParameterTooltip": "Pridať parameter",
             "removeAdditionalParameterTooltip": "Odstrániť parameter",


### PR DESCRIPTION
This PR allows users to upload any image freely,
so that the client takes care of scaling and cropping

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8820 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
