### PR TITLE
#8973 It is not possible to close the Measure tool when burger menu is configured in a Context

### DIFF
--- a/web/client/components/map/cesium/MeasurementSupport.jsx
+++ b/web/client/components/map/cesium/MeasurementSupport.jsx
@@ -55,7 +55,8 @@ function MeasurementSupport({
         MeasureTypes.HEIGHT_FROM_TERRAIN,
         MeasureTypes.ANGLE_3D,
         MeasureTypes.SLOPE
-    ]
+    ],
+    onClose
 }, { messages }) {
 
     const [clearId, setClearId] = useState(0);
@@ -141,6 +142,7 @@ function MeasurementSupport({
                         valueField="value"
                     />
                 }
+                onClose={onClose}
             >
                 <ButtonToolbar>
                     <ButtonGroup>

--- a/web/client/components/mapcontrols/measure/MeasureComponent.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureComponent.jsx
@@ -153,8 +153,7 @@ class MeasureComponent extends React.Component {
         onChangeFormat: () => {},
         onMount: () => {},
         onUpdateOptions: () => {},
-        onAddAsLayer: () => {},
-        onClose: () => {}
+        onAddAsLayer: () => {}
     };
 
     UNSAFE_componentWillReceiveProps(nextProps) {

--- a/web/client/components/mapcontrols/measure/MeasureComponent.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureComponent.jsx
@@ -92,7 +92,8 @@ class MeasureComponent extends React.Component {
         onMount: PropTypes.func,
         onUpdateOptions: PropTypes.func,
         showCoordinateEditor: PropTypes.bool,
-        isCoordinateEditorEnabled: PropTypes.bool
+        isCoordinateEditorEnabled: PropTypes.bool,
+        onClose: PropTypes.func
     };
 
     static contextTypes = {
@@ -152,7 +153,8 @@ class MeasureComponent extends React.Component {
         onChangeFormat: () => {},
         onMount: () => {},
         onUpdateOptions: () => {},
-        onAddAsLayer: () => {}
+        onAddAsLayer: () => {},
+        onClose: () => {}
     };
 
     UNSAFE_componentWillReceiveProps(nextProps) {
@@ -291,6 +293,7 @@ class MeasureComponent extends React.Component {
                 header={
                     <MeasureToolbar
                         info={this.renderPanel(isFeatureInvalid)}
+                        onClose={this.props.onClose}
                     >
                         <ButtonToolbar>
                             <Toolbar

--- a/web/client/components/mapcontrols/measure/MeasureToolbar.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureToolbar.jsx
@@ -7,16 +7,18 @@
  */
 
 import React from 'react';
-import { Glyphicon } from 'react-bootstrap';
+import { Glyphicon, Button } from 'react-bootstrap';
 
 /**
  * Wrapper to apply similar style to measure toolbars
  * @name MeasureToolbar
  * @prop {node} info include this node content under the measure div info container
+ * @prop {function} onClose callback to apply to the close button, the button will not be displayed if undefined
  */
 function MeasureToolbar({
     children,
-    info
+    info,
+    onClose
 }) {
     return (
         <div
@@ -29,6 +31,16 @@ function MeasureToolbar({
             <div className="ms-measure-info">
                 {info}
             </div>
+            {onClose ?
+                <Button
+                    className="square-button-md no-border"
+                    onClick={(event) => {
+                        event.stopPropagation();
+                        onClose();
+                    }}
+                >
+                    <Glyphicon glyph="1-close"/>
+                </Button> : null}
         </div>
     );
 }

--- a/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
+++ b/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
@@ -44,7 +44,7 @@ describe("test the MeasureComponent", () => {
         expect(domNode).toExist();
         const domButtons = domNode.getElementsByTagName('button');
         expect(domButtons).toExist();
-        expect(domButtons.length).toBe(7);
+        expect(domButtons.length).toBe(6);
         const disabledButtons = domNode.querySelectorAll('button.disabled');
         expect(disabledButtons.length).toBe(2);
     });
@@ -80,7 +80,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(7);
+        expect(buttons.length).toBe(6);
         const disabledButtons = cmpDom.querySelectorAll('button.disabled');
         expect(disabledButtons.length).toBe(2);
 
@@ -110,7 +110,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(7);
+        expect(buttons.length).toBe(6);
         const disabledButtons = cmpDom.querySelectorAll('button.disabled');
         expect(disabledButtons.length).toBe(2);
 
@@ -140,7 +140,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(7);
+        expect(buttons.length).toBe(6);
         const disabledButtons = cmpDom.querySelectorAll('button.disabled');
         expect(disabledButtons.length).toBe(2);
 
@@ -171,7 +171,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(7);
+        expect(buttons.length).toBe(6);
         const disabledButtons = cmpDom.querySelectorAll('button.disabled');
         expect(disabledButtons.length).toBe(2);
 
@@ -467,7 +467,7 @@ describe("test the MeasureComponent", () => {
         expect(toolBarGroup.length).toBe(3);
 
         const buttons = document.querySelectorAll('button');
-        expect(buttons.length).toBe(8);
+        expect(buttons.length).toBe(7);
         expect(buttons[0].classList.contains('disabled')).toBe(false);
         expect(buttons[1].classList.contains('disabled')).toBe(false);
         expect(buttons[2].classList.contains('disabled')).toBe(false);
@@ -523,7 +523,7 @@ describe("test the MeasureComponent", () => {
         expect(toolBarGroup.length).toBe(3);
 
         const buttons = document.querySelectorAll('button');
-        expect(buttons.length).toBe(8);
+        expect(buttons.length).toBe(7);
         // By default LineString is selected
         expect(buttons[0].className).toContain('active');
 

--- a/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
+++ b/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
@@ -44,7 +44,7 @@ describe("test the MeasureComponent", () => {
         expect(domNode).toExist();
         const domButtons = domNode.getElementsByTagName('button');
         expect(domButtons).toExist();
-        expect(domButtons.length).toBe(6);
+        expect(domButtons.length).toBe(7);
         const disabledButtons = domNode.querySelectorAll('button.disabled');
         expect(disabledButtons.length).toBe(2);
     });
@@ -80,7 +80,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(6);
+        expect(buttons.length).toBe(7);
         const disabledButtons = cmpDom.querySelectorAll('button.disabled');
         expect(disabledButtons.length).toBe(2);
 
@@ -110,7 +110,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(6);
+        expect(buttons.length).toBe(7);
         const disabledButtons = cmpDom.querySelectorAll('button.disabled');
         expect(disabledButtons.length).toBe(2);
 
@@ -140,7 +140,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(6);
+        expect(buttons.length).toBe(7);
         const disabledButtons = cmpDom.querySelectorAll('button.disabled');
         expect(disabledButtons.length).toBe(2);
 
@@ -171,7 +171,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(6);
+        expect(buttons.length).toBe(7);
         const disabledButtons = cmpDom.querySelectorAll('button.disabled');
         expect(disabledButtons.length).toBe(2);
 
@@ -467,7 +467,7 @@ describe("test the MeasureComponent", () => {
         expect(toolBarGroup.length).toBe(3);
 
         const buttons = document.querySelectorAll('button');
-        expect(buttons.length).toBe(7);
+        expect(buttons.length).toBe(8);
         expect(buttons[0].classList.contains('disabled')).toBe(false);
         expect(buttons[1].classList.contains('disabled')).toBe(false);
         expect(buttons[2].classList.contains('disabled')).toBe(false);
@@ -523,7 +523,7 @@ describe("test the MeasureComponent", () => {
         expect(toolBarGroup.length).toBe(3);
 
         const buttons = document.querySelectorAll('button');
-        expect(buttons.length).toBe(7);
+        expect(buttons.length).toBe(8);
         // By default LineString is selected
         expect(buttons[0].className).toContain('active');
 

--- a/web/client/plugins/__tests__/Measure-test.jsx
+++ b/web/client/plugins/__tests__/Measure-test.jsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Measure from '../Measure';
+import { getPluginForTest } from './pluginsTestUtils';
+import { Simulate } from 'react-dom/test-utils';
+
+describe('Measure Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('should trigger the correct close action', () => {
+        const { Plugin, store } = getPluginForTest(Measure, { controls: { measure: { enabled: true } } });
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        const measureToolbarNode = document.querySelector('.ms-measure-toolbar');
+        expect(measureToolbarNode).toBeTruthy();
+        const closeNode = measureToolbarNode.querySelector('.glyphicon-1-close');
+        expect(closeNode).toBeTruthy();
+        Simulate.click(closeNode.parentNode);
+        expect(store.getState().controls.measure.enabled).toBe(false);
+    });
+});

--- a/web/client/plugins/__tests__/Measure-test.jsx
+++ b/web/client/plugins/__tests__/Measure-test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, GeoSolutions Sas.
+ * Copyright 2023, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/web/client/plugins/measure/index.js
+++ b/web/client/plugins/measure/index.js
@@ -11,6 +11,7 @@ import MeasureComponentComp from '../../components/mapcontrols/measure/MeasureCo
 import MeasureDialogComp from '../../components/mapcontrols/measure/MeasureDialog';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import { setControlProperty } from '../../actions/controls';
 import {
     toggleMeasurement,
     changeMeasurementState,
@@ -31,6 +32,9 @@ import {
     defaultUnitOfMeasure
 } from '../../utils/MeasureUtils';
 import addI18NProps from '../../components/I18N/enhancers/addI18NProps';
+import Loader from '../../components/misc/Loader';
+import MeasureToolbar from '../../components/mapcontrols/measure/MeasureToolbar';
+
 // number format localization for measurements
 const addFormatNumber = addI18NProps(['formatNumber']);
 
@@ -51,7 +55,7 @@ const MeasureSupportWithFormatNumber = addFormatNumber(({
 }) => {
     const Support = measureSupports[mapType];
     return Support
-        ? (<Suspense fallback={<div/>}>
+        ? (<Suspense fallback={<MeasureToolbar onClose={props.onClose}><Loader size={20} /></MeasureToolbar>}>
             <Support
                 {...props}
                 {...defaultOptions}
@@ -119,7 +123,8 @@ export const MeasureSupport = connect(
         changeGeometry,
         setTextLabels,
         changeMeasurement,
-        onChangeUnitOfMeasure: changeUom
+        onChangeUnitOfMeasure: changeUom,
+        onClose: setControlProperty.bind(null, 'measure', 'enabled', false)
     }
 )(MeasureSupportComponent);
 


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces a new button for the measure toolbar that allow the user to close it directly

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8973

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The measure toolbar include a close button


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
