### PR TITLE
[Backport 2022.02.xx] #8817 Add a configuration to enable/disable Identify dropdown (#8818)

### DIFF
--- a/web/client/components/geostory/common/MapEditor.jsx
+++ b/web/client/components/geostory/common/MapEditor.jsx
@@ -67,7 +67,8 @@ const MapEditor = ({
     editNode,
     closeNodeEditor,
     CloseBtn = () => (null),
-    isDrawEnabled
+    isDrawEnabled,
+    hideIdentifyOptions
 }) => {
     return (mode === Modes.EDIT && isFocused ? <div
         key="left-column"
@@ -110,6 +111,7 @@ const MapEditor = ({
                         onChangeMap={onChangeMap}
                         selectedNodes={selectedNodes}
                         onSelect={onNodeSelect}
+                        hideIdentifyOptions={hideIdentifyOptions}
                     />
                 ]}
         </BorderLayout>}

--- a/web/client/components/geostory/common/map/Controls.jsx
+++ b/web/client/components/geostory/common/map/Controls.jsx
@@ -21,7 +21,8 @@ const SelectLocalized = localizedProps(["placeholder", "options"])(Select);
 
 export const Controls = ({
     map = {zoomControl: true, mapInfoControl: false},
-    onChangeMap = () => {}
+    onChangeMap = () => { },
+    ...props
 } = {}) => {
     const mapOptions = map && map.mapOptions || {};
     const options = applyDefaults({
@@ -84,7 +85,7 @@ export const Controls = ({
                 className="ms-geostory-map-controls-switch"
                 checked={options.mapInfoControl}
             />
-            {options.mapInfoControl && <FeatureInfoFormatSelector
+            {options.mapInfoControl && !props.hideIdentifyOptions && <FeatureInfoFormatSelector
                 disabled={!options.mapInfoControl}
                 popoverMessage="geostory.builder.settings.templateTooltip"
                 infoFormat={options.mapOptions && options.mapOptions.mapInfoFormat || "application/json"}

--- a/web/client/plugins/GeoStory.jsx
+++ b/web/client/plugins/GeoStory.jsx
@@ -94,7 +94,7 @@ const GeoStory = ({
 
     return (<BorderLayout
         className="ms-geostory"
-        columns={[<MapEditor {...props} buttonItems={props.items?.filter(item => item.target === 'mapEditorToolbar')} add={addFunc} update={onUpdate} mode={mode} />]}>
+        columns={[<MapEditor {...props} buttonItems={props.items?.filter(item => item.target === 'mapEditorToolbar')} add={addFunc} update={onUpdate} mode={mode} hideIdentifyOptions={props.hideIdentifyOptions} />]}>
         <Story
             {...story}
             {...props} // add actions
@@ -137,6 +137,7 @@ GeoStory.defaultProps = {
  * @prop {object} cfg.mediaEditorSettings.sources[sourceId].addMediaEnabled[mediaType] enable add button (supported service types: geostory)
  * @prop {object} cfg.mediaEditorSettings.sources[sourceId].editMediaEnabled[mediaType] enable edit button (supported service types: geostory and geostore)
  * @prop {object} cfg.mediaEditorSettings.sources[sourceId].removeMediaEnabled[mediaType] enable remove button (supported service types: geostory)
+ * @prop {object} cfg.hideIdentifyOptions allow the exclusion of Identify drop down in map configuration
  * @example
  * // example of mediaEditorSettings configuration with only the geostory service
  * {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Identify dropdown is enabled/disabled through Geostory cfg

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8817 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
