### PR TITLE
[Backport 2022.02.xx-c040] 8341 Leader line property - a line that connect the mark, icon, model or label to ground in 3D view  (#8797)

### DIFF
--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -858,69 +858,117 @@ example:
 
 Available logical operators:
 
-- `||` OR operator
-- `&&` AND operator
+| Operator | Description |
+| --- | --- |
+| `\|\|` | OR operator |
+| `&&` | AND operator |
 
 Available comparison operators:
 
-- `==` equal to
-- `*=` like (for string type)
-- `!=` is not
-- `<` less than
-- `<=` less and equal than
-- `>` grater than
-- `>=` grater and equal than
+| Operator | Description |
+| --- | --- |
+| `==` | equal to |
+| `*=` | like (for string type) |
+| `!=` | is not |
+| `<` | less than |
+| `<=` | less and equal than |
+| `>` | grater than |
+| `>=` | grater and equal than |
 
 The `symbolizer` could be of following `kinds`:
 
 - `Mark` symbolizer properties
-  - `kind` must be equal to `Mark`
-  - `color` fill color of the mark
-  - `fillOpacity` fill opacity of the mark
-  - `strokeColor` stroke color of the mark
-  - `strokeOpacity` stroke opacity of the mark
-  - `strokeWidth` stroke width of the mark
-  - `radius` radius size in px of the mark
-  - `msBringToFront` this boolean will allow setting the `disableDepthTestDistance` value for the feature. This would only apply on Cesium maps.
-  - `wellKnownName` rendered shape, one of Circle, Square, Triangle, Star, Cross, X, shape://vertline, shape://horline, shape://slash, shape://backslash, shape://dot, shape://plus, shape://times, shape://oarrow or shape://carrow
+
+  | Property | Description | 2D | 3D |
+  | --- | --- | --- | --- |
+  | `kind` | must be equal to **Mark** | x | x |
+  | `color` | fill color of the mark | x | x |
+  | `fillOpacity` | fill opacity of the mark | x | x |
+  | `strokeColor` | stroke color of the mark | x | x |
+  | `strokeOpacity` | stroke opacity of the mark | x | x |
+  | `strokeWidth` | stroke width of the mark | x | x |
+  | `radius` | radius size in px of the mark | x | x |
+  | `wellKnownName` | rendered shape, one of Circle, Square, Triangle, Star, Cross, X, shape://vertline, shape://horline, shape://slash, shape://backslash, shape://dot, shape://plus, shape://times, shape://oarrow or shape://carrow | x | x |
+  | `msBringToFront` | this boolean will allow setting the **disableDepthTestDistance** value for the feature. This would |  | x |
+  | `msHeightReference` | reference to compute the distance of the point geometry, one of **none**, **ground** or **clamp** |  | x |
+  | `msHeight` | height of the point, the original geometry is applied if undefined  |  | x |
+  | `msLeaderLineColor` | color of the leading line connecting the point to the terrain  |  | x |
+  | `msLeaderLineOpacity` | opacity of the leading line connecting the point to the terrain |  | x |
+  | `msLeaderLineWidth` | width of the leading line connecting the point to the terrain |  | x |
 
 - `Icon` symbolizer properties
-  - `kind` must be equal to `Icon`
-  - `image` url of the image to use as icon
-  - `size` size of the icon
-  - `opacity` opacity of the icon
-  - `rotate` rotation of the icon
-  - `msBringToFront` this boolean will allow setting the `disableDepthTestDistance` value for the feature. This would only apply on Cesium maps.
+  | Property | Description | 2D | 3D |
+  | --- | --- | --- | --- |
+  | `kind` | must be equal to **Icon** | x | x |
+  | `image` | url of the image to use as icon | x | x |
+  | `size` | size of the icon | x | x |
+  | `opacity` | opacity of the icon | x | x |
+  | `rotate` | rotation of the icon | x | x |
+  | `msBringToFront` | this boolean will allow setting the **disableDepthTestDistance** value for the feature. This would |  | x |
+  | `msHeightReference` | reference to compute the distance of the point geometry, one of **none**, **ground** or **clamp** |  | x |
+  | `msHeight` | height of the point, the original geometry is applied if undefined  |  | x |
+  | `msLeaderLineColor` | color of the leading line connecting the point to the terrain  |  | x |
+  | `msLeaderLineOpacity` | opacity of the leading line connecting the point to the terrain |  | x |
+  | `msLeaderLineWidth` | width of the leading line connecting the point to the terrain |  | x |
 
 - `Line` symbolizer properties
-  - `kind` must be equal to `Line`
-  - `color` stroke color of the line
-  - `opacity` stroke opacity of the line
-  - `width` stroke width of the line
-  - `dasharray` array that represent the dashed line intervals
-  - `msClampToGround` this boolean will allow setting the `clampToGround` value for the feature. This would only apply on Cesium maps.
+  | Property | Description | 2D | 3D |
+  | --- | --- | --- | --- |
+  | `kind` | must be equal to **Line** | x | x |
+  | `color` | stroke color of the line | x | x |
+  | `opacity` | stroke opacity of the line | x | x |
+  | `width` | stroke width of the line | x | x |
+  | `dasharray` | array that represent the dashed line intervals | x | x |
+  | `msClampToGround` | this boolean will allow setting the **clampToGround** value for the feature. This would only apply on Cesium maps. |  | x |
 
 - `Fill` symbolizer properties
-  - `kind` must be equal to `Fill`
-  - `color` fill color of the polygon
-  - `fillOpacity` fill opacity of the polygon
-  - `outlineColor` outline color of the polygon
-  - `outlineOpacity` outline opacity of the polygon
-  - `outlineWidth` outline width of the polygon
-  - `msClassificationType` allow setting `classificationType` value for the feature. This would only apply on polygon graphics in Cesium maps.
-  - `msClampToGround` this boolean will allow setting the `clampToGround` value for the feature. This would only apply on Cesium maps.
+  | Property | Description | 2D | 3D |
+  | --- | --- | --- | --- |
+  | `kind` | must be equal to **Fill** | x | x |
+  | `color` | fill color of the polygon | x | x |
+  | `fillOpacity` | fill opacity of the polygon | x | x |
+  | `outlineColor` | outline color of the polygon | x | x |
+  | `outlineOpacity` | outline opacity of the polygon | x | x |
+  | `outlineWidth` | outline width of the polygon | x | x |
+  | `msClassificationType` | allow setting **classificationType** value for the feature. This would only apply on polygon graphics in Cesium maps. |  | x |
+  | `msClampToGround` | this boolean will allow setting the **clampToGround** value for the feature. This would only apply on Cesium maps. |  | x |
 
 - `Text` symbolizer properties
-  - `kind` must be equal to `Text`
-  - `label` text to show in the label, the {{propertyKey}} notetion allow to access feature properties (eg. 'feature name is {{name}}')
-  - `font` array of font family names
-  - `size` font size of the label
-  - `fontStyle` font style of the label: normal or italic
-  - `fontWeight` font style of the label: normal or bold
-  - `color` font color of the label
-  - `haloColor` halo color of the label
-  - `haloWidth` halo width of the label
-  - `offset` array of x and y values offset of the label
+  | Property | Description | 2D | 3D |
+  | --- | --- | --- | --- |
+  | `kind` | must be equal to **Text** | x | x |
+  | `label` | text to show in the label, the {{propertyKey}} notetion allow to access feature properties (eg. 'feature name is {{name}}') | x | x |
+  | `font` | array of font family names | x | x |
+  | `size` | font size of the label | x | x |
+  | `fontStyle` | font style of the label: normal or italic | x | x |
+  | `fontWeight` | font style of the label: normal or bold | x | x |
+  | `color` | font color of the label | x | x |
+  | `haloColor` | halo color of the label | x | x |
+  | `haloWidth` | halo width of the label | x | x |
+  | `offset` | array of x and y values offset of the label | x | x |
+  | `msBringToFront` | this boolean will allow setting the **disableDepthTestDistance** value for the feature. This would |  | x |
+  | `msHeightReference` | reference to compute the distance of the point geometry, one of **none**, **ground** or **clamp** |  | x |
+  | `msHeight` | height of the point, the original geometry is applied if undefined  |  | x |
+  | `msLeaderLineColor` | color of the leading line connecting the point to the terrain  |  | x |
+  | `msLeaderLineOpacity` | opacity of the leading line connecting the point to the terrain |  | x |
+  | `msLeaderLineWidth` | width of the leading line connecting the point to the terrain |  | x |
+
+- `Model` symbolizer properties (custom symbolizer to visualize 3D model as point geometries)
+  | Property | Description | 2D | 3D |
+  | --- | --- | --- | --- |
+  | `kind` | must be equal to **Model** |  | x |
+  | `model` | url of a 3D .glb file |  | x |
+  | `heading` | heading rotation |  | x |
+  | `pitch` | pitch rotation |  | x |
+  | `roll` | roll rotation |  | x |
+  | `scale` | scale factor |  | x |
+  | `color` | color mixed with the mesh texture/material |  | x |
+  | `opacity` | color opacity |  | x |
+  | `msHeightReference` | reference to compute the distance of the point geometry, one of **none**, **ground** or **clamp** |  | x |
+  | `msHeight` | height of the point, the original geometry is applied if undefined  |  | x |
+  | `msLeaderLineColor` | color of the leading line connecting the point to the terrain  |  | x |
+  | `msLeaderLineOpacity` | opacity of the leading line connecting the point to the terrain |  | x |
+  | `msLeaderLineWidth` | width of the leading line connecting the point to the terrain |  | x |
 
 #### Legacy Vector Style (deprecated)
 

--- a/web/client/components/map/cesium/plugins/VectorLayer.js
+++ b/web/client/components/map/cesium/plugins/VectorLayer.js
@@ -45,8 +45,9 @@ const createLayer = (options, map) => {
                                     entities: dataSource?.entities?.values,
                                     map,
                                     opacity: options.opacity ?? 1
+                                }).then(() => {
+                                    map.scene.requestRender();
                                 });
