### PR TITLE
#8795 Attribute table has highlighted boolean empty cells even if they are not changed

### DIFF
--- a/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
@@ -22,6 +22,7 @@ import assign from 'object-assign';
  * @prop {boolean} forceSelection forces the editor to use a `defaultOption` as value
  * @prop {string} defaultOption value used as default if forceSelection is true
  * @prop {boolean} allowEmpty if true it accept empty string as value
+ * @prop {string} emptyValue is an empty string
  *
  */
 class DropDownEditor extends AttributeEditor {
@@ -38,7 +39,8 @@ class DropDownEditor extends AttributeEditor {
         value: PropTypes.string,
         filter: PropTypes.string,
         values: PropTypes.array,
-        labels: PropTypes.array
+        labels: PropTypes.array,
+        emptyValue: PropTypes.string
     };
     static defaultProps = {
         isValid: () => true,
@@ -46,7 +48,8 @@ class DropDownEditor extends AttributeEditor {
         filter: "contains",
         values: [],
         forceSelection: true,
-        allowEmpty: true
+        allowEmpty: true,
+        emptyValue: ""
     };
     constructor(props) {
         super(props);
@@ -71,7 +74,9 @@ class DropDownEditor extends AttributeEditor {
                     oldValue: this.props.defaultOption,
                     changedValue: this.getValueByLabel(updated[this.props.column && this.props.column.key]),
                     data: this.props.values,
-                    allowEmpty: this.props.allowEmpty})};
+                    allowEmpty: this.props.allowEmpty,
+                    emptyValue: this.props.emptyValue
+                })};
             }
             if (this.props.allowEmpty) {
                 return updated;
@@ -81,7 +86,9 @@ class DropDownEditor extends AttributeEditor {
                 oldValue: this.props.defaultOption,
                 changedValue: this.getValueByLabel(updated[this.props.column && this.props.column.key]),
                 data: this.props.values,
-                allowEmpty: this.props.allowEmpty})};
+                allowEmpty: this.props.allowEmpty,
+                emptyValue: this.props.emptyValue
+            })};
         };
     }
     render() {

--- a/web/client/components/data/featuregrid/editors/index.jsx
+++ b/web/client/components/data/featuregrid/editors/index.jsx
@@ -12,7 +12,7 @@ const types = {
     "string": (props) => props.autocompleteEnabled ?
         <AutocompleteEditor dataType="string" {...props}/> :
         <Editor dataType="string" {...props}/>,
-    "boolean": (props) => <DropDownEditor dataType="string" {...props} value={props.value && props.value.toString()} filter={false} values={["true", "false"]}/>,
+    "boolean": (props) => <DropDownEditor dataType="string" {...props} value={props.value && props.value.toString()} emptyValue={null}filter={false} values={["true", "false"]}/>,
     "date-time": (props) => <DateTimeEditor dataType="date-time" calendar time popupPosition="top" {...props} />,
     "date": (props) => <DateTimeEditor dataType="date"time={false} calendar popupPosition="top" {...props} />,
     "time": (props) => <DateTimeEditor dataType="time" calendar={false} time popupPosition="top" {...props} />

--- a/web/client/components/data/featuregrid/editors/index.jsx
+++ b/web/client/components/data/featuregrid/editors/index.jsx
@@ -12,7 +12,7 @@ const types = {
     "string": (props) => props.autocompleteEnabled ?
         <AutocompleteEditor dataType="string" {...props}/> :
         <Editor dataType="string" {...props}/>,
-    "boolean": (props) => <DropDownEditor dataType="string" {...props} value={props.value && props.value.toString()} emptyValue={null}filter={false} values={["true", "false"]}/>,
+    "boolean": (props) => <DropDownEditor dataType="string" {...props} value={props.value && props.value.toString()} emptyValue={null} filter={false} values={["true", "false"]}/>,
     "date-time": (props) => <DateTimeEditor dataType="date-time" calendar time popupPosition="top" {...props} />,
     "date": (props) => <DateTimeEditor dataType="date"time={false} calendar popupPosition="top" {...props} />,
     "time": (props) => <DateTimeEditor dataType="time" calendar={false} time popupPosition="top" {...props} />

--- a/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
+++ b/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
@@ -24,7 +24,7 @@ class CellRenderer extends React.Component {
     }
     render() {
         const isProperty = this.context.isProperty(this.props.column.key);
-        const isModified = (this.props.rowData._new && isProperty) || this.context.isModified(this.props.rowData.id, this.props.column.key);
+        const isModified = (this.props.rowData._new && isProperty);
         const isValid = isProperty ? this.context.isValid(this.props.rowData.get(this.props.column.key), this.props.column.key) : true;
         const className = (isModified ? ['modified'] : [])
             .concat(isValid ? [] : ['invalid']).join(" ");

--- a/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
+++ b/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
@@ -24,7 +24,7 @@ class CellRenderer extends React.Component {
     }
     render() {
         const isProperty = this.context.isProperty(this.props.column.key);
-        const isModified = (this.props.rowData._new && isProperty);
+        const isModified = (this.props.rowData._new && isProperty) || this.context.isModified(this.props.rowData.id, this.props.column.key);
         const isValid = isProperty ? this.context.isValid(this.props.rowData.get(this.props.column.key), this.props.column.key) : true;
         const className = (isModified ? ['modified'] : [])
             .concat(isValid ? [] : ['invalid']).join(" ");

--- a/web/client/plugins/featuregrid/gridEvents.js
+++ b/web/client/plugins/featuregrid/gridEvents.js
@@ -15,10 +15,18 @@ export default {
     onTemporaryChanges: (v) => activateTemporaryChanges(v),
     onGridRowsUpdated: ({fromRow, toRow, updated}, rowGetter) => {
 
+        const updatedValue = {
+            Boolean: {Boolean: null},
+            String: {String: null}
+        };
+
         let features = range(fromRow, toRow).map(r => rowGetter(r)).filter(f =>
             Object.keys(updated || {}).filter(k => f.properties[k] !== updated[k]).length > 0
         );
-        return featureModified(features, updated);
+        const key = Object.keys(updated)[0];
+        const newValue = updated.String === '' || updated.Boolean === '' ? updatedValue[key] : updated;
+        const checkedFeatures = updated.String === '' || updated.Boolean === '' ? [] : features;
+        return featureModified(checkedFeatures, newValue);
     },
     onRowsToggled: (rows, rowGetter) => selectFeatures(rows.map(r => rowGetter(r.rowIdx)), false),
     onRowsSelected: (rows, rowGetter) => selectFeatures(rows.map(r => rowGetter(r.rowIdx)), true),

--- a/web/client/plugins/featuregrid/gridEvents.js
+++ b/web/client/plugins/featuregrid/gridEvents.js
@@ -14,19 +14,10 @@ export default {
     onAddFilter: (update = {}) => updateFilter(update),
     onTemporaryChanges: (v) => activateTemporaryChanges(v),
     onGridRowsUpdated: ({fromRow, toRow, updated}, rowGetter) => {
-
-        const updatedValue = {
-            Boolean: {Boolean: null},
-            String: {String: null}
-        };
-
         let features = range(fromRow, toRow).map(r => rowGetter(r)).filter(f =>
             Object.keys(updated || {}).filter(k => f.properties[k] !== updated[k]).length > 0
         );
-        const key = Object.keys(updated)[0];
-        const newValue = updated.String === '' || updated.Boolean === '' ? updatedValue[key] : updated;
-        const checkedFeatures = updated.String === '' || updated.Boolean === '' ? [] : features;
-        return featureModified(checkedFeatures, newValue);
+        return featureModified(features, updated);
     },
     onRowsToggled: (rows, rowGetter) => selectFeatures(rows.map(r => rowGetter(r.rowIdx)), false),
     onRowsSelected: (rows, rowGetter) => selectFeatures(rows.map(r => rowGetter(r.rowIdx)), true),

--- a/web/client/utils/FeatureGridEditorUtils.js
+++ b/web/client/utils/FeatureGridEditorUtils.js
@@ -7,9 +7,9 @@
 */
 
 
-export const forceSelection = ( {oldValue, changedValue, data, allowEmpty}) => {
+export const forceSelection = ( {oldValue, changedValue, data, allowEmpty, emptyValue = ""}) => {
     if (allowEmpty && changedValue === "") {
-        return null;
+        return emptyValue;
     }
     return data.indexOf(changedValue) !== -1 ? changedValue : oldValue;
 };

--- a/web/client/utils/FeatureGridEditorUtils.js
+++ b/web/client/utils/FeatureGridEditorUtils.js
@@ -9,7 +9,7 @@
 
 export const forceSelection = ( {oldValue, changedValue, data, allowEmpty}) => {
     if (allowEmpty && changedValue === "") {
-        return "";
+        return null;
     }
     return data.indexOf(changedValue) !== -1 ? changedValue : oldValue;
 };

--- a/web/client/utils/__tests__/FeatureGridEditorUtils-test.js
+++ b/web/client/utils/__tests__/FeatureGridEditorUtils-test.js
@@ -27,6 +27,15 @@ describe('FeatureGridEditorUtils', () => {
         const newVal = forceSelection({oldValue, changedValue, data, allowEmpty});
         expect(newVal).toBe("");
     });
+    it('forceSelection allowEmpty=true with no change at all and the emptyValue is null ', () => {
+        const oldValue = "";
+        const changedValue = "";
+        const data = ["new", "old", "agile"];
+        const allowEmpty = true;
+        const emptyValue = null;
+        const newVal = forceSelection({oldValue, changedValue, data, allowEmpty, emptyValue});
+        expect(newVal).toBe(null);
+    });
     it('forceSelection allowEmpty=false with "" value', () => {
         const oldValue = "old";
         const changedValue = "";


### PR DESCRIPTION
## Description
The PR fixes the issue with the attribute table cells being highlighted even if they are not changed

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8795 

**What is the new behavior?**
The attribute table cells are no longer highlighted are when not changed.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Demo

https://user-images.githubusercontent.com/22595454/215998823-349993ff-7762-4792-9de2-1573888c4151.mp4


