### PR TITLE
#9016: Fix - Catalog panel mode reset on changing map

### DIFF
--- a/web/client/components/catalog/CatalogServiceEditor.jsx
+++ b/web/client/components/catalog/CatalogServiceEditor.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import Spinner from "react-spinkit";
 
 import { FormGroup, Form, Col } from "react-bootstrap";
@@ -52,6 +52,9 @@ export default ({
     autoSetVisibilityLimits = false
 }) => {
     const [valid, setValid] = useState(true);
+    useEffect(() => {
+        return () => onChangeCatalogMode("view");
+    }, []);
     return (<BorderLayout
         bodyClassName="ms2-border-layout-body catalog"
         header={

--- a/web/client/components/catalog/__tests__/CatalogServiceEditor-test.jsx
+++ b/web/client/components/catalog/__tests__/CatalogServiceEditor-test.jsx
@@ -152,4 +152,13 @@ describe('Test CatalogServiceEditor', () => {
         let placeholder = defaultPlaceholder(service);
         expect(placeholder).toBe("e.g. https://mydomain.com/geoserver/wms");
     });
+    it('test reset view mode of catalog on unmount', (done) => {
+        ReactDOM.render(<CatalogServiceEditor onChangeCatalogMode={(value) => {
+            expect(value).toBe("view");
+            done();
+        }
+        } />, document.getElementById("container"));
+
+        ReactDOM.render(<div/>, document.getElementById("container"));
+    });
 });


### PR DESCRIPTION
## Description
This PR fixes the catalog mode not reset when changing map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue
**What is the current behavior?**
- #9016 

**What is the new behavior?**
The catalog mode is reset to view when the component is unmounted. i.e the mode set to view when changing map

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
