### PR TITLE
#9011 Persist 3D map orientation after saving a map

### DIFF
--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -67,6 +67,7 @@ The following options define the map options (projection, position, layers):
 - `layers: {object[]}` list of layers to be loaded on the map
 - `groups {object[]}`: contains information about the layer groups
 - `visualizationMode: {string}` defines if the map should be visualized in "2D" or "3D"
+- `viewerOptions: {object}` could contain viewer specific properties, eg. camera orientation and camera position for 3D visualization mode
 
 i.e.
 
@@ -78,6 +79,18 @@ i.e.
     "center": {"x": 1000000.000000, "y": 5528000.000000, "crs": "EPSG:900913"},
     "zoom": 15,
     "visualizationMode": "2D",
+    "viewerOptions": {
+      "cameraPosition": {
+        "longitude": 0,
+        "latitude": 0,
+        "height": 0
+      },
+      "orientation": {
+        "heading": 0,
+        "pitch": 0,
+        "roll": 0
+      }
+    },
     "mapOptions": {
       "view": {
         "scales": [175000, 125000, 100000, 75000, 50000, 25000, 10000, 5000, 2500],

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -68,31 +68,6 @@ const appConfig = {
 };
 ```
 
-### Remove flyTo from the default map options
-
-The localConfig.json provides configuration for the default map options including the flyTo boolean that add a transition animation when the camera change positions for Cesium maps. While this feature could be useful for presentations such as in the map views plugin or zoom to extent actions, it does not work well with the default behavior of the map that should avoid transition similarly to the 2D maps.
-For this reason it is suggested to remove the flyTo property from the default map options inside the localConfig.json file:
-
-```diff
-{
-    "defaultMapOptions": {
-        "cesium": {
--           "flyTo": true,
-            "navigationTools": true,
-            "showSkyAtmosphere": true,
-            "showGroundAtmosphere": false,
-            "enableFog": false,
-            "depthTestAgainstTerrain": false,
-            "terrainProvider": {
-                "type": "ellipsoid"
-            }
-        },
-        "floatingIdentifyDelay": 1000
-    },
-}
-
-```
-
 ## Migration from 2022.02.02 to 2023.01.00
 
 ### Log4j update to Log4j2

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -87,6 +87,31 @@ const appConfig = {
 };
 ```
 
+### Remove flyTo from the default map options
+
+The localConfig.json provides configuration for the default map options including the flyTo boolean that add a transition animation when the camera change positions for Cesium maps. While this feature could be useful for presentations such as in the map views plugin or zoom to extent actions, it does not work well with the default behavior of the map that should avoid transition similarly to the 2D maps.
+For this reason it is suggested to remove the flyTo property from the default map options inside the localConfig.json file:
+
+```diff
+{
+    "defaultMapOptions": {
+        "cesium": {
+-           "flyTo": true,
+            "navigationTools": true,
+            "showSkyAtmosphere": true,
+            "showGroundAtmosphere": false,
+            "enableFog": false,
+            "depthTestAgainstTerrain": false,
+            "terrainProvider": {
+                "type": "ellipsoid"
+            }
+        },
+        "floatingIdentifyDelay": 1000
+    },
+}
+
+```
+
 ## Migration from 2022.02.02 to 2023.01.00
 
 ### Log4j update to Log4j2

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -205,7 +205,8 @@ class CesiumMap extends React.Component {
                     roll: parseFloat(this.props.orientate.roll)
                 }
             };
-            this.setView(position);
+            this.map.camera.cancelFlight();
+            this.map.camera.flyTo(position, this.props.mapOptions.defaultFlightOptions);
         }
 
         if (prevProps && (this.props.mapOptions.showSkyAtmosphere !== prevProps?.mapOptions?.showSkyAtmosphere)) {
@@ -449,11 +450,7 @@ class CesiumMap extends React.Component {
 
     setView = (position) => {
         this.map.camera.cancelFlight();
-        if (this.props.mapOptions && this.props.mapOptions.flyTo) {
-            this.map.camera.flyTo(position, this.props.mapOptions.defaultFlightOptions);
-        } else {
-            this.map.camera.setView(position);
-        }
+        this.map.camera.setView(position);
     };
 
     subscribeClickEvent = (map) => {

--- a/web/client/components/map/cesium/__tests__/Map-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test.jsx
@@ -164,8 +164,8 @@ describe('CesiumMap', () => {
                     zoom={5}
                     onMapViewChanges={(center, zoom, bbox, size, id, projection, options) => {
                         try {
-                            expect(Math.round(center.y * precision) / precision).toBe(30);
-                            expect(Math.round(center.x * precision) / precision).toBe(20);
+                            expect(Math.round(Math.round(center.y * precision) / precision)).toBe(30);
+                            expect(Math.round(Math.round(center.x * precision) / precision)).toBe(20);
                             expect(zoom).toBe(5);
                             expect(bbox.bounds).toBeTruthy();
                             expect(bbox.crs).toBeTruthy();
@@ -468,6 +468,38 @@ describe('CesiumMap', () => {
         expect(ref.map).toBeTruthy();
         expect(ref.map.cesiumNavigation).toBeTruthy();
         expect(ref.map.cesiumNavigation.destroy).toBeTruthy();
+    });
+    it('should set correct orientation on mount', () => {
+        let ref;
+        act(() => {
+            ReactDOM.render(
+                <CesiumMap
+                    ref={value => { ref = value; } }
+                    center={{
+                        x: 14,
+                        y: 42
+                    }}
+                    zoom={9}
+                    viewerOptions={{
+                        cameraPosition: {
+                            longitude: 12.390726809383557,
+                            latitude: 41.71232944851886,
+                            height: 352553
+                        },
+                        orientation: {
+                            heading: 5.677102807289052,
+                            pitch: -0.6948024901340912,
+                            roll: 0.000016578416068391277
+                        }
+                    }}
+                />
+                , document.getElementById("container"));
+        });
+        expect(ref.map).toBeTruthy();
+        expect(ref.map.camera).toBeTruthy();
+        expect(Math.round(ref.map.camera.heading)).toBe(6);
+        expect(Math.round(ref.map.camera.pitch)).toBe(-1);
+        expect(Math.round(ref.map.camera.roll)).toBe(0);
     });
     describe("hookRegister", () => {
         it("default", () => {

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -29,7 +29,6 @@
     "loadAfterTheme": true,
     "defaultMapOptions": {
       "cesium": {
-          "flyTo": true,
           "navigationTools": true,
           "showSkyAtmosphere": true,
           "showGroundAtmosphere": false,

--- a/web/client/epics/__tests__/maptype-test.js
+++ b/web/client/epics/__tests__/maptype-test.js
@@ -10,10 +10,12 @@ import expect from 'expect';
 
 import { onLocationChanged } from 'connected-react-router';
 
-import { syncMapType, restore2DMapTypeOnLocationChange  } from '../maptype';
+import { syncMapType, restoreDefaultVisualizationMode  } from '../maptype';
 import { changeVisualizationMode, VISUALIZATION_MODE_CHANGED } from '../../actions/maptype';
 import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
 import { VisualizationModes } from '../../utils/MapTypeUtils';
+import { resetDashboard } from '../../actions/dashboard';
+import { loadGeostory } from '../../actions/geostory';
 
 const NUM_ACTIONS = 1;
 
@@ -45,13 +47,26 @@ describe('maptype epics', () => {
         }, STATE);
     });
 
-    it('restore 2D map when changing location from a 3d mode', (done) => {
+    it('restore default mode when reset dashboard', (done) => {
         const STATE_3D = {
             maptype: {
                 mapType: "cesium"
             }
         };
-        testEpic(restore2DMapTypeOnLocationChange, NUM_ACTIONS, onLocationChanged({pathname: "/"}, "PUSH" ), (actions) => {
+        testEpic(restoreDefaultVisualizationMode, NUM_ACTIONS, resetDashboard(), (actions) => {
+            expect(actions.length).toEqual(NUM_ACTIONS);
+            expect(actions[0].type).toEqual(VISUALIZATION_MODE_CHANGED);
+            expect(actions[0].visualizationMode).toEqual(VisualizationModes._2D);
+            done();
+        }, STATE_3D);
+    });
+    it('restore default mode when load geostory', (done) => {
+        const STATE_3D = {
+            maptype: {
+                mapType: "cesium"
+            }
+        };
+        testEpic(restoreDefaultVisualizationMode, NUM_ACTIONS, loadGeostory(), (actions) => {
             expect(actions.length).toEqual(NUM_ACTIONS);
             expect(actions[0].type).toEqual(VISUALIZATION_MODE_CHANGED);
             expect(actions[0].visualizationMode).toEqual(VisualizationModes._2D);

--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -27,7 +27,7 @@ import { addMarker, hideMarker } from '../actions/search';
 import { updateMapView } from '../actions/map';
 import { updateUrlOnScrollSelector } from '../selectors/geostory';
 import { shareSelector } from "../selectors/controls";
-import {mapTypeSelector} from "../selectors/maptype";
+import { mapTypeSelector } from "../selectors/maptype";
 /**
  * Share Plugin allows to share the current URL (location.href) in some different ways.
  * You can share it on socials networks(facebook,twitter,google+,linkedIn)
@@ -71,8 +71,17 @@ const Share = connect(createSelector([
     (state) => state.mapInfo && state.mapInfo.formatCoord || ConfigUtils.getConfigProp("defaultCoordinateFormat"),
     state => state.search && state.search.markerPosition || {},
     updateUrlOnScrollSelector,
-    state => get(state, 'map.present.viewerOptions')
-], (isVisible, version, map, mapType, context, settings, formatCoords, point, isScrollPosition, viewerOptions) => ({
+    state => get(state, 'map.present.viewerOptions'),
+    state => {
+        const map = mapSelector(state);
+        // get the camera position available in the 3D mode
+        const cameraPosition = map?.viewerOptions?.cameraPosition;
+        const center = cameraPosition
+            ? [cameraPosition.longitude, cameraPosition.latitude]
+            : map?.center;
+        return center && ConfigUtils.getCenter(center);
+    }
+], (isVisible, version, map, mapType, context, settings, formatCoords, point, isScrollPosition, viewerOptions, center) => ({
     isVisible,
     shareUrl: location.href,
     shareApiUrl: getApiUrl(location.href),
@@ -81,7 +90,7 @@ const Share = connect(createSelector([
     viewerOptions,
     mapType,
     bbox: isVisible && map && map.bbox && getExtentFromViewport(map.bbox),
-    center: map && map.center && ConfigUtils.getCenter(map.center),
+    center,
     zoom: map && map.zoom,
     showAPI: !context,
     embedOptions: {

--- a/web/client/test-resources/mergeConfigs/04_full_localConfig.json
+++ b/web/client/test-resources/mergeConfigs/04_full_localConfig.json
@@ -22,7 +22,6 @@
     "loadAfterTheme": true,
     "defaultMapOptions": {
       "cesium": {
-          "flyTo": true,
           "navigationTools": true,
           "terrainProvider": {
               "type": "ellipsoid"

--- a/web/client/test-resources/mergeConfigs/05_result_Config.json
+++ b/web/client/test-resources/mergeConfigs/05_result_Config.json
@@ -18,7 +18,6 @@
     "loadAfterTheme": true,
     "defaultMapOptions": {
       "cesium": {
-          "flyTo": true,
           "navigationTools": true,
           "terrainProvider": {
               "type": "ellipsoid"

--- a/web/client/utils/MapTypeUtils.js
+++ b/web/client/utils/MapTypeUtils.js
@@ -35,7 +35,7 @@ const DEFAULT_VISUALIZATION_MODES_CONFIG = {
     }
 };
 
-const getDefaultVisualizationMode = () => {
+export const getDefaultVisualizationMode = () => {
     const customMapTypeConfig = getConfigProp('mapType') || {};
     const { defaultVisualizationMode = VisualizationModes._2D } = customMapTypeConfig;
     return defaultVisualizationMode;

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -487,7 +487,8 @@ export function saveMapConfiguration(currentMap, currentLayers, currentGroups, c
         mapInfoControl: currentMap.mapInfoControl,
         zoom: currentMap.zoom,
         mapOptions: currentMap.mapOptions || {},
-        ...(currentMap.visualizationMode && { visualizationMode: currentMap.visualizationMode })
+        ...(currentMap.visualizationMode && { visualizationMode: currentMap.visualizationMode }),
+        ...(currentMap.viewerOptions && { viewerOptions: currentMap.viewerOptions })
     };
 
     const layers = currentLayers.map((layer) => {

--- a/web/client/utils/QueryParamsUtils.js
+++ b/web/client/utils/QueryParamsUtils.js
@@ -187,6 +187,9 @@ export const paramActions = {
             })
         ];
     },
+    // In 2D mode the camera position and the center match the same latitude and longitude
+    // while in 3D mode the center represents the position of the camera and not the actual targeted center on the globe
+    // because it could differ based on the camera orientation (heading, pitch and roll)
     center: (parameters, state) => {
         const map = mapSelector(state);
         const mapType = mapTypeSelector(state);

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -42,6 +42,7 @@ import {
     getZoomFromResolution,
     getResolutionObject
 } from '../MapUtils';
+import { VisualizationModes } from '../MapTypeUtils';
 
 const POINT = "Point";
 const CIRCLE = "Circle";
@@ -2425,6 +2426,66 @@ describe('Test the MapUtils', () => {
                     },
                     units: 'm',
                     zoom: 10
+                },
+                version: 2
+            });
+        });
+        it('save map configuration with viewerOptions and visualizationMode', () => {
+
+            const flat = [];
+
+            const groups = [];
+
+            const mapConfig = {
+                center: { x: 9, y: 44, crs: 'EPSG:4326' },
+                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                projection: 'EPSG:900913',
+                units: 'm',
+                mapInfoControl: true,
+                zoom: 10,
+                visualizationMode: VisualizationModes._3D,
+                viewerOptions: {
+                    cameraPosition: {
+                        longitude: 12,
+                        latitude: 41,
+                        height: 352553
+                    },
+                    orientation: {
+                        heading: 5.35,
+                        pitch: -0.50,
+                        roll: 0.00
+                    }
+                }
+            };
+
+            const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', {});
+            expect(saved).toEqual({
+                map: {
+                    center: { x: 9, y: 44, crs: 'EPSG:4326' },
+                    backgrounds: [],
+                    mapInfoControl: true,
+                    groups: [],
+                    layers: [],
+                    mapOptions: {},
+                    maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                    projection: 'EPSG:900913',
+                    text_search_config: '',
+                    bookmark_search_config: {},
+                    units: 'm',
+                    zoom: 10,
+                    visualizationMode: VisualizationModes._3D,
+                    viewerOptions: {
+                        cameraPosition: {
+                            longitude: 12,
+                            latitude: 41,
+                            height: 352553
+                        },
+                        orientation: {
+                            heading: 5.35,
+                            pitch: -0.50,
+                            roll: 0.00
+                        }
+                    }
                 },
                 version: 2
             });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces following changes related to the 3D visualization mode (Cesium):

- updated computation of the center of the map based on where the camera is looking at
- stored cameraPosition and orientation inside the viewerOptions that will be included in the json map configuration payload
- changed some behaviour in the internal set view of the map so we also removed the flyTo default map options from localConfig.json because is not needed anymore. The main reason of this change is to make consistent the internal setView of 3D with the 2D mode where there are no animations while setting the views

```diff
{
    "defaultMapOptions": {
        "cesium": {
-           "flyTo": true,
            "navigationTools": true,
            "showSkyAtmosphere": true,
            "showGroundAtmosphere": false,
            "enableFog": false,
            "depthTestAgainstTerrain": false,
            "terrainProvider": {
                "type": "ellipsoid"
            }
        },
        "floatingIdentifyDelay": 1000
    },
}

```

- update how the share tool gets the center value in 3D mode to be sure it matches the camera position

The viewerOptions key was already implemented with the orientation property so this PR is only extending it including the camera position and persisting it in the map configuration

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9011

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The orientation and camera position of cesium viewer are persisted and saved in the map configuration.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