-                                map.scene.requestRender();
                             }
                         });
                 });
@@ -92,8 +93,9 @@ Layers.registerType('vector', {
                                     entities: layer.dataSource.entities.values,
                                     map,
                                     opacity: newOptions.opacity ?? 1
+                                }).then(() => {
+                                    map.scene.requestRender();
                                 });
-                                map.scene.requestRender();
                             }
                         });
                 });

--- a/web/client/components/map/cesium/plugins/WFSLayer.js
+++ b/web/client/components/map/cesium/plugins/WFSLayer.js
@@ -60,8 +60,9 @@ const createLayer = (options, map) => {
                                             entities: dataSource?.entities?.values,
                                             map,
                                             opacity: options.opacity ?? 1
+                                        }).then(() => {
+                                            map.scene.requestRender();
                                         });
-                                        map.scene.requestRender();
                                     }
                                 });
                         });
@@ -110,8 +111,9 @@ Layers.registerType('wfs', {
                                     entities: layer.dataSource.entities.values,
                                     map,
                                     opacity: newOptions.opacity ?? 1
+                                }).then(() => {
+                                    map.scene.requestRender();
                                 });
-                                map.scene.requestRender();
                             }
                         });
                 });

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -40,6 +40,17 @@ const heightPoint3dOptions = {
                 ...numberAttributes
             ];
         }
