### PR TITLE
#8795 Attribute table has highlighted empty cells even if they are not changed

### DIFF
--- a/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
+++ b/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
@@ -24,7 +24,7 @@ class CellRenderer extends React.Component {
     }
     render() {
         const isProperty = this.context.isProperty(this.props.column.key);
-        const isModified = (this.props.rowData._new && isProperty) || this.context.isModified(this.props.rowData.id, this.props.column.key);
+        const isModified = (this.props.rowData._new && isProperty);
         const isValid = isProperty ? this.context.isValid(this.props.rowData.get(this.props.column.key), this.props.column.key) : true;
         const className = (isModified ? ['modified'] : [])
             .concat(isValid ? [] : ['invalid']).join(" ");

--- a/web/client/plugins/MapViews.jsx
+++ b/web/client/plugins/MapViews.jsx
@@ -109,11 +109,19 @@ export default createPlugin(pluginName, {
         SidebarMenu: {
             name: 'mapViews',
             position: 2000,
-            tool: ConnectedMapViewsButton
+            tool: ConnectedMapViewsButton,
+            priority: 1
+        },
+        BurgerMenu: {
+            name: 'mapviews',
+            position: 9,
+            tool: () => <ConnectedMapViewsButton menuItem />,
+            priority: 2
         },
         Map: {
             name: pluginName,
-            Tool: MapViewsPlugin
+            Tool: MapViewsPlugin,
+            alwaysRender: true
         }
     }
 });


### PR DESCRIPTION
## Description
The PR fixes the issue with the attribute table cells being highlighted even if they are not changed

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8795 

**What is the new behavior?**
The attribute table cells are no longer highlighted are when not changed.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Demo

https://user-images.githubusercontent.com/22595454/215998823-349993ff-7762-4792-9de2-1573888c4151.mp4


