### PR TITLE
#8902 - Performance improvements for cesium tileprovider

### DIFF
--- a/web/client/components/map/cesium/__tests__/TileProviderLayer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/TileProviderLayer-test.jsx
@@ -9,7 +9,7 @@ describe('TileProviderLayer', () => {
             { url: 'http://{s}.test.com/{z}/{x}/{y}.png', data: {}, expected: 'http://{s}.test.com/{z}/{x}/{y}.png' },
             { url: 'http://{s}.test.com/{name}/{z}/{x}/{y}.png', data: {name: "test"}, expected: 'http://{s}.test.com/test/{z}/{x}/{y}.png' },
             { url: 'http://{s}.test.com/{name}.{variant}/{style}/{z}/{x}/{y}.png', data: {name: "name", variant: "variant", style: "style"}, expected: 'http://{s}.test.com/name.variant/style/{z}/{x}/{y}.png' },
-            { url: 'https://osm-prod.noncd.db.de:8100/styles/dbs-osm-railway/{z}/{x}/{y}.png?key=asdasdasdasdasdasdasd', data: {}, expected: 'https://osm-prod.noncd.db.de:8100/styles/dbs-osm-railway/{z}/{x}/{y}.png?key=asdasdasdasdasdasdasd'}
+            { url: 'https://very.long.domain.to.test.regex.speed:8100/long/path/{z}/{x}/{y}.png?key=LONG_KEY_TO_USE_TOO', data: {}, expected: 'https://very.long.domain.to.test.regex.speed:8100/long/path/{z}/{x}/{y}.png?key=LONG_KEY_TO_USE_TOO' }
         ];
         samples.forEach((sample) => {
             expect(template(sample.url, sample.data)).toBe(sample.expected);

--- a/web/client/components/map/cesium/__tests__/TileProviderLayer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/TileProviderLayer-test.jsx
@@ -1,0 +1,19 @@
+import expect from 'expect';
+import {template} from '../plugins/TileProviderLayer';
+
+
+describe('TileProviderLayer', () => {
+    it('template function', () => {
+        const samples = [
+            { url: 'http://test.com/{z}/{x}/{y}.png', data: {}, expected: 'http://test.com/{z}/{x}/{y}.png'},
+            { url: 'http://{s}.test.com/{z}/{x}/{y}.png', data: {}, expected: 'http://{s}.test.com/{z}/{x}/{y}.png' },
+            { url: 'http://{s}.test.com/{name}/{z}/{x}/{y}.png', data: {name: "test"}, expected: 'http://{s}.test.com/test/{z}/{x}/{y}.png' },
+            { url: 'http://{s}.test.com/{name}.{variant}/{style}/{z}/{x}/{y}.png', data: {name: "name", variant: "variant", style: "style"}, expected: 'http://{s}.test.com/name.variant/style/{z}/{x}/{y}.png' },
+            { url: 'https://osm-prod.noncd.db.de:8100/styles/dbs-osm-railway/{z}/{x}/{y}.png?key=asdasdasdasdasdasdasd', data: {}, expected: 'https://osm-prod.noncd.db.de:8100/styles/dbs-osm-railway/{z}/{x}/{y}.png?key=asdasdasdasdasdasdasd'}
+        ];
+        samples.forEach((sample) => {
+            expect(template(sample.url, sample.data)).toBe(sample.expected);
+        });
+
+    });
+});

--- a/web/client/components/map/cesium/plugins/TileProviderLayer.js
+++ b/web/client/components/map/cesium/plugins/TileProviderLayer.js
@@ -42,15 +42,22 @@ function NoProxy() {
 
 NoProxy.prototype.getURL = (r) => r;
 
-function template(str, data) {
+/**
+ * Returns the URL passed as parameter, replacing all the variables with the values in the data object, except for the variables x, y, z and s, that are reserved for the tile coordinates and server.
+ * @param {string} URL the string to replace
+ * @param {object} data data to use for replacement
+ * @returns {string}
+ */
+export function template(str, data) {
 
-    return str.replace(/(?!(\{?[zyxs]?\}))\{*([\w_]+)*\}/g, function() {
-        let st = arguments[0];
-        let key = arguments[1] ? arguments[1] : arguments[2];
+    return str.replace(/{([^{}]+)}/g, function(textMatched, key) {
+        if (['x', 'y', 'z', 's'].includes(key)) {
+            return textMatched;
+        }
         let value = data[key];
 
         if (value === undefined) {
-            throw new Error('No value provided for variable ' + st);
+            throw new Error('No value provided for variable ' + key);
 
         } else if (typeof value === 'function') {
             value = value(data);


### PR DESCRIPTION
## Description

The performance issue increases on string size. When the string is short, is similar, but when the string grows the tileprovider layer blocks. 

Here the result of a performance benchmark:

![image](https://user-images.githubusercontent.com/1279510/211605577-a87873c8-3416-43db-8427-a3008f8e8d12.png)

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
closes #8902

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
