### PR TITLE
Format fixes for plugin general guidelines

### DIFF
--- a/docs/developer-guide/plugins-howto.md
+++ b/docs/developer-guide/plugins-howto.md
@@ -1135,14 +1135,18 @@ describe("MyPlugin Test", () => {
 
 ## General Guidelines
 
-- Components
-  - define the plugin component(s) into dedicated JSX file(s), so that they can be reused outside of the plugin
-  - connect the component(s) in the plugin JSX file
-- State
-  - define your own state fragment (and related actions and reducers) to handle internal state, and use existing actions and state fragments from MapStore2 to interact with the framework
-- Selectors
-  - use existing selectors when possible to connect the state, eventually using reselect to compose them together or with your own selectors
+### Components
+- Define the plugin component(s) into dedicated JSX file(s), so that they can be reused outside of the plugin
+- Connect the component(s) in the plugin JSX file
+
+### State
+- Define your own state fragment (and related actions and reducers) to handle internal state, and use existing actions and state fragments from MapStore2 to interact with the framework
+
+### Selectors
+- Use existing selectors when possible to connect the state, eventually using reselect to compose them together or with your own selectors
+
+### General
 - Avoid as much as possible direct interactions between different plugins; plugins are meant to be independent modules, so they should be able to work if other plugins appear / disappear from the application configuration
-  - interact with other plugins and the application itself using actions and state sharing
-  - creating side effects to make plugins interact in more strict ways should not be done at the plugin level, orchestrating different plugins should be delegated at the top (application) level
-  - use containers configuration to combine plugins in containers
+- Interact with other plugins and the application itself using actions and state sharing
+- Creating side effects to make plugins interact in more strict ways should not be done at the plugin level, orchestrating different plugins should be delegated at the top (application) level
+- Use containers configuration to combine plugins in containers

--- a/docs/developer-guide/plugins-howto.md
+++ b/docs/developer-guide/plugins-howto.md
@@ -1136,16 +1136,20 @@ describe("MyPlugin Test", () => {
 ## General Guidelines
 
 ### Components
+
 - Define the plugin component(s) into dedicated JSX file(s), so that they can be reused outside of the plugin
 - Connect the component(s) in the plugin JSX file
 
 ### State
+
 - Define your own state fragment (and related actions and reducers) to handle internal state, and use existing actions and state fragments from MapStore2 to interact with the framework
 
 ### Selectors
+
 - Use existing selectors when possible to connect the state, eventually using reselect to compose them together or with your own selectors
 
 ### General
+
 - Avoid as much as possible direct interactions between different plugins; plugins are meant to be independent modules, so they should be able to work if other plugins appear / disappear from the application configuration
 - Interact with other plugins and the application itself using actions and state sharing
 - Creating side effects to make plugins interact in more strict ways should not be done at the plugin level, orchestrating different plugins should be delegated at the top (application) level


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Currently it looks like the following 

![image](https://user-images.githubusercontent.com/1280027/222103789-6f61d2c3-714f-4e93-8f11-67cacbeeed11.png)

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [X] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8542 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
