### PR TITLE
#9031 Ensure WMS layer format is still visible after saving a map

### DIFF
--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -115,6 +115,7 @@ export default class extends React.Component {
         return null;
     };
     render() {
+        const formatValue = this.props.element && this.props.element.format || "image/png";
         return (
             <Grid
                 fluid
@@ -138,7 +139,13 @@ export default class extends React.Component {
                                         ? []
                                         : (this.props.element?.imageFormats || this.props.formats || []).map((format) => format?.value ? format : ({ value: format, label: format }))
                                     }
-                                    value={this.props.element && this.props.element.format || "image/png"}
+                                    value={{ value: formatValue, label: formatValue }}
+                                    onOpen={() => {
+                                        if (!this.props.element?.imageFormats
+                                        || this.props.element?.imageFormats?.length === 0) {
+                                            this.onFormatOptionsFetch(this.props.element?.url);
+                                        }
+                                    }}
                                     onChange={({ value }) => {
                                         this.props.onChange("format", value);
                                     }}/>

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -114,6 +114,43 @@ describe('test Layer Properties Display module component', () => {
         ReactTestUtils.Simulate.click(formatRefresh[0]);
     });
 
+    it('tests Display component for wms with format fetch on select open if the imageFormats options is empty', (done) => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'some url'
+        };
+        const settings = {
+            options: {opacity: 0.7}
+        };
+        mockAxios.onGet().reply(() => {
+            return [200, GET_CAP_RESPONSE];
+        });
+        const handlers = {
+            onChange: (prop, value) =>{
+                try {
+                    expect(prop).toBe("imageFormats");
+                    expect(value).toBeTruthy();
+                    expect(value[0]).toEqual("image/png");
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }
+        };
+
+        ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        const selectFormat = document.querySelector('.format-select .Select-input > input');
+        expect(selectFormat).toBeTruthy();
+        ReactTestUtils.act(() => {
+            ReactTestUtils.Simulate.focus(selectFormat);
+            ReactTestUtils.Simulate.keyDown(selectFormat, { key: 'ArrowDown', keyCode: 40 });
+        });
+    });
+
     it('tests Display component for wms with localized layer styles enabled', () => {
         const l = {
             name: 'layer00',


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR improve the behavior of the select format input to:

- make the value always visible
- request list of available format if the imageFormats property of the WMS layer is missing or empty

Ref https://github.com/geosolutions-it/MapStore2/pull/9054#issuecomment-1488659991

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9031
#8906

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The WMS format value is visible in the layer settings after saving a map

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
