### PR TITLE
improve getFeatureInfo requests interoperability with mapserver & IGN french services

### DIFF
--- a/web/client/utils/mapinfo/wms.js
+++ b/web/client/utils/mapinfo/wms.js
@@ -75,6 +75,7 @@ export default {
                       bounds.maxy,
                 feature_count: maxItems,
                 info_format: infoFormat,
+                format: layer.format,
                 ENV,
                 ...assign({}, params)
             }, layer),

--- a/web/client/utils/mapinfo/wms.js
+++ b/web/client/utils/mapinfo/wms.js
@@ -63,7 +63,7 @@ export default {
                 id: layer.id,
                 layers: layer.name,
                 query_layers: queryLayers,
-                styles: layer.style,
+                styles: (layer.style ? layer.style : ''),
                 x: widthBBox % 2 === 1 ? Math.ceil(widthBBox / 2) : widthBBox / 2,
                 y: widthBBox % 2 === 1 ? Math.ceil(widthBBox / 2) : widthBBox / 2,
                 height: heightBBox,


### PR DESCRIPTION
## Description

when doing GFI tests for #9031 / #9054 (see https://github.com/geosolutions-it/MapStore2/pull/9054#issuecomment-1486509312) and #9126 i found out that by default GFI requests against https://demo.mapserver.org/cgi-bin/wms and  https://wxs.ign.fr/administratif/geoportail/r/wms mostly failed because of missing queryparams, some mandatory, some optional..

All IGN WMS webservices listed on https://geoservices.ign.fr/services-web-experts & https://geoservices.ign.fr/services-web-essentiels are based off the same infrastructure so will complain about the missing format.

note that the construct added in 0546dc13aa9554e0a75ba86c4a67054c8c1e4ca2 is similar to https://github.com/geosolutions-it/MapStore2/blob/master/web/client/utils/PrintUtils.js#L534 or https://github.com/geosolutions-it/MapStore2/blob/master/web/client/components/map/openlayers/plugins/WMSLayer.js#L121 or https://github.com/geosolutions-it/MapStore2/blob/master/web/client/utils/leaflet/WMSUtils.js#L31 but when testing my change i simply couldnt use `styles: layer.style || ''`, it wouldn't give the expected outcome (eg the query was sent without `styles` param). But maybe the situation is different there ?

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
## Issue

**What is the current behavior?**

on https://mapstore.geosolutionsgroup.com/mapstore/#/viewer/new, add the `cities` layer from https://demo.mapserver.org/cgi-bin/wms, try to perform a GFI request, it fails and looking at the returned exception you get:
```
msWMSLoadGetMapParams(): WMS server error. Missing required parameter STYLES. Note to service administrators: defining the "wms_allow_getmap_without_styles" "true" MAP.WEB.METADATA item will disable this check (backward compatibility with behaviour of MapServer < 8.0) 
```
on https://mapstore.geosolutionsgroup.com/mapstore/#/viewer/new (or any other mapstore running master), add the `ADMINEXPRESS-COG-CARTO.LATEST` layer from https://wxs.ign.fr/administratif/geoportail/r/wms (one needs to add it to useCORS, otherwise you'll get a 403 via the proxy), try to do a GFI on it, you'll get a 400 code with this return value:
```
<ServiceExceptionReport xmlns="http://www.opengis.net/ogc">
<ServiceException code="MissingParameterValue" >
  Parametre FORMAT absent.
</ServiceException>
</ServiceExceptionReport>
```

**What is the new behavior?**
both requests now succeed. (well, sometimes the IGN services crashes or return an exception or a 500 code, but that's another story to tell :)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

I've checked that GFI requests on the `test:Linea_costa` from the default geoserver were still functional with the extra `styles` & `format` query params.

## Other useful information

Another strange thing that surfaced while testing this, selecting `text/html` when querying the `cities` layer from the demo mapserver service fails to display the HTML returned by the service, while it seems perfectly valid ?

https://demo.mapserver.org/cgi-bin/wms?service=WMS&version=1.1.1&request=GetFeatureInfo&exceptions=application%2Fjson&id=cities__093f6f00-e442-11ed-890d-716378984790&layers=cities&query_layers=cities&styles=&x=51&y=51&height=101&width=101&srs=EPSG:3857&bbox=537944.6958139992,5738490.7892525345,541804.7657424005,5742350.859180937&feature_count=10&info_format=text%2Fhtml&format=image%2Fpng&ENV=mapstore_language:en gives what looked like proper html to me, but mapstore fails to display it in the results pane ? the same error doesnt reproduce with html requests against layers from https://wms.craig.fr/ign which is also mapserver.

@tdipisa can this be reviewed in conjunction with #9126 ?