### PR TITLE
[Backport 2022.02.xx-c040] #8831 Date formats in attributes table (#8832)

### DIFF
--- a/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import DateTimePicker from "../../../misc/datetimepicker";
 import utcDateWrapper from "../../../misc/enhancers/utcDateWrapper";
 import moment from "moment";
+import {dateFormats} from "../../../../utils/FeatureGridUtils";
 
 /**
  * Date time picker enhanced with UTC and timezone offset
@@ -15,12 +16,6 @@ const UTCDateTimePicker = utcDateWrapper({
     dateTypeProp: "dataType",
     setDateProp: "onBlur"
 })(DateTimePicker);
-
-const formats = {
-    'date-time': 'YYYY-MM-DDTHH:mm:ss[Z]',
-    'time': 'HH:mm:ss',
-    'date': 'YYYY-MM-DD[Z]'
-};
 
 /**
  * date, date-time, time editor for FeatureGrid
@@ -67,7 +62,7 @@ class DateTimeEditor extends AttributeEditor {
     componentDidMount() {
         const {dataType, value} = this.props;
         this.props.onTemporaryChanges?.(true);
-        const convertedDate = moment.utc(value, formats[dataType]);
+        const convertedDate = moment.utc(value, dateFormats[dataType]);
         if (value) {
             this.setState({ date: convertedDate.isValid() ? convertedDate.toDate() : null});
         }
@@ -78,7 +73,7 @@ class DateTimeEditor extends AttributeEditor {
         const { value, dataType } = this.props;
 
         if (prevValue !== value || prevDataType !== dataType) {
-            const convertedDate = moment.utc(value, formats[dataType]);
+            const convertedDate = moment.utc(value, dateFormats[dataType]);
             this.setState({ date: convertedDate.isValid() ? convertedDate.toDate() : null});
         }
     }
@@ -97,7 +92,7 @@ class DateTimeEditor extends AttributeEditor {
             value={date}
             calendar={calendar}
             time={time}
-            format={formats[dataType]}
+            format={dateFormats[dataType]}
             options={{
                 shouldCalendarSetHours
             }}

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -171,7 +171,7 @@ const featuresToGrid = compose(
                             return props.editors(desc.localType, generalProps);
                         },
                         getFilterRenderer: getFilterRendererFunc,
-                        getFormatter: (desc) => getFormatter(desc)
+                        getFormatter: (desc) => getFormatter(desc, props.dateFormats)
                     }))
             });
             return result;

--- a/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
+++ b/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
@@ -62,4 +62,23 @@ describe('Tests for the formatter functions', () => {
         expect(formatter({value: null})).toBe(null);
         expect(formatter({value: undefined})).toBe(null);
     });
+    it('test getFormatter for date / date-time / time', () => {
+        const dateFormats = {
+            date: 'YYYY',
+            "date-time": 'YYYY DD',
+            time: 'HH:mm'
+        };
+        const dateFormatter = getFormatter({localType: "date"}, dateFormats);
+        const dateTimeFormatter = getFormatter({localType: "date-time"}, dateFormats);
+        const timeFormatter = getFormatter({localType: "time"}, dateFormats);
+        expect(typeof dateFormatter).toBe("function");
+        expect(dateFormatter()).toBe(null);
+        expect(dateFormatter({value: '2015-02-01T12:45:00Z'})).toBe('2015');
+        expect(typeof dateTimeFormatter).toBe("function");
+        expect(dateTimeFormatter()).toBe(null);
+        expect(dateTimeFormatter({value: '2015-02-01Z'})).toBe('2015 01');
+        expect(typeof timeFormatter).toBe("function");
+        expect(timeFormatter()).toBe(null);
+        expect(timeFormatter({value: '12:45:00Z'})).toBe('12:45');
+    });
 });

--- a/web/client/components/data/featuregrid/formatters/index.js
+++ b/web/client/components/data/featuregrid/formatters/index.js
@@ -6,13 +6,15 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-import { isNil } from 'lodash';
+import { isNil, get } from 'lodash';
 import React from 'react';
 import reactStringReplace from "react-string-replace";
+import moment from "moment";
 
 import NumberFormat from '../../../I18N/Number';
+import { dateFormats as defaultDateFormats } from "../../../../utils/FeatureGridUtils";
 
-export const getFormatter = (desc) => {
+export const getFormatter = (desc, dateFormats) => {
     if (desc.localType === 'boolean') {
         return ({value} = {}) => !isNil(value) ? <span>{value.toString()}</span> : null;
     } else if (['int', 'number'].includes(desc.localType)) {
@@ -23,6 +25,11 @@ export const getFormatter = (desc) => {
         )) : null;
     } else if (desc.localType === 'Geometry') {
         return () => null;
+    } else if (['date', 'date-time', 'time'].includes(desc.localType)) {
+        const format = get(dateFormats, desc.localType) ?? defaultDateFormats[desc.localType];
+        return ({value} = {}) => {
+            return !isNil(value) ? moment(value, defaultDateFormats[desc.localType]).format(format) : null;
+        };
     }
     return null;
 };

--- a/web/client/components/widgets/widget/TableWidget.jsx
+++ b/web/client/components/widgets/widget/TableWidget.jsx
@@ -50,7 +50,8 @@ export default getWidgetFilterRenderers(({
     dataGrid = {},
     virtualScroll = true,
     gridOpts = defaultGridOpts,
-    options = {}
+    options = {},
+    dateFormats
 }) =>
     (<WidgetContainer
         id={`widget-chart-${id}`}
@@ -93,7 +94,8 @@ export default getWidgetFilterRenderers(({
                 describeFeatureType={describeFeatureType}
                 pagination={pagination}
                 gridOpts={gridOpts}
-                options={options}/>
+                options={options}
+                dateFormats={dateFormats}/>
         </BorderLayout>
     </WidgetContainer>
 

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -296,6 +296,7 @@ class Widgets extends React.Component {
  * @prop {boolean|string|array} [toolsOptions.showPin] show lock tool. By default is visible only to the admin
  * @prop {boolean|string|array} [toolsOptions.showHide] show the "hide tool" for the widget (the tool allows to hide the widget to users that have `seeHidden=false` ). By default is false, in the most common case it should be the same of `seeHidden`.
  * @prop {boolean|string|array} [toolsOptions.seeHidden] hides the widgets under particular conditions
+ * @prop {object} [dateFormats] object containing custom formats for one of the date/time attribute types. Once specified, custom formats will be applied for specific attribute types in Table widget. Following keys are supported: "date-time", "date", "time".
  *
  */
 const WidgetsPlugin = autoDisableWidgets(Widgets);

