### PR TITLE
[Backport 2023.01.xx] Fix #9050. Handle filters array on LOAD_FITLTER action (#9051)

### DIFF
--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -1039,6 +1039,14 @@ describe('Test the queryform reducer', () => {
                     }
                 }
             },
+            filters: [{
+                format: "logic",
+                logic: "AND",
+                filters: [{
+                    format: 'cql',
+                    body: 'ATTRIBUTE1 = \'VALUE1\''
+                }]
+            }],
             spatialField: {
                 method: "BBOX",
                 operation: "DWITHIN",
@@ -1059,6 +1067,7 @@ describe('Test the queryform reducer', () => {
         expect(newState.crossLayerFilter.attribute).toBe("ATTRIBUTE1");
         expect(newState.spatialField.attribute).toBe("GEOMETRY");
         expect(newState.spatialField.method).toBe("BBOX");
+        expect(newState.filters).toEqual(newFilter.filters);
     });
     it('attribute property on load an undefied filter', () => {
         const initialState = {

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -574,7 +574,7 @@ function queryform(state = initialState, action) {
     case LOAD_FILTER:
         const {attribute, ...other} = initialState.spatialField;
         const cleanInitialState = assign({}, initialState, {spatialField: {...other}});
-        const {spatialField, filterFields, groupFields, crossLayerFilter, attributePanelExpanded, spatialPanelExpanded, crossLayerExpanded} = (action.filter || cleanInitialState);
+        const {spatialField, filterFields, groupFields, crossLayerFilter, attributePanelExpanded, spatialPanelExpanded, crossLayerExpanded, filters} = (action.filter || cleanInitialState);
         return {...state,
             ...{
                 attributePanelExpanded,
@@ -586,6 +586,7 @@ function queryform(state = initialState, action) {
                     attribute: spatialField && spatialField.attribute || state.spatialField && state.spatialField.attribute
 
                 },
+                filters: filters ?? [],
                 filterFields,
                 groupFields,
                 crossLayerFilter: {


### PR DESCRIPTION
[Backport 2023.01.xx] Fix #9050. Handle filters array on LOAD_FITLTER action (#9051)