### PR TITLE
[Backport 2023.01.xx] #8905 Allow to set singletile option on a wms catalog entry (#9022)

### DIFF
--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -91,6 +91,15 @@ export default ({
                 </Checkbox>
             </Col>
         </FormGroup>
+        {!isNil(service.type) && service.type === "wms" && <FormGroup controlId="singleTile" key="singleTile">
+            <Col xs={12}>
+                <Checkbox
+                    onChange={(e) => onChangeServiceProperty("layerOptions", { ...service.layerOptions, singleTile: e.target.checked })}
+                    checked={!isNil(service?.layerOptions?.singleTile) ? service.layerOptions.singleTile : false}>
+                    <Message msgId="catalog.singleTile.label" />&nbsp;<InfoPopover text={<Message msgId="catalog.singleTile.tooltip" />} />
+                </Checkbox>
+            </Col>
+        </FormGroup>}
         {!isNil(service.type) && service.type === "wms" && <FormGroup controlId="allowUnsecureLayers" key="allowUnsecureLayers">
             <Col xs={12}>
                 <Checkbox
@@ -167,7 +176,7 @@ export default ({
                 <Select
                     value={getTileSizeSelectOptions([service.layerOptions?.tileSize || 256])[0]}
                     options={tileSelectOptions}
-                    onChange={event => onChangeServiceProperty("layerOptions", { tileSize: event && event.value })} />
+                    onChange={event => onChangeServiceProperty("layerOptions", { ...service.layerOptions, tileSize: event && event.value })} />
             </Col >
         </FormGroup>
         {!isNil(service.type) && service.type === "csw" &&

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -11,6 +11,7 @@ import ReactDOM from 'react-dom';
 import expect from 'expect';
 import RasterAdvancedSettings from "../RasterAdvancedSettings";
 import TestUtils from "react-dom/test-utils";
+import { waitFor } from '@testing-library/react';
 
 describe('Test Raster advanced settings', () => {
     beforeEach((done) => {
@@ -32,7 +33,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
-        expect(fields.length).toBe(9);
+        expect(fields.length).toBe(10);
     });
     it('test csw advanced options', () => {
         ReactDOM.render(<RasterAdvancedSettings service={{type: "csw", autoload: false}}/>, document.getElementById("container"));
@@ -53,7 +54,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
         const autload = document.querySelectorAll('input[type="checkbox"]')[0];
-        expect(autload).toExist();
+        expect(autload).toBeTruthy();
         TestUtils.Simulate.change(autload, { "target": { "checked": true }});
         expect(spyOn).toHaveBeenCalled();
     });
@@ -67,7 +68,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
         const hideThumbnail = document.querySelectorAll('input[type="checkbox"]')[0];
-        expect(hideThumbnail).toExist();
+        expect(hideThumbnail).toBeTruthy();
         TestUtils.Simulate.change(hideThumbnail, { "target": { "checked": true }});
         expect(spyOn).toHaveBeenCalled();
     });
@@ -81,7 +82,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
         const localizedLayerStyles = document.querySelectorAll('input[type="checkbox"]')[1];
-        expect(localizedLayerStyles).toExist();
+        expect(localizedLayerStyles).toBeTruthy();
         TestUtils.Simulate.change(localizedLayerStyles, { "target": { "checked": true }});
         expect(spyOn).toHaveBeenCalled();
     });
@@ -100,7 +101,7 @@ describe('Test Raster advanced settings', () => {
         const autoSetVisibilityLimits = document.querySelectorAll('input[type="checkbox"]')[1];
         const formGroup = document.querySelectorAll('.form-group')[2];
         expect(formGroup.textContent.trim()).toBe('catalog.autoSetVisibilityLimits.label');
-        expect(autoSetVisibilityLimits).toExist();
+        expect(autoSetVisibilityLimits).toBeTruthy();
         expect(spyOn).toHaveBeenCalled();
         expect(spyOn.calls[0].arguments).toEqual([ 'autoSetVisibilityLimits', true ]);
     });
@@ -118,18 +119,19 @@ describe('Test Raster advanced settings', () => {
         const autoSetVisibilityLimits = document.querySelectorAll('input[type="checkbox"]')[1];
         const formGroup = document.querySelectorAll('.form-group')[2];
         expect(formGroup.textContent.trim()).toBe('catalog.autoSetVisibilityLimits.label');
-        expect(autoSetVisibilityLimits).toExist();
+        expect(autoSetVisibilityLimits).toBeTruthy();
         TestUtils.Simulate.change(autoSetVisibilityLimits, { "target": { "checked": true }});
         expect(spyOn).toHaveBeenCalled();
         expect(spyOn.calls[0].arguments).toEqual([ 'autoSetVisibilityLimits', true ]);
     });
-    it('test component when showTemplate true', () => {
+    it('test component when showTemplate true', (done) => {
         ReactDOM.render(<RasterAdvancedSettings
             service={{type: "csw", showTemplate: true}}/>, document.getElementById("container"));
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
-        const metadataTemplate = document.querySelector('.ql-editor');
-        expect(metadataTemplate).toExist();
+        waitFor(() => expect(document.querySelector('.ql-editor')).toBeTruthy())
+            .then(() => done())
+            .catch(done);
     });
     it('test component onToggleTemplate showTemplate', () => {
         const action = {
@@ -142,7 +144,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
         const showTemplate = document.querySelectorAll('input[type="checkbox"]')[2];
-        expect(showTemplate).toExist();
+        expect(showTemplate).toBeTruthy();
         TestUtils.Simulate.change(showTemplate, { "target": { "checked": true }});
         expect(spyOnToggleTemplate).toHaveBeenCalled();
     });
@@ -157,7 +159,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
         const format = document.querySelectorAll('input[role="combobox"]')[0];
-        expect(format).toExist();
+        expect(format).toBeTruthy();
         TestUtils.Simulate.change(format, { target: { value: 'image/png' } });
         TestUtils.Simulate.keyDown(format, { keyCode: 9, key: 'Tab' });
         expect(spyOn).toHaveBeenCalled();
@@ -174,7 +176,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
         const layerOption = document.querySelectorAll('input[role="combobox"]')[1];
-        expect(layerOption).toExist();
+        expect(layerOption).toBeTruthy();
         TestUtils.Simulate.change(layerOption, { target: { value: "512" }});
         TestUtils.Simulate.keyDown(layerOption, { keyCode: 9, key: 'Tab' });
         expect(spyOn).toHaveBeenCalled();
@@ -190,10 +192,10 @@ describe('Test Raster advanced settings', () => {
         />, document.getElementById("container"));
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
-        const allowUnsecureLayers = document.querySelectorAll('input[type="checkbox"]')[2];
-        const formGroup = document.querySelectorAll('.form-group')[3];
+        const allowUnsecureLayers = document.querySelectorAll('input[type="checkbox"]')[3];
+        const formGroup = document.querySelectorAll('.form-group')[4];
         expect(formGroup.textContent.trim()).toBe('catalog.allowUnsecureLayers.label');
-        expect(allowUnsecureLayers).toExist();
+        expect(allowUnsecureLayers).toBeTruthy();
         TestUtils.Simulate.change(allowUnsecureLayers, { "target": { "checked": true }});
         expect(spyOn).toHaveBeenCalled();
         expect(spyOn.calls[0].arguments).toEqual([ 'allowUnsecureLayers', true ]);
@@ -202,5 +204,24 @@ describe('Test Raster advanced settings', () => {
         TestUtils.Simulate.change(allowUnsecureLayers, { "target": { "checked": false }});
         expect(spyOn).toHaveBeenCalled();
         expect(spyOn.calls[1].arguments).toEqual([ 'allowUnsecureLayers', false ]);
+    });
+    it('test component onChangeServiceProperty singleTile', () => {
+        const action = {
+            onChangeServiceProperty: () => {}
+        };
+        const spyOn = expect.spyOn(action, 'onChangeServiceProperty');
+        ReactDOM.render(<RasterAdvancedSettings
+            onChangeServiceProperty={action.onChangeServiceProperty}
+            service={{ type: "wms" }}
+        />, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const formGroup = document.querySelectorAll('.form-group')[3];
+        expect(formGroup.textContent.trim()).toBe('catalog.singleTile.label');
+        const singleTileLayer = formGroup.querySelector('input[type="checkbox"]');
+        expect(singleTileLayer).toBeTruthy();
+        TestUtils.Simulate.change(singleTileLayer, { "target": { "checked": true }});
+        expect(spyOn).toHaveBeenCalled();
+        expect(spyOn.calls[0].arguments).toEqual([ 'layerOptions', { singleTile: true } ]);
     });
 });

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1539,6 +1539,10 @@
                 "label": "Sichtbarkeitsgrenze festlegen",
                 "tooltip": "Wendet automatisch die vom Server vorgeschlagenen Sichtbarkeitsgrenzen an"
             },
+            "singleTile": {
+                "label": "Single Tile",
+                "tooltip": "Die Ebene wird als einzelnes Kachelbild gerendert, wenn sie mit aktivierter Option zur Karte hinzugefügt wird."
+            },
           "domainAliases": {
             "title": "Domain-Aliasse",
             "helpTooltip": "Diese Option wird verwendet, um Inhalte auf mehrere Subdomains aufzuteilen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1501,6 +1501,10 @@
                 "label": "Set Visibility Limit",
                 "tooltip": "Automatically applies the visibility limits suggested by the server"
            },
+           "singleTile": {
+                "label": "Single Tile",
+                "tooltip": "The layer is rendered as a single tile image when added to the map with this option enabled"
+            },
            "allowUnsecureLayers": {
                 "label": "Allow not secure layers",
                 "tooltip": "Adding layer to map with this option enabled, forces the application to apply proxy"

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1501,6 +1501,10 @@
                 "label": "Establecer límite de visibilidad",
                 "tooltip": "Aplica automáticamente los límites de visibilidad sugeridos por el servidor"
             },
+            "singleTile": {
+                "label": "Single Tile",
+                "tooltip": "La capa se representa como una sola imagen de mosaico cuando se agrega al mapa con esta opción habilitada"
+            },
             "domainAliases": {
               "title": "Alias de dominio",
               "helpTooltip": "Esta opción se utiliza para dividir el contenido en varios subdominios",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1502,6 +1502,10 @@
                 "label": "Définir la limite de visibilité",
                 "tooltip": "Applique automatiquement les limites de visibilité suggérées par le serveur"
             },
+            "singleTile": {
+                "label": "Single Tile",
+                "tooltip": "La couche est rendue sous la forme d'une seule image de tuile lorsqu'elle est ajoutée à la carte avec cette option activée"
+            },
             "domainAliases": {
               "title": "Alias de domaine",
               "helpTooltip": "Cette option est utilisée pour diviser le contenu sur plusieurs sous-domaines",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1504,7 +1504,7 @@
             },
             "singleTile": {
                 "label": "Single Tile",
-                "tooltip": "La couche est rendue sous la forme d'une seule image de tuile lorsqu'elle est ajoutée à la carte avec cette option activée"
+                "tooltip": "Lorsque cette option est activée, la couche ajoutée à la carte est rendue sous la forme d'une seule image"
             },
             "domainAliases": {
               "title": "Alias de domaine",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1501,6 +1501,10 @@
                 "label": "Imposta limite di visibilità",
                 "tooltip": "Applica automaticamente i limiti di visibilità suggeriti dal server"
             },
+            "singleTile": {
+                "label": "Single Tile",
+                "tooltip": "Il layer viene renderizzato come immagine a singola tile quando aggiunto alla mappa con questa opzione abilitata"
+            },
             "domainAliases": {
               "title": "Alias di dominio",
               "helpTooltip": "Questa opzione viene utilizzata per suddividere il contenuto in più sottodomini",


### PR DESCRIPTION
This Backport include also ccfaafc7297c40b9e0054ca409e8ddaef60933cc from https://github.com/geosolutions-it/MapStore2/pull/9041

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces the single tile options for wms catalogs.
This new option is visible under the advanced settings of the catalog editor.

![image](https://user-images.githubusercontent.com/19175505/225363344-ccdf230e-c1a2-44a9-adf6-b8daf1a6d7a6.png)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8905

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The wms catalog advanced settings allows to select the single tile options to apply it to all the added layers

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
