### PR TITLE
#8745 Fixed date/time/date-time editor for feature grid

### DIFF
--- a/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
@@ -3,7 +3,6 @@ import AttributeEditor from "./AttributeEditor";
 import React from "react";
 import DateTimePicker from "../../../misc/datetimepicker";
 import utcDateWrapper from "../../../misc/enhancers/utcDateWrapper";
-import moment from "moment";
 import {dateFormats} from "../../../../utils/FeatureGridUtils";
 
 /**
@@ -14,7 +13,7 @@ import {dateFormats} from "../../../../utils/FeatureGridUtils";
 const UTCDateTimePicker = utcDateWrapper({
     dateProp: "value",
     dateTypeProp: "dataType",
-    setDateProp: "onBlur"
+    setDateProp: "onChange"
 })(DateTimePicker);
 
 /**
@@ -35,7 +34,8 @@ class DateTimeEditor extends AttributeEditor {
         onTemporaryChanges: PropTypes.func,
         calendar: PropTypes.bool,
         time: PropTypes.bool,
-        shouldCalendarSetHours: PropTypes.bool
+        onChange: PropTypes.func,
+        onBlur: PropTypes.func
     };
 
     static contextTypes = {
@@ -47,9 +47,8 @@ class DateTimeEditor extends AttributeEditor {
         column: {},
         calendar: true,
         time: false,
-        shouldCalendarSetHours: false,
-        min: new Date(1500, 0, 1),
-        max: new Date(2099, 0, 1)
+        onChange: () => {},
+        onBlur: () => {}
     };
 
     constructor() {
@@ -58,44 +57,38 @@ class DateTimeEditor extends AttributeEditor {
             date: null
         };
     }
-
     componentDidMount() {
-        const {dataType, value} = this.props;
+        this.date = this.props.value;
         this.props.onTemporaryChanges?.(true);
-        const convertedDate = moment.utc(value, dateFormats[dataType]);
-        if (value) {
-            this.setState({ date: convertedDate.isValid() ? convertedDate.toDate() : null});
-        }
     }
-
-    componentDidUpdate(prevProps) {
-        const { value: prevValue, dataType: prevDataType } = prevProps;
-        const { value, dataType } = this.props;
-
-        if (prevValue !== value || prevDataType !== dataType) {
-            const convertedDate = moment.utc(value, dateFormats[dataType]);
-            this.setState({ date: convertedDate.isValid() ? convertedDate.toDate() : null});
-        }
-    }
-
     componentWillUnmount() {
         this.props.onTemporaryChanges?.(false);
     }
+    onChange = (date) => {
+        this.date = date;
+    };
+
+    getValue = () => {
+        return {
+            [this.props.column.key]: this.date
+        };
+    };
 
     render() {
-        const {shouldCalendarSetHours, dataType, calendar, time} = this.props;
-        const { date } = this.state;
+        const {dataType, calendar, time} = this.props;
+        const { value } = this.props;
         return (<UTCDateTimePicker
             {...this.props}
             type={dataType}
-            defaultValue={date}
-            value={date}
+            defaultValue={value}
+            value={value}
+            onChange={this.onChange}
             calendar={calendar}
             time={time}
-            format={dateFormats[dataType]}
             options={{
-                shouldCalendarSetHours
+                shouldCalendarSetHours: false
             }}
+            format={dateFormats[dataType]}
         />);
     }
 }

--- a/web/client/components/data/featuregrid/editors/__tests__/DateTimeEditor-test.jsx
+++ b/web/client/components/data/featuregrid/editors/__tests__/DateTimeEditor-test.jsx
@@ -36,4 +36,39 @@ describe('FeatureGrid DateTimeEditor component', () => {
         expect(cmp).toExist();
         expect(moment.utc(cmp.getValue().columnKey).toISOString()).toBe(date.toISOString());
     });
+    it('DateTimeEditor Editor with time', () => {
+        const date = moment.utc('2010-01-01T12:00:00').toDate();
+        const cmp = ReactDOM.render(<DateTimeEditor
+            value={date}
+            rowIdx={1}
+            column={testColumn}
+            time/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        expect(moment.utc(cmp.getValue().columnKey).toISOString()).toBe(date.toISOString());
+    });
+    it('DateTimeEditor Editor with time and calendar', () => {
+        const date = moment.utc('2010-01-01T12:00:00').toDate();
+        const cmp = ReactDOM.render(<DateTimeEditor
+            value={date}
+            rowIdx={1}
+            column={testColumn}
+            time
+            calendar/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        expect(moment.utc(cmp.getValue().columnKey).toISOString()).toBe(date.toISOString());
+    }
+    );
+    it('getValue returns the current value set in the editor', () => {
+        const date = moment.utc('2010-01-01T12:00:00').toDate();
+        const cmp = ReactDOM.render(<DateTimeEditor
+            value={date}
+            rowIdx={1}
+            column={testColumn}
+            time
+            calendar/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        expect(cmp.getValue()[testColumn.key]).toEqual(date);
+        cmp.onChange(moment.utc('2010-01-02T12:00:00').toDate());
+        expect(cmp.getValue()[testColumn.key]).toEqual(moment.utc('2010-01-02T12:00:00').toDate());
+    });
 });

--- a/web/client/components/data/featuregrid/editors/index.jsx
+++ b/web/client/components/data/featuregrid/editors/index.jsx
@@ -13,8 +13,8 @@ const types = {
         <AutocompleteEditor dataType="string" {...props}/> :
         <Editor dataType="string" {...props}/>,
     "boolean": (props) => <DropDownEditor dataType="string" {...props} value={props.value && props.value.toString()} filter={false} values={["true", "false"]}/>,
-    "date-time": (props) => <DateTimeEditor dataType="date-time" time popupPosition="top" {...props} />,
-    "date": (props) => <DateTimeEditor dataType="date" popupPosition="top" {...props} />,
+    "date-time": (props) => <DateTimeEditor dataType="date-time" calendar time popupPosition="top" {...props} />,
+    "date": (props) => <DateTimeEditor dataType="date"time={false} calendar popupPosition="top" {...props} />,
     "time": (props) => <DateTimeEditor dataType="time" calendar={false} time popupPosition="top" {...props} />
 };
 export default (type, props) => types[type] ? types[type](props) : types.defaultEditor(props);

--- a/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
+++ b/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
@@ -80,5 +80,6 @@ describe('Tests for the formatter functions', () => {
         expect(typeof timeFormatter).toBe("function");
         expect(timeFormatter()).toBe(null);
         expect(timeFormatter({value: '12:45:00Z'})).toBe('12:45');
+        expect(timeFormatter({ value: '1970-01-01T02:30:00Z' })).toBe('02:30'); // still able to format time even when found a full date (sometimes GeoServer returns full date instead of time only)
     });
 });

--- a/web/client/components/data/featuregrid/formatters/index.js
+++ b/web/client/components/data/featuregrid/formatters/index.js
@@ -13,6 +13,7 @@ import moment from "moment";
 
 import NumberFormat from '../../../I18N/Number';
 import { dateFormats as defaultDateFormats } from "../../../../utils/FeatureGridUtils";
+const DEFAULT_DATE_PART = "1970-01-01";
 
 export const getFormatter = (desc, dateFormats) => {
     if (desc.localType === 'boolean') {
@@ -25,10 +26,23 @@ export const getFormatter = (desc, dateFormats) => {
         )) : null;
     } else if (desc.localType === 'Geometry') {
         return () => null;
-    } else if (['date', 'date-time', 'time'].includes(desc.localType)) {
+    } else if (['date', 'date-time'].includes(desc.localType)) {
         const format = get(dateFormats, desc.localType) ?? defaultDateFormats[desc.localType];
         return ({value} = {}) => {
-            return !isNil(value) ? moment(value, defaultDateFormats[desc.localType]).format(format) : null;
+            return !isNil(value)
+                ? moment.utc(value).isValid() // geoserver sometimes returns UTC for time.
+                    ? moment.utc(value).format(format)
+                    : moment(value).format(format)
+                : null;
+        };
+    } else if ( ['time'].includes(desc.localType) ) {
+        const format = get(dateFormats, desc.localType) ?? defaultDateFormats[desc.localType];
+        return ({value} = {}) => {
+            return !isNil(value)
+                ? moment.utc(value).isValid() // geoserver sometimes returns full UTC string for time.
+                    ? moment.utc(value).format(format)
+                    : moment(`${DEFAULT_DATE_PART}T${value}`).utc().format(format)
+                : null;
         };
     }
     return null;

--- a/web/client/components/misc/datetimepicker/DateTimePicker.js
+++ b/web/client/components/misc/datetimepicker/DateTimePicker.js
@@ -74,18 +74,7 @@ class DateTimePicker extends Component {
         time: true,
         onChange: () => { },
         value: null,
-        popupPosition: 'bottom',
-        options: {
-            shouldCalendarSetHours: true
-        }
-    }
-
-    constructor() {
-        super();
-        this.fallbackDate = new Date();
-        this.fallbackDate.setHours(0);
-        this.fallbackDate.setMinutes(0);
-        this.fallbackDate.setSeconds(0);
+        popupPosition: 'bottom'
     }
 
     state = {
@@ -163,7 +152,7 @@ class DateTimePicker extends Component {
                 </div>
                 <div className={`rw-calendar-popup rw-popup-container ${popupPosition === 'top' ? 'rw-dropup' : ''} ${!calendarVisible ? 'rw-popup-animating' : ''}`} style={{ display: calendarVisible ? 'block' : 'none', overflow: calendarVisible ? 'visible' : 'hidden', height: '285px' }}>
                     <div className={`rw-popup`} style={{ transform: calendarVisible ? 'translateY(0)' : 'translateY(-100%)', padding: '0', borderRadius: '4px', position: calendarVisible ? '' : 'absolute' }}>
-                        <Calendar tabIndex="-1" ref={this.attachCalRef} onMouseDown={this.handleMouseDown} onChange={this.handleCalendarChange} {...props} />
+                        <Calendar tabIndex="-1" ref={this.attachCalRef} onMouseDown={this.handleMouseDown} onChange={this.handleCalendarChange} {...props} value={new Date(this.props.value)}/>
                     </div>
                 </div>
             </div>
@@ -306,13 +295,7 @@ class DateTimePicker extends Component {
     }
 
     handleCalendarChange = value => {
-        let date;
-        if (this.props.options?.shouldCalendarSetHours) {
-            date = setTime(value, new Date());
-        } else {
-            // keep hours value defined by value in state or default date
-            date = setTime(value, this.state.date ?? this.props.value ?? this.fallbackDate);
-        }
+        const date = setTime(value, this.state.date || new Date());
         const inputValue = this.format(date);
         this.setState({ date, inputValue, open: '' });
         this.props.onChange(date, `${this.state.operator}${inputValue}`);

--- a/web/client/components/misc/datetimepicker/__tests__/DateTimePicker-test.js
+++ b/web/client/components/misc/datetimepicker/__tests__/DateTimePicker-test.js
@@ -149,7 +149,7 @@ describe('DateTimePicker component', () => {
             done();
         };
         const dateObj = moment.utc(date, 'YYYY-MM-DDTHH:mm:ss[Z]').toDate();
-        ReactDOM.render(<DateTimePicker format="YYYY-MM-DDTHH:mm:ss[Z]" options={{ shouldCalendarSetHours: false }} value={dateObj} currentDate={dateObj} onChange={handleChange} />, document.getElementById("container"));
+        ReactDOM.render(<DateTimePicker format="YYYY-MM-DDTHH:mm:ss[Z]" value={dateObj} currentDate={dateObj} onChange={handleChange} />, document.getElementById("container"));
         const container = document.getElementById('container');
         const calendar = container.querySelector('.rw-btn-calendar');
         TestUtils.Simulate.click(calendar);

--- a/web/client/components/misc/enhancers/__tests__/utcDateWrapper-test.jsx
+++ b/web/client/components/misc/enhancers/__tests__/utcDateWrapper-test.jsx
@@ -72,7 +72,7 @@ describe('utcDateWrapper enhancher', () => {
         expect(inputs[0].value).toBe('02/01/2018 03:00:00');
     });
 
-    it.only('UTCDateWrapper calls onSetDate', (done) => {
+    it('UTCDateWrapper calls onSetDate', (done) => {
         const actions = {
             onSetDate: () => { }
         };

--- a/web/client/components/misc/enhancers/__tests__/utcDateWrapper-test.jsx
+++ b/web/client/components/misc/enhancers/__tests__/utcDateWrapper-test.jsx
@@ -72,7 +72,7 @@ describe('utcDateWrapper enhancher', () => {
         expect(inputs[0].value).toBe('02/01/2018 03:00:00');
     });
 
-    it('UTCDateWrapper calls onSetDate', (done) => {
+    it.only('UTCDateWrapper calls onSetDate', (done) => {
         const actions = {
             onSetDate: () => { }
         };
@@ -106,6 +106,109 @@ describe('utcDateWrapper enhancher', () => {
         ];
         TESTS.map((t, i) =>
             ReactDOM.render(<Sink onSetDate={actions.onSetDate} date={new Date(t)} check={check(new Date(t), t, i, i === TESTS.length - 1 ? () => done() : undefined)}/>, document.getElementById("container")));
+        TESTS.map((t, i) =>
+            ReactDOM.render(<Sink onSetDate={actions.onSetDate} date={new Date(t)} type="date" check={check(new Date(t), t, i, i === TESTS.length - 1 ? () => done() : undefined)} />, document.getElementById("container")));
     });
+    it('UTCDateWrapper calls onSetDate', (done) => {
+        const actions = {
+            onSetDate: () => { }
+        };
+        const spyonSetDate = expect.spyOn(actions, 'onSetDate');
 
+        const check = (date, expectedUTCString, index, callback = () => {}) => (props) => {
+            expect(props).toExist();
+            // check component as expectedUTCDate
+            // check the current date is properly shifted
+            expect(date.getTime() + date.getTimezoneOffset() * 60000).toEqual(props.date.getTime());
+
+            // test callback
+            props.onSetDate(props.date);
+            expect(spyonSetDate).toHaveBeenCalled();
+
+            // check the returned date is properly converted back to UTC Date
+            expect(spyonSetDate.calls[index].arguments[0].toISOString()).toBe(expectedUTCString);
+            callback();
+        };
+        const Sink = utcDateWrapper()(createSink( props => {
+            props.check(props);
+        }));
+        const TESTS = [
+            "2010-01-01T00:00:00.000Z",
+            "2010-01-02T00:00:00.000Z",
+            "2010-01-02T23:59:59.999Z",
+            "2010-12-31T00:00:00.000Z",
+            "2010-12-31T23:59:59.999Z",
+            "2010-01-01T00:00:00.000Z",
+            "2018-06-01T12:38:42.100Z"
+        ];
+        TESTS.map((t, i) =>
+            ReactDOM.render(<Sink onSetDate={actions.onSetDate} date={new Date(t)} check={check(new Date(t), t, i, i === TESTS.length - 1 ? () => done() : undefined)}/>, document.getElementById("container")));
+    });
+    it('UTCDateWrapper calls onSetDate for type date', (done) => {
+        const actions = {
+            onSetDate: () => { }
+        };
+        const spyonSetDate = expect.spyOn(actions, 'onSetDate');
+
+        const check = (date, expectedUTCString, index, callback = () => { }) => (props) => {
+            expect(props).toExist();
+            // check component as expectedUTCDate
+            // check the current date is properly shifted
+
+            // test callback
+            props.onSetDate(props.date);
+            expect(spyonSetDate).toHaveBeenCalled();
+
+            // check the returned date is properly converted back to UTC Date
+            expect(spyonSetDate.calls[index].arguments[0]).toBe(expectedUTCString);
+            callback();
+        };
+        const Sink = utcDateWrapper()(createSink(props => {
+            props.check(props);
+        }));
+        const TESTS = [
+            "2010-01-01T00:00:00.000Z",
+            "2010-01-02T00:00:00.000Z",
+            "2010-01-02T23:59:59.999Z",
+            "2010-12-31T00:00:00.000Z",
+            "2010-12-31T23:59:59.999Z",
+            "2010-01-01T00:00:00.000Z",
+            "2018-06-01T12:38:42.100Z"
+        ];
+        TESTS.map((t, i) =>
+            ReactDOM.render(<Sink onSetDate={actions.onSetDate} type="date" date={new Date(t)} check={check(new Date(t), `${t.split("T")[0]}Z`, i, i === TESTS.length - 1 ? () => done() : undefined)} />, document.getElementById("container")));
+    });
+    it('UTCDateWrapper calls onSetDate for type date', (done) => {
+        const actions = {
+            onSetDate: () => { }
+        };
+        const spyonSetDate = expect.spyOn(actions, 'onSetDate');
+
+        const check = (date, expectedUTCString, index, callback = () => { }) => (props) => {
+            expect(props).toExist();
+            // test callback
+            props.onSetDate(props.date);
+            expect(spyonSetDate).toHaveBeenCalled();
+
+            // check the returned date is properly converted back to UTC Date
+            expect(spyonSetDate.calls[index].arguments[0]).toBe(expectedUTCString);
+            callback();
+        };
+        const Sink = utcDateWrapper()(createSink(props => {
+            props.check(props);
+        }));
+        const TESTS = [
+            "2010-01-01T00:00:00.000Z",
+            "2010-01-02T00:00:00.000Z",
+            "2010-01-02T23:59:59.999Z",
+            "2010-12-31T00:00:00.000Z",
+            "2010-12-31T23:59:59.999Z",
+            "2010-01-01T00:00:00.000Z",
+            "2018-06-01T12:38:42.100Z"
+        ];
+        TESTS.map((t, i) => {
+            const expectedString = `${t.split("T")[1].split('.')[0]}Z`; // 2010-01-01T00:00:00.000Z --> 00:00:00Z
+            ReactDOM.render(<Sink onSetDate={actions.onSetDate} type="time" date={new Date(t)} check={check(new Date(t), expectedString, i, i === TESTS.length - 1 ? () => done() : undefined)} />, document.getElementById("container"));
+        });
+    });
 });

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -349,7 +349,7 @@ export const getAttributesNames = (attributes) => {
 
 export const dateFormats = {
     'date-time': 'YYYY-MM-DDTHH:mm:ss[Z]',
-    'time': 'HH:mm:ss',
+    'time': 'HH:mm:ss[Z]',
     'date': 'YYYY-MM-DD[Z]'
 };
 


### PR DESCRIPTION
## Description
This PR fixes the issues found in https://github.com/geosolutions-it/MapStore2/issues/8745#issuecomment-1326229211 providing a more robust way to handle dates. 

During my investigation I noticed that even if the application seemed to work, in fact the values was not correctly set to the current selection. So I needed to refactor the editor component to fix these issues. 

As quoted here, GeoServer JSON format for 'time' field returns a full ISO String (probably a bug). 
With this PR:
 - I made the formatter of rows smart enough to format also full iso string correctly
 - I noticed several errors during editing due to race conditions. I fixed the editor in order to avoid these problems (`setState` is not enough because the featuregrid calls `getValue` on the component. If I override `getValue` reading the current state, I'll have the previous one. So I used `this.date` to store most recent change. This seems to solve all the strange editing behaviors.
 - Calendar sometimes was buggy and set the time in arbitrary way. With these fixes, the datePicker preservers the time when date is selected. 
 
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8745

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
