### PR TITLE
#8936 Contexts do not load on mobile for DEV,QA

### DIFF
--- a/web/client/components/plugins/PluginsContainer.jsx
+++ b/web/client/components/plugins/PluginsContainer.jsx
@@ -10,8 +10,6 @@ import PropTypes from 'prop-types';
 import PluginsUtils from '../../utils/PluginsUtils';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
-import isObject from 'lodash/isObject';
-import isArray from 'lodash/isArray';
 import { componentFromProp } from 'recompose';
 
 const Component = componentFromProp('component');
@@ -119,15 +117,7 @@ class PluginsContainer extends React.Component {
     };
 
     getPluginsConfig = (props) => {
-        if (props.pluginsConfig) {
-            if (isArray(props.pluginsConfig)) {
-                return props.pluginsConfig;
-            }
-            if (isObject(props.pluginsConfig)) {
-                return props.pluginsConfig[this.props.mode] || props.pluginsConfig[props.defaultMode] || [];
-            }
-        }
-        return [];
+        return PluginsUtils.getPagePluginsConfig(props);
     };
 
     renderPlugins = (plugins) => {

--- a/web/client/components/plugins/enhancers/withModulePlugins.js
+++ b/web/client/components/plugins/enhancers/withModulePlugins.js
@@ -9,24 +9,13 @@
 import React, { useEffect, useMemo } from 'react';
 import useModulePlugins from "../../../hooks/useModulePlugins";
 import {getPlugins} from "../../../utils/ModulePluginsUtils";
-
-const getPluginsConfig = ({pluginsConfig: config, mode = 'desktop', defaultMode}) => {
-    if (config) {
-        if (Array.isArray(config)) {
-            return config;
-        }
-        if (typeof config === 'object') {
-            return config[mode] || config[defaultMode] || [];
-        }
-    }
-    return [];
-};
+import {getPagePluginsConfig} from '../../../utils/PluginsUtils';
 
 /**
  * HOC to provide additional logic layer for module plugins loading and caching
  * @param {function(): string[]} getPluginsConfigCallback - callback to extract proper part of plugins configuration passed with `pluginsConfig` prop
  */
-const withModulePlugins = (getPluginsConfigCallback = getPluginsConfig) => (Component) => ({ onLoaded = () => {
+const withModulePlugins = (getPluginsConfigCallback = getPagePluginsConfig) => (Component) => ({ onLoaded = () => {
 }, pluginsConfig, plugins = {}, loaderComponent, ...props }) => {
     const config = getPluginsConfigCallback({pluginsConfig, ...props});
     const { plugins: loadedPlugins, pending } = useModulePlugins({

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -506,6 +506,30 @@ export const setRefToWrappedComponent = (name) => {
 };
 
 /**
+ * Extract the list of plugins from a pluginsConfig property
+ * @param {object} [options]
+ * @param {object|array} [options.pluginsConfig] list of plugins or an object where every key represents a mode that list plugins
+ * @param {string} [options.mode] mode to detect correct list of plugins in a pluginsConfig object
+ * @param {string} [options.defaultMode] default mode to use if the mode is not available
+ * @returns {array} list of plugins
+ */
+export const getPagePluginsConfig = ({
+    pluginsConfig,
+    mode = 'desktop',
+    defaultMode = 'desktop'
+}) => {
+    if (pluginsConfig) {
+        if (isArray(pluginsConfig)) {
+            return pluginsConfig;
+        }
+        if (isObject(pluginsConfig)) {
+            return pluginsConfig[mode] || pluginsConfig[defaultMode] || [];
+        }
+    }
+    return [];
+};
+
+/**
  * Custom react-redux connect function that can override state property with plugin config.
  * The plugin config properties are taken from the **pluginCfg** property.
  * @param {function} [mapStateToProps] state to properties selector
@@ -640,5 +664,6 @@ export default {
     handleExpression,
     getMorePrioritizedContainer,
     getPluginConfiguration,
-    isMapStorePlugin
+    isMapStorePlugin,
+    getPagePluginsConfig
 };

--- a/web/client/utils/__tests__/PluginsUtils-test.js
+++ b/web/client/utils/__tests__/PluginsUtils-test.js
@@ -635,20 +635,24 @@ describe('PluginsUtils', () => {
         expect(items3.length).toBe(1);
     });
     it('getPagePluginsConfig', () => {
+        // check default behaviour
         expect(PluginsUtils.getPagePluginsConfig({
             pluginsConfig: [{ name: 'Map' }]
         })).toEqual([{ name: 'Map' }]);
+        // check default mode with pluginsConfig defined for desktop
         expect(PluginsUtils.getPagePluginsConfig({
             pluginsConfig: {
                 desktop: [{ name: 'Map' }]
             }
         })).toEqual([{ name: 'Map' }]);
+        // check when mode selected is not present, use the default one
         expect(PluginsUtils.getPagePluginsConfig({
             pluginsConfig: {
                 desktop: [{ name: 'Map' }]
             },
             mode: 'mobile'
         })).toEqual([{ name: 'Map' }]);
+        // check if mobile mode is present, it is used instead of the default one
         expect(PluginsUtils.getPagePluginsConfig({
             pluginsConfig: {
                 desktop: [{ name: 'Map' }, { name: 'TOC' }],

--- a/web/client/utils/__tests__/PluginsUtils-test.js
+++ b/web/client/utils/__tests__/PluginsUtils-test.js
@@ -634,4 +634,27 @@ describe('PluginsUtils', () => {
         const items3 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container3", "Container3", true, []);
         expect(items3.length).toBe(1);
     });
+    it('getPagePluginsConfig', () => {
+        expect(PluginsUtils.getPagePluginsConfig({
+            pluginsConfig: [{ name: 'Map' }]
+        })).toEqual([{ name: 'Map' }]);
+        expect(PluginsUtils.getPagePluginsConfig({
+            pluginsConfig: {
+                desktop: [{ name: 'Map' }]
+            }
+        })).toEqual([{ name: 'Map' }]);
+        expect(PluginsUtils.getPagePluginsConfig({
+            pluginsConfig: {
+                desktop: [{ name: 'Map' }]
+            },
+            mode: 'mobile'
+        })).toEqual([{ name: 'Map' }]);
+        expect(PluginsUtils.getPagePluginsConfig({
+            pluginsConfig: {
+                desktop: [{ name: 'Map' }, { name: 'TOC' }],
+                mobile: [{ name: 'Map' }]
+            },
+            mode: 'mobile'
+        })).toEqual([{ name: 'Map' }]);
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The module plugins system was importing the plugins configuration because it was looking specifically for a mobile mode not included in context. There was also a difference in the way we got the plugin config inside the plugin container and the module plugin HOC. This PR creates a common function to align the behaviours in these two components.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8936

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The module plugins are loaded correctly also in mobile using by default the desktop mode

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
