### PR TITLE
#8982 Issues between charts and filters

### DIFF
--- a/web/client/epics/dashboard.js
+++ b/web/client/epics/dashboard.js
@@ -32,7 +32,7 @@ import { loadFilter, QUERY_FORM_SEARCH } from '../actions/queryform';
 import { CHECK_LOGGED_USER, LOGIN_SUCCESS, LOGOUT } from '../actions/security';
 import { isDashboardEditing, isDashboardAvailable } from '../selectors/dashboard';
 import { isLoggedIn } from '../selectors/security';
-import { getEditingWidgetLayer, getEditingWidgetFilter, getSelectedChartId } from '../selectors/widgets';
+import { getEditingWidgetLayer, getEditingWidgetFilter, getWidgetFilterKey } from '../selectors/widgets';
 import { pathnameSelector } from '../selectors/router';
 import { download, readJson } from '../utils/FileUtils';
 import { createResource, updateResource, getResource } from '../api/persistence';
@@ -76,14 +76,6 @@ export const closeDashboardEditorOnExit = (action$, {getState = () => {}} = {}) 
     .switchMap(() => Rx.Observable.of(setEditing(false)));
 
 /**
- * Get editor change key for updating filter object
- */
-const getFilterKey = (state) => {
-    const selectedChartId = getSelectedChartId(state);
-    // Set chart key if editor widget type is chart
-    return selectedChartId ? `charts[${selectedChartId}].filter` : "filter";
-};
-/**
      * Manages interaction with QueryPanel and Dashboard
      */
 export const handleDashboardWidgetsFilterPanel = (action$, {getState = () => {}} = {}) => action$.ofType(OPEN_FILTER_EDITOR)
