### PR TITLE
#9014: Fix - Crash on new context when expanding search service options

### DIFF
--- a/web/client/plugins/SearchServicesConfig.jsx
+++ b/web/client/plugins/SearchServicesConfig.jsx
@@ -213,12 +213,12 @@ class SearchServicesConfigPanel extends React.Component {
 }
 
 const SearchServicesPlugin = connect(({controls = {}, searchconfig = {}}) => ({
-    enabled: controls.searchservicesconfig && controls.searchservicesconfig.enabled || false,
+    enabled: get(controls, "searchservicesconfig.enabled", false),
     pages: [ServiceList, WFSServiceProps, ResultsProps, WFSOptionalProps],
-    page: searchconfig && searchconfig.page || 0,
-    service: searchconfig && searchconfig.service,
-    initServiceValues: searchconfig && searchconfig.init_service_values,
-    textSearchConfig: searchconfig && searchconfig.textSearchConfig,
+    page: get(searchconfig, "page", 0),
+    service: get(searchconfig, "service", {}),
+    initServiceValues: get(searchconfig, "init_service_values", {}),
+    textSearchConfig: get(searchconfig, "textSearchConfig", {}),
     editIdx: searchconfig && searchconfig.editIdx
 }), {
     toggleControl,

--- a/web/client/plugins/__tests__/SearchServicesConfig-test.jsx
+++ b/web/client/plugins/__tests__/SearchServicesConfig-test.jsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import SearchServicesConfigPlugin from '../SearchServicesConfig';
+import { getPluginForTest } from './pluginsTestUtils';
+
+describe('SearchServicesConfig Plugin', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="container"></div>';
+    });
+
+    afterEach(() => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+    });
+
+    it('creates a SearchServicesConfig plugin with default configuration', () => {
+        const {Plugin} = getPluginForTest(SearchServicesConfigPlugin, {});
+        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+        expect(document.getElementById('search-services-config-editor')).toBeFalsy();
+    });
+    it('creates a SearchServicesConfig plugin with searchconfig null', () => {
+        const state = {controls: {searchservicesconfig: {enabled: true}}, searchconfig: null};
+        const {Plugin} = getPluginForTest(SearchServicesConfigPlugin, state);
+        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+        expect(document.getElementById('search-services-config-editor')).toBeTruthy();
+        expect(document.getElementsByClassName('services-config-editor')[0]).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Description
This PR fixes app crash when loading a context with `SearchServicesConfig` plugin

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9014

**What is the new behavior?**
The app doesn't crash when loading context with `SearchServicesConfig` plugin with default state

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
