### PR TITLE
#9036: Fix - Catalog mode and result retention

### DIFF
--- a/web/client/components/catalog/CatalogServiceEditor.jsx
+++ b/web/client/components/catalog/CatalogServiceEditor.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, {useState, useEffect} from 'react';
+import React, {useState} from 'react';
 import Spinner from "react-spinkit";
 
 import { FormGroup, Form, Col } from "react-bootstrap";
@@ -52,9 +52,6 @@ export default ({
     autoSetVisibilityLimits = false
 }) => {
     const [valid, setValid] = useState(true);
-    useEffect(() => {
-        return () => onChangeCatalogMode("view");
-    }, []);
     return (<BorderLayout
         bodyClassName="ms2-border-layout-body catalog"
         header={

--- a/web/client/components/catalog/__tests__/CatalogServiceEditor-test.jsx
+++ b/web/client/components/catalog/__tests__/CatalogServiceEditor-test.jsx
@@ -152,13 +152,4 @@ describe('Test CatalogServiceEditor', () => {
         let placeholder = defaultPlaceholder(service);
         expect(placeholder).toBe("e.g. https://mydomain.com/geoserver/wms");
     });
-    it('test reset view mode of catalog on unmount', (done) => {
-        ReactDOM.render(<CatalogServiceEditor onChangeCatalogMode={(value) => {
-            expect(value).toBe("view");
-            done();
-        }
-        } />, document.getElementById("container"));
-
-        ReactDOM.render(<div/>, document.getElementById("container"));
-    });
 });

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -207,6 +207,9 @@ class MetadataExplorerComponent extends React.Component {
         servicesWithBackgrounds: {}
     };
 
+    componentWillUnmount() {
+        this.props.closeCatalog();
+    }
     render() {
         // TODO: separate catalog props from Container props (and handlers)
         const layerBaseConfig = {

--- a/web/client/plugins/__tests__/MetadataExplorer-test.jsx
+++ b/web/client/plugins/__tests__/MetadataExplorer-test.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import MetadataExplorerPlugin from '../MetadataExplorer';
+import { getPluginForTest } from './pluginsTestUtils';
+
+describe('MetadataExplorer Plugin', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="container"></div>';
+    });
+
+    afterEach(() => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+    });
+
+    it('creates a MetadataExplorerPlugin plugin with default configuration', () => {
+        const {Plugin} = getPluginForTest(MetadataExplorerPlugin, {});
+        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+        expect(document.getElementById('catalog-root')).toBeTruthy();
+    });
+    it('test MetadataExplorerPlugin plugin on unmount', () => {
+        const {Plugin, actions} = getPluginForTest(MetadataExplorerPlugin, {});
+        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+
+        ReactDOM.render(<div/>, document.getElementById("container"));
+        expect(actions.length).toBe(4);
+        expect(actions[0].type).toBe("CATALOG:CATALOG_CLOSE");
+        expect(actions[1].type).toBe("SET_CONTROL_PROPERTIES");
+        expect(actions[1].control).toBe("metadataexplorer");
+        expect(actions[2].type).toBe("CATALOG:CHANGE_CATALOG_MODE");
+        expect(actions[2].mode).toBe("view");
+        expect(actions[3].type).toBe("CATALOG:RESET_CATALOG");
+    });
+});


### PR DESCRIPTION
## Description
This PR fixes the catalog mode and result retention when navigated away from map without closing the catalog panel followed by loading a new map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
 - #9036

**What is the new behavior?**

- The catalog mode is reset to view when panel is unmounted
- The catalog result is cleared when panel is unmounted. This fixes the invalid result from being loaded when previously loaded result are from a different service

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
