### PR TITLE
#8935 Improve UX of Visual Style Editor for WFS/Vector layers

### DIFF
--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -35,7 +35,8 @@ export const fields = {
         value,
         onChange = () => {},
         disableAlpha,
-        format
+        format,
+        disabled
     }) => {
 
         // needed for slider
@@ -72,10 +73,12 @@ export const fields = {
 
         return (
             <PropertyField
-                label={label}>
+                label={label}
+                disabled={disabled}>
                 <ColorSelector
                     color={value}
                     line={config.stroke}
+                    disabled={disabled}
                     disableAlpha={config.disableAlpha || disableAlpha}
                     onChangeColor={(color) => color && onChange(color)}/>
             </PropertyField>
@@ -109,7 +112,8 @@ export const fields = {
     input: ({ label, value, config = {}, onChange = () => {}, disabled, placeholderId }) => {
         return (
             <PropertyField
-                label={label}>
+                label={label}
+                disabled={disabled}>
                 <FormGroup>
                     <InputGroup style={config?.maxWidth ? { maxWidth: config?.maxWidth } : {}}>
                         <DebouncedFormControl
@@ -133,7 +137,8 @@ export const fields = {
     multiInput: (props) => {
         return (
             <PropertyField
-                label={props.label}>
+                label={props.label}
+                disabled={props.disabled}>
                 <MultiInput {...props} />
             </PropertyField>
         );
@@ -206,15 +211,18 @@ export const fields = {
     model: ({
         label,
         value,
-        onChange
+        onChange,
+        disabled
     }) => {
         const [error, setError] = useState(false);
         return (
             <PropertyField
                 label={label}
                 invalid={error}
+                disabled={disabled}
             >
                 <ModelInput
+                    disabled={disabled}
                     label={label}
                     value={value}
                     onChange={onChange}

--- a/web/client/components/styleeditor/ModelInput.jsx
+++ b/web/client/components/styleeditor/ModelInput.jsx
@@ -19,11 +19,13 @@ const Glyphicon = tooltip(GlyphiconRB);
  * @memberof components.styleeditor
  * @name ModelInput
  * @class
+ * @prop {string} disabled href of the image
  * @prop {string} value href of the image
  * @prop {function} onChange returns the updated href value of the model
  * @prop {function} onError callback to check if the url is valid
  */
 function ModelInput({
+    disabled,
     value,
     onChange = () => {},
     onError = () => {}
@@ -49,6 +51,7 @@ function ModelInput({
             style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
             <FormGroup style={{ flex: 1 }}>
                 <DebouncedFormControl
+                    disabled={disabled}
                     placeholder="styleeditor.placeholderEnterModelUrl"
                     style={{ paddingRight: 26 }}
                     value={moduleUrl}

--- a/web/client/components/styleeditor/PropertyField.jsx
+++ b/web/client/components/styleeditor/PropertyField.jsx
@@ -16,13 +16,13 @@ function PropertyField({ children, label, tools, divider, invalid, warning, disa
     }
     const warningClassName = warning ? ' ms-symbolizer-value-warning' : '';
     const validationClassName = invalid ? ' ms-symbolizer-value-invalid' : '';
-    const disabledClassName = disabled ? ' ms-symbolizer-value-disabled' : '';
+    const disabledClassName = disabled ? ' ms-symbolizer-field-disabled' : '';
     return (
         <div
-            className="ms-symbolizer-field">
+            className={'ms-symbolizer-field' + disabledClassName}>
             <div className="ms-symbolizer-label"><Message msgId={label} /></div>
             <div
-                className={'ms-symbolizer-value' + validationClassName + disabledClassName + warningClassName}
+                className={'ms-symbolizer-value' + validationClassName + warningClassName}
                 // prevent drag and drop when interacting with property input
                 onDragStart={(event) => {
                     event.stopPropagation();

--- a/web/client/components/styleeditor/RulesEditor.jsx
+++ b/web/client/components/styleeditor/RulesEditor.jsx
@@ -211,6 +211,7 @@ const RulesEditor = forwardRef(({
                                     glyph: block.glyphAdd || block.glyph,
                                     visible: block.supportedTypes.indexOf(geometryType) !== -1,
                                     tooltipId: block.tooltipAddId,
+                                    disabled: block?.disableAdd ? block.disableAdd() : false,
                                     onClick: () => handleAdd({
                                         name: '',
                                         ruleId: uuidv1(),

--- a/web/client/components/styleeditor/__tests__/VisualStyleEditor-test.js
+++ b/web/client/components/styleeditor/__tests__/VisualStyleEditor-test.js
@@ -13,6 +13,7 @@ import expect from 'expect';
 import { Simulate, act } from 'react-dom/test-utils';
 import { DragDropContext as dragDropContext } from 'react-dnd';
 import testBackend from 'react-dnd-test-backend';
+import { waitFor } from '@testing-library/react';
 
 const VisualStyleEditor = dragDropContext(testBackend)(VisualStyleEditorComponent);
 
@@ -287,4 +288,389 @@ describe('VisualStyleEditor', () => {
             'glyphicon glyphicon-redo'
         ]);
     });
+    it('should disable add model symbolizer when enable3dStyleOptions is false', () => {
+        ReactDOM.render(<VisualStyleEditor
+            format="geostyler"
+            geometryType="vector"
+            code={{ name: '', rules: [] }}
+            enable3dStyleOptions={false}
+            defaultStyleJSON={null}
+            exactMatchGeometrySymbol
+            config={{
+                simple: true,
+                fonts: []
+            }}
+            debounceTime={1}
+        />, document.getElementById('container'));
+        const disabledButtons = document.querySelectorAll('.ms-style-rules-editor-right button.disabled');
+        expect([...disabledButtons].map(node => node.children[0].getAttribute('class'))).toEqual([
+            'glyphicon glyphicon-model-plus'
+        ]);
+    });
+    it('should disable mark symbolizer properties when enable3dStyleOptions is false and not undefined', (done) => {
+        const styleBody = {
+            "name": "",
+            "rules": [
+                {
+                    "name": "",
+                    "ruleId": "1",
+                    "symbolizers": [
+                        {
+                            "kind": "Mark",
+                            "wellKnownName": "Star",
+                            "color": "#ffe500",
+                            "fillOpacity": 1,
+                            "strokeColor": "#050505",
+                            "strokeOpacity": 1,
+                            "strokeWidth": 2,
+                            "radius": 19,
+                            "rotate": 0,
+                            "msBringToFront": true,
+                            "msHeightReference": "none",
+                            "symbolizerId": "1",
+                            "msHeight": {
+                                "type": "attribute",
+                                "name": "height"
+                            }
+                        }
+                    ]
+                }
+            ]
+        };
+        act(() => {
+            ReactDOM.render(<VisualStyleEditor
+                format="geostyler"
+                code={styleBody}
+                enable3dStyleOptions={false}
+                geometryType="vector"
+                defaultStyleJSON={styleBody}
+                exactMatchGeometrySymbol
+                config={{
+                    simple: true,
+                    fonts: []
+                }}
+                debounceTime={1}
+            />, document.getElementById('container'));
+        });
+        waitFor(() => expect(document.querySelector('.ms-style-rule')).toBeTruthy())
+            .then(() => {
+                const disabledFields = document.querySelectorAll('.ms-symbolizer-field-disabled .ms-symbolizer-label span');
+                expect([...disabledFields].map(node => node.innerHTML)).toEqual([
+                    'styleeditor.msBringToFront',
+                    'styleeditor.heightReferenceFromGround',
+                    'styleeditor.height',
+                    'styleeditor.leaderLineColor',
+                    'styleeditor.leaderLineWidth'
+                ]);
+                done();
+            }).catch(done);
+    });
+    it('should disable icon symbolizer properties when enable3dStyleOptions is false and not undefined', (done) => {
+        const styleBody = {
+            "name": "",
+            "rules": [
+                {
+                    "name": "",
+                    "ruleId": "1",
+                    "symbolizers": [
+                        {
+                            "kind": "Icon",
+                            "image": "http://path/to/img.png",
+                            "opacity": 1,
+                            "size": 32,
+                            "rotate": 0,
+                            "msBringToFront": false,
+                            "msHeightReference": "none",
+                            "symbolizerId": "1"
+                        }
+                    ]
+                }
+            ]
+        };
+        act(() => {
+            ReactDOM.render(<VisualStyleEditor
+                format="geostyler"
+                code={styleBody}
+                enable3dStyleOptions={false}
+                geometryType="vector"
+                defaultStyleJSON={styleBody}
+                exactMatchGeometrySymbol
+                config={{
+                    simple: true,
+                    fonts: []
+                }}
+                debounceTime={1}
+            />, document.getElementById('container'));
+        });
+        waitFor(() => expect(document.querySelector('.ms-style-rule')).toBeTruthy())
+            .then(() => {
+                const disabledFields = document.querySelectorAll('.ms-symbolizer-field-disabled .ms-symbolizer-label span');
+                expect([...disabledFields].map(node => node.innerHTML)).toEqual([
+                    'styleeditor.msBringToFront',
+                    'styleeditor.heightReferenceFromGround',
+                    'styleeditor.height',
+                    'styleeditor.leaderLineColor',
+                    'styleeditor.leaderLineWidth'
+                ]);
+                done();
+            }).catch(done);
+    });
+    it('should disable text symbolizer properties when enable3dStyleOptions is false and not undefined', (done) => {
+        const styleBody = {
+            "name": "",
+            "rules": [
+                {
+                    "name": "",
+                    "ruleId": "1",
+                    "symbolizers": [
+                        {
+                            "kind": "Text",
+                            "color": "#333333",
+                            "size": 14,
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                            "haloColor": "#ffffff",
+                            "haloWidth": 1,
+                            "allowOverlap": true,
+                            "offset": [
+                                0,
+                                0
+                            ],
+                            "msBringToFront": false,
+                            "msHeightReference": "none",
+                            "symbolizerId": "1",
+                            "label": "{{name}}",
+                            "font": [
+                                "Arial"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+        act(() => {
+            ReactDOM.render(<VisualStyleEditor
+                format="geostyler"
+                code={styleBody}
+                enable3dStyleOptions={false}
+                geometryType="vector"
+                defaultStyleJSON={styleBody}
+                exactMatchGeometrySymbol
+                config={{
+                    simple: true,
+                    fonts: ["Arial"]
+                }}
+                debounceTime={1}
+            />, document.getElementById('container'));
+        });
+        waitFor(() => expect(document.querySelector('.ms-style-rule')).toBeTruthy())
+            .then(() => {
+                const disabledFields = document.querySelectorAll('.ms-symbolizer-field-disabled .ms-symbolizer-label span');
+                expect([...disabledFields].map(node => node.innerHTML)).toEqual([
+                    'styleeditor.msBringToFront',
+                    'styleeditor.heightReferenceFromGround',
+                    'styleeditor.height',
+                    'styleeditor.leaderLineColor',
+                    'styleeditor.leaderLineWidth'
+                ]);
+                done();
+            }).catch(done);
+    });
+    it('should disable model symbolizer properties when enable3dStyleOptions is false and not undefined', (done) => {
+        const styleBody = {
+            "name": "",
+            "rules": [
+                {
+                    "name": "",
+                    "ruleId": "1",
+                    "symbolizers": [
+                        {
+                            "kind": "Model",
+                            "model": "https://path/to/model.glb",
+                            "scale": 3,
+                            "color": "#ffffff",
+                            "opacity": 1,
+                            "msHeightReference": "none",
+                            "symbolizerId": "1",
+                            "msHeight": 0,
+                            "heading": 67
+                        }
+                    ]
+                }
+            ]
+        };
+        act(() => {
+            ReactDOM.render(<VisualStyleEditor
+                format="geostyler"
+                code={styleBody}
+                enable3dStyleOptions={false}
+                geometryType="vector"
+                defaultStyleJSON={styleBody}
+                exactMatchGeometrySymbol
+                config={{
+                    simple: true,
+                    fonts: []
+                }}
+                debounceTime={1}
+            />, document.getElementById('container'));
+        });
+        waitFor(() => expect(document.querySelector('.ms-style-rule')).toBeTruthy())
+            .then(() => {
+                const disabledFields = document.querySelectorAll('.ms-symbolizer-field-disabled .ms-symbolizer-label span');
+                expect([...disabledFields].map(node => node.innerHTML)).toEqual([
+                    'styleeditor.model',
+                    'styleeditor.scale',
+                    'styleeditor.pitch',
+                    'styleeditor.roll',
+                    'styleeditor.heading',
+                    'styleeditor.color',
+                    'styleeditor.heightReferenceFromGround',
+                    'styleeditor.height',
+                    'styleeditor.leaderLineColor',
+                    'styleeditor.leaderLineWidth'
+                ]);
+                done();
+            }).catch(done);
+    });
+    it('should disable line symbolizer properties when enable3dStyleOptions is false and not undefined', (done) => {
+        const styleBody = {
+            "name": "",
+            "rules": [
+                {
+                    "name": "",
+                    "symbolizers": [
+                        {
+                            "kind": "Line",
+                            "color": "#252525",
+                            "opacity": 1,
+                            "width": 1,
+                            "symbolizerId": "1",
+                            "dasharray": [
+                                8,
+                                8
+                            ],
+                            "msClampToGround": false
+                        }
+                    ],
+                    "ruleId": "1"
+                }
+            ]
+        };
+        act(() => {
+            ReactDOM.render(<VisualStyleEditor
+                format="geostyler"
+                code={styleBody}
+                enable3dStyleOptions={false}
+                geometryType="vector"
+                defaultStyleJSON={styleBody}
+                exactMatchGeometrySymbol
+                config={{
+                    simple: true,
+                    fonts: []
+                }}
+                debounceTime={1}
+            />, document.getElementById('container'));
+        });
+        waitFor(() => expect(document.querySelector('.ms-style-rule')).toBeTruthy())
+            .then(() => {
+                const disabledFields = document.querySelectorAll('.ms-symbolizer-field-disabled .ms-symbolizer-label span');
+                expect([...disabledFields].map(node => node.innerHTML)).toEqual([ 'styleeditor.clampToGround' ]);
+                done();
+            }).catch(done);
+    });
+    it('should disable line symbolizer properties when enable3dStyleOptions is true and not undefined', (done) => {
+        const styleBody = {
+            "name": "",
+            "rules": [
+                {
+                    "name": "",
+                    "symbolizers": [
+                        {
+                            "kind": "Line",
+                            "color": "#252525",
+                            "opacity": 1,
+                            "width": 1,
+                            "symbolizerId": "1",
+                            "dasharray": [
+                                8,
+                                8
+                            ],
+                            "msClampToGround": false
+                        }
+                    ],
+                    "ruleId": "1"
+                }
+            ]
+        };
+        act(() => {
+            ReactDOM.render(<VisualStyleEditor
+                format="geostyler"
+                code={styleBody}
+                enable3dStyleOptions
+                geometryType="vector"
+                defaultStyleJSON={styleBody}
+                exactMatchGeometrySymbol
+                config={{
+                    simple: true,
+                    fonts: []
+                }}
+                debounceTime={1}
+            />, document.getElementById('container'));
+        });
+        waitFor(() => expect(document.querySelector('.ms-style-rule')).toBeTruthy())
+            .then(() => {
+                const disabledFields = document.querySelectorAll('.ms-symbolizer-field-disabled .ms-symbolizer-label span');
+                expect([...disabledFields].map(node => node.innerHTML)).toEqual([
+                    'styleeditor.lineCap',
+                    'styleeditor.lineJoin'
+                ]);
+                done();
+            }).catch(done);
+    });
+    it('should disable fill symbolizer properties when enable3dStyleOptions is false and not undefined', (done) => {
+        const styleBody = {
+            "name": "",
+            "rules": [
+                {
+                    "name": "",
+                    "symbolizers": [
+                        {
+                            "kind": "Fill",
+                            "color": "#ff8e00",
+                            "opacity": 0.1,
+                            "fillOpacity": 0.63,
+                            "symbolizerId": "1",
+                            "msClassificationType": "terrain"
+                        }
+                    ],
+                    "ruleId": "1"
+                }
+            ]
+        };
+        act(() => {
+            ReactDOM.render(<VisualStyleEditor
+                format="geostyler"
+                code={styleBody}
+                enable3dStyleOptions={false}
+                geometryType="vector"
+                defaultStyleJSON={styleBody}
+                exactMatchGeometrySymbol
+                config={{
+                    simple: true,
+                    fonts: []
+                }}
+                debounceTime={1}
+            />, document.getElementById('container'));
+        });
+        waitFor(() => expect(document.querySelector('.ms-style-rule')).toBeTruthy())
+            .then(() => {
+                const disabledFields = document.querySelectorAll('.ms-symbolizer-field-disabled .ms-symbolizer-label span');
+                expect([...disabledFields].map(node => node.innerHTML)).toEqual([
+                    'styleeditor.classificationtype',
+                    'styleeditor.clampOutlineToGround'
+                ]);
+                done();
+            }).catch(done);
+    });
+
 });

--- a/web/client/components/styleeditor/config/property.js
+++ b/web/client/components/styleeditor/config/property.js
@@ -22,7 +22,8 @@ const property = {
         pattern,
         disableAlpha,
         getGroupParams,
-        getGroupConfig
+        getGroupConfig,
+        isDisabled
     }) => ({
         type: 'color',
         label,
@@ -55,9 +56,10 @@ const property = {
                 [opacityKey]: a,
                 ...(pattern && {[graphicKey]: undefined})
             };
-        }
+        },
+        isDisabled
     }),
-    width: ({ key = 'width', label = 'Width', fallbackValue = 1, dasharrayKey = 'dasharray' }) => ({
+    width: ({ key = 'width', label = 'Width', fallbackValue = 1, dasharrayKey = 'dasharray', isDisabled }) => ({
         type: 'input',
         label,
         config: {
@@ -83,7 +85,8 @@ const property = {
                         : undefined
                 })
             };
-        }
+        },
+        isDisabled
     }),
     dasharray: ({ key = 'dasharray', label = 'Dash array' }) => ({
         type: 'dash',
@@ -124,7 +127,7 @@ const property = {
             };
         }
     }),
-    cap: ({ key = 'cap', label = 'Line cap' }) => ({
+    cap: ({ key = 'cap', label = 'Line cap', isDisabled }) => ({
         type: 'toolbar',
         label,
         config: {
@@ -143,9 +146,10 @@ const property = {
             return {
                 [key]: value
             };
-        }
+        },
+        isDisabled
     }),
-    join: ({ key = 'join', label = 'Line join' }) => ({
+    join: ({ key = 'join', label = 'Line join', isDisabled }) => ({
         type: 'toolbar',
         label,
         config: {
@@ -164,7 +168,8 @@ const property = {
             return {
                 [key]: value
             };
-        }
+        },
+        isDisabled
     }),
     colorMapType: ({ key = 'colorMapType', label = 'Color map type', isDisabled }) => ({
         type: 'toolbar',
@@ -208,7 +213,7 @@ const property = {
             };
         }
     }),
-    number: ({ key = 'scale', label = 'Scale', min, max, fallbackValue, maxWidth, uom }) => ({
+    number: ({ key = 'scale', label = 'Scale', min, max, fallbackValue, maxWidth, uom, isDisabled }) => ({
         type: 'input',
         label,
         config: {
@@ -226,7 +231,8 @@ const property = {
             return {
                 [key]: value === undefined ? undefined : parseFloat(value)
             };
-        }
+        },
+        isDisabled
     }),
     opacity: ({ key = 'opacity', label = 'Opacity' }) => ({
         type: 'slider',
@@ -292,7 +298,7 @@ const property = {
             };
         }
     }),
-    msClampToGround: ({ key = 'msClampToGround', label = 'Clamp to ground' }) => ({
+    msClampToGround: ({ key = 'msClampToGround', label = 'Clamp to ground', isDisabled }) => ({
         type: 'toolbar',
         label,
         config: {
@@ -309,9 +315,10 @@ const property = {
                 [key]: value
             };
         },
-        setValue: (value) => !!value
+        setValue: (value) => !!value,
+        isDisabled
     }),
-    msBringToFront: ({ key = 'msBringToFront', label = 'Arrange' }) => ({
+    msBringToFront: ({ key = 'msBringToFront', label = 'Arrange', isDisabled }) => ({
         type: 'toolbar',
         label,
         config: {
@@ -328,9 +335,10 @@ const property = {
                 [key]: value
             };
         },
-        setValue: (value) => !!value
+        setValue: (value) => !!value,
+        isDisabled
     }),
-    msClassificationType: ({ key = 'msClassificationType', label = 'PolygonType' }) => ({
+    msClassificationType: ({ key = 'msClassificationType', label = 'PolygonType', isDisabled }) => ({
         type: 'toolbar',
         label,
         config: {
@@ -349,9 +357,10 @@ const property = {
             return {
                 [key]: value
             };
-        }
+        },
+        isDisabled
     }),
-    msHeightReference: ({ key = 'msHeightReference', label = 'Height reference from ground' }) => ({
+    msHeightReference: ({ key = 'msHeightReference', label = 'Height reference from ground', isDisabled }) => ({
         type: 'toolbar',
         label,
         config: {
@@ -371,7 +380,8 @@ const property = {
                 [key]: value,
                 ...(value === 'clamp' && { msHeight: undefined })
             };
-        }
+        },
+        isDisabled
     }),
     shape: ({ label, key = 'wellKnownName' }) => ({
         type: 'mark',
@@ -392,7 +402,7 @@ const property = {
             };
         }
     }),
-    model: ({ label, key = 'model' }) => ({
+    model: ({ label, key = 'model', isDisabled }) => ({
         type: 'model',
         label,
         config: {},
@@ -400,7 +410,7 @@ const property = {
             return {
                 [key]: value
             };
-        }
+        }, isDisabled
     }),
     fontStyle: ({ label, key = 'fontStyle' }) => ({
         type: 'toolbar',

--- a/web/client/themes/default/less/style-editor.less
+++ b/web/client/themes/default/less/style-editor.less
@@ -598,6 +598,10 @@ Ported to CodeMirror by Peter Kroon
     > .ms-symbolizer-label {
         flex: 1;
     }
+    &.ms-symbolizer-field-disabled {
+        opacity: 0.4;
+        filter: saturate(0%);
+    }
     .ms-symbolizer-value {
         display: flex;
         align-items: center;
@@ -621,9 +625,6 @@ Ported to CodeMirror by Peter Kroon
         }
         &.ms-symbolizer-value-warning {
             outline: 1px solid @ms-warning;
-        }
-        &.ms-symbolizer-value-disabled {
-            opacity: 0.4;
         }
     }
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduce a disabled state for the properties that are not available for the style editor in 2D mode for WFS/Vector layers.

This PR solves also the issue #8301

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8935

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Visual Style Editor properties are disabled if not available in a specific viewer (2D/3D switch)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