--- a/web/client/plugins/featuregrid/FeatureEditor.jsx
+++ b/web/client/plugins/featuregrid/FeatureEditor.jsx
@@ -90,6 +90,7 @@ const Dock = connect(createSelector(
   * @prop {string} cfg.snapConfig.strategy defines strategy function for loading features. Supported values are "bbox" and "all".
   * @prop {number} cfg.snapConfig.maxFeatures defines features limit for request that loads vector data of WMS layer.
   * @prop {array} cfg.snapConfig.additionalLayers Array of additional layers to include into snapping layers list. Provides a way to include layers from "state.additionallayers"
+  * @prop {object} cfg.dateFormats object containing custom formats for one of the date/time attribute types. Following keys are supported: "date-time", "date", "time"
   *
   * @classdesc
   * `FeatureEditor` Plugin, also called *FeatureGrid*, provides functionalities to browse/edit data via WFS. The grid can be configured to use paging or
@@ -116,18 +117,23 @@ const Dock = connect(createSelector(
   *         }
   *       }]
   *     },
-  *   "editingAllowedRoles": ["ADMIN"],
-  *   "snapTool": true,
-  *   "snapConfig": {
-  *     "vertex": true,
-  *     "edge": true,
-  *     "pixelTolerance": 10,
- *      "additionalLayers": [
- *         "ADDITIONAL_LAYER_ID"
- *      ],
- *      "strategy": "bbox",
- *      "maxFeatures": 4000
-  *   },
+  *     "editingAllowedRoles": ["ADMIN"],
+  *     "snapTool": true,
+  *     "snapConfig": {
+  *       "vertex": true,
+  *       "edge": true,
+  *       "pixelTolerance": 10,
+  *       "additionalLayers": [
+  *         "ADDITIONAL_LAYER_ID"
+  *       ],
+  *       "strategy": "bbox",
+  *       "maxFeatures": 4000
+  *     },
+  *     "dateFormats": {
+  *       "date-time": "YYYY-MM-DDTHH:mm:ss[Z]",
+  *       "date": "YYYY-MM-DD[Z]",
+  *       "time": "HH:mm:ss[Z]"
+  *     }
   *   }
   * }
   * ```
@@ -238,6 +244,7 @@ const FeatureDock = (props = {
                         scrollDebounce={props.scrollDebounce}
                         size={props.size}
                         actionOpts={{maxZoom}}
+                        dateFormats={props.dateFormats}
                     />
                 </BorderLayout> }
 

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -346,3 +346,10 @@ export const getAttributesList = (attributes, customAttributesSettings) => {
 export const getAttributesNames = (attributes) => {
     return attributes?.map(attribute => isPlainObject(attribute) ? attribute.name : attribute);
 };
+
+export const dateFormats = {
+    'date-time': 'YYYY-MM-DDTHH:mm:ss[Z]',
+    'time': 'HH:mm:ss',
+    'date': 'YYYY-MM-DD[Z]'
+};
+


### PR DESCRIPTION
## Description
This PR provides changes necessary for support of custom formatting for `date`, `date-time` and `time` attribute types inside of the feature editor attributes table and inside of the Table widget.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8831 

**What is the new behavior?**
`FeatureEditor` and `Widgets` plugins allows to define custom format for attribute types mentioned above.

```json
{
  "name": "FeatureEditor",
  "cfg": {
    "dateFormats": {
      "date": "YY-MM-DD",
      "date-time": "YY-MM-DDTHH:mm[Z]"
    }
  }
}
```

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
