### PR TITLE
[Backport 2022.02.xx] #8670 Polygon Type style settings are not highlighted on user selection

### DIFF
--- a/web/client/components/styleeditor/config/property.js
+++ b/web/client/components/styleeditor/config/property.js
@@ -333,8 +333,7 @@ const property = {
             return {
                 [key]: value
             };
-        },
-        setValue: (value) => !!value
+        }
     }),
     msHeightReference: ({ key = 'msHeightReference', label = 'Height reference from ground' }) => ({
         type: 'toolbar',


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Polygon type was not selected for incorrect setValue method. The msClassificationType property should use the default setValue without implementing its own one.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8670

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The polygon type option is correctly selected in fill symbolizer for 3D views

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
