### PR TITLE
#7928: Fix - Mobile - Extra page on GFI panel

### DIFF
--- a/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
+++ b/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
@@ -266,6 +266,7 @@ describe('DefaultViewer', () => {
         expect(gfiViewer.childNodes.length).toBe(2);
         expect(gfiViewer.childNodes[0]).toEqual(alertInfo);
         expect(gfiViewer.childNodes[1]).toEqual(swipeableView);
+        expect(gfiViewer.childNodes[1].childNodes.length).toBe(1);
 
     });
 });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -42,7 +42,7 @@ import {
 
 import { MAP_CONFIG_LOADED } from '../actions/config';
 import { RESET_CONTROLS } from '../actions/controls';
-import { MAP_TYPE_CHANGED } from './../actions/maptype';
+import { MAP_TYPE_CHANGED } from '../actions/maptype';
 
 import { getValidator } from '../utils/MapInfoUtils';
 


### PR DESCRIPTION
## Description
This PR fixes displaying of extra pages in GFI panel in mobile when making a GFI query

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#7928 

**What is the new behavior?**

- **Desktop** - _Click_ and _Hover_ behavior is unaffected
- **Mobile** - Only valid responses pages are displayed and can swipe to view only those (Empty pages are not displayed)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
