### PR TITLE
#8859 Fixed default current date for calendar in datetime picker

### DIFF
--- a/web/client/components/misc/datetimepicker/DateTimePicker.js
+++ b/web/client/components/misc/datetimepicker/DateTimePicker.js
@@ -160,7 +160,6 @@ class DateTimePicker extends Component {
                             onChange={this.handleCalendarChange}
                             {...props}
                             value={!isNil(this.props.value) ? new Date(this.props.value) : undefined}
-                            currentDate={!isNil(this.props.value) ? new Date(this.props.value) : new Date() }
                         />
                     </div>
                 </div>

--- a/web/client/components/misc/datetimepicker/DateTimePicker.js
+++ b/web/client/components/misc/datetimepicker/DateTimePicker.js
@@ -153,7 +153,7 @@ class DateTimePicker extends Component {
                 </div>
                 <div className={`rw-calendar-popup rw-popup-container ${popupPosition === 'top' ? 'rw-dropup' : ''} ${!calendarVisible ? 'rw-popup-animating' : ''}`} style={{ display: calendarVisible ? 'block' : 'none', overflow: calendarVisible ? 'visible' : 'hidden', height: '285px' }}>
                     <div className={`rw-popup`} style={{ transform: calendarVisible ? 'translateY(0)' : 'translateY(-100%)', padding: '0', borderRadius: '4px', position: calendarVisible ? '' : 'absolute' }}>
-                        <Calendar 
+                        <Calendar
                             tabIndex="-1"
                             ref={this.attachCalRef}
                             onMouseDown={this.handleMouseDown}

--- a/web/client/components/misc/datetimepicker/DateTimePicker.js
+++ b/web/client/components/misc/datetimepicker/DateTimePicker.js
@@ -153,7 +153,8 @@ class DateTimePicker extends Component {
                 </div>
                 <div className={`rw-calendar-popup rw-popup-container ${popupPosition === 'top' ? 'rw-dropup' : ''} ${!calendarVisible ? 'rw-popup-animating' : ''}`} style={{ display: calendarVisible ? 'block' : 'none', overflow: calendarVisible ? 'visible' : 'hidden', height: '285px' }}>
                     <div className={`rw-popup`} style={{ transform: calendarVisible ? 'translateY(0)' : 'translateY(-100%)', padding: '0', borderRadius: '4px', position: calendarVisible ? '' : 'absolute' }}>
-                        <Calendar tabIndex="-1"
+                        <Calendar 
+                            tabIndex="-1"
                             ref={this.attachCalRef}
                             onMouseDown={this.handleMouseDown}
                             onChange={this.handleCalendarChange}

--- a/web/client/components/misc/datetimepicker/DateTimePicker.js
+++ b/web/client/components/misc/datetimepicker/DateTimePicker.js
@@ -7,12 +7,13 @@
  */
 
 import React, { Component } from 'react';
+
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { Calendar } from 'react-widgets';
 import localizer from 'react-widgets/lib/localizers/moment';
 import { Tooltip } from 'react-bootstrap';
-import { isDate } from 'lodash';
+import { isDate, isNil } from 'lodash';
 import OverlayTrigger from '../OverlayTrigger';
 import Hours from './Hours';
 
@@ -152,7 +153,14 @@ class DateTimePicker extends Component {
                 </div>
                 <div className={`rw-calendar-popup rw-popup-container ${popupPosition === 'top' ? 'rw-dropup' : ''} ${!calendarVisible ? 'rw-popup-animating' : ''}`} style={{ display: calendarVisible ? 'block' : 'none', overflow: calendarVisible ? 'visible' : 'hidden', height: '285px' }}>
                     <div className={`rw-popup`} style={{ transform: calendarVisible ? 'translateY(0)' : 'translateY(-100%)', padding: '0', borderRadius: '4px', position: calendarVisible ? '' : 'absolute' }}>
-                        <Calendar tabIndex="-1" ref={this.attachCalRef} onMouseDown={this.handleMouseDown} onChange={this.handleCalendarChange} {...props} value={new Date(this.props.value)}/>
+                        <Calendar tabIndex="-1"
+                            ref={this.attachCalRef}
+                            onMouseDown={this.handleMouseDown}
+                            onChange={this.handleCalendarChange}
+                            {...props}
+                            value={!isNil(this.props.value) ? new Date(this.props.value) : undefined}
+                            currentDate={!isNil(this.props.value) ? new Date(this.props.value) : new Date() }
+                        />
                     </div>
                 </div>
             </div>

--- a/web/client/components/misc/datetimepicker/__tests__/DateTimePicker-test.js
+++ b/web/client/components/misc/datetimepicker/__tests__/DateTimePicker-test.js
@@ -60,7 +60,23 @@ describe('DateTimePicker component', () => {
         const calendar = container.querySelector('.rw-calendar-popup');
         expect(calendar.style.display).toBe('block');
     });
-
+    it('calendar opens to today when value is null or undefined', function() {
+        ReactDOM.render(<DateTimePicker/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const button = container.querySelector('.rw-btn-calendar');
+        TestUtils.Simulate.click(button);
+        const monthLabel = document.querySelector('#container > div > div.rw-calendar-popup.rw-popup-container .rw-btn-view');
+        expect(monthLabel.innerHTML).toBe(moment().format('MMMM YYYY'));
+    });
+    it('calendar opens at the values date', function() {
+        const value = "01-01-2010";
+        ReactDOM.render(<DateTimePicker value={value} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const button = container.querySelector('.rw-btn-calendar');
+        TestUtils.Simulate.click(button);
+        const monthLabel = document.querySelector('#container > div > div.rw-calendar-popup.rw-popup-container .rw-btn-view');
+        expect(monthLabel.innerHTML).toBe(moment(value).format('MMMM YYYY'));
+    });
     it('DateTimePicker show hours on time button click', function() {
         ReactDOM.render(<DateTimePicker />, document.getElementById("container"));
         const container = document.getElementById('container');


### PR DESCRIPTION
## Description

The datetime picker now starts on current date when value is null or undefined. This fixes both filter and editor start date. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8859

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
