### PR TITLE
Improve handling of supported GetFeatureInfo formats

### DIFF
--- a/web/client/api/catalog/WMS.js
+++ b/web/client/api/catalog/WMS.js
@@ -13,6 +13,7 @@ import { Observable } from 'rxjs';
 import { getConfigProp, cleanDuplicatedQuestionMarks } from '../../utils/ConfigUtils';
 import { getLayerTitleTranslations } from '../../utils/LayersUtils';
 import { isValidGetFeatureInfoFormat, isValidGetMapFormat } from '../../utils/WMSUtils';
+import { INFO_FORMATS_BY_MIME_TYPE } from '../../utils/FeatureInfoUtils';
 import {
     extractOGCServicesReferences,
     toURLArray,
@@ -75,6 +76,7 @@ const recordToLayer = (record, {
 
     const {
         format: defaultFormat,
+        infoFormat,
         localizedLayerStyles,
         allowUnsecureLayers,
         autoSetVisibilityLimits,
@@ -86,12 +88,16 @@ const recordToLayer = (record, {
     const format = supportedGetMapFormats?.find((value) => value === defaultFormat)
         || supportedGetMapFormats[0]
         || defaultFormat;
+    const featureInfo = infoFormat && INFO_FORMATS_BY_MIME_TYPE[infoFormat]
+        ? { format: INFO_FORMATS_BY_MIME_TYPE[infoFormat] }
+        : null;
 
     let layer = {
         type: 'wms',
         requestEncoding: record.requestEncoding, // WMTS KVP vs REST, KVP by default
         style: record.style,
         format,
+        featureInfo: featureInfo,
         url: layerURL,
         capabilitiesURL: record.capabilitiesURL,
         queryable: record.queryable,

--- a/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
@@ -79,7 +79,7 @@ export default class extends React.Component {
     render() {
         // the selected value if missing on that layer should be set to the general info format value and not the first one.
         const data = this.getInfoFormat(this.supportedInfoFormats());
-        return (
+        return this.state.loading ? <Loader /> : (
             <span>
                 <Accordion
                     fillContainer

--- a/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
@@ -49,7 +49,7 @@ export default class extends React.Component {
 
     componentDidMount() {
         // we dont know supported infoFormats yet
-        if (!this.props.element.infoFormats || this.props.element.infoFormats?.length === 0) {
+        if (this.props.element.url && !this.props.element.infoFormats || this.props.element.infoFormats?.length === 0) {
             this.setState({ loading: true });
             getSupportedFormat(this.props.element.url, true)
                 .then(({ infoFormats }) => {

--- a/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
@@ -41,6 +41,25 @@ export default class extends React.Component {
         formatCards: {}
     };
 
+    state = {
+        loading: false
+    };
+
+    componentDidMount() {
+        // we dont know supported infoFormats yet
+        if (!this.props.element.infoFormats || this.props.element.infoFormats?.length === 0) {
+            this.setState({ loading: true });
+            getSupportedFormat(this.props.element.url, true)
+                .then(({ infoFormats }) => {
+                    this.props.onChange("infoFormats", infoFormats);
+                    this.setState({ loading: false });
+                })
+                .catch(() => {
+                    this.setState({ loading: false });
+                })
+        }
+    }
+
     getInfoFormat = (infoFormats) => {
         return Object.keys(infoFormats).map((infoFormat) => {
             const Body = this.props.formatCards[infoFormat] && this.props.formatCards[infoFormat].body;

--- a/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
@@ -56,7 +56,7 @@ export default class extends React.Component {
                 })
                 .catch(() => {
                     this.setState({ loading: false });
-                })
+                });
         }
     }
 

--- a/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
@@ -10,6 +10,8 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 import Accordion from '../../../misc/panels/Accordion';
+import { getSupportedFormat } from '../../../../api/WMS';
+import Loader from '../../../misc/Loader';
 import { Glyphicon } from 'react-bootstrap';
 import Message from '../../../I18N/Message';
 import includes from 'lodash/includes';

--- a/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
@@ -81,7 +81,19 @@ export default class extends React.Component {
     render() {
         // the selected value if missing on that layer should be set to the general info format value and not the first one.
         const data = this.getInfoFormat(this.supportedInfoFormats());
-        return this.state.loading ? <Loader /> : (
+        return this.state.loading ? (
+            <div
+                style={{
+                    position: 'relative',
+                    width: '100%',
+                    height: '100%',
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center'
+                }}>
+                <Loader size={150}/>
+            </div>
+        ) : (
             <span>
                 <Accordion
                     fillContainer

--- a/web/client/components/catalog/CatalogServiceEditor.jsx
+++ b/web/client/components/catalog/CatalogServiceEditor.jsx
@@ -48,6 +48,7 @@ export default ({
     tileSizeOptions = [256, 512],
     formatsLoading,
     layerOptions = {},
+    infoFormatOptions,
     services,
     autoSetVisibilityLimits = false
 }) => {
@@ -86,6 +87,7 @@ export default ({
                 selectedService={selectedService}
                 onFormatOptionsFetch={onFormatOptionsFetch}
                 formatsLoading={formatsLoading}
+                infoFormatOptions={infoFormatOptions}
                 autoSetVisibilityLimits={autoSetVisibilityLimits}
             />
             <FormGroup controlId="buttons" key="buttons">

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -60,6 +60,7 @@ const getServerTypeOptions = () => {
 export default ({
     service,
     formatOptions = [],
+    infoFormatOptions = [],
     onChangeServiceFormat = () => { },
     onChangeServiceProperty = () => {},
     currentWMSCatalogLayerSize,

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -186,6 +186,30 @@ export default ({
             </Col >
         </FormGroup>
         <FormGroup style={advancedRasterSettingsStyles}>
+            <Col xs={6}>
+                <ControlLabel><Message msgId="infoFormatLbl" /></ControlLabel>
+            </Col >
+            <Col xs={6} style={{marginBottom: '5px', display: 'flex', alignItems: 'center' }}>
+                <div style={{ flex: 1 }}>
+                    <Select
+                        isLoading={props.formatsLoading}
+                        onOpen={() => onFormatOptionsFetch(service.url)}
+                        value={service && service.infoFormat}
+                        clearable
+                        options={props.formatsLoading ? [] : infoFormatOptions.map((format) => ({ value: format, label: format }))}
+                        onChange={event => onChangeServiceProperty("infoFormat", event && event.value)} />
+                </div>
+                <Button
+                    disabled={props.formatsLoading}
+                    tooltipId="catalog.format.refresh"
+                    className="square-button-md no-border"
+                    onClick={() => onFormatOptionsFetch(service.url, true)}
+                    key="format-refresh">
+                    <Glyphicon glyph="refresh" />
+                </Button>
+            </Col >
+        </FormGroup>
+        <FormGroup style={advancedRasterSettingsStyles}>
             <Col xs={6} >
                 <ControlLabel><Message msgId="layerProperties.wmsLayerTileSize" /></ControlLabel>
             </Col >

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -236,11 +236,29 @@ describe('Test Raster advanced settings', () => {
         />, document.getElementById("container"));
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
-        const serverTypeOption = document.querySelectorAll('input[role="combobox"]')[2];
+        const serverTypeOption = document.querySelectorAll('input[role="combobox"]')[3];
         expect(serverTypeOption).toBeTruthy();
         TestUtils.Simulate.change(serverTypeOption, { target: { value: "geoserver" }});
         TestUtils.Simulate.keyDown(serverTypeOption, { keyCode: 9, key: 'Tab' });
         expect(spyOn).toHaveBeenCalled();
         expect(spyOn.calls[0].arguments).toEqual([ 'layerOptions', { serverType: "geoserver" } ]);
+    });
+    it('test component onChangeServiceProperty infoFormat', () => {
+        const action = {
+            onChangeServiceProperty: () => {}
+        };
+        const spyOn = expect.spyOn(action, 'onChangeServiceProperty');
+        ReactDOM.render(<RasterAdvancedSettings
+            infoFormatOptions={['text/html', 'text/plain', 'application/json']}
+            onChangeServiceProperty={action.onChangeServiceProperty}
+            service={{ type: "wms" }}/>, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const infoFormatOption = document.querySelectorAll('input[role="combobox"]')[1];
+        expect(infoFormatOption).toBeTruthy();
+        TestUtils.Simulate.change(infoFormatOption, { target: { value: "application/json" }});
+        TestUtils.Simulate.keyDown(infoFormatOption, { keyCode: 9, key: 'Tab' });
+        expect(spyOn).toHaveBeenCalled();
+        expect(spyOn.calls[0].arguments).toEqual([ 'infoFormat', 'application/json' ]);
     });
 });

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -33,7 +33,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
-        expect(fields.length).toBe(11);
+        expect(fields.length).toBe(12);
     });
     it('test csw advanced options', () => {
         ReactDOM.render(<RasterAdvancedSettings service={{type: "csw", autoload: false}}/>, document.getElementById("container"));
@@ -41,7 +41,7 @@ describe('Test Raster advanced settings', () => {
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
         const cswFilters = document.getElementsByClassName("catalog-csw-filters");
-        expect(fields.length).toBe(9);
+        expect(fields.length).toBe(10);
         expect(cswFilters).toBeTruthy();
     });
     it('test component onChangeServiceProperty autoload', () => {
@@ -176,7 +176,7 @@ describe('Test Raster advanced settings', () => {
             service={{type: "wms", layerOptions: {tileSize: 256}}}/>, document.getElementById("container"));
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
-        const layerOption = document.querySelectorAll('input[role="combobox"]')[1];
+        const layerOption = document.querySelectorAll('input[role="combobox"]')[2];
         expect(layerOption).toBeTruthy();
         TestUtils.Simulate.change(layerOption, { target: { value: "512" }});
         TestUtils.Simulate.keyDown(layerOption, { keyCode: 9, key: 'Tab' });

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -181,6 +181,7 @@ describe('Test Raster advanced settings', () => {
         TestUtils.Simulate.change(layerOption, { target: { value: "512" }});
         TestUtils.Simulate.keyDown(layerOption, { keyCode: 9, key: 'Tab' });
         expect(spyOn).toHaveBeenCalled();
+        expect(spyOn.calls[0].arguments).toEqual([ 'layerOptions', { tileSize: 512 } ]);
     });
     it('test component onChangeServiceProperty allowUnsecureLayers', () => {
         const action = {

--- a/web/client/utils/FeatureInfoUtils.js
+++ b/web/client/utils/FeatureInfoUtils.js
@@ -21,7 +21,7 @@ export const INFO_FORMATS_BY_MIME_TYPE = {
     "text/plain": "TEXT",
     "text/html": "HTML",
     "text/javascript": "JSONP",
-    "application/json": "JSON",
+    "application/json": "PROPERTIES",
     "application/vnd.ogc.gml": "GML2",
     "application/vnd.ogc.gml/3.1.1": "GML3"
 };


### PR DESCRIPTION
## Description
cf #9007 & georchestra/mapstore2-georchestra#302

Improve the handling of supported `GetFeatureInfo` formats by:
- fetching the supported `infoFormats` and allowing the administrator to select a default `infoFormat` for a catalog entry
- defaulting the `infoFormat` to this selected value for layers added from that catalog entry
- saving the supported `infoFormats` in the service entry so that it's persisted upon map export/import

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [x] Feature

## Issue


**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fixes #9007

**What is the new behavior?**
only supported infoformats are made available to end-users.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
test plan:
1)
- add a new wms catalog using https://demo.mapserver.org/cgi-bin/wms (which supports only `text/plain` and `text/html`)
- go to the advanced properties for the catalog entry
- refresh supported infoFormats -> only `text/plain` and `text/html` are available
- select `text/html`
- add the `continents` layer from the server
- go to the layer properties, check featureinfo tab -> `HTML` is highlighted, and only `HTML` and `TEXT` are available
- export map, import it -> the default selected values for service & layer should still be `text/html` & `HTML`.
- the exported map has this for the service:
```
         "mapserver" : { 
            "autoload" : false,
            "domainAliases" : [], 
            "formatUrlUsed" : "https://demo.mapserver.org/cgi-bin/wms",
            "infoFormat" : "text/html",
            "layerOptions" : { 
               "serverType" : "no-vendor"
            },  
            "oldService" : "mapserver",
            "showAdvancedSettings" : true,
            "supportedFormats" : { 
               "imageFormats" : [ 
                  "image/png",
                  "image/jpeg",
                  "image/png; mode=8bit",
                  "image/vnd.jpeg-png",
                  "image/vnd.jpeg-png8"
               ],  
               "infoFormats" : [ 
                  "text/html",
                  "text/plain"
               ]   
            },  
```
- and for the layer:
```
            "description" : "World continents",
            "dimensions" : [],
            "featureInfo" : {
               "format" : "HTML"
            },
            "format" : "image/png",
            "handleClickOnLayer" : false,
            "hidden" : false,
            "hideLoading" : false,
            "id" : "continents__e1696c80-e368-11ed-98cc-39a0b9c341ef",
            "name" : "continents",
```
2)
- do the same test using the default geoserver, all 3 formats are listed. If one defaults to `application/json` and add a layer, strangely in the featureinfo tab of the layer properties no format is highlighted, but `properties` seems used by default. @allyoucanmap any idea ?

3) 
- add a new wms catalog using https://demo.mapserver.org/cgi-bin/wms (which supports only `text/plain` and `text/html`)
- add the `continents` layer from the server
- go to the layer properties, check featureinfo tab -> select `HTML`
- export map, import it -> the default values for layer should still be  `HTML` like above. If going to the featureinfo tab of the layer properties, only `HTML` and `PLAIN` are listed, because the client queries the getcapabilities when displaying the layer properties.

4) (this one wont be reproducible if you dont have a mapserver at hand)
- add a new wms catalog from a local mapserver, with all formats supported
- fetch supported formats in the advanced catalog settings, `text/html`, `text/plain` & `application/json` are listed
- set `"wms_getfeatureinfo_formatlist" "gml"` in the mapserver config, getcapabilities contains `text/plain` &`gml`, fetch them in the catalog properties -> only `text/plain` is listed
- disable getfeatureinfo requests by setting `"ows_enable_request" "* !GetFeatureInfo"` in mapserver config, fetch formats -> "No results found"

5)
- add a new wms catalog from https://wxs-gpu.mongeoportail.ign.fr/externe/vkd1evhid6jdj5h4hkhyzjto/wms/v
- fetch formats in the advanced settings, all formats are supported, choose `text/html`
- add the `du` layer (look for "document")
- zoom to `mauzun`
- click anywhere -> the GFI infor should be displayed in an HTML table with `du_bdd_production_v1-zone_urba_du` in the table heading

note that for 1), 2) & 3) doing actual GFI requests will fail because of #8599, cf https://github.com/geosolutions-it/MapStore2/pull/9054#issuecomment-1486509312. I'll eventually look at tackling this one.