### PR TITLE
#9101 - Persist also refresh option in layers configuration when map is saved

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -608,6 +608,7 @@ export const saveLayer = (layer) => {
         tiled: layer.tiled,
         type: layer.type,
         url: layer.url,
+        refresh: layer.refresh,
         bbox: layer.bbox,
         visibility: layer.visibility,
         singleTile: layer.singleTile || false,


### PR DESCRIPTION
## Description

Added the "refresh" property in the "saveLayer" function.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9101

When adding the refresh property to a layer by editing the .json file, when you try to save the new map the property is not saved.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
