### PR TITLE
#9020 Change style for 3D tiles or WFS layer on geostory and dashboard

### DIFF
--- a/web/client/components/widgets/builder/wizard/map/enhancers/__tests__/nodeEditor-test.jsx
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/__tests__/nodeEditor-test.jsx
@@ -70,5 +70,25 @@ describe('nodeEditor enhancer', () => {
             map={{ groups: [{ id: 'GROUP' }], layers: [{ id: "LAYER", group: "GROUP", options: {} }] }} />, document.getElementById("container"));
         expect(spyonChange).toHaveBeenCalledWith("map.layers[0].something", "newValue");
     });
+    it('should return only the visible tabs based on node type', () => {
 
+        const defaultMap = { groups: [{ id: 'GROUP' }], layers: [{ id: "LAYER:WMS", type: 'wms', group: "GROUP", options: {} }, { id: "LAYER", group: "GROUP", options: {} }] };
+
+        const TestComponent = nodeEditor(({ tabs }) => {
+            return (<ul>{tabs.map(({ id }) => <li key={id}>{id}</li>)}</ul>);
+        });
+
+        ReactDOM.render(<TestComponent editNode={"GROUP"}  map={defaultMap}/>, document.getElementById("container"));
+
+        expect([...document.querySelectorAll('li')].map(node => node.innerHTML)).toEqual(['general']);
+
+        ReactDOM.render(<TestComponent editNode={"LAYER"}  map={defaultMap}/>, document.getElementById("container"));
+
+        expect([...document.querySelectorAll('li')].map(node => node.innerHTML)).toEqual(['general', 'display']);
+
+        ReactDOM.render(<TestComponent editNode={"LAYER:WMS"}  map={defaultMap}/>, document.getElementById("container"));
+
+        expect([...document.querySelectorAll('li')].map(node => node.innerHTML)).toEqual(['general', 'display', 'style']);
+
+    });
 });

--- a/web/client/components/widgets/builder/wizard/map/enhancers/nodeEditor.js
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/nodeEditor.js
@@ -24,7 +24,7 @@ import withSelectedNode from './withSelectedNode';
 const WMSStyle = withCapabilitiesRetrieval(WMSStyleComp);
 
 const withDefaultTabs = withProps((props) => ({
-    tabs: props.tabs || [{
+    tabs: (props.tabs || [{
         id: 'general',
         titleId: 'layerProperties.general',
         tooltipId: 'layerProperties.general',
@@ -47,7 +47,7 @@ const withDefaultTabs = withProps((props) => ({
         glyph: 'dropper',
         visible: props.settings && props.settings.nodeType === 'layers' && props.element && props.element.type === "wms",
         Component: WMSStyle
-    }]
+    }]).filter(({ visible }) => !!visible)
 }));
 
 /**


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes the layer settings tabs logic that was not working properly. The visible flag of the tab was not used so all the layers type was showing the WMS style selector

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9020

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The style setting tab of layer inside map widgets will be visible only for WMS layers

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
