### PR TITLE
#9034: Fix - Spinner no longer appear when saving a resource

### DIFF
--- a/web/client/components/resources/modals/__tests__/Save-test.jsx
+++ b/web/client/components/resources/modals/__tests__/Save-test.jsx
@@ -10,6 +10,7 @@ import expect from 'expect';
 import { find, get } from 'lodash';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
 
 import MetadataModal from '../Save';
 
@@ -165,5 +166,57 @@ describe('This test for dashboard save form', () => {
         expect(saveButton).toExist();
         expect(saveButton.classList.contains('disabled')).toBe(false);
     });
+    it('modal save button is disabled when resource is loading', () => {
+        const user = {role: 'ADMIN'};
+        const Modal = ReactDOM.render(<MetadataModal user={user} show loading  id="map-save"/>, document.getElementById('container'));
+        expect(Modal).toBeTruthy();
 
+        const buttons = document.getElementsByTagName('button');
+        const saveButton = find(buttons, button => button.childNodes[0] && (button.childNodes[0].textContent === 'save' ||
+            get(button.childNodes[0].childNodes[0], 'textContent') === 'save'));
+        const closeButton = find(buttons, button => button.childNodes[0] && (button.childNodes[0].textContent === 'close' ||
+            get(button.childNodes[0].childNodes[0], 'textContent') === 'close'));
+        const closeButtonModal = document.querySelector('.glyphicon-1-close');
+
+        // Save button
+        expect(saveButton).toBeTruthy();
+        expect(saveButton.classList.contains('disabled')).toBe(true);
+        // Close button
+        expect(closeButton).toBeTruthy();
+        expect(closeButton.classList.contains('disabled')).toBe(true);
+        // Close button on modal header
+        expect(closeButtonModal).toBeFalsy();
+    });
+    it('modal save button is disabled when save is in progress', () => {
+        const user = {role: 'ADMIN'};
+        const Modal = ReactDOM.render(<MetadataModal user={user} show  id="map-save"/>, document.getElementById('container'));
+        expect(Modal).toBeTruthy();
+
+        const buttons = document.getElementsByTagName('button');
+        const saveButton = find(buttons, button => button.childNodes[0] && (button.childNodes[0].textContent === 'save' ||
+            get(button.childNodes[0].childNodes[0], 'textContent') === 'save'));
+        expect(saveButton).toBeTruthy();
+        TestUtils.Simulate.click(saveButton);
+        expect(saveButton.classList.contains('disabled')).toBe(true);
+    });
+    it('modal display spinner when loading', () => {
+        const user = {role: 'ADMIN'};
+        const Modal = ReactDOM.render(<MetadataModal user={user} loading show  id="map-save"/>, document.getElementById('container'));
+        expect(Modal).toBeTruthy();
+        const [spinner] = document.getElementsByClassName('mapstore-inline-loader');
+        expect(spinner).toBeTruthy();
+    });
+    it('modal hide spinner when error', () => {
+        const user = {role: 'ADMIN'};
+        let Modal = ReactDOM.render(<MetadataModal  user={user} show  id="map-save"/>, document.getElementById('container'));
+        expect(Modal).toBeTruthy();
+        const buttons = document.getElementsByTagName('button');
+        const saveButton = find(buttons, button => button.childNodes[0] && (button.childNodes[0].textContent === 'save' ||
+            get(button.childNodes[0].childNodes[0], 'textContent') === 'save'));
+        TestUtils.Simulate.click(saveButton);
+        Modal = ReactDOM.render(<MetadataModal errors={["Network error"]}  user={user} show  id="map-save"/>, document.getElementById('container'));
+        expect(Modal).toBeTruthy();
+        const [spinner] = document.getElementsByClassName('mapstore-inline-loader');
+        expect(spinner).toBeFalsy();
+    });
 });

--- a/web/client/themes/default/less/loaders.less
+++ b/web/client/themes/default/less/loaders.less
@@ -56,7 +56,7 @@
     }
     .mapstore-inline-loader {
         margin: @padding-left-square-md;
-        .mapstore-circle-loader-with-css-variables(@icon-size-md/10, @icon-size-md, @theme-vars[loader-primary-color], @theme-vars[loader-primary-fade-color]);
+        .mapstore-circle-loader-with-css-variables((@icon-size-md/10), @icon-size-md, @theme-vars[loader-primary-color], @theme-vars[loader-primary-fade-color]);
     }
 }
 


### PR DESCRIPTION
## Description
This PR fixes the spinner when saving a resource in the save modal

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9034 

**What is the new behavior?**

- When resource is loading or when save is in progress the inline spinner is displayed at the bottom-left area of the modal
- Save and close button is displayed when resource/save in progress
- Same behavior for Map, dashboard and geostory

### Screenshot
![image](https://user-images.githubusercontent.com/26929983/226906671-64830a34-3171-4ee5-ac9a-9eb62e3c29b7.png)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