+    }),
+    msLeaderLineColor: property.color({
+        key: 'msLeaderLineColor',
+        opacityKey: 'msLeaderLineOpacity',
+        label: 'styleeditor.leaderLineColor',
+        stroke: true
+    }),
+    msLeaderLineWidth: property.width({
+        key: 'msLeaderLineWidth',
+        label: 'styleeditor.leaderLineWidth',
+        fallbackValue: 0
     })
 };
 

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2439,7 +2439,9 @@
             "pitch": "Rotation der X-Achse",
             "roll": "Drehung der Y-Achse",
             "color": "Farbe",
-            "pointHeight": "Punkthöhe"
+            "pointHeight": "Punkthöhe",
+            "leaderLineColor": "Farbe der Führungslinie",
+            "leaderLineWidth": "Breite der Führungslinie"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2412,7 +2412,9 @@
             "pitch": "X axis rotation",
             "roll": "Y axis rotation",
             "color": "Color",
-            "pointHeight": "Point height"
+            "pointHeight": "Point height",
+            "leaderLineColor": "Leader line color",
+            "leaderLineWidth": "Leader line width"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2401,7 +2401,9 @@
             "pitch": "Rotación del eje X",
             "roll": "Rotación del eje Y",
             "color": "Color",
-            "pointHeight": "Altura del punto"
+            "pointHeight": "Altura del punto",
+            "leaderLineColor": "Color de línea de guía",
+            "leaderLineWidth": "Ancho de la línea guía"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2402,7 +2402,9 @@
             "pitch": "Rotation de l'axe X",
             "roll": "Rotation de l'axe Y",
             "color": "Couleur",
