### PR TITLE
[Backport c040-2022.02.xx]#8783 Map view on Sidebar cover the Burger Menu (#8929)

### DIFF
--- a/web/client/plugins/MapViews.jsx
+++ b/web/client/plugins/MapViews.jsx
@@ -237,11 +237,19 @@ export default createPlugin(pluginName, {
         SidebarMenu: {
             name: 'mapViews',
             position: 2000,
-            tool: ConnectedMapViewsButton
+            tool: ConnectedMapViewsButton,
+            priority: 1
+        },
+        BurgerMenu: {
+            name: 'mapviews',
+            position: 9,
+            tool: () => <ConnectedMapViewsButton menuItem />,
+            priority: 2
         },
         Map: {
             name: pluginName,
-            Tool: MapViewsPlugin
+            Tool: MapViewsPlugin,
+            alwaysRender: true
         }
     }
 });


### PR DESCRIPTION
## Description
  This PR fixes the issue of the view map view button covering the burger menu.

**Please check if the PR fulfils these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#8783

**What is the new behavior?**
The View map button appears under the burger Menu list and is no longer appearing on top of the burger menu icon.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
