### PR TITLE
#8798 Removed Jpeg and png format from defaults in raster layer download

### DIFF
--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -71,8 +71,6 @@ class DownloadDialog extends React.Component {
             {name: 'application/json', label: 'GeoJSON', type: 'vector', validServices: ['wps']},
             {name: 'application/arcgrid', label: 'ArcGrid', type: 'raster', validServices: ['wps']},
             {name: 'image/tiff', label: 'TIFF', type: 'raster', validServices: ['wps']},
-            {name: 'image/png', label: 'PNG', type: 'raster', validServices: ['wps']},
-            {name: 'image/jpeg', label: 'JPEG', type: 'raster', validServices: ['wps']},
             {name: 'application/wfs-collection-1.0', label: 'wfs-collection-1.0', type: 'vector', validServices: ['wps']},
             {name: 'application/wfs-collection-1.1', label: 'wfs-collection-1.1', type: 'vector', validServices: ['wps']},
             {name: 'application/zip', label: 'Shapefile', type: 'vector', validServices: ['wps']},


### PR DESCRIPTION
## Description
As for this comment. https://github.com/geosolutions-it/mapstore2/issues/8798#issuecomment-1335449855

This PR removes PNG and JPEG formats from default available formats for raster data. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8798

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The JPEG and PNG formats are not pesent anymore

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