-            "pointHeight": "Hauteur du point"
+            "pointHeight": "Hauteur du point",
+            "leaderLineColor": "Couleur de la ligne de repère",
+            "leaderLineWidth": "Largeur de la ligne de repère"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2403,7 +2403,9 @@
             "pitch": "Rotazione asse X",
             "roll": "Rotazione asse Y",
             "color": "Colore",
-            "pointHeight": "Altezza punto"
+            "pointHeight": "Altezza punto",
+            "leaderLineColor": "Colore linea guida",
+            "leaderLineWidth": "Spessore linea guida"
         },
         "playback": {
             "settings": {

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -121,10 +121,14 @@ export const clickedPointToGeoJson = (clickedPoint) => {
                         : [])
                 ]
             },
+            properties: {
+                id: 'get-feature-info-point'
+            },
             style: [{
                 iconUrl,
                 iconAnchor: [12, 41], // in leaflet there is no anchor in fraction
-                iconSize: [25, 41]
+                iconSize: [25, 41],
+                leaderLine: clickedPoint.height !== undefined
             }]
 
         }

--- a/web/client/utils/VectorStyleUtils.js
+++ b/web/client/utils/VectorStyleUtils.js
@@ -721,7 +721,9 @@ function msStyleToSymbolizer(style, feature) {
             fontWeight: style.fontWeight,
             color: style.fillColor,
             haloColor: style.color,
-            haloWidth: 1
+            haloWidth: 1,
+            msHeightReference: 'none',
+            msBringToFront: true
         });
     }
     if (style.symbolizerKind === 'Mark') {
@@ -734,7 +736,8 @@ function msStyleToSymbolizer(style, feature) {
             strokeWidth: style.weight,
             radius: style.radius ?? 10,
             wellKnownName: 'Circle',
-            msHeightReference: 'none'
+            msHeightReference: 'none',
+            msBringToFront: true
         });
     }
     if (isAttrPresent(style, ['iconUrl']) && !style.iconGlyph && !style.iconShape) {
@@ -744,7 +747,14 @@ function msStyleToSymbolizer(style, feature) {
             size: max(style.iconSize || [32]),
             opacity: 1,
             rotate: 0,
-            msHeightReference: 'none'
+            msHeightReference: 'none',
+            msBringToFront: true,
+            // only needed for get feature info marker
+            ...(style.leaderLine && {
+                msLeaderLineColor: '#333333',
+                msLeaderLineOpacity: 1,
+                msLeaderLineWidth: 1
+            })
         });
     }
     if (isMarkerStyle(style)) {
@@ -754,7 +764,8 @@ function msStyleToSymbolizer(style, feature) {
             size: 45,
             opacity: 1,
             rotate: 0,
-            msHeightReference: 'none'
+            msHeightReference: 'none',
+            msBringToFront: true
         });
     }
     if (isSymbolStyle(style)) {
@@ -771,7 +782,8 @@ function msStyleToSymbolizer(style, feature) {
                     size: style.size,
                     opacity: 1,
                     rotate: 0,
-                    msHeightReference: 'none'
+                    msHeightReference: 'none',
+                    msBringToFront: true
                 };
             })
             .catch(() => ({}));

--- a/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
+++ b/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
@@ -9,16 +9,20 @@
 import * as Cesium from 'cesium';
 import expect from 'expect';
 import CesiumStyleParser from '../CesiumStyleParser';
