### PR TITLE
#8998: Fix - Layers with visibility scale limits do not print if useFixedScales configured

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -380,7 +380,7 @@ export default {
                         const map = this.props.printingService.getMapConfiguration();
                         return {
                             ...map,
-                            layers: this.filterLayers(map.layers, map.zoom, map.projection)
+                            layers: this.filterLayers(map.layers, this.props.useFixedScales ? map.scaleZoom : map.zoom, map.projection)
                         };
                     };
                     getMapSize = (layout) => {
@@ -390,16 +390,11 @@ export default {
                             height: currentLayout && currentLayout.map.height / currentLayout.map.width * this.props.mapWidth || 270
                         };
                     };
-                    getPreviewZoom = (mapZoom) => {
-                        if (this.props.useFixedScales) {
-                            const scales = getPrintScales(this.props.capabilities);
-                            return getNearestZoom(mapZoom, scales);
-                        }
-                        return mapZoom;
-                    };
                     getPreviewResolution = (zoom, projection) => {
                         const dpu = dpi2dpu(DEFAULT_SCREEN_DPI, projection);
-                        const scale = this.props.scales[this.getPreviewZoom(zoom)];
+                        const scale = this.props.useFixedScales
+                            ? getPrintScales(this.props.capabilities)[zoom]
+                            : this.props.scales[zoom];
                         return scale / dpu;
                     };
                     getLayout = (props) => {


### PR DESCRIPTION
## Description
This PR fixes the incorrect scales used for checking visibility limits when `useFixedScales: true`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #8998 

**What is the new behavior?**
The layers configured with visibility limits can be previewed and printed when falls inside resolution limits of current map config

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
