### PR TITLE
[Backport 2023.01.xx] #8972 Application crashes in mobile if dashboard maps are generated with an id starting with a number (#8975)

### DIFF
--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -124,8 +124,8 @@ class LeafletMap extends React.Component {
             minZoom: limits && limits.minZoom,
             maxZoom: limits && limits.maxZoom || 23
         }, this.props.mapOptions, this.crs ? {crs: this.crs} : {});
-
-        const map = L.map(this.getDocument().querySelector(`#${this.props.id} > .map-viewport`), assign({ zoomControl: false }, mapOptions) ).setView([this.props.center.y, this.props.center.x],
+        // it is not possible to use #<id> in a query selector if the id starts with a number
+        const map = L.map(this.getDocument().querySelector(`[id='${this.props.id}'] > .map-viewport`), assign({ zoomControl: false }, mapOptions) ).setView([this.props.center.y, this.props.center.x],
             Math.round(this.props.zoom));
 
         this.map = map;

--- a/web/client/components/map/leaflet/__tests__/Map-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Map-test.jsx
@@ -76,6 +76,13 @@ describe('LeafletMap', () => {
         expect(ReactDOM.findDOMNode(map).id).toBe('mymap');
     });
 
+    it('creates a div for leaflet map with a numerical id', () => {
+        const map = ReactDOM.render(<LeafletMap id="7" center={{y: 43.9, x: 10.3}} zoom={11} mapOptions={{zoomAnimation: false}}/>, document.getElementById("container"));
+        expect(map).toExist();
+        expect(ReactDOM.findDOMNode(map).id).toBe('7');
+    });
+
+
     it('creates a div for leaflet map with default id (map)', () => {
         const map = ReactDOM.render(<LeafletMap center={{y: 43.9, x: 10.3}} zoom={11} mapOptions={{zoomAnimation: false}}/>, document.getElementById("container"));
         expect(map).toExist();


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR update the leaflet map id selector to support also id that starts with a number

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8972

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Map id starting with number does not break the application

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
