### PR TITLE
#8933 Search bar covers Identify header when vector layers are queried

### DIFF
--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -479,7 +479,7 @@ describe('identify Epics', () => {
             layers: LAYERS
         };
         const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } })];
-        testEpic(getFeatureInfoOnFeatureInfoClick, 4, sentActions, ([a0, a1, a2, a3]) => {
+        testEpic(getFeatureInfoOnFeatureInfoClick, 5, sentActions, ([a0, a1, a2, a3, a4]) => {
             try {
                 expect(a0).toExist();
                 expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
@@ -487,7 +487,9 @@ describe('identify Epics', () => {
                 expect(a1.type).toBe(GET_VECTOR_INFO);
                 expect(a2.type).toBe(FORCE_UPDATE_MAP_LAYOUT);
                 expect(a3.type).toBe(NEW_MAPINFO_REQUEST);
-                expect(a3).toExist();
+                expect(a3.reqId).toExist();
+                expect(a3.request).toExist();
+                expect(a4.type).toBe(LOAD_FEATURE_INFO);
                 done();
             } catch (ex) {
                 done(ex);
@@ -1191,36 +1193,6 @@ describe('identify Epics', () => {
         });
     });
     describe('setMapTriggerEpic', () => {
-        it('should register event if hover is trigger in mapInfo', (done) => {
-            const epicResponse = actions => {
-                expect(actions[0].type).toBe(REGISTER_EVENT_LISTENER);
-                done();
-            };
-            testEpic(setMapTriggerEpic, 1, configureMap(), epicResponse, {mapInfo: {configuration: {trigger: 'hover'}}});
-        });
-        it('should unregister event if no mapInfo or no trigger is present in mapInfo', (done) => {
-            const epicResponse = actions => {
-                expect(actions[0].type).toBe(UNREGISTER_EVENT_LISTENER);
-                done();
-            };
-            testEpic(setMapTriggerEpic, 1, configureMap(), epicResponse, {});
-        });
-        it('should unregister identifyFloatingTool event if mapType is changed to cesium', (done) => {
-            const epicResponse = actions => {
-                expect(actions[0].type).toBe(UNREGISTER_EVENT_LISTENER);
-                done();
-            };
-            testEpic(setMapTriggerEpic, 1, changeMapType("cesium"), epicResponse, {
-                mapInfo: {
-                    configuration: {
-                        trigger: "click"
-                    }
-                }
-            });
-        });
-    });
-
-    describe('setMapTriggerEpi', () => {
         it('should register event if hover is trigger in mapInfo', (done) => {
             const epicResponse = actions => {
                 expect(actions[0].type).toBe(REGISTER_EVENT_LISTENER);

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -485,11 +485,9 @@ describe('identify Epics', () => {
                 expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
                 expect(a1).toExist();
                 expect(a1.type).toBe(GET_VECTOR_INFO);
-                expect(a2.type).toBe(NEW_MAPINFO_REQUEST);
-                expect(a2.reqId).toExist();
-                expect(a2.request).toExist();
+                expect(a2.type).toBe(FORCE_UPDATE_MAP_LAYOUT);
+                expect(a3.type).toBe(NEW_MAPINFO_REQUEST);
                 expect(a3).toExist();
-                expect(a3.type).toBe(LOAD_FEATURE_INFO);
                 done();
             } catch (ex) {
                 done(ex);
@@ -1193,6 +1191,36 @@ describe('identify Epics', () => {
         });
     });
     describe('setMapTriggerEpic', () => {
+        it('should register event if hover is trigger in mapInfo', (done) => {
+            const epicResponse = actions => {
+                expect(actions[0].type).toBe(REGISTER_EVENT_LISTENER);
+                done();
+            };
+            testEpic(setMapTriggerEpic, 1, configureMap(), epicResponse, {mapInfo: {configuration: {trigger: 'hover'}}});
+        });
+        it('should unregister event if no mapInfo or no trigger is present in mapInfo', (done) => {
+            const epicResponse = actions => {
+                expect(actions[0].type).toBe(UNREGISTER_EVENT_LISTENER);
+                done();
+            };
+            testEpic(setMapTriggerEpic, 1, configureMap(), epicResponse, {});
+        });
+        it('should unregister identifyFloatingTool event if mapType is changed to cesium', (done) => {
+            const epicResponse = actions => {
+                expect(actions[0].type).toBe(UNREGISTER_EVENT_LISTENER);
+                done();
+            };
+            testEpic(setMapTriggerEpic, 1, changeMapType("cesium"), epicResponse, {
+                mapInfo: {
+                    configuration: {
+                        trigger: "click"
+                    }
+                }
+            });
+        });
+    });
+
+    describe('setMapTriggerEpi', () => {
         it('should register event if hover is trigger in mapInfo', (done) => {
             const epicResponse = actions => {
                 expect(actions[0].type).toBe(REGISTER_EVENT_LISTENER);

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -146,7 +146,7 @@ export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { }
                             }))
                             .startWith(newMapInfoRequest(reqId, param));
                     }
-                    return Rx.Observable.of(getVectorInfo(layer, request, metadata, queryableLayers));
+                    return Rx.Observable.of(getVectorInfo(layer, request, metadata, queryableLayers), forceUpdateMapLayout());
                 });
             // NOTE: multiSelection is inside the event
             // TODO: move this flag in the application state


### PR DESCRIPTION
## Description
The PR fixes the issue of the search being covered by the identify header when the vector layers are queried.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue
#8933 

**What is the current behavior?**
#8933 

**What is the new behavior?**
The search bar extends to the left and is not covered by the identify layer

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information

https://user-images.githubusercontent.com/22595454/218694673-0adbcdf3-bfe9-4a16-9b4a-aa76ac86cd14.mp4


