### PR TITLE
Fix #9120 Layer settings performance improvement

### DIFF
--- a/web/client/components/TOC/enhancers/__tests__/tocitemssettings-test.js
+++ b/web/client/components/TOC/enhancers/__tests__/tocitemssettings-test.js
@@ -24,26 +24,6 @@ describe("test updateSettingsLifecycle", () => {
         setTimeout(done);
     });
 
-    it('test mounted component', () => {
-        const testHandlers = {
-            onUpdateOriginalSettings: () => {},
-            onUpdateInitialSettings: () => {}
-        };
-
-        const spyOnUpdateOriginalSettings = expect.spyOn(testHandlers, 'onUpdateOriginalSettings');
-        const spyOnUpdateInitialSettings = expect.spyOn(testHandlers, 'onUpdateInitialSettings');
-
-        const Component = settingsLifecycle(() => <div></div>);
-        ReactDOM.render(<Component
-            element={{}}
-            onUpdateOriginalSettings={testHandlers.onUpdateOriginalSettings}
-            onUpdateInitialSettings={testHandlers.onUpdateInitialSettings}
-        />, document.getElementById("container"));
-
-        expect(spyOnUpdateOriginalSettings).toHaveBeenCalled();
-        expect(spyOnUpdateInitialSettings).toHaveBeenCalled();
-    });
-
     it('test mounted retrieve data layer', () => {
         const testHandlers = {
             onRetrieveLayerData: () => {}
@@ -115,12 +95,9 @@ describe("test updateSettingsLifecycle", () => {
 
     it('test component update', () => {
         const testHandlers = {
-            onUpdateOriginalSettings: () => {},
             onUpdateInitialSettings: () => {},
             onSetTab: () => {}
         };
-        const spyOnUpdateOriginalSettings = expect.spyOn(testHandlers, 'onUpdateOriginalSettings');
-        const spyOnUpdateInitialSettings = expect.spyOn(testHandlers, 'onUpdateInitialSettings');
         const spyOnSetTab = expect.spyOn(testHandlers, 'onSetTab');
 
         const Component = settingsLifecycle(() => <div></div>);
@@ -128,8 +105,6 @@ describe("test updateSettingsLifecycle", () => {
         ReactDOM.render(<Component
             initialActiveTab="display"
             settings={{expanded: false}}
-            onUpdateOriginalSettings={testHandlers.onUpdateOriginalSettings}
-            onUpdateInitialSettings={testHandlers.onUpdateInitialSettings}
             onSetTab={testHandlers.onSetTab}
         />, document.getElementById("container"));
 
@@ -137,13 +112,9 @@ describe("test updateSettingsLifecycle", () => {
             initialActiveTab="display"
             element={{type: 'wms', description: 'description'}}
             settings={{expanded: true}}
-            onUpdateOriginalSettings={testHandlers.onUpdateOriginalSettings}
-            onUpdateInitialSettings={testHandlers.onUpdateInitialSettings}
             onSetTab={testHandlers.onSetTab}
         />, document.getElementById("container"));
 
-        expect(spyOnUpdateOriginalSettings).toHaveBeenCalled();
-        expect(spyOnUpdateInitialSettings).toHaveBeenCalled();
         expect(spyOnSetTab).toHaveBeenCalled();
         expect(spyOnSetTab).toHaveBeenCalledWith("display");
     });
@@ -157,7 +128,6 @@ describe("test updateSettingsLifecycle", () => {
         const Component = settingsLifecycle(({onClose}) => <div id="test-close" onClick={() => onClose()}></div>);
         ReactDOM.render(<Component
             onUpdateNode={testHandlers.onUpdateNode}
-            originalSettings={{}}
             settings={{node: '0', nodeType: 'layer', options: {}}}
             onHideSettings={testHandlers.onHideSettings}/>, document.getElementById("container"));
 
@@ -176,7 +146,6 @@ describe("test updateSettingsLifecycle", () => {
 
         const Component = settingsLifecycle(({onClose}) => <div id="test-close" onClick={() => onClose()}></div>);
         ReactDOM.render(<Component
-            originalSettings={{}}
             settings={{node: '0', nodeType: 'layer', options: { opacity: 1.0 }}}
             onHideSettings={testHandlers.onHideSettings} />, document.getElementById("container"));
 
@@ -194,7 +163,6 @@ describe("test updateSettingsLifecycle", () => {
 
         const Component = settingsLifecycle(({onClose}) => <div id="test-close" onClick={() => onClose()}></div>);
         ReactDOM.render(<Component
-            originalSettings={{}}
             settings={{node: '0', nodeType: 'layer', options: { style: 'new-style' }}}
             onHideSettings={testHandlers.onHideSettings} />, document.getElementById("container"));
 
@@ -216,7 +184,6 @@ describe("test updateSettingsLifecycle", () => {
 
         const Component = settingsLifecycle(({onClose}) => <div id="test-close" onClick={() => onClose(tabCloseActions)}></div>);
         ReactDOM.render(<Component
-            originalSettings={{}}
             settings={{node: '0', nodeType: 'layer', options: { style: 'new-style' }}}
         />, document.getElementById("container"));
 
@@ -238,7 +205,6 @@ describe("test updateSettingsLifecycle", () => {
 
         const Component = settingsLifecycle(({onClose}) => <div id="test-close" onClick={() => onClose(tabCloseActions)}></div>);
         ReactDOM.render(<Component
-            originalSettings={{}}
             settings={{node: '0', nodeType: 'layer', options: { style: 'new-style' }}}
         />, document.getElementById("container"));
 
@@ -260,7 +226,6 @@ describe("test updateSettingsLifecycle", () => {
 
         const Component = settingsLifecycle(({onClose}) => <div id="test-close" onClick={() => onClose(tabCloseActions)}></div>);
         ReactDOM.render(<Component
-            originalSettings={{}}
             settings={{node: '0', nodeType: 'layer', options: { style: 'new-style' }}}
         />, document.getElementById("container"));
 

--- a/web/client/components/TOC/enhancers/tocItemsSettings.js
+++ b/web/client/components/TOC/enhancers/tocItemsSettings.js
@@ -34,7 +34,7 @@ export const settingsState = compose(
  */
 export const settingsLifecycle = compose(
     withHandlers({
-        onClose: ({ onUpdateInitialSettings = () => {}, onHideSettings = () => {}, onUpdateOriginalSettings = () => {} }) => (tabsCloseActions = []) => {
+        onClose: ({ onHideSettings = () => {}}) => (tabsCloseActions = []) => {
             if (isArray(tabsCloseActions)) {
                 tabsCloseActions.forEach(tabOnClose => {
                     if (isFunction(tabOnClose)) {
@@ -42,25 +42,12 @@ export const settingsLifecycle = compose(
                     }
                 });
             }
-            onUpdateOriginalSettings({});
             onHideSettings();
             // clean up internal settings state
-            onUpdateInitialSettings({});
+
         }
     }),
     lifecycle({
-        UNSAFE_componentWillMount() {
-            const {
-                element = {},
-                onUpdateOriginalSettings = () => { },
-                onUpdateInitialSettings = () => { }
-            } = this.props;
-
-            // store changed keys
-            onUpdateOriginalSettings({ });
-            // store initial settings (internal state)
-            onUpdateInitialSettings({ ...element });
-        },
         componentWillReceiveProps(newProps) {
             // an empty description does not trigger the single layer getCapabilites,
             // it does only for missing description
@@ -77,15 +64,11 @@ export const settingsLifecycle = compose(
             const {
                 initialActiveTab = 'general',
                 settings = {},
-                onUpdateOriginalSettings = () => { },
-                onUpdateInitialSettings = () => { },
+
                 onSetTab = () => { }
             } = this.props;
 
             if (!settings.expanded && newProps.settings && newProps.settings.expanded) {
-                // update initial and original settings
-                onUpdateOriginalSettings({ });
-                onUpdateInitialSettings({ ...newProps.element });
                 onSetTab(initialActiveTab);
             }
         }

--- a/web/client/containers/Embedded.jsx
+++ b/web/client/containers/Embedded.jsx
@@ -7,7 +7,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import assign from 'object-assign';
 import ModulePluginsContainer from "../product/pages/containers/ModulePluginsContainer";
 import { connect } from 'react-redux';
 
@@ -18,9 +17,7 @@ import ConfigUtils from '../utils/ConfigUtils';
 
 const PluginsContainer = connect((state) => ({
     mode: urlQuery.mode || (state.browser && state.browser.mobile ? 'mobile' : 'desktop'),
-    pluginsState: assign({}, state && state.controls, state && state.layers && state.layers.settings && {
-        layerSettings: state.layers.settings
-    }),
+    pluginsState: state && state.controls,
     monitoredState: getMonitoredState(state, ConfigUtils.getConfigProp('monitorState'))
 }))(ModulePluginsContainer);
 

--- a/web/client/containers/MapViewer.jsx
+++ b/web/client/containers/MapViewer.jsx
@@ -24,15 +24,11 @@ const PluginsContainer = connect(
         state => state.mode,
         state => state?.browser?.mobile,
         state => state.controls,
-        state => state?.layers?.settings,
         state => getMonitoredState(state, ConfigUtils.getConfigProp('monitorState')),
-        (statePluginsConfig, stateMode, mobile, controls, layerSettings, monitoredState) => ({
+        (statePluginsConfig, stateMode, mobile, controls, monitoredState) => ({
             statePluginsConfig,
             mode: urlQuery.mode || stateMode || (mobile ? 'mobile' : 'desktop'),
-            pluginsState: {
-                ...controls,
-                ...(layerSettings && { layerSettings })
-            },
+            pluginsState: controls,
             monitoredState
         })
     )

--- a/web/client/epics/__tests__/layers-test.js
+++ b/web/client/epics/__tests__/layers-test.js
@@ -23,7 +23,6 @@ import {
     layerLoad
 } from '../../actions/layers';
 
-import { SET_CONTROL_PROPERTY } from '../../actions/controls';
 import { SHOW_NOTIFICATION } from '../../actions/notifications';
 import { testEpic } from './epicTestUtils';
 import { refresh, updateDimension, updateSettingsParamsEpic } from '../layers';
@@ -144,9 +143,6 @@ describe('layers Epics', () => {
                         id: 'layerid',
                         name: 'layerName',
                         style: ''
-                    },
-                    originalSettings: {
-
                     }
                 }
             }
@@ -154,17 +150,12 @@ describe('layers Epics', () => {
 
         testEpic(
             updateSettingsParamsEpic,
-            2,
+            1,
             updateSettingsParams({style: 'generic'}),
             actions => {
-                expect(actions.length).toBe(2);
+                expect(actions.length).toBe(1);
                 actions.map((action) => {
                     switch (action.type) {
-                    case SET_CONTROL_PROPERTY:
-                        expect(action.control).toBe('layersettings');
-                        expect(action.property).toBe('originalSettings');
-                        expect(action.value).toEqual({ style: '' });
-                        break;
                     case UPDATE_SETTINGS:
                         expect(action.options).toEqual({style: 'generic'});
                         break;
@@ -185,9 +176,6 @@ describe('layers Epics', () => {
                         id: 'layerId',
                         name: 'layerName',
                         style: ''
-                    },
-                    originalSettings: {
-
                     }
                 }
             },
@@ -203,17 +191,12 @@ describe('layers Epics', () => {
 
         testEpic(
             updateSettingsParamsEpic,
-            3,
+            2,
             updateSettingsParams({style: 'generic'}, true),
             actions => {
-                expect(actions.length).toBe(3);
+                expect(actions.length).toBe(2);
                 actions.map((action) => {
                     switch (action.type) {
-                    case SET_CONTROL_PROPERTY:
-                        expect(action.control).toBe('layersettings');
-                        expect(action.property).toBe('originalSettings');
-                        expect(action.value).toEqual({ style: '' });
-                        break;
                     case UPDATE_SETTINGS:
                         expect(action.options).toEqual({style: 'generic'});
                         break;
@@ -238,9 +221,47 @@ describe('layers Epics', () => {
                         id: 'layerId',
                         name: 'layerName',
                         style: ''
-                    },
-                    originalSettings: {
+                    }
+                }
+            },
+            layers: {
+                settings: {
+                    expanded: true,
+                    node: 'layerId',
+                    nodeType: 'layers',
+                    options: { opacity: 1 }
+                },
+                flat: [{
+                    id: 'layerId',
+                    name: 'layerName',
+                    opacity: 1
+                }]
+            }
+        };
 
+        testEpic(
+            updateSettingsParamsEpic,
+            2,
+            [updateSettingsParams({name: 'layerName_changed'}, true), layerLoad('layerId')],
+            actions => {
+                expect(actions.length).toBe(2);
+                expect(actions[0].type).toBe(UPDATE_SETTINGS);
+                expect(actions[0].options).toEqual({name: 'layerName_changed'});
+                expect(actions[1].type).toBe(UPDATE_NODE);
+                expect(actions[1].node).toEqual('layerId');
+                expect(actions[1].nodeType).toEqual('layers');
+                expect(actions[1].options).toEqual({opacity: 1, name: 'layerName_changed'});
+            }, state, done);
+    });
+
+    it('test updateSettingsParamsEpic with layer name with layer load error', done => {
+        const state = {
+            controls: {
+                layersettings: {
+                    initialSettings: {
+                        id: 'layerId',
+                        name: 'layerName',
+                        style: ''
                     }
                 }
             },
@@ -262,69 +283,18 @@ describe('layers Epics', () => {
         testEpic(
             updateSettingsParamsEpic,
             3,
-            [updateSettingsParams({name: 'layerName_changed'}, true), layerLoad('layerId')],
+            [updateSettingsParams({name: 'layerName_changed'}, true), layerLoad('layerId', true)],
             actions => {
                 expect(actions.length).toBe(3);
                 expect(actions[0].type).toBe(UPDATE_SETTINGS);
                 expect(actions[0].options).toEqual({name: 'layerName_changed'});
-                expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[1].control).toBe('layersettings');
-                expect(actions[1].property).toBe('originalSettings');
-                expect(actions[1].value).toEqual({name: 'layerName'});
-                expect(actions[2].type).toBe(UPDATE_NODE);
-                expect(actions[2].node).toEqual('layerId');
-                expect(actions[2].nodeType).toEqual('layers');
-                expect(actions[2].options).toEqual({opacity: 1, name: 'layerName_changed'});
-            }, state, done);
-    });
 
-    it('test updateSettingsParamsEpic with layer name with layer load error', done => {
-        const state = {
-            controls: {
-                layersettings: {
-                    initialSettings: {
-                        id: 'layerId',
-                        name: 'layerName',
-                        style: ''
-                    },
-                    originalSettings: {
-
-                    }
-                }
-            },
-            layers: {
-                settings: {
-                    expanded: true,
-                    node: 'layerId',
-                    nodeType: 'layers',
-                    options: { opacity: 1 }
-                },
-                flat: [{
-                    id: 'layerId',
-                    name: 'layerName',
-                    opacity: 1
-                }]
-            }
-        };
-
-        testEpic(
-            updateSettingsParamsEpic,
-            4,
-            [updateSettingsParams({name: 'layerName_changed'}, true), layerLoad('layerId', true)],
-            actions => {
-                expect(actions.length).toBe(4);
-                expect(actions[0].type).toBe(UPDATE_SETTINGS);
-                expect(actions[0].options).toEqual({name: 'layerName_changed'});
-                expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[1].control).toBe('layersettings');
-                expect(actions[1].property).toBe('originalSettings');
-                expect(actions[1].value).toEqual({name: 'layerName'});
-                expect(actions[2].type).toBe(UPDATE_NODE);
-                expect(actions[2].node).toEqual('layerId');
-                expect(actions[2].nodeType).toEqual('layers');
-                expect(actions[2].options).toEqual({opacity: 1, name: 'layerName_changed'});
-                expect(actions[3].type).toBe(SHOW_NOTIFICATION);
-                expect(actions[3].level).toBe('error');
+                expect(actions[1].type).toBe(UPDATE_NODE);
+                expect(actions[1].node).toEqual('layerId');
+                expect(actions[1].nodeType).toEqual('layers');
+                expect(actions[1].options).toEqual({opacity: 1, name: 'layerName_changed'});
+                expect(actions[2].type).toBe(SHOW_NOTIFICATION);
+                expect(actions[2].level).toBe('error');
             }, state, done);
     });
 });

--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -7,15 +7,12 @@
  */
 
 import expect from 'expect';
+import {find} from 'lodash';
 
 import {
     UPDATE_NODE,
     UPDATE_SETTINGS_PARAMS
 } from '../../actions/layers';
-
-import {
-    SET_CONTROL_PROPERTY
-} from '../../actions/controls';
 
 import {
     SHOW_NOTIFICATION
@@ -695,17 +692,13 @@ describe('Test styleeditor epics', () => {
                 code: '* { stroke: #ff0000; }'
             }
         };
-        const NUMBER_OF_ACTIONS = 6;
+        const NUMBER_OF_ACTIONS = 4;
         const results = (actions) => {
             expect(actions.length).toBe(NUMBER_OF_ACTIONS);
             try {
                 expect(actions[1].type).toBe(UPDATE_SETTINGS_PARAMS);
-                expect(actions[2].type).toBe(LOADED_STYLE);
-                expect(actions[3].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[4].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[5].type).toBe(SHOW_NOTIFICATION);
-
-                expect(actions[5].level).toBe('success');
+                expect(find(actions, {type: SHOW_NOTIFICATION}).level).toBe('success');
+                expect(find(actions, {type: LOADED_STYLE})).toBeTruthy();
             } catch (e) {
                 done(e);
             }

--- a/web/client/epics/layers.js
+++ b/web/client/epics/layers.js
@@ -23,8 +23,6 @@ import {
 } from '../actions/layers';
 
 import { getLayersWithDimension, layerSettingSelector, getLayerFromId } from '../selectors/layers';
-import { setControlProperty } from '../actions/controls';
-import { initialSettingsSelector, originalSettingsSelector } from '../selectors/controls';
 import { basicError } from '../utils/NotificationUtils';
 import { getCapabilitiesUrl, getLayerTitleTranslations, removeWorkspace } from '../utils/LayersUtils';
 import assign from 'object-assign';
@@ -116,10 +114,7 @@ export const updateDimension = (action$, {getState = () => {}} = {}) =>
         );
 
 /**
- * Update original and initial state of layer settings.
- * Initial settings is the layer object before settings session started.
- * Original settings contains only changed properties keys with initial value stored during settings session.
- * Action performed: updateSettings, setControlProperty and updateNode (updateNode only if action.update is true)
+  * Action performed: `updateSettings`, `setControlProperty` and `updateNode` (`updateNode` only if action.update is true)
  * @memberof epics.layers
  * @param {external:Observable} action$ manages `UPDATE_SETTINGS_PARAMS`
  * @return {external:Observable}
@@ -130,20 +125,10 @@ export const updateSettingsParamsEpic = (action$, store) =>
 
             const state = store.getState();
             const settings = layerSettingSelector(state);
-            const initialSettings = initialSettingsSelector(state);
-            const orig = originalSettingsSelector(state);
             const layer = settings?.nodeType === 'layers' ? getLayerFromId(state, settings?.node) : null;
-
-            let originalSettings = { ...(orig || {}) };
-            // TODO one level only storage of original settings for the moment
-            Object.keys(newParams).forEach((key) => {
-                originalSettings[key] = initialSettings && initialSettings[key];
-            });
-
             return Rx.Observable.of(
                 updateSettings(newParams),
                 // update changed keys to verify only modified values (internal state)
-                setControlProperty('layersettings', 'originalSettings', originalSettings),
                 ...(update ? [updateNode(
                     settings.node,
                     settings.nodeType,

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -14,7 +14,6 @@ import { UPDATE_NODE, updateNode, updateSettingsParams } from '../actions/layers
 import { updateAdditionalLayer, removeAdditionalLayer, updateOptionsByOwner } from '../actions/additionallayers';
 import { getDescribeLayer } from '../actions/layerCapabilities';
 import { getLayerCapabilities } from '../observables/wms';
-import { setControlProperty } from '../actions/controls';
 import { findGeoServerName } from '../utils/LayersUtils';
 import { getLayerOptions } from '../utils/WMSUtils';
 
@@ -59,7 +58,6 @@ import {
 
 import { getSelectedLayer, layerSettingSelector } from '../selectors/layers';
 import { generateTemporaryStyleId, generateStyleId, STYLE_OWNER_NAME, getNameParts, detectStyleCodeChanges } from '../utils/StyleEditorUtils';
-import { initialSettingsSelector, originalSettingsSelector } from '../selectors/controls';
 import { updateStyleService } from '../api/StyleEditor';
 
 /*
@@ -682,8 +680,6 @@ export const deleteStyleEpic = (action$, store) =>
             const state = store.getState();
             const layer = getUpdatedLayer(state);
             const { baseUrl = '' } = styleServiceSelector(state);
-            const originalSettings = originalSettingsSelector(state);
-            const initialSettings = initialSettingsSelector(state);
 
             return Rx.Observable.defer(() =>
                 LayersAPI.removeStyles({
@@ -697,10 +693,7 @@ export const deleteStyleEpic = (action$, store) =>
                     return Rx.Observable.concat(
                         Rx.Observable.of(
                             updateSettingsParams({style: '', availableStyles}, true),
-                            loadedStyle(),
-                            // style has been deleted so original and initial settings must be overrided
-                            setControlProperty('layersettings', 'originalSettings', {...originalSettings, style: ''}),
-                            setControlProperty('layersettings', 'initialSettings', {...initialSettings, style: ''})
+                            loadedStyle()
                         ),
                         deleteStyle({
                             styleName,

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -17,6 +17,7 @@ import {hideSettings, updateNode, updateSettings, updateSettingsParams} from '..
 import {toggleStyleEditor} from '../actions/styleeditor';
 import {updateSettingsLifecycle} from "../components/TOC/enhancers/tocItemsSettings";
 import TOCItemsSettings from '../components/TOC/TOCItemsSettings';
+import { activeTabSettingsSelector } from '../selectors/controls';
 import {elementSelector, groupsSelector, layerSettingSelector} from '../selectors/layers';
 import {currentLocaleLanguageSelector, currentLocaleSelector} from '../selectors/locale';
 import {isLocalizedLayerStylesEnabledSelector} from '../selectors/localizedLayerStyles';

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -17,8 +17,8 @@ import {hideSettings, updateNode, updateSettings, updateSettingsParams} from '..
 import {toggleStyleEditor} from '../actions/styleeditor';
 import {updateSettingsLifecycle} from "../components/TOC/enhancers/tocItemsSettings";
 import TOCItemsSettings from '../components/TOC/TOCItemsSettings';
-import { activeTabSettingsSelector, initialSettingsSelector, originalSettingsSelector } from '../selectors/controls';
-import {elementSelector, groupsSelector, layerSettingSelector, layersSelector} from '../selectors/layers';
+import { activeTabSettingsSelector, originalSettingsSelector } from '../selectors/controls';
+import {elementSelector, groupsSelector, layerSettingSelector} from '../selectors/layers';
 import {currentLocaleLanguageSelector, currentLocaleSelector} from '../selectors/locale';
 import {isLocalizedLayerStylesEnabledSelector} from '../selectors/localizedLayerStyles';
 import {mapLayoutValuesSelector} from '../selectors/maplayout';
@@ -32,19 +32,16 @@ import { isCesium } from '../selectors/maptype';
 
 const tocItemsSettingsSelector = createSelector([
     layerSettingSelector,
-    layersSelector,
     groupsSelector,
     currentLocaleSelector,
     currentLocaleLanguageSelector,
     state => mapLayoutValuesSelector(state, {height: true}),
     isAdminUserSelector,
-    initialSettingsSelector,
-    originalSettingsSelector,
     activeTabSettingsSelector,
     elementSelector,
     isLocalizedLayerStylesEnabledSelector,
     isCesium
-], (settings, layers, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, initialSettings, originalSettings, activeTab, element, isLocalizedLayerStylesEnabled, isCesiumActive) => ({
+], (settings, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, activeTab, element, isLocalizedLayerStylesEnabled, isCesiumActive) => ({
     settings,
     element,
     groups,
@@ -52,8 +49,6 @@ const tocItemsSettingsSelector = createSelector([
     currentLocaleLanguage,
     dockStyle,
     isAdmin,
-    initialSettings,
-    originalSettings,
     activeTab,
     isLocalizedLayerStylesEnabled,
     isCesiumActive
@@ -91,8 +86,6 @@ const TOCItemsSettingsPlugin = compose(
         onUpdateSettings: updateSettings,
         onUpdateNode: updateNode,
         onRetrieveLayerData: getLayerCapabilities,
-        onUpdateOriginalSettings: setControlProperty.bind(null, 'layersettings', 'originalSettings'),
-        onUpdateInitialSettings: setControlProperty.bind(null, 'layersettings', 'initialSettings'),
         onSetTab: setControlProperty.bind(null, 'layersettings', 'activeTab'),
         onUpdateParams: updateSettingsParams,
         onToggleStyleEditor: toggleStyleEditor
@@ -105,9 +98,7 @@ const TOCItemsSettingsPlugin = compose(
     getContext({
         loadedPlugins: PropTypes.object
     }),
-    withPropsOnChange(({items = []} = {}, {items: nextItems} = {}) => {
-        return items !== nextItems; // TODO: check if equal
-    }, (props) => ({
+    withPropsOnChange(["items", "settings"], (props) => ({
         tabs: defaultSettingsTabs(props)
     }))
 )(TOCItemsSettings);

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -17,7 +17,6 @@ import {hideSettings, updateNode, updateSettings, updateSettingsParams} from '..
 import {toggleStyleEditor} from '../actions/styleeditor';
 import {updateSettingsLifecycle} from "../components/TOC/enhancers/tocItemsSettings";
 import TOCItemsSettings from '../components/TOC/TOCItemsSettings';
-import { activeTabSettingsSelector, originalSettingsSelector } from '../selectors/controls';
 import {elementSelector, groupsSelector, layerSettingSelector} from '../selectors/layers';
 import {currentLocaleLanguageSelector, currentLocaleSelector} from '../selectors/locale';
 import {isLocalizedLayerStylesEnabledSelector} from '../selectors/localizedLayerStyles';

--- a/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
+++ b/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
@@ -189,7 +189,7 @@ export const getStyleTabPlugin = ({ settings, items = [], loadedPlugins, onToggl
         ];
         if (thematicConfig) {
             return {
-                Component: props.activeTab === 'style' && thematicPlugin.plugin && getConfiguredPlugin(thematicPlugin, loadedPlugins, <LoadingView width={100} height={100} />),
+                Component: props.activeTab === 'style' && thematicPlugin.plugin,
                 toolbar
             };
         }

--- a/web/client/selectors/__tests__/controls-test.js
+++ b/web/client/selectors/__tests__/controls-test.js
@@ -13,8 +13,6 @@ import {
     wfsDownloadSelector,
     widgetBuilderAvailable,
     widgetBuilderSelector,
-    initialSettingsSelector,
-    originalSettingsSelector,
     activeTabSettingsSelector,
     drawerEnabledControlSelector,
     showCoordinateEditorSelector,
@@ -43,9 +41,6 @@ const state = {
                 id: 'layerId',
                 name: 'layerName',
                 style: ''
-            },
-            originalSettings: {
-                style: 'generic'
             },
             activeTab: 'style'
         },
@@ -81,22 +76,7 @@ describe('Test controls selectors', () => {
         expect(retVal).toExist();
         expect(retVal).toBe(true);
     });
-    it('test initialSettingsSelector', () => {
-        const retVal = initialSettingsSelector(state);
-        expect(retVal).toExist();
-        expect(retVal).toEqual({
-            id: 'layerId',
-            name: 'layerName',
-            style: ''
-        });
-    });
-    it('test originalSettingsSelector', () => {
-        const retVal = originalSettingsSelector(state);
-        expect(retVal).toExist();
-        expect(retVal).toEqual({
-            style: 'generic'
-        });
-    });
+
     it('test activeTabSettingsSelector', () => {
         const retVal = activeTabSettingsSelector(state);
         expect(retVal).toExist();

--- a/web/client/selectors/controls.js
+++ b/web/client/selectors/controls.js
@@ -28,7 +28,6 @@ export const printSelector = (state) => get(state, "controls.print.enabled");
 export const wfsDownloadSelector = state => !!get(state, "controls.layerdownload.enabled");
 export const widgetBuilderAvailable = state => get(state, "controls.widgetBuilder.available", false);
 export const widgetBuilderSelector = (state) => get(state, "controls.widgetBuilder.enabled");
-export const originalSettingsSelector = state => get(state, "controls.layersettings.originalSettings") || {};
 export const activeTabSettingsSelector = state => get(state, "controls.layersettings.activeTab") || 'general';
 export const drawerEnabledControlSelector = (state) => get(state, "controls.drawer.enabled", false);
 export const unsavedMapSelector = (state) => get(state, "controls.unsavedMap.enabled", false);

--- a/web/client/selectors/controls.js
+++ b/web/client/selectors/controls.js
@@ -28,7 +28,6 @@ export const printSelector = (state) => get(state, "controls.print.enabled");
 export const wfsDownloadSelector = state => !!get(state, "controls.layerdownload.enabled");
 export const widgetBuilderAvailable = state => get(state, "controls.widgetBuilder.available", false);
 export const widgetBuilderSelector = (state) => get(state, "controls.widgetBuilder.enabled");
-export const initialSettingsSelector = state => get(state, "controls.layersettings.initialSettings") || {};
 export const originalSettingsSelector = state => get(state, "controls.layersettings.originalSettings") || {};
 export const activeTabSettingsSelector = state => get(state, "controls.layersettings.activeTab") || 'general';
 export const drawerEnabledControlSelector = (state) => get(state, "controls.drawer.enabled", false);


### PR DESCRIPTION
## Description

This PR is required for #9099 . It: 
- cleans up unnecessary code for handling some state that is not used anymore (initialSettings and originalSettings). 
- Remove core changes that forced re-render of the whole application on every change on layer settings.
- Refactor of thematic layer to not rely on old lazy load system, but using `Suspense` instead.
- Improves a little the management of TocItemsSettings tabs (not a complete rewrite, that could be more useful, but the one necessary to support thematic layer).


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9120

**What is the new behavior?**

The warning is not present anymore. From test with direct editors ( that need to be added, are now fast enough to be usable).

https://user-images.githubusercontent.com/1279510/233392060-c3269be4-4cc7-4d8c-b9cd-4ca9a550e00e.mp4



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