-import { getImageIdFromSymbolizer } from '../../VectorStyleUtils';
+import { getImageIdFromSymbolizer, geoStylerStyleFilter } from '../../VectorStyleUtils';
 
 let images = [];
 
 const parser = new CesiumStyleParser({
     getImageIdFromSymbolizer,
-    drawIcons: () => Promise.resolve(images)
+    drawIcons: () => Promise.resolve(images),
+    geoStylerStyleFilter
 });
 
 describe('CesiumStyleParser', () => {
+    afterEach(() => {
+        images = [];
+    });
     describe('readStyle', () => {
         it('should return null, read function not implemented', (done) => {
             parser.readStyle()
@@ -65,18 +69,16 @@ describe('CesiumStyleParser', () => {
                             coordinates: [[[7, 41], [14, 41], [14, 46], [7, 46], [7, 41]]]
                         }
                     }).then((dataSource) => {
-                        try {
-                            const entities = dataSource?.entities?.values;
-                            styleFunc({ entities });
-                            expect({ ...entities[0].polygon.material.color.getValue() }).toEqual({ red: 1, green: 0, blue: 0, alpha: 0.5 });
-                            expect(entities[0].polygon.classificationType.getValue()).toEqual(Cesium.ClassificationType.TERRAIN);
-                            expect(entities[0].polyline.width.getValue()).toBe(2);
-                            expect({ ...entities[0].polyline.material.color.getValue() }).toEqual({ red: 0, green: 1, blue: 0, alpha: 0.25 });
-                            expect(entities[0].polyline.clampToGround.getValue()).toBe(true);
-                        } catch (e) {
-                            done(e);
-                        }
-                        done();
+                        const entities = dataSource?.entities?.values;
+                        return styleFunc({ entities })
+                            .then(() => {
+                                expect({ ...entities[0].polygon.material.color.getValue() }).toEqual({ red: 1, green: 0, blue: 0, alpha: 0.5 });
+                                expect(entities[0].polygon.classificationType.getValue()).toEqual(Cesium.ClassificationType.TERRAIN);
+                                expect(entities[0].polyline.width.getValue()).toBe(2);
+                                expect({ ...entities[0].polyline.material.color.getValue() }).toEqual({ red: 0, green: 1, blue: 0, alpha: 0.25 });
+                                expect(entities[0].polyline.clampToGround.getValue()).toBe(true);
+                                done();
+                            }).catch(done);
                     });
                 });
         });
@@ -109,16 +111,14 @@ describe('CesiumStyleParser', () => {
                             coordinates: [[7, 41], [14, 41], [14, 46], [7, 46]]
                         }
                     }).then((dataSource) => {
-                        try {
-                            const entities = dataSource?.entities?.values;
-                            styleFunc({ entities });
-                            expect({ ...entities[0].polyline.material.color.getValue() }).toEqual({ red: 1, green: 0, blue: 0, alpha: 0.5 });
-                            expect(entities[0].polyline.width.getValue()).toBe(2);
-                            expect(entities[0].polyline.clampToGround.getValue()).toBe(true);
-                        } catch (e) {
-                            done(e);
-                        }
-                        done();
+                        const entities = dataSource?.entities?.values;
+                        return styleFunc({ entities })
+                            .then(() => {
+                                expect({ ...entities[0].polyline.material.color.getValue() }).toEqual({ red: 1, green: 0, blue: 0, alpha: 0.5 });
+                                expect(entities[0].polyline.width.getValue()).toBe(2);
+                                expect(entities[0].polyline.clampToGround.getValue()).toBe(true);
+                                done();
+                            }).catch(done);
                     });
                 });
         });