@@ -103,7 +95,7 @@ export const handleDashboardWidgetsFilterPanel = (action$, {getState = () => {}}
             // then close the query panel, open widget form and update the current filter for the widget in editing
                 .switchMap( action =>
                     (action.filterObj
-                        ? Rx.Observable.of(onEditorChange(getFilterKey(getState()), action.filterObj))
+                        ? Rx.Observable.of(onEditorChange(getWidgetFilterKey(getState()), action.filterObj))
                         : Rx.Observable.empty()
                     )
                         .merge(Rx.Observable.of(

--- a/web/client/epics/widgetsbuilder.js
+++ b/web/client/epics/widgetsbuilder.js
@@ -24,7 +24,7 @@ import { setControlProperty, TOGGLE_CONTROL } from '../actions/controls';
 import { ADD_LAYER } from '../actions/layers';
 import { LOCATION_CHANGE } from 'connected-react-router';
 import { featureTypeSelected } from '../actions/wfsquery';
-import { getWidgetLayer, getEditingWidgetFilter } from '../selectors/widgets';
+import { getWidgetLayer, getEditingWidgetFilter, getWidgetFilterKey } from '../selectors/widgets';
 import { wfsFilter } from '../selectors/query';
 import { widgetBuilderAvailable } from '../selectors/controls';
 const getFTSelectedArgs = (state) => {
@@ -90,7 +90,7 @@ export const handleWidgetsFilterPanel = (action$, {getState = () => {}} = {}) =>
                 // then close the query panel, open widget form and update the current filter for the widget in editing
                     .switchMap( action =>
                         (action.filterObj
-                            ? Rx.Observable.of(onEditorChange("filter", action.filterObj))
+                            ? Rx.Observable.of(onEditorChange(getWidgetFilterKey(getState()), action.filterObj))
                             : Rx.Observable.empty()
                         )
                             .merge(Rx.Observable.of(

--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -120,6 +120,22 @@ describe('Test the widgets reducer', () => {
                     }, {
                         id: "widget4",
                         layer: Object.assign({}, targetLayer)
+                    },
+                    {
+                        id: "widget5",
+                        widgetType: "chart",
+                        charts: [
+                            {
+                                layer: Object.assign({}, targetLayer)
+                            },
+                            {
+                                layer: {
+                                    visibility: false,
+                                    name: "layer3",
+                                    id: "3"
+                                }
+                            }
+                        ]
                     }]
                 }
             }
@@ -129,11 +145,13 @@ describe('Test the widgets reducer', () => {
         const newState = widgets(state, updateWidgetLayer(newTargetLayer));
 
         const widgetObjects = newState.containers[DEFAULT_TARGET].widgets;
-        expect(widgetObjects.length).toBe(4);
+        expect(widgetObjects.length).toBe(5);
         expect(widgetObjects[0].layer).toEqual(state.containers[DEFAULT_TARGET].widgets[0].layer);
         expect(widgetObjects[1].layer).toEqual(newTargetLayer);
         expect(widgetObjects[2].layer).toEqual(state.containers[DEFAULT_TARGET].widgets[2].layer);
         expect(widgetObjects[3].layer).toEqual(newTargetLayer);
+        expect(widgetObjects[4].charts[0].layer).toEqual(newTargetLayer);
+        expect(widgetObjects[4].charts[1].layer).toEqual(state.containers[DEFAULT_TARGET].widgets[4].charts[1].layer);
     });
     it('deleteWidget', () => {
         const state = {

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -141,7 +141,17 @@ function widgetsReducer(state = emptyState, action) {
             const _widgets = get(state, `containers[${DEFAULT_TARGET}].widgets`);
             if (_widgets) {
                 return set(`containers[${DEFAULT_TARGET}].widgets`,
-                    _widgets.map(w => get(w, "layer.id") === action.layer.id ? set("layer", action.layer, w) : w), state);
+                    _widgets.map(w => {
+                        if (w.widgetType === "chart" && w?.charts) {
+                            // every chart stores the layer object configuration
+                            // so we need to loop around them to update correctly the layer properties
+                            // including the layerFilter
+                            return set("charts", w.charts.map((chart) =>
+                                get(chart, "layer.id") === action.layer.id ? set("layer", action.layer, chart) : chart
+                            ), w);
+                        }
+                        return get(w, "layer.id") === action.layer.id ? set("layer", action.layer, w) : w;
+                    }), state);
             }
         }
         return state;

--- a/web/client/selectors/__tests__/widgets-test.js
+++ b/web/client/selectors/__tests__/widgets-test.js
@@ -25,7 +25,9 @@ import {
     availableDependenciesForEditingWidgetSelector,
     returnToFeatureGridSelector,
     isTrayEnabled,
-    getVisibleFloatingWidgets, getChartWidgetLayers
+    getVisibleFloatingWidgets,
+    getChartWidgetLayers,
+    getWidgetFilterKey
 } from '../widgets';
 
 import { set } from '../../utils/ImmutableUtils';
@@ -638,4 +640,13 @@ describe('widgets selectors', () => {
         expect(result[1].id).toBe('widget2');
         expect(result[2].id).toBe('widget3');
     });
+    it('getWidgetFilterKey without chart', () => {
+        const state = set("widgets.builder.editor", { widgetType: "table" }, {});
+        expect(getWidgetFilterKey(state)).toBe("filter");
+    });
+    it('getWidgetFilterKey with chart', () => {
+        const state = set("widgets.builder.editor", { widgetType: "chart", selectedChartId: "chart-01" }, {});
+        expect(getWidgetFilterKey(state)).toBe("charts[chart-01].filter");
+    });
+
 });

--- a/web/client/selectors/widgets.js
+++ b/web/client/selectors/widgets.js
@@ -174,3 +174,14 @@ export const widgetsConfig = createStructuredSelector({
     layouts: getFloatingWidgetsLayout,
     catalogs: dashboardServicesSelector
 });
+
+
+/**
+ * Get editor change key for updating filter object
+ * @param {object} state the state
+ */
+export const getWidgetFilterKey = (state) => {
+    const selectedChartId = getSelectedChartId(state);
+    // Set chart key if editor widget type is chart
+    return selectedChartId ? `charts[${selectedChartId}].filter` : "filter";
+};


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces following changes:
- share the filter key selector between dahsboards and widgets on map to get the correct value
- ensure the correct update for layer inside chart widget

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8982

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The filters of chart widget are correctly applied

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
