### PR TITLE
Fix #9075. Handle cases when domain isnot in format start--end

### DIFF
--- a/web/client/epics/__tests__/timeline-test.js
+++ b/web/client/epics/__tests__/timeline-test.js
@@ -617,6 +617,169 @@ describe('timeline Epics', () => {
                 }
             });
         });
+        it("setRangeOnInit on domain returned as list", (done) => {
+            testEpic(setRangeOnInit, 3, initializeRange(), ([action1, action2, action3]) => {
+                const { time, type } = action1;
+                const { offsetTime, type: typeOff} = action2;
+                const { type: typeRange } = action3;
+                expect(time).toEqual("2000-01-01T00:00:00.000Z");
+                expect(offsetTime).toBeTruthy();
+                expect(type).toBe(SET_CURRENT_TIME);
+                expect(typeOff).toBe(SET_OFFSET_TIME);
+                expect(typeRange).toBe(RANGE_CHANGED);
+                done();
+            }, {
+                timeline: {
+                    selectedLayer: "TEST_LAYER",
+                    settings: {
+                        initialMode: 'range',
+                        initialSnap: 'fullRange'
+                    }
+                },
+                dimension: {
+                    currentTime: "2000-01-01T00:00:00.000Z",
+                    offsetTime: "2001-12-31T00:00:00.000Z",
+                    data: {
+                        time: {
+                            TEST_LAYER: {
+                                name: "time",
+                                domain: "2000-01-01T00:00:00.000Z,2001-12-31T00:00:00.000Z"
+                            }
+                        }
+                    }
+                },
+                layers: {
+                    flat: [{
+                        id: 'TEST_LAYER',
+                        name: 'TEST_LAYER',
+                        type: 'wms',
+                        visibility: true,
+                        url: 'base/web/client/test-resources/wmts/DomainValues.xml',
+                        dimensions: [
+                            {
+                                source: {
+                                    type: 'multidim-extension',
+                                    url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                                },
+                                name: 'time'
+                            }
+                        ],
+                        params: {
+                            time: '2000-06-08T00:00:00.000Z'
+                        }
+                    }]
+                }
+            });
+        });
+        it("setRangeOnInit on domain returned as single time", (done) => {
+            testEpic(setRangeOnInit, 3, initializeRange(), ([action1, action2, action3]) => {
+                const { time, type } = action1;
+                const { offsetTime, type: typeOff} = action2;
+                const { type: typeRange } = action3;
+                expect(time).toBeTruthy();
+                expect(offsetTime).toBeTruthy();
+                expect(time).toBe("2000-01-01T00:00:00.000Z");
+                expect(type).toBe(SET_CURRENT_TIME);
+                expect(typeOff).toBe(SET_OFFSET_TIME);
+                expect(typeRange).toBe(RANGE_CHANGED);
+                done();
+            }, {
+                timeline: {
+                    selectedLayer: "TEST_LAYER",
+                    settings: {
+                        initialMode: 'range',
+                        initialSnap: 'fullRange'
+                    }
+                },
+                dimension: {
+                    currentTime: "2000-01-01T00:00:00.000Z",
+                    offsetTime: "2001-12-31T00:00:00.000Z",
+                    data: {
+                        time: {
+                            TEST_LAYER: {
+                                name: "time",
+                                domain: "2000-01-01T00:00:00.000Z"
+                            }
+                        }
+                    }
+                },
+                layers: {
+                    flat: [{
+                        id: 'TEST_LAYER',
+                        name: 'TEST_LAYER',
+                        type: 'wms',
+                        visibility: true,
+                        url: 'base/web/client/test-resources/wmts/DomainValues.xml',
+                        dimensions: [
+                            {
+                                source: {
+                                    type: 'multidim-extension',
+                                    url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                                },
+                                name: 'time'
+                            }
+                        ],
+                        params: {
+                            time: '2000-06-08T00:00:00.000Z'
+                        }
+                    }]
+                }
+            });
+        });
+        it("setRangeOnInit on domain returned empty", (done) => {
+            testEpic(setRangeOnInit, 3, initializeRange(), ([action1, action2, action3]) => {
+                const { time, type } = action1;
+                const { offsetTime, type: typeOff} = action2;
+                const { type: typeRange } = action3;
+                expect(time).toBeTruthy();
+                expect(offsetTime).toBeTruthy();
+                expect(type).toBe(SET_CURRENT_TIME);
+                expect(typeOff).toBe(SET_OFFSET_TIME);
+                expect(typeRange).toBe(RANGE_CHANGED);
+                done();
+            }, {
+                timeline: {
+                    selectedLayer: "TEST_LAYER",
+                    settings: {
+                        initialMode: 'range',
+                        initialSnap: 'fullRange'
+                    }
+                },
+                dimension: {
+                    currentTime: "2000-01-01T00:00:00.000Z",
+                    offsetTime: "2001-12-31T00:00:00.000Z",
+                    data: {
+                        time: {
+                            TEST_LAYER: {
+                                name: "time",
+                                domain: ""
+                            }
+                        }
+                    }
+                },
+                layers: {
+                    flat: [{
+                        id: 'TEST_LAYER',
+                        name: 'TEST_LAYER',
+                        type: 'wms',
+                        visibility: true,
+                        url: 'base/web/client/test-resources/wmts/DomainValues.xml',
+                        dimensions: [
+                            {
+                                source: {
+                                    type: 'multidim-extension',
+                                    url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                                },
+                                name: 'time'
+                            }
+                        ],
+                        params: {
+                            time: '2000-06-08T00:00:00.000Z'
+                        }
+                    }]
+                }
+            });
+        });
     });
     it("updateTimelineDataOnMapLoad", (done) =>{
         const config = {

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -203,7 +203,7 @@ const loadRangeData = (id, timeData, getState) => {
  * Update timeline with current, offset and the range data
  * on range initialization
  * @param state application state
- * @param {string|string[]} values the range values. It can be an array or a domain string. (`start--end`, `start,x1,x2,x3,end` or `start,end`)
+ * @param {string|string[]} value the range values. It can be an array or a domain string. (`start--end`, `start,x1,x2,x3,end` or `start,end`)
  * @param {string} [currentTime]
  * @returns {Observable}
  */


### PR DESCRIPTION
## Description
This PR fixes #9075 handling the cases when DescribeDomain does not return "start--end" format. 

- No data: empty string (range is set as for saved data)
- 1 value only: only current time is set, range is set to default interval
- list of values, getting start and end value to set the range. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9075
**What is the new behavior?**

Timeline do not crash. Current value is not null.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
