### PR TITLE
#9001 Made project branch parametric

### DIFF
--- a/createProject.js
+++ b/createProject.js
@@ -14,6 +14,11 @@ const paramsDesc = [{
     "default": 'standard',
     validate: () => true
 }, {
+    label: 'MapStore base branch (master):',
+    name: 'branch',
+    "default": 'master',
+    validate: () => true
+}, {
     label: 'Project Name: ',
     name: 'projectName',
     "default": '',
@@ -95,7 +100,7 @@ function doWork(params) {
         })
         .then(() => {
             process.stdout.write('git init\n');
-            return project.updateSubmoduleBranch(params.outFolder);
+            return project.updateSubmoduleBranch(params.outFolder, params.branch);
         })
         .then(() => {
             return project.createFirstCommit(params.outFolder);

--- a/docs/developer-guide/project-creation-script.md
+++ b/docs/developer-guide/project-creation-script.md
@@ -37,12 +37,13 @@ npm install
 Finally, to create the project, use the following command:
 
 ```sh
-node ./createProject.js <projectType> <projectName> <projectVersion> <projectDescription> <gitRepositoryUrl> <outputFolder>
+node ./createProject.js
 ```
 
-Note that projectName and outputFolder are mandatory:
+The command line will ask some questions about the project to create. (You can press enter to accept the default value, indicated between parenthesis, or type a new one):
 
 * **projectName**: short project name that will be used as the repository name on github, webapp path and name in package.json
+* **branch/tag**: the base branch/tag to use for the project (e.g. v2022.02.02, or master)
 * **projectType**: type of project to create, currently one type of projects is supported:
   * **standard**: is a copy of the standard MapStore project, ready to be used and customized
 * **projectVersion**: project version in package.json (X.Y.Z)
@@ -53,7 +54,15 @@ Note that projectName and outputFolder are mandatory:
 Usage:
 
 ```sh
-node ./createProject.js standard MyProject "1.0.0" "this is my awesome project" "" ../MY_PROJECT_NAME
+node ./createProject.js
+
+Project Type (standard):
+MapStore base branch (master):v2023.01.01
+Project Name: my_project
+Project Version (1.0.0):
+Project Description (Project Name):
+Repository URL:
+Output folder: ../my_project
 ```
 
 At the end of the script execution, the given outputFolder will be populated by all the configuration files needed to start working on the project. Moreover, the local git repository will be initialized and the MapStore sub-module added and downloaded.

--- a/utility/projects/projectLib.js
+++ b/utility/projects/projectLib.js
@@ -64,11 +64,11 @@ const createFirstCommit = (outFolder) => {
  * @param {string} outFolder the folder where to apply the checkout
  * @return {Promise} the promise to continue the flow of project creation
  */
-const updateSubmoduleBranch = (outFolder) => {
+const updateSubmoduleBranch = (outFolder, branch) => {
     const git = require('simple-git')();
     const gitProjectMs2 = require('simple-git')(`${outFolder}/MapStore2`);
 
-    const stableBranch = "2022.02.xx";
+    const stableBranch = branch || "2023.01.xx";
 
     return new Promise((resolve, reject) => {
         try {


### PR DESCRIPTION
## Description

In order to automate the release process, this hard-coded string that need to be updated on every commit must be removed.
For this reason, I propose to make this script parametric. The project creation will rely on master branch.

If a user wants to build the project from a release branch, he have to specify the branch/commit as parameter. 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9001

**What is the new behavior?**
Removing this hardcoded version, we can move on with automation

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
