### PR TITLE
[Backport 2022.02.xx] #8959 Add hide options for service selector of LayerDownload plugin (#8960)

### DIFF
--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -49,7 +49,8 @@ class DownloadDialog extends React.Component {
         formatsLoading: PropTypes.bool,
         virtualScroll: PropTypes.bool,
         customAttributeSettings: PropTypes.object,
-        attributes: PropTypes.array
+        attributes: PropTypes.array,
+        hideServiceSelector: PropTypes.bool
     };
 
     static defaultProps = {
@@ -82,7 +83,8 @@ class DownloadDialog extends React.Component {
             {name: "EPSG:4326", label: "WGS84"}
         ],
         virtualScroll: true,
-        downloadOptions: {}
+        downloadOptions: {},
+        hideServiceSelector: false
     };
 
     componentDidUpdate(oldProps) {
@@ -145,6 +147,7 @@ class DownloadDialog extends React.Component {
                             virtualScroll={this.props.virtualScroll}
                             customAttributesSettings={this.props.customAttributeSettings}
                             attributes={this.props.attributes}
+                            hideServiceSelector={this.props.hideServiceSelector}
                         />}
             </div>
             {!this.props.checkingWPSAvailability && <div role="footer">

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -42,7 +42,8 @@ class DownloadOptions extends React.Component {
         layer: PropTypes.object,
         formatsLoading: PropTypes.bool,
         virtualScroll: PropTypes.bool,
-        services: PropTypes.arrayOf(PropTypes.object)
+        services: PropTypes.arrayOf(PropTypes.object),
+        hideServiceSelector: PropTypes.bool
     };
 
     static defaultProps = {
@@ -60,7 +61,8 @@ class DownloadOptions extends React.Component {
         services: [
             { value: "wps", label: "WPS" },
             { value: "wfs", label: "WFS" }
-        ]
+        ],
+        hideServiceSelector: false
     };
 
     constructor(props) {
@@ -76,7 +78,7 @@ class DownloadOptions extends React.Component {
 
     render() {
         return (<form>
-            {this.props.wpsAvailable && this.props.wfsAvailable &&
+            {!this.props.hideServiceSelector && this.props.wpsAvailable && this.props.wfsAvailable &&
                 <>
                     <label><Message msgId="layerdownload.service" /></label>
                     <Select

--- a/web/client/components/data/download/__tests__/DownloadDialog-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadDialog-test.jsx
@@ -52,4 +52,20 @@ describe('Test for DownloadDialog component', () => {
         expect(dialog).toBeTruthy();
         expect(dialog.getElementsByTagName('form')[0]).toBeTruthy();
     });
+    it('should not render service selector with true hideServiceSelector prop', () => {
+        const selectedLayer = {
+            type: 'wms',
+            visibility: true,
+            id: 'mapstore:states__7',
+            search: {
+                url: '/geoserver/wfs'
+            }
+        };
+        ReactDOM.render(<DownloadDialog enabled service="wps" wpsAvailable layer={selectedLayer} hideServiceSelector />, document.getElementById("container"));
+        const dialog = document.getElementById('mapstore-export');
+        expect(dialog).toBeTruthy();
+        expect(dialog.getElementsByTagName('form')[0]).toBeTruthy();
+        const selectors = dialog.querySelectorAll('.Select');
+        expect(selectors.length).toBe(2);
+    });
 });

--- a/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
@@ -51,4 +51,10 @@ describe('Test for DownloadOptions component', () => {
         const selectors = form.querySelectorAll('.Select');
         expect(selectors.length).toBe(2);
     });
+    it('should not render service selector if hideServiceSelector is true', () => {
+        ReactDOM.render(<DownloadOptions wpsAvailable wfsAvailable hideServiceSelector service="wps" />, document.getElementById("container"));
+        const form = document.getElementsByTagName('form')[0];
+        const selectors = form.querySelectorAll('.Select');
+        expect(selectors.length).toBe(2);
+    });
 });

--- a/web/client/plugins/LayerDownload.jsx
+++ b/web/client/plugins/LayerDownload.jsx
@@ -60,7 +60,8 @@ import { createPlugin } from '../utils/PluginsUtils';
  * @prop {object[]} srsList An array of name-label objects for the allowed srs available. Use name:'native' to omit srsName param in wfs filter
  * @prop {string} defaultSrs Default selected srs
  * @prop {string} closeGlyph The icon to use for close the dialog
- * @prop {string} defaultSelectedService The service that should be used by default for donwloading. Valid values: "wfs", "wps"
+ * @prop {string} defaultSelectedService The service that should be used by default for downloading. Valid values: "wfs", "wps"
+ * @prop {bool} hideServiceSelector hide service selector input from the user interface
  * @example
  * {
  *  "name": "LayerDownload",
@@ -77,7 +78,8 @@ import { createPlugin } from '../utils/PluginsUtils';
  *            {"name": "EPSG:4326", "label": "WGS84"}
  *    ],
  *    "defaultSrs": "native",
- *    "defaultSelectedService": "wfs"
+ *    "defaultSelectedService": "wfs",
+ *    "hideServiceSelector": true
  *  }
  * }
  * // it is possible to support GeoPackage format when the targeted GeoServer uses wps download extensions


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds the cfg `hideServiceSelector` option for the LayerDownload plugin to hide the service selector input

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
- [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8959

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

A new hideServiceSelector option for the LayerDownload plugin to hide the service selector field

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
