### PR TITLE
#8974 Measure plugin is not detecting the correct map type

### DIFF
--- a/web/client/plugins/Measure.jsx
+++ b/web/client/plugins/Measure.jsx
@@ -23,7 +23,7 @@ import {
     setCurrentFeature
 } from '../actions/measurement';
 import { measureSelector, showCoordinateEditorSelector } from '../selectors/controls';
-import { isOpenlayers } from '../selectors/maptype';
+import { isOpenlayers, mapTypeSelector } from '../selectors/maptype';
 import {
     isCoordinateEditorEnabledSelector,
     isTrueBearingEnabledSelector,
@@ -160,11 +160,18 @@ const Measure = connect(
         onAddAsLayer: addAsLayer
     }, null, {pure: false})(MeasureDialog);
 
-function MeasurePlugin(props) {
+// the connect for mapType is needed in case the mapType is not provided by the hash pathname
+const MeasurePlugin = connect(
+    createSelector([
+        mapTypeSelector
+    ], (mapType) => ({
+        mapType
+    }))
+)((props) => {
     return props.mapType === 'cesium'
         ? null
         : <Measure {...props} />;
-}
+});
 
 export default createPlugin('Measure', {
     component: MeasurePlugin,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR add a selector to Measure plugin to ensure that the mapType is always correctly provided

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8974

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
