### PR TITLE
[Backport 2023.01.xx] #9014: Fix - Crash on new context when expanding search service option

### DIFF
--- a/web/client/plugins/SearchServicesConfig.jsx
+++ b/web/client/plugins/SearchServicesConfig.jsx
@@ -213,12 +213,12 @@ class SearchServicesConfigPanel extends React.Component {
 }
 
 const SearchServicesPlugin = connect(({controls = {}, searchconfig = {}}) => ({
-    enabled: controls.searchservicesconfig && controls.searchservicesconfig.enabled || false,
+    enabled: get(controls, "searchservicesconfig.enabled", false),
     pages: [ServiceList, WFSServiceProps, ResultsProps, WFSOptionalProps],
-    page: searchconfig && searchconfig.page || 0,
-    service: searchconfig && searchconfig.service,
-    initServiceValues: searchconfig && searchconfig.init_service_values,
-    textSearchConfig: searchconfig && searchconfig.textSearchConfig,
+    page: get(searchconfig, "page", 0),
+    service: get(searchconfig, "service", {}),
+    initServiceValues: get(searchconfig, "init_service_values", {}),
+    textSearchConfig: get(searchconfig, "textSearchConfig", {}),
     editIdx: searchconfig && searchconfig.editIdx
 }), {
     toggleControl,

--- a/web/client/plugins/__tests__/SearchServicesConfig-test.jsx
+++ b/web/client/plugins/__tests__/SearchServicesConfig-test.jsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import SearchServicesConfigPlugin from '../SearchServicesConfig';
+import { getPluginForTest } from './pluginsTestUtils';
+
+describe('SearchServicesConfig Plugin', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="container"></div>';
+    });
+
+    afterEach(() => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+    });
+
+    it('creates a SearchServicesConfig plugin with default configuration', () => {
+        const {Plugin} = getPluginForTest(SearchServicesConfigPlugin, {});
+        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+        expect(document.getElementById('search-services-config-editor')).toBeFalsy();
+    });
+    it('creates a SearchServicesConfig plugin with searchconfig null', () => {
+        const state = {controls: {searchservicesconfig: {enabled: true}}, searchconfig: null};
+        const {Plugin} = getPluginForTest(SearchServicesConfigPlugin, state);
+        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+        expect(document.getElementById('search-services-config-editor')).toBeTruthy();
+        expect(document.getElementsByClassName('services-config-editor')[0]).toBeTruthy();
+    });
+});


### PR DESCRIPTION
[Backport 2023.01.xx] #9014: Crash on new context when expanding search service option (#9027)