### PR TITLE
#8965 Allow map widgets also in 3D mode

### DIFF
--- a/web/client/plugins/widgets/autoDisableWidgets.js
+++ b/web/client/plugins/widgets/autoDisableWidgets.js
@@ -10,18 +10,16 @@ import { createSelector } from 'reselect';
 
 import { connect } from 'react-redux';
 import { rightPanelOpenSelector, bottomPanelOpenSelector } from '../../selectors/maplayout';
-import { isCesium } from '../../selectors/maptype';
 
 /**
- * enhances the component disabling it (setting `enabled` property to `false`) when rightPanel, bottomPanel are open or when the maptype is cesium.
+ * enhances the component disabling it (setting `enabled` property to `false`) when rightPanel or when bottomPanel are open
  */
 const autoDisableWidgets = connect(
     createSelector(
         rightPanelOpenSelector,
         bottomPanelOpenSelector,
-        isCesium,
-        (rightPanel, bottomPanel, cesium) => ({
-            enabled: !rightPanel && !bottomPanel && !cesium
+        (rightPanel, bottomPanel) => ({
+            enabled: !rightPanel && !bottomPanel
         })
     )
 );

--- a/web/client/themes/default/less/cesium.less
+++ b/web/client/themes/default/less/cesium.less
@@ -31,5 +31,8 @@
 }
 
 #map .cesium-viewer .compass {
-    right: 40px;
+    // we downscale the compass
+    // to make it fit in between widgets and sidebar
+    transform: scale(0.75);
+    right: 26px;
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR removes the checks to disable widgets for 3D maps. Parts of this issue was already implemented in #8990 in particular the computation of the bounds used to filter widgets content using the [computeViewRectangle](https://github.com/geosolutions-it/MapStore2/pull/8990/files#diff-9ce82637a196bd31df03f384d6ef4cbeb8c9a255fb4914b5b070615f8ee3bf58R528) method from cesium

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8965

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The Widgets are visible on top of the 3D maps

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