@@ -151,16 +151,14 @@ describe('CesiumStyleParser', () => {
                             coordinates: [[7, 41], [14, 41], [14, 46], [7, 46]]
                         }
                     }).then((dataSource) => {
-                        try {
-                            const entities = dataSource?.entities?.values;
-                            styleFunc({ entities });
-                            expect({ ...entities[0].polyline.material.color.getValue() }).toEqual({ red: 1, green: 0, blue: 0, alpha: 0.5 });
-                            expect(entities[0].polyline.material.dashLength.getValue()).toBe(8);
-                            expect(entities[0].polyline.material.dashPattern.getValue()).toBe(65280);
-                        } catch (e) {
-                            done(e);
-                        }
-                        done();
+                        const entities = dataSource?.entities?.values;
+                        return styleFunc({ entities })
+                            .then(() => {
+                                expect({ ...entities[0].polyline.material.color.getValue() }).toEqual({ red: 1, green: 0, blue: 0, alpha: 0.5 });
+                                expect(entities[0].polyline.material.dashLength.getValue()).toBe(8);
+                                expect(entities[0].polyline.material.dashPattern.getValue()).toBe(65280);
+                                done();
+                            }).catch(done);
                     });
                 });
         });
@@ -209,18 +207,16 @@ describe('CesiumStyleParser', () => {
                             coordinates: [7, 41]
                         }
                     }).then((dataSource) => {
-                        try {
-                            const entities = dataSource?.entities?.values;
-                            styleFunc({ entities });
-                            expect(entities[0].billboard.image.getValue()).toBe(canvas);
-                            expect(entities[0].billboard.scale.getValue()).toBe(1);
-                            expect(entities[0].billboard.rotation.getValue()).toBe(-Math.PI / 2);
-                            expect(entities[0].billboard.disableDepthTestDistance.getValue()).toBe(Number.POSITIVE_INFINITY);
-                            expect(entities[0].billboard.heightReference.getValue()).toBe(Cesium.HeightReference.NONE);
-                        } catch (e) {
-                            done(e);
-                        }
-                        done();
+                        const entities = dataSource?.entities?.values;
+                        return styleFunc({ entities })
+                            .then(() => {
+                                expect(entities[0].billboard.image.getValue()).toBe(canvas);
+                                expect(entities[0].billboard.scale.getValue()).toBe(1);
+                                expect(entities[0].billboard.rotation.getValue()).toBe(-Math.PI / 2);
+                                expect(entities[0].billboard.disableDepthTestDistance.getValue()).toBe(Number.POSITIVE_INFINITY);
+                                expect(entities[0].billboard.heightReference.getValue()).toBe(Cesium.HeightReference.NONE);
+                                done();
+                            }).catch(done);
                     });
                 });
         });
@@ -265,19 +261,17 @@ describe('CesiumStyleParser', () => {
                             coordinates: [7, 41]
                         }
                     }).then((dataSource) => {
-                        try {
-                            const entities = dataSource?.entities?.values;
-                            styleFunc({ entities });
-                            expect(entities[0].billboard.image.getValue()).toBe(img);
-                            expect({ ...entities[0].billboard.color.getValue() }).toEqual({ red: 1, green: 1, blue: 1, alpha: 0.5 });
-                            expect(entities[0].billboard.scale.getValue()).toBe(0.125);
-                            expect(entities[0].billboard.rotation.getValue()).toBe(-Math.PI / 2);
-                            expect(entities[0].billboard.disableDepthTestDistance.getValue()).toBe(Number.POSITIVE_INFINITY);
-                            expect(entities[0].billboard.heightReference.getValue()).toBe(Cesium.HeightReference.NONE);
-                        } catch (e) {
-                            done(e);
-                        }
-                        done();
+                        const entities = dataSource?.entities?.values;
+                        return styleFunc({ entities })
+                            .then(() => {
+                                expect(entities[0].billboard.image.getValue()).toBe(img);
+                                expect({ ...entities[0].billboard.color.getValue() }).toEqual({ red: 1, green: 1, blue: 1, alpha: 0.5 });
+                                expect(entities[0].billboard.scale.getValue()).toBe(0.125);
+                                expect(entities[0].billboard.rotation.getValue()).toBe(-Math.PI / 2);
+                                expect(entities[0].billboard.disableDepthTestDistance.getValue()).toBe(Number.POSITIVE_INFINITY);
+                                expect(entities[0].billboard.heightReference.getValue()).toBe(Cesium.HeightReference.NONE);
+                                done();
+                            }).catch(done);
                     });
                 });
         });
