### PR TITLE
#8898 Add authkey to WMS BIL Terrain layers

### DIFF
--- a/web/client/plugins/MapViews.jsx
+++ b/web/client/plugins/MapViews.jsx
@@ -109,11 +109,19 @@ export default createPlugin(pluginName, {
         SidebarMenu: {
             name: 'mapViews',
             position: 2000,
-            tool: ConnectedMapViewsButton
+            tool: ConnectedMapViewsButton,
+            priority: 1
+        },
+        BurgerMenu: {
+            name: 'mapviews',
+            position: 9,
+            tool: () => <ConnectedMapViewsButton menuItem />,
+            priority: 2
         },
         Map: {
             name: pluginName,
-            Tool: MapViewsPlugin
+            Tool: MapViewsPlugin,
+            alwaysRender: true
         }
     }
 });

--- a/web/client/utils/cesium/GeoServerBILTerrainProvider.js
+++ b/web/client/utils/cesium/GeoServerBILTerrainProvider.js
@@ -302,13 +302,14 @@ function parseOptions(options) {
             severUrl = severUrl.substring(0, index);
         }
         const urlGetCapabilities = `${severUrl}?SERVICE=WMS&REQUEST=GetCapabilities&tiled=true`;
-        let updatedCapabilitiesUrl = getCapabilitiesUrl({ url: urlGetCapabilities, name: options.layerName });
-        if (defined(options.proxy)) {
-            updatedCapabilitiesUrl = options.proxy.getURL(updatedCapabilitiesUrl);
-        }
+        let updatedCapabilitiesUrl = getCapabilitiesUrl({ url: urlGetCapabilities, name: options.layerName, authKey: options.authkey });
         const isWorkSpaceCapabilities = updatedCapabilitiesUrl !== urlGetCapabilities;
 
-        return Resource.fetchXML(updatedCapabilitiesUrl)
+        return Resource.fetchXML({
+            url: updatedCapabilitiesUrl,
+            proxy: options.proxy,
+            queryParameters: options.params
+        })
             .then((xml) => {
                 return getMetadataDescription(
                     fromWSMCapabilitiesToOptions(xml, { ...options, isWorkSpaceCapabilities })
@@ -406,8 +407,10 @@ GeoServerBILTerrainProvider.prototype.getHeightmapTerrainDataArray = function(x,
         }
         const proxy = this._options.proxy || { getURL: v => v };
         requestPromise = Resource.fetchArrayBuffer({
-            url: proxy.getURL(urlValue),
+            url: urlValue,
+            proxy: proxy,
             headers: this._options.headers,
+            queryParameters: this._options.params,
             request: new Request({
                 // we need to disable throttle
                 // if the current level matches the zoom used by sample terrain

--- a/web/client/utils/cesium/WMSUtils.js
+++ b/web/client/utils/cesium/WMSUtils.js
@@ -9,6 +9,7 @@
 import { getAuthenticationHeaders } from "../SecurityUtils";
 import { getProxyUrl, needProxy } from "../ProxyUtils";
 import ConfigUtils from "../ConfigUtils";
+import {getAuthenticationParam} from "../LayersUtils";
 
 const PARAM_OPTIONS = ["layers", "styles", "style", "format", "transparent", "version", "tiled", "opacity", "zindex", "srs", "singletile", "_v_", "filterobj" ];
 
@@ -60,6 +61,7 @@ export const getProxy = (options) => {
 export const wmsToCesiumOptionsBIL = (options) => {
     let url = options.url;
     const headers = getAuthenticationHeaders(url, options.securityToken);
+    const params = getAuthenticationParam(options);
     // MapStore only supports "image/bil" format for WMS provider
     return {
         url,
@@ -75,7 +77,8 @@ export const wmsToCesiumOptionsBIL = (options) => {
         waterMask: options.waterMask,
         offset: options.offset,
         highest: options.highest,
-        lowest: options.lowest
+        lowest: options.lowest,
+        params
     };
 };
 


### PR DESCRIPTION
## Description
The PR implements the support for authkey for WMS BIL Terrain layers so also the private one could be accessible and visualized by the application.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#8898 

**What is the new behavior?**
The authkey for WMS BIL Terrain layers is added to the existing wms payload 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
