### PR TITLE
[Backport 2023.01.xx] #9006 wms legend from mapserver not available in 3d mode because of wrong empty scale parameter (#9024)

### DIFF
--- a/web/client/components/TOC/fragments/legend/Legend.jsx
+++ b/web/client/components/TOC/fragments/legend/Legend.jsx
@@ -51,6 +51,14 @@ class Legend extends React.Component {
     onImgError = () => {
         this.setState(() => ({error: true}));
     }
+    getScale = (props) => {
+        if (props.scales && props.currentZoomLvl !== undefined && props.scaleDependent) {
+            const zoom = Math.round(props.currentZoomLvl);
+            const scale = props.scales[zoom] ?? props.scales[props.scales.length - 1];
+            return Math.round(scale);
+        }
+        return null;
+    };
     getUrl = (props, urlIdx) => {
         if (props.layer && props.layer.type === "wms" && props.layer.url) {
             const layer = props.layer;
@@ -63,6 +71,7 @@ class Legend extends React.Component {
             let urlObj = urlUtil.parse(url);
 
             const cleanParams = clearNilValuesForParams(layer.params);
+            const scale = this.getScale(props);
             let query = assign({}, {
                 service: "WMS",
                 request: "GetLegendGraphic",
@@ -78,7 +87,7 @@ class Legend extends React.Component {
             props.language && layer.localizedLayerStyles ? {LANGUAGE: props.language} : {},
             addAuthenticationToSLD(cleanParams || {}, props.layer),
             cleanParams && cleanParams.SLD_BODY ? {SLD_BODY: cleanParams.SLD_BODY} : {},
-            props.scales && props.currentZoomLvl && props.scaleDependent ? {SCALE: Math.round(props.scales[props.currentZoomLvl])} : {});
+            scale !== null ? { SCALE: scale } : {});
             addAuthenticationParameter(url, query);
 
             return urlUtil.format({

--- a/web/client/components/TOC/fragments/legend/__tests__/Legend-test.jsx
+++ b/web/client/components/TOC/fragments/legend/__tests__/Legend-test.jsx
@@ -10,10 +10,11 @@ import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Rx from 'rxjs';
+import url from 'url';
 
 import Legend from '../Legend';
 
-const TestUtils = require('react-dom/test-utils');
+import * as TestUtils from 'react-dom/test-utils';
 
 describe("test the Layer legend", () => {
     beforeEach((done) => {
@@ -165,5 +166,47 @@ describe("test the Layer legend", () => {
         expect(legendComponent.props.legendWidth).toBe(20);
         expect(legendComponent.props.legendHeight).toBe(30);
         expect(legendComponent.props.scaleDependent).toBe(scaleDependentCustom);
+    });
+    it('should apply the scale correctly even for zoom with decimal values', () => {
+        const layer = {
+            "type": "wms",
+            "url": "http://test2/reflector/open/service",
+            "visibility": true,
+            "title": "test layer 3 (no group)",
+            "name": "layer3",
+            "format": "image/png"
+        };
+        ReactDOM.render(
+            <Legend
+                layer={layer}
+                currentZoomLvl={2.3456}
+                scales={[10000, 5000, 2000, 1000]}
+            />,
+            document.getElementById("container"));
+        const legendImage = document.querySelector("img");
+        expect(legendImage).toBeTruthy();
+        const { query } = url.parse(legendImage.getAttribute('src'), true);
+        expect(query.SCALE).toBe('2000');
+    });
+    it('should apply the scale correctly even for zoom exceed the maximum scales index', () => {
+        const layer = {
+            "type": "wms",
+            "url": "http://test2/reflector/open/service",
+            "visibility": true,
+            "title": "test layer 3 (no group)",
+            "name": "layer3",
+            "format": "image/png"
+        };
+        ReactDOM.render(
+            <Legend
+                layer={layer}
+                currentZoomLvl={10}
+                scales={[10000, 5000, 2000, 1000]}
+            />,
+            document.getElementById("container"));
+        const legendImage = document.querySelector("img");
+        expect(legendImage).toBeTruthy();
+        const { query } = url.parse(legendImage.getAttribute('src'), true);
+        expect(query.SCALE).toBe('1000');
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR improves the selection of scales for the legend graphic request.
Previously it was not possible to select the correct scale when the zoom level had decimal values (3D viewer), the commit in the PR ensure to round the zoom level value before using it as index to get the correct scale value.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9006

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The scale parameter for legend graphic request is correctly selected based on the current zoom level even in the 3D viewer

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