@@ -317,17 +311,16 @@ describe('CesiumStyleParser', () => {
                             coordinates: [7, 41]
                         }
                     }).then((dataSource) => {
-                        try {
-                            const entities = dataSource?.entities?.values;
-                            styleFunc({ entities });
-                            expect(entities[0].model.uri.getValue()._url).toBe('/path/to/file.glb');
-                            expect({ ...entities[0].model.color.getValue() }).toEqual({ red: 1, green: 1, blue: 1, alpha: 0.5 });
-                            expect(entities[0].model.scale.getValue()).toBe(1);
-                            expect(entities[0].model.heightReference.getValue()).toBe(Cesium.HeightReference.RELATIVE_TO_GROUND);
-                        } catch (e) {
-                            done(e);
-                        }
-                        done();
+                        const entities = dataSource?.entities?.values;
+                        return styleFunc({ entities })
+                            .then(() => {
+                                expect(entities[0].model.uri.getValue()._url).toBe('/path/to/file.glb');
+                                expect({ ...entities[0].model.color.getValue() }).toEqual({ red: 1, green: 1, blue: 1, alpha: 0.5 });
+                                expect(entities[0].model.scale.getValue()).toBe(1);
+                                expect(entities[0].model.heightReference.getValue()).toBe(Cesium.HeightReference.RELATIVE_TO_GROUND);
+                                done();
+                            })
+                            .catch(done);
                     });
                 });
         });
@@ -370,22 +363,178 @@ describe('CesiumStyleParser', () => {
                             coordinates: [7, 41]
                         }
                     }).then((dataSource) => {
-                        try {
-                            const entities = dataSource?.entities?.values;
-                            styleFunc({ entities });
-                            expect(entities[0].label.text.getValue()).toBe('Hello World!');
-                            expect(entities[0].label.font.getValue()).toBe('italic bold 32px Arial');
-                            expect({ ...entities[0].label.pixelOffset.getValue() }).toEqual({ x: 16, y: 16 });
-                            expect({ ...entities[0].label.fillColor.getValue() }).toEqual({ red: 0, green: 0, blue: 0, alpha: 1 });
-                            expect({ ...entities[0].label.outlineColor.getValue() }).toEqual({ red: 1, green: 1, blue: 1, alpha: 1 });
-                            expect(entities[0].label.outlineWidth.getValue()).toBe(2);
-                            expect(entities[0].label.heightReference.getValue()).toBe(Cesium.HeightReference.NONE);
-
-                        } catch (e) {
-                            done(e);
-                        }
-                        done();
+                        const entities = dataSource?.entities?.values;
+                        return styleFunc({ entities })
+                            .then(() => {
+                                expect(entities[0].label.text.getValue()).toBe('Hello World!');
+                                expect(entities[0].label.font.getValue()).toBe('italic bold 32px Arial');
+                                expect({ ...entities[0].label.pixelOffset.getValue() }).toEqual({ x: 16, y: 16 });
+                                expect({ ...entities[0].label.fillColor.getValue() }).toEqual({ red: 0, green: 0, blue: 0, alpha: 1 });
+                                expect({ ...entities[0].label.outlineColor.getValue() }).toEqual({ red: 1, green: 1, blue: 1, alpha: 1 });
+                                expect(entities[0].label.outlineWidth.getValue()).toBe(2);
+                                expect(entities[0].label.heightReference.getValue()).toBe(Cesium.HeightReference.NONE);
+                                done();
+                            }).catch(done);
                     });
