### PR TITLE
Fix readme demo instances urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ MapStore is Free and Open Source software, it is based on OpenLayers, Leaflet an
 
 We have the following instances:
 
-1. a DEV instance, which can be accessed <a href="http://dev-mapstore.geosolutionsgroup.com" target="_blank">here</a>, where all the changes are deployed once they are published on the Master branch of our repo
-2. a QA instance, which can be accessed  <a href="http://qa-mapstore.geosolutionsgroup.com" target="_blank">here</a>, that becomes active 1 week before any release, during the hardening phase, and deploys the release branch whenever a fix is pushed onto it.
-3. a STABLE instance, which can be accessed <a href="http://mapstore.geosolutionsgroup.com" target="_blank">here</a>, that gets deployed on demand after each release.
+1. a DEV instance, which can be accessed <a href="http://dev-mapstore.geosolutionsgroup.com/mapstore/#/" target="_blank">here</a>, where all the changes are deployed once they are published on the Master branch of our repo
+2. a QA instance, which can be accessed  <a href="http://qa-mapstore.geosolutionsgroup.com/mapstore/#/" target="_blank">here</a>, that becomes active 1 week before any release, during the hardening phase, and deploys the release branch whenever a fix is pushed onto it.
+3. a STABLE instance, which can be accessed <a href="http://mapstore.geosolutionsgroup.com/mapstore/#/" target="_blank">here</a>, that gets deployed on demand after each release.
 
 As a user you need to be aware of STABLE and DEV, QA is used internally before a release; for 1 Week it will diverge from STABLE as it is actually anticipating the next stable.
 So, if you want to test latest features use DEV, if you are not that brave use STABLE. You might forget that QA exists unless you are parte of the developers team.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fix readme demo instances urls because sometimes if i have not yet accessed the demo instances at the right url using only hostname ends up here
![image](https://user-images.githubusercontent.com/11991428/203032230-46eb3856-822e-49b8-be00-f9d38412f833.png)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
see above

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
demo urls should go directly to right url

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
