### PR TITLE
[Backport C047-2021.02.xx] #8911 MapStore AvailableStyles component won't filter styles

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ markdown_extensions:
   - markdown.extensions.attr_list
   - codehilite:
       linenums: true
-pages:
+nav:
   - User Guide:
     - Home Page Overview: 'user-guide/home-page.md'
     - Managing Users and Groups:

--- a/web/client/components/styleeditor/StyleList.jsx
+++ b/web/client/components/styleeditor/StyleList.jsx
@@ -62,10 +62,10 @@ const StyleList = ({
     availableStyles = [],
     onSelect,
     formatColors = {
-        sld: '#33ffaa',
-        css: '#ffaa33'
+        sld: "#33ffaa",
+        css: "#ffaa33"
     },
-    filterText,
+    filterText = "",
     onFilter = () => {}
 }) => (
     <BorderLayout
@@ -74,39 +74,70 @@ const StyleList = ({
             <Filter
                 filterPlaceholder="styleeditor.styleListfilterPlaceholder"
                 filterText={filterText}
-                onFilter={onFilter}/>
-        }>
+                onFilter={onFilter}
+            />
+        }
+    >
         <SideGrid
             size="sm"
             onItemClick={({ name }) => onSelect({ style: name }, true)}
             items={availableStyles
-                .filter(({name = '', title = '', _abstract = '', metadata = {} }) => !filterText
-                    || filterText && (
-                        name.indexOf(filterText) !== -1
-                        || metadata?.title?.indexOf(filterText) !== -1
-                        || metadata?.description?.indexOf(filterText) !== -1
-                        || title.indexOf(filterText) !== -1
-                        || _abstract.indexOf(filterText) !== -1
-                    ))
-                .map(style => ({
+                .filter(
+                    ({
+                        name = "",
+                        title = "",
+                        _abstract = "",
+                        metadata = {}
+                    }) =>
+                        name.toLowerCase().includes(filterText.toLowerCase())
+                        ||
+                        metadata?.title?.toLowerCase().includes(filterText.toLowerCase()) ||
+                        metadata?.description?.toLowerCase().includes(filterText.toLowerCase())
+                        ||
+                        title
+                            .toLowerCase()
+                            .includes(filterText.toLowerCase()) ||
+                        _abstract
+                            .toLowerCase()
+                            .includes(filterText.toLowerCase())
+                )
+                .map((style) => ({
                     ...style,
-                    title: style?.metadata?.title || style.label || style.title || style.name,
-                    description: style?.metadata?.description || style._abstract,
+                    title:
+                        style?.metadata?.title ||
+                        style.label ||
+                        style.title ||
+                        style.name,
+                    description:
+                        style?.metadata?.description || style._abstract,
                     selected: enabledStyle === style.name,
-                    preview: style.format &&
-                            <SVGPreview
-                                backgroundColor="#333333"
-                                texts={[
-                                    {
-                                        text: getFormatText(style.format).toUpperCase(),
-                                        fill: formatColors[style.format] || '#f2f2f2',
-                                        style: {
-                                            fontSize: 70,
-                                            fontWeight: 'bold'
-                                        }
-                                    }]}/> || <Glyphicon glyph="geoserver" />,
-                    tools: showDefaultStyleIcon && defaultStyle === style.name ? <Glyphicon glyph="star" tooltipId="styleeditor.defaultStyle"/> : null
-                }))} />
+                    preview: (style.format && (
+                        <SVGPreview
+                            backgroundColor="#333333"
+                            texts={[
+                                {
+                                    text: getFormatText(
+                                        style.format
+                                    ).toUpperCase(),
+                                    fill:
+                                        formatColors[style.format] || "#f2f2f2",
+                                    style: {
+                                        fontSize: 70,
+                                        fontWeight: "bold"
+                                    }
+                                }
+                            ]}
+                        />
+                    )) || <Glyphicon glyph="geoserver" />,
+                    tools:
+                        showDefaultStyleIcon && defaultStyle === style.name ? (
+                            <Glyphicon
+                                glyph="star"
+                                tooltipId="styleeditor.defaultStyle"
+                            />
+                        ) : null
+                }))}
+        />
     </BorderLayout>
 );
 

--- a/web/client/components/styleeditor/__tests__/StyleList-test.jsx
+++ b/web/client/components/styleeditor/__tests__/StyleList-test.jsx
@@ -206,4 +206,84 @@ describe('test StyleList module component', () => {
         const icon2 = cards[1].querySelectorAll('.glyphicon');
         expect(icon2.length).toBe(0);
     });
+
+    it('test styleList onFilter', () => {
+
+        ReactDOM.render(<StyleList
+            filterText="point"
+            defaultStyle="point"
+            enabledStyle="square"
+            showDefaultStyleIcon
+            availableStyles={
+                [
+                    {
+                        name: 'point',
+                        filename: 'default_point.sld',
+                        format: 'sld',
+                        title: 'A boring default style',
+                        _abstract: 'A sample style that just prints out a purple square'
+                    },
+                    {
+                        name: 'points',
+                        filename: 'default_point.sld',
+                        format: 'css',
+                        title: 'A cool style',
+                        _abstract: 'simple and cool'
+                    },
+                    {
+                        name: 'square',
+                        filename: 'square.css',
+                        format: 'css',
+                        title: 'Square',
+                        _abstract: 'Simple square'
+                    },
+                    {
+                        name: 'circle',
+                        filename: 'circle.css',
+                        format: 'css',
+                        title: 'Circle',
+                        _abstract: 'Simple circle'
+                    }
+                ]
+            }/>, document.getElementById("container"));
+        const cards = document.querySelectorAll('.mapstore-side-card');
+        expect(cards.length).toBe(2);
+    });
+
+    it('test styleList onFilter for metadata', () => {
+
+        ReactDOM.render(<StyleList
+            filterText="main"
+            defaultStyle="point"
+            enabledStyle="square"
+            showDefaultStyleIcon
+            availableStyles={
+                [
+                    {
+                        name: 'point',
+                        filename: 'default_point.sld',
+                        format: 'sld',
+                        title: 'A boring default style',
+                        _abstract: 'A sample style that just prints out a purple square',
+                        metadata: {
+                            title: 'main style',
+                            describe: 'It can control the layout of multiple web pages all at once.'
+                        }
+                    },
+                    {
+                        name: 'points',
+                        filename: 'default_point.sld',
+                        format: 'css',
+                        title: 'A cool style',
+                        _abstract: 'simple and cool',
+                        metadata: {
+                            title: 'alternative styles',
+                            describe: 'Used to apply a unique style to a single HTML element.'
+                        }
+                    }
+                ]
+            }/>, document.getElementById("container"));
+        const cards = document.querySelectorAll('.mapstore-side-card');
+        expect(cards.length).toBe(1);
+    });
 });


### PR DESCRIPTION
## Description
The PR fixes the styles search filter not working. Previously, if you typed a text in the text bar to search for styles by their title, description or abstract, there was no observable change in the styles displayed. This PR fixes that issue.

**Please check if the PR fulfils these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


## Issue
**What is the current behaviour?**
#8911

**What is the new behaviour?**
The AvaliableStyles component will show all available styles for the selected layer, on the top, there is a text bar to filter the layer based on their attributes if any test is typed in the text box the filtering works fine and the styles display as filtered.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Demo
https://user-images.githubusercontent.com/22595454/213687626-ce1dd8f5-99a7-4cb3-88d6-8742a33bc996.mp4



