### PR TITLE
Fix #9050. Handle filters array on LOAD_FITLTER action

### DIFF
--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -1030,7 +1030,7 @@ describe('Test the queryform reducer', () => {
         let newState = queryform({crossLayerFilter: {attribute: "ATTRIBUTE"}}, action);
         expect(newState.crossLayerFilter.attribute).toBe("ATTRIBUTE");
     });
-    it('test loadFilter', () => {
+    it.only('test loadFilter', () => {
         const newFilter = {
             crossLayerFilter: {
                 collectGeometries: {
@@ -1039,6 +1039,14 @@ describe('Test the queryform reducer', () => {
                     }
                 }
             },
+            filters: [{
+                format: "logic",
+                logic: "AND",
+                filters: [{
+                    format: 'cql',
+                    body: 'ATTRIBUTE1 = \'VALUE1\''
+                }]
+            }],
             spatialField: {
                 method: "BBOX",
                 operation: "DWITHIN",
@@ -1059,6 +1067,7 @@ describe('Test the queryform reducer', () => {
         expect(newState.crossLayerFilter.attribute).toBe("ATTRIBUTE1");
         expect(newState.spatialField.attribute).toBe("GEOMETRY");
         expect(newState.spatialField.method).toBe("BBOX");
+        expect(newState.filters).toEqual(newFilter.filters);
     });
     it('attribute property on load an undefied filter', () => {
         const initialState = {

--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -1030,7 +1030,7 @@ describe('Test the queryform reducer', () => {
         let newState = queryform({crossLayerFilter: {attribute: "ATTRIBUTE"}}, action);
         expect(newState.crossLayerFilter.attribute).toBe("ATTRIBUTE");
     });
-    it.only('test loadFilter', () => {
+    it('test loadFilter', () => {
         const newFilter = {
             crossLayerFilter: {
                 collectGeometries: {

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -574,7 +574,7 @@ function queryform(state = initialState, action) {
     case LOAD_FILTER:
         const {attribute, ...other} = initialState.spatialField;
         const cleanInitialState = assign({}, initialState, {spatialField: {...other}});
-        const {spatialField, filterFields, groupFields, crossLayerFilter, attributePanelExpanded, spatialPanelExpanded, crossLayerExpanded} = (action.filter || cleanInitialState);
+        const {spatialField, filterFields, groupFields, crossLayerFilter, attributePanelExpanded, spatialPanelExpanded, crossLayerExpanded, filters} = (action.filter || cleanInitialState);
         return {...state,
             ...{
                 attributePanelExpanded,
@@ -586,6 +586,7 @@ function queryform(state = initialState, action) {
                     attribute: spatialField && spatialField.attribute || state.spatialField && state.spatialField.attribute
 
                 },
+                filters: filters ?? [],
                 filterFields,
                 groupFields,
                 crossLayerFilter: {


### PR DESCRIPTION
## Description

This PR fixes the missing load of filters array when a filter is reloaded (for instance from the layer) into the query form.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9050

**What is the new behavior?**
Fix #9050

No functional changes on main project, this actually influences only custom filters. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
