### PR TITLE
#9110: Fix - Maps widget dropdown menu is not visible on embedded dashboard

### DIFF
--- a/web/client/product/appConfigDashboardEmbedded.js
+++ b/web/client/product/appConfigDashboardEmbedded.js
@@ -11,6 +11,7 @@ import version from '../reducers/version';
 
 import dashboard from '../reducers/dashboard';
 import widgets from '../reducers/widgets';
+import maptype from '../reducers/maptype';
 
 export default {
     pages: [{
@@ -28,7 +29,8 @@ export default {
     baseReducers: {
         version,
         dashboard,
-        widgets
+        widgets,
+        maptype
     },
     storeOpts: {
         persist: {


### PR DESCRIPTION
## Description
This PR fixes the Maps widget dropdown menu not visible on embedded dashboard. 
Issue was caused by leaflet map which is used by default and a class `leaflet-pane` was setting a `z-index: 400`. 
The issue is fixed by letting dashboard embedded use the default map type configured in localConfig for desktop

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


## Issue

**What is the current behavior?**
#9110 

**What is the new behavior?**
<img width="657" alt="image" src="https://user-images.githubusercontent.com/26929983/233097511-4aecb3a3-230d-403e-85b4-58a92f3d6e32.png">



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