+                });
+        });
+
+        it('should add leader line to all point geometries symbolizer', (done) => {
+
+            const leaderLineOptions = {
+                msLeaderLineColor: '#ff0000',
+                msLeaderLineOpacity: 0.5,
+                msLeaderLineWidth: 2
+            };
+
+            const style = {
+                name: '',
+                rules: [
+                    {
+                        filter: ['==', 'id', 1],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Mark',
+                                wellKnownName: 'Circle',
+                                color: '#ff0000',
+                                fillOpacity: 0.5,
+                                strokeColor: '#00ff00',
+                                strokeOpacity: 0.25,
+                                strokeWidth: 3,
+                                radius: 16,
+                                rotate: 90,
+                                msBringToFront: true,
+                                ...leaderLineOptions
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['==', 'id', 2],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Icon',
+                                image: 'path/to/image',
+                                opacity: 0.5,
+                                size: 32,
+                                rotate: 90,
+                                msBringToFront: true,
+                                ...leaderLineOptions
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['==', 'id', 3],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Text',
+                                label: '{{text}} World!',
+                                offset: [16, 16],
+                                color: '#000000',
+                                haloColor: '#ffffff',
+                                haloWidth: 2,
+                                fontStyle: 'italic',
+                                fontWeight: 'bold',
+                                font: ['Arial'],
+                                size: 32,
+                                rotate: 90,
+                                ...leaderLineOptions
+                            }
+                        ]
+                    },
+                    {
+                        filter: ['==', 'id', 4],
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Model',
+                                model: '/path/to/file.glb',
+                                scale: 1,
+                                heading: 0,
+                                roll: 0,
+                                pitch: 0,
+                                color: '#ffffff',
+                                opacity: 0.5,
+                                msHeightReference: 'relative',
+                                height: 10,
+                                ...leaderLineOptions
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            const canvas = document.createElement('canvas');
+
+            images.push({
+                id: getImageIdFromSymbolizer(style.rules[0].symbolizers[0]),
+                image: canvas,
+                width: 32,
+                height: 32
+            });
+
+            const img = new Image();
+
+            images.push({
+                id: getImageIdFromSymbolizer(style.rules[1].symbolizers[0]),
+                image: img,
+                width: 256,
+                height: 256
+            });
+
+            parser.writeStyle(style)
+                .then((styleFunc) => {
+                    Cesium.GeoJsonDataSource.load({
+                        type: 'FeatureCollection',
+                        features: [1, 2, 3, 4].map(id => ({
+                            type: 'Feature',
+                            properties: {
+                                text: 'Hello',
+                                id
+                            },
+                            geometry: {
+                                type: 'Point',
+                                coordinates: [7, 41, 500]
+                            }
+                        }))
+                    }).then((dataSource) => {
+                        const entities = dataSource?.entities?.values;
+                        return styleFunc({ entities })
+                            .then((styledEntities) => {
+                                expect(styledEntities.length).toBe(4);
+                                const [
+                                    markKind,
+                                    iconKind,
+                                    textKind,
+                                    modelKind
+                                ] = styledEntities;
+                                expect(markKind.billboard).toBeTruthy();
+                                expect(iconKind.billboard).toBeTruthy();
+                                expect(textKind.label).toBeTruthy();
+                                expect(modelKind.model).toBeTruthy();
+
+                                expect(markKind.polyline).toBeTruthy();
+                                expect(iconKind.polyline).toBeTruthy();
+                                expect(textKind.polyline).toBeTruthy();
+                                expect(modelKind.polyline).toBeTruthy();
+
+                                styledEntities.forEach(entity => {
+                                    expect({ ...entity.polyline.material.color.getValue() }).toEqual({ red: 1, green: 0, blue: 0, alpha: 0.5 });
+                                    expect(entity.polyline.width.getValue()).toBe(2);
+                                });
+
+                                expect(textKind.billboard).toBeTruthy();
+                                expect({ ...textKind.billboard.color.getValue() }).toEqual({ red: 1, green: 0, blue: 0, alpha: 0.5 });
+                                expect({ ...textKind.billboard.pixelOffset.getValue() }).toEqual({ x: 8, y: 8 });
+                                const leaderLineCanvas = textKind.billboard.image.getValue();
+                                expect(leaderLineCanvas.width).toBe(16);
+                                expect(leaderLineCanvas.height).toBe(16);
+                                done();
+                            })
+                            .catch(done);
+                    }).catch(done);
                 });
         });
     });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces leader line options for 3D visual style editor for WFS and Vector layers

Preview:

![image](https://user-images.githubusercontent.com/19175505/201170726-3ede083f-d5ea-4716-b1f4-5ce9f4554d2d.png)

UI Components:

![image](https://user-images.githubusercontent.com/19175505/201170802-a3e6f37c-a5fc-48f3-9dc4-805bc10e4300.png)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8341

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

This PR introduces leader line options for 3D visual style editor for WFS and Vector layers

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
