### PR TITLE
Query panel alias support

### DIFF
--- a/web/client/actions/__tests__/wfsquery-test.js
+++ b/web/client/actions/__tests__/wfsquery-test.js
@@ -48,10 +48,11 @@ describe('wfsquery actions', () => {
         expect(type).toBe(INIT_QUERY_PANEL);
     });
     it('featureTypeSelected', () => {
-        let {type, url, typeName} = featureTypeSelected("/geoserver/", "topp:states");
+        let {type, url, typeName, fields} = featureTypeSelected("/geoserver/", "topp:states", [{name: "name", alias: "alias"}]);
         expect(type).toBe(FEATURE_TYPE_SELECTED);
         expect(url).toBe("/geoserver/");
         expect(typeName).toBe("topp:states");
+        expect(fields).toEqual([{name: "name", alias: "alias"}]);
     });
     it('featureTypeError', () => {
         let {type, error, typeName} = featureTypeError("topp:states", "ERROR");

--- a/web/client/actions/wfsquery.js
+++ b/web/client/actions/wfsquery.js
@@ -46,11 +46,12 @@ export function initQueryPanel() {
         type: INIT_QUERY_PANEL
     };
 }
-export function featureTypeSelected(url, typeName) {
+export function featureTypeSelected(url, typeName, fields = []) {
     return {
         type: FEATURE_TYPE_SELECTED,
         url,
-        typeName
+        typeName,
+        fields
     };
 }
 export function featureTypeLoaded(typeName, featureType) {

--- a/web/client/components/I18N/LocalizedString.jsx
+++ b/web/client/components/I18N/LocalizedString.jsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import React, {isValidElement} from 'react';
 import PropTypes from 'prop-types';
 const FALLBACK_LOCALE = 'en-US';
 /**
  * Extracts the localized string from the given value. If the value is an object, it will return the value for the current locale or the default string, otherwise it will return the value itself.
- * @param {string|object} value the value to extract the localized string from
+ * @param {string|object} value the value to extract the localized string from.
  * @param {string} locale the current locale code (e.g. 'en-US')
  * @returns {string} the localized string
  */
 export const extractLocalizedString = (value, locale) => {
-    if (value && typeof value === 'object') {
+    if (value && typeof value === 'object' && !isValidElement(value)) {
         return value?.[locale] || value.default || value?.[FALLBACK_LOCALE] || '';
     }
     return value;
@@ -20,7 +20,7 @@ export const extractLocalizedString = (value, locale) => {
  */
 class LocalizedString extends React.Component {
     static propTypes = {
-        value: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+        value: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.node])
     };
 
     static contextTypes = {

--- a/web/client/components/I18N/__tests__/LocalizedString-test.jsx
+++ b/web/client/components/I18N/__tests__/LocalizedString-test.jsx
@@ -5,7 +5,7 @@ import LocalizedString from '../LocalizedString';
 import { IntlProvider, addLocaleData } from 'react-intl';
 
 import { act } from 'react-dom/test-utils';
-describe('LocalizedString component', () => {
+describe('component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setTimeout(done);
@@ -15,24 +15,24 @@ describe('LocalizedString component', () => {
         document.body.innerHTML = '';
         setTimeout(done);
     });
-    it('LocalizedString rendering with defaults', () => {
+    it('rendering with defaults', () => {
         ReactDOM.render(<LocalizedString />, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toBeTruthy();
     });
-    it('LocalizedString rendering with value', () => {
+    it('rendering with value', () => {
         ReactDOM.render(<LocalizedString value="test" />, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toBeTruthy();
         expect(container.innerText).toBe('test');
     });
-    it('LocalizedString rendering with value and locale', () => {
+    it('rendering with value and locale', () => {
         ReactDOM.render(<IntlProvider locale="en-US"><LocalizedString value={{ "en-US": "EN-US"}} /></IntlProvider>, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toBeTruthy();
         expect(container.innerText).toBe('EN-US');
     });
-    it('LocalizedString rendering with value and locale different from default', () => {
+    it('rendering with value and locale different from default', () => {
         addLocaleData({ locale: 'it-IT', parentLocale: 'it' }); // this is needed to avoid error: "Missing locale data for locale: "it-IT". Using default locale: "en" as fallback."
         act(() => {
             ReactDOM.render(<IntlProvider locales={{en: {}, it: {}}} locale="it-IT"><LocalizedString value={{ "default": "default", 'it-IT': 'test' }} /></IntlProvider>, document.getElementById("container"));
@@ -40,5 +40,13 @@ describe('LocalizedString component', () => {
         const container = document.getElementById('container');
         expect(container).toBeTruthy();
         expect(container.innerText).toBe('test');
+    });
+    it('rendering object that is a valid react element', () => {
+        // in this case it should remder simply the react element
+        ReactDOM.render(<LocalizedString value={<div id="TEST">test</div>} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        expect(container).toBeTruthy();
+        expect(container.querySelector('#TEST')).toBeTruthy();
+        expect(container.querySelector('#TEST').innerText).toBe('test');
     });
 });

--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -350,10 +350,10 @@ class Toolbar extends React.Component {
     }
 
     browseData = () => {
+        const layer = this.props.selectedLayers[0] || {};
         this.props.onToolsActions.onBrowseData({
-            url: this.props.selectedLayers[0].search.url || this.props.selectedLayers[0].url,
-            name: this.props.selectedLayers[0].name,
-            id: this.props.selectedLayers[0].id
+            ...layer,
+            url: layer?.search?.url || layer.url
         });
     }
 

--- a/web/client/components/TOC/__tests__/Toolbar-test.jsx
+++ b/web/client/components/TOC/__tests__/Toolbar-test.jsx
@@ -112,10 +112,9 @@ describe('TOC Toolbar', () => {
 
         TestUtils.Simulate.click(btn[3]);
         expect(spyLayerFilter).toHaveBeenCalled();
-        expect(spyBrowseData).toHaveBeenCalledWith({
-            url: selectedLayers[0].search.url,
-            name: selectedLayers[0].name,
-            id: selectedLayers[0].id
+        expect(spyBrowseData.calls[0].arguments[0]).toEqual({
+            ...selectedLayers[0],
+            url: selectedLayers[0].search.url
         });
         TestUtils.Simulate.click(btn[5]);
         expect(spyDownload).toHaveBeenCalled();

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -99,8 +99,7 @@ export default props => {
         latlng,
         showEdit: showEdit && isEditingAllowed && !!targetResponse && responseValidForEdit(targetResponse),
         onEdit: onEdit.bind(null, layer && {
-            id: layer.id,
-            name: layer.name,
+            ...layer,
             url: get(layer, 'search.url')
         })
     });

--- a/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
+++ b/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import expect from 'expect';
 import ReactDOM from 'react-dom';
 import IdentifyContainer from '../IdentifyContainer';
-import TestUtils from 'react-dom/test-utils';
+import TestUtils, {act} from 'react-dom/test-utils';
 import ConfigUtils from '../../../../utils/ConfigUtils';
 import getFeatureButtons from '../../../../plugins/identify/featureButtons';
 
@@ -300,5 +300,42 @@ describe("test IdentifyContainer", () => {
         />, document.getElementById("container"));
         let coordinateEditorContainer = document.querySelectorAll('.coordinate-editor');
         expect(coordinateEditorContainer[0].style['z-index']).toBe('1');
+    });
+    it('onEdit handler', () => {
+        const handlers = {
+            onEdit: () => {}
+        };
+        const onEditSpy = expect.spyOn(handlers, 'onEdit');
+        // TODO: refactor identifyContainer to avoid onEdit association with edit button
+        // to be so messy
+        const bt = {
+            glyph: 'pencil',
+            tooltipId: 'identify.edit',
+            onClick: handlers.onEdit
+        };
+        const RESPONSE1 = {layer: {search: {url: 'search_url'}, fields: []}};
+        act(() => {
+
+            ReactDOM.render(<IdentifyContainer
+                getToolButtons={({onEdit: f}) => [{...bt, onClick: () => f()}] }
+                enabled
+                index={0}
+                showEdit
+                isEditingAllowed
+                requests={[{}]}
+                responses={[RESPONSE1]}
+                onEdit={handlers.onEdit}
+            />, document.getElementById("container"));
+        });
+        const editButton = document.querySelector('.glyphicon-pencil');
+        TestUtils.Simulate.click(editButton);
+        expect(onEditSpy).toHaveBeenCalled();
+        expect(onEditSpy.calls[0].arguments[0]).toEqual({
+            ...RESPONSE1.layer,
+            // the call of onEdit overrides the layer URL with the search URL
+            url: RESPONSE1.layer.search.url
+        });
+
+
     });
 });

--- a/web/client/components/data/query/FilterField.jsx
+++ b/web/client/components/data/query/FilterField.jsx
@@ -10,7 +10,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComboField from './ComboField';
 import assign from 'object-assign';
-import { getMessageById } from '../../../utils/LocaleUtils';
+
+import localizedProps from '../../misc/enhancers/localizedProps';
+
+// support for localized attribute names and placeholder
+export const AttributeNameField = localizedProps('placeholder')(localizedProps('fieldOptions', 'label', 'object')(ComboField));
 
 class FilterField extends React.Component {
     static propTypes = {
@@ -78,12 +82,12 @@ class FilterField extends React.Component {
         return (
             <div className="filter-field-row">
                 <div className="filter-field-attribute">
-                    <ComboField
+                    <AttributeNameField
                         dropUp={this.props.dropUp}
-                        valueField={'id'}
-                        textField={'name'}
-                        fieldOptions={this.props.attributes.map((attribute) => { return {id: attribute.attribute, name: attribute.label}; })}
-                        placeholder={getMessageById(this.context.messages, "queryform.attributefilter.combo_placeholder")}
+                        valueField={'attribute'}
+                        textField={'label'}
+                        fieldOptions={this.props.attributes}
+                        placeholder="queryform.attributefilter.combo_placeholder"
                         fieldValue={this.props.filterField.attribute}
                         attType={selectedAttribute && selectedAttribute.type}
                         fieldName="attribute"

--- a/web/client/components/data/query/__tests__/FilterField-test.jsx
+++ b/web/client/components/data/query/__tests__/FilterField-test.jsx
@@ -8,7 +8,10 @@
 import React from 'react';
 
 import ReactDOM from 'react-dom';
-import FilterField from '../FilterField.jsx';
+import {Simulate, act} from 'react-dom/test-utils';
+import Localized from '../../../I18N/Localized';
+
+import FilterField, {AttributeNameField} from '../FilterField.jsx';
 import ComboField from '../ComboField.jsx';
 import DateField from '../DateField.jsx';
 import expect from 'expect';
@@ -24,6 +27,39 @@ describe('FilterField', () => {
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
         document.body.innerHTML = '';
         setTimeout(done);
+    });
+    it('AttributeNameField localization of labels and placeholders', () => {
+        const attributes = [{
+            attribute: "Attribute",
+            label: {
+                "default": "Attribute-default",
+                "en-US": "Attribute1-en-US"
+            }
+        }];
+        let attributeField;
+        act(() => {
+
+            attributeField = ReactDOM.render(<Localized locale="en-US" messages={{path: "TEST"}}>
+                <AttributeNameField
+                    fieldOptions={attributes}
+                    valueField={'attribute'}
+                    textField={'label'}
+                    placeholder={'path'}
+                /></Localized>, document.getElementById("container"));
+            expect(attributeField).toExist();
+
+        });
+        const attributeFieldDOMNode = expect(ReactDOM.findDOMNode(attributeField));
+        expect(attributeFieldDOMNode).toExist();
+        // check the localized placeholder
+        expect(attributeFieldDOMNode.actual.querySelector('.rw-placeholder').innerHTML).toBe("TEST");
+        // check the localized label
+        // click on the arrow to open the dropdown
+        act(() => {
+            Simulate.click(attributeFieldDOMNode.actual.querySelector('.rw-i-caret-down'));
+        });
+        // check the localized label
+        expect(attributeFieldDOMNode.actual.querySelector('.rw-list-option.rw-state-focus').innerHTML).toBe("Attribute1-en-US");
     });
 
     it('creates the FilterField component', () => {

--- a/web/client/components/data/query/enhancers/__tests__/crossLayerFilter-test.jsx
+++ b/web/client/components/data/query/enhancers/__tests__/crossLayerFilter-test.jsx
@@ -86,4 +86,50 @@ describe('crossLayerFilter enhancer', () => {
             searchUrl="base/web/client/test-resources/wfs/states-capabilities.xml"
         />), document.getElementById("container"));
     });
+    it('layer with fields', (done) => {
+        const actions = {
+            setCrossLayerFilterParameter: () => { }
+        };
+        const spysetCrossLayerFilterParameter = expect.spyOn(actions, 'setCrossLayerFilterParameter');
+        const Sink = crossLayerFilter(createSink( props => {
+            try {
+                expect(props).toExist();
+                if (!props.loadingAttributes) {
+                    expect(props.attributes).toExist();
+                    expect(props.attributes.length).toBe(22);
+                    // check alias is used as label for the field "STATE_NAME"
+                    expect(props.attributes[0].label).toBe("State Name");
+                    expect(spysetCrossLayerFilterParameter).toHaveBeenCalledWith("collectGeometries.queryCollection[geometryName]", "the_geom");
+                    done();
+                }
+            } catch (e) {
+                done(e);
+            }
+
+        }));
+        ReactDOM.render((<Sink
+            setCrossLayerFilterParameter={actions.setCrossLayerFilterParameter}
+            crossLayerExpanded
+            layers={[{
+                name: "topp:states",
+                fields: [{
+                    name: "STATE_NAME",
+                    alias: "State Name"
+                }, {
+                    name: "STATE_FIPS"
+                }],
+                search: {
+                    url: "base/web/client/test-resources/wfs/describe-states.json"
+                }
+            }]}
+            crossLayerFilter={{
+                collectGeometries: {
+                    queryCollection: {
+                        typeName: "topp:states"
+                    }
+                }
+            }}
+            searchUrl="base/web/client/test-resources/wfs/states-capabilities.xml"
+        />), document.getElementById("container"));
+    });
 });

--- a/web/client/components/data/query/enhancers/crossLayerFilter.js
+++ b/web/client/components/data/query/enhancers/crossLayerFilter.js
@@ -58,7 +58,7 @@ const retrieveCrossLayerAttributes = ($props, setQueryCollectionParameter) => $p
                     setQueryCollectionParameter("geometryName", geomProp);
                 }
             })
-            .map(({data = {}} = {}) => describeFeatureTypeToAttributes(data))
+            .map(({data = {}} = {}) => describeFeatureTypeToAttributes(data, layer?.fields))
             .map(attributes => ({
                 attributes,
                 loadingAttributes: false

--- a/web/client/components/misc/enhancers/__tests__/localizedProps-test.jsx
+++ b/web/client/components/misc/enhancers/__tests__/localizedProps-test.jsx
@@ -13,7 +13,7 @@ import {createSink, withContext, compose} from 'recompose';
 import expect from 'expect';
 import localizedProps from '../localizedProps';
 
-describe('localizedProps enhancher', () => {
+describe('localizedProps enhancer', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setTimeout(done);
@@ -103,8 +103,9 @@ describe('localizedProps enhancher', () => {
 
         const Sink = compose(
             withContext(
-                {messages: {}},
+                {messages: {}, locale: "it-IT"},
                 () => ({
+                    locale: "it-IT",
                     messages: { path: { to: { msg1: "localized", msg2: "localized2" } } }
                 })
             ),
@@ -116,6 +117,113 @@ describe('localizedProps enhancher', () => {
             expect(props.options[1].label).toBe("localized2");
         }));
         ReactDOM.render((<Sink options={["path.to.msg1", "path.to.msg2"]}/>), document.getElementById("container"));
+    });
+    describe('object mode', () => {
+        it('localize normal string (render the string)', () => {
+            const Sink = compose(
+                withContext(
+                    {messages: {}, locale: "it-IT"},
+                    () => ({
+                        locale: "it-IT",
+                        messages: { }
+                    })
+                ),
+                localizedProps("options", undefined, "object")
+            )(createSink( props => {
+                expect(props).toExist();
+                expect(props.options).toExist();
+                expect(props.options).toBe("localized");
+            }));
+            ReactDOM.render((<Sink options={"localized"}/>), document.getElementById("container"));
+        });
+        it('localize with a valid rect element (render the element)', () => {
+            const EL = <div>localized</div>;
+            const Sink = compose(
+                withContext(
+                    {messages: {}, locale: "it-IT"},
+                    () => ({
+                        locale: "it-IT",
+                        messages: { }
+                    })
+                ),
+                localizedProps("options", undefined, "object")
+            )(createSink( props => {
+                expect(props).toExist();
+                expect(props.options).toExist();
+                expect(props.options).toBe(EL);
+            }));
+            ReactDOM.render((<Sink options={EL}/>), document.getElementById("container"));
+        });
+        it('localize object with locale present', () => {
+            const localizedString = {
+                "en-US": "localized",
+                "it-IT": "localized-IT"
+            };
+            const Sink = compose(
+                withContext(
+                    {locale: "it-IT", messages: {}},
+                    () => ({
+                        locale: "it-IT",
+                        messages: { }
+                    })
+                ),
+                localizedProps("options", undefined, "object")
+            )(createSink( props => {
+                expect(props).toExist();
+                expect(props.options).toExist();
+                expect(props.options).toBe("localized-IT");
+            }));
+            ReactDOM.render((<Sink options={localizedString}/>), document.getElementById("container"));
+        });
+        it('localizedProps with mode "object" and default', () => {
+            const localizedString = {
+                "default": "default",
+                "en-US": "localized"
+            };
+            const Sink = compose(
+                withContext(
+                    {messages: {}, locale: "it-IT"},
+                    () => ({
+                        locale: "it-IT",
+                        messages: { }
+                    })
+                ),
+                localizedProps("options", undefined, "object")
+            )(createSink( props => {
+                expect(props).toExist();
+                expect(props.options).toExist();
+                expect(props.options).toBe("default");
+            }));
+            ReactDOM.render((<Sink options={localizedString}/>), document.getElementById("container"));
+        });
+        it('localizedProps with mode "object" using an array', () => {
+            const localizedString = {
+                "en-US": "localized",
+                "it-IT": "localized-IT"
+            };
+            const localizedString2 = {
+                "en-US": "localized2",
+                "it-IT": "localized-IT2"
+            };
+            const options = [{label: localizedString}, {label: localizedString2}];
+            const Sink = compose(
+                withContext(
+                    {locale: "it-IT", messages: {}},
+                    () => ({
+                        locale: "it-IT",
+                        messages: {}
+                    })
+                ),
+                localizedProps("options", "label", "object")
+            )(createSink( props => {
+                expect(props).toExist();
+                expect(props.options).toExist();
+                expect(props.options[0].label).toBe("localized-IT");
+                expect(props.options[1].label).toBe("localized-IT2");
+
+            }));
+            ReactDOM.render((<Sink options={options}/>), document.getElementById("container"));
+        });
     });
 
 });

--- a/web/client/components/misc/enhancers/localizedProps.js
+++ b/web/client/components/misc/enhancers/localizedProps.js
@@ -8,6 +8,7 @@
 
 
 import { getMessageById } from '../../../utils/LocaleUtils';
+import { extractLocalizedString } from '../../I18N/LocalizedString';
 
 import PropTypes from 'prop-types';
 import { castArray, isArray, isNil, isString } from 'lodash';
@@ -23,39 +24,67 @@ const getMessage = (messages, path, defaultProp = "label") => {
             return {...item, [defaultProp]: !isNil(msg) ? msg : path};
         });
     }
-    const msg = getMessageById(messages, path);
+    const msg = path ? getMessageById(messages, path) : path;
     return !isNil(msg) ? msg : path;
 };
-const accumulate = (props, messages, labelName) => (acc = {}, propName) => ({
-    ...acc,
-    [propName]: props[propName] && getMessage(messages, props[propName], labelName)
-});
+const getLocalizedObjectEntry = (items, locale, defaultProp = "label") => {
+    if (isArray(items)) {
+        return items.map((item) => {
+            const msg = extractLocalizedString(item[defaultProp] || isString(item) && item || "", locale);
+            return {...item, [defaultProp]: !isNil(msg) ? msg : items};
+        });
+    }
+    const msg = extractLocalizedString(items, locale);
+    return !isNil(msg) ? msg : items;
+};
 
+const accumulate = (props, {messages, locale, mode}, labelName) => (acc = {}, propName) => ({
+    ...acc,
+    [propName]: mode === 'msgId' ? getMessage(messages, props[propName], labelName) : getLocalizedObjectEntry(props[propName], locale, labelName)
+});
 /**
- * Converts the msgId provided for the props indicated as arguments into localized
- * strings getting them from the context.
+ * Converts the properties indicated in the `propNames` parameter to localized.
+ * If the property is a string, tries to get the localized string from the context.
+ *
  * @name localizedProps
  * @memberof components.misc.enhancers
- * @param  {string|[string]} propNames Name of the prop(s) to replace. can be an array or a single prop
+ * @param  {string|string[]} propNames Name of the prop(s) to replace. can be an array or a single prop
  * @param  {string} localizedKey Name of the prop used to localize properties in arrays, default "label"
- * @return {HOC}         An HOC that replaces the prop string with localized string.
+ * @param {string} [mode="msgId"] the mode of the localized string, default "msgId". Can be "msgId" or "object". The possible values are:
+ * .- `"msgId"`, so the localized string is a string is retrieved from the context
+ *  - `"object"` the localized value is a string or an object with the localized strings for each language. (e.g. `{"it-IT": "italian", "en-US": "English", default: "DefaultString"}`)
+ * @return {HOC} An HOC that replaces the prop string with localized string.
  * @example
+ * // --- using msgId mode (Default) ---
+ * // - localize single string ...
  * const Input = localizedProps('placeholder')(BootstrapInput);
+ * //... and render
+ * return (<Input placeholder="path.to.placeholder.message" />)
+ * // - localize array of strings ...
  * const CustomSelect = localizedProps('options', 'customLabel')(ReactSelect);
+ * //... and render
+ * return (<CustomSelect options={[{customLabel: "path1", value: v}, {customLabel: "path2", value: v}]} />)
+ * // - by default the localized string is in the "label" property...
  * const Select = localizedProps('options')(ReactSelect);
- * // render
- * //...
- * <Input placeholder="path.to.placeholder.message" />
- * or
- * <CustomSelect options={[{customLabel: "path1", value: v}, {customLabel: "path2", value: v}]} />
- * <Select options={[{label: "path1", value: v}, {label: "path2", value: v}]} />
+ * // ... and render
+ * return (<Select options={[{label: "path1", value: v}, {label: "path2", value: v}]} />)
+ * // -- using the object mode, extract the localized string from the object passed as prop
+ * // - localize single string ...
+ * const Input = localizedProps('placeholder', undefined, 'object')(BootstrapInput);
+ * //... and render
+ * return (<Input placeholder={{default: "path.to.placeholder.message", "it-IT": "italian"}} />)
+ * // - localize array of strings ...
+ * const CustomSelect = localizedProps('options', 'customLabel', 'object')(ReactSelect);
+ * // ... and render
+ * return (<CustomSelect options={[{customLabel: {default: "path1", "it-IT": "italian"}, value: v}]} />)
  */
-export default (propNames, localizedKey = "label") => compose(
+export default (propNames, localizedKey = "label", mode = 'msgId') => compose(
     getContext({
-        messages: PropTypes.object
+        messages: PropTypes.object,
+        locale: PropTypes.string
     }),
-    mapProps(({messages, ...props}) => ({
+    mapProps(({messages, locale, ...props}) => ({
         ...props,
-        ...(castArray(propNames).reduce(accumulate(props, messages, localizedKey), {}))
+        ...(castArray(propNames).reduce(accumulate(props, {locale, messages, mode}, localizedKey), {}))
     })
     ));

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -525,7 +525,12 @@ const state = {
             id: "TEST_LAYER",
             title: "Test Layer",
             filterObj,
-            nativeCrs: "EPSG:4326"
+            nativeCrs: "EPSG:4326",
+            fields: [{
+                name: "attribute1",
+                type: "string",
+                alias: "Attribute 1"
+            }]
         }]
     },
     highlight: {
@@ -637,25 +642,31 @@ describe('featuregrid Epics', () => {
 
     describe('featureGridBrowseData epic', () => {
         const LAYER = state.layers.flat[0];
-        const checkInitActions = ([a1, a2, a3]) => {
-            // close TOC
-            expect(a1.type).toBe(SET_CONTROL_PROPERTY);
-            expect(a1.control).toBe('drawer');
-            expect(a1.property).toBe('enabled');
-            expect(a1.value).toBe(false);
-            // set feature grid layer
-            expect(a2.type).toBe(SET_LAYER);
-            expect(a2.id).toBe(LAYER.id);
-            // open feature grid
-            expect(a3.type).toBe(OPEN_FEATURE_GRID);
-        };
+
         it('browseData action initializes featuregrid', done => {
             testEpic(featureGridBrowseData, 5, browseData(LAYER), ([ a1, a2, a3, a4, a5 ]) => {
-                expect(a1.type).toBe(QUERY_FORM_RESET);
-                checkInitActions([a2, a3, a4]);
-                // sets the feature type selected for search
-                expect(a5.type).toBe(FEATURE_TYPE_SELECTED);
-                done();
+                try {
+                    expect(a1.type).toBe(QUERY_FORM_RESET);
+                    // close TOC
+                    expect(a2.type).toBe(SET_CONTROL_PROPERTY);
+                    expect(a2.control).toBe('drawer');
+                    expect(a2.property).toBe('enabled');
+                    expect(a2.value).toBe(false);
+                    // set feature grid layer
+                    expect(a3.type).toBe(SET_LAYER);
+                    expect(a3.id).toBe(LAYER.id);
+                    // open feature grid
+                    expect(a4.type).toBe(OPEN_FEATURE_GRID);
+                    // sets the feature type selected for search
+                    expect(a5.type).toBe(FEATURE_TYPE_SELECTED);
+                    // check fields of layer are passed if any
+                    expect(a5.fields.length).toBe(1);
+                    expect(a5.fields).toBe(LAYER.fields);
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+
             }, state);
         });
     });

--- a/web/client/epics/__tests__/layerfilter-test.js
+++ b/web/client/epics/__tests__/layerfilter-test.js
@@ -39,20 +39,26 @@ describe('layerFilter Epics', () => {
 
         // State need a selected layers
         const state = {layers: {
-            flat: [{id: "topp:states__5", name: "topp:states", url: "url"}],
+            flat: [{id: "topp:states__5", name: "topp:states", url: "url", fields: [{name: "STATE_NAME", type: "string", alias: "State Name"}]}],
             selected: ["topp:states__5"]}
         };
-        testEpic(handleLayerFilterPanel, 6, action, (actions) => {
-            expect(actions[0].type).toBe("FEATURE_TYPE_SELECTED");
-            expect(actions[0].url).toBe("url");
-            expect(actions[1].type).toBe("QUERYFORM:LOAD_FILTER");
-            expect(actions[2].type).toBe("LAYER_FILTER:INIT_LAYER_FILTER");
-            expect(actions[3].type).toBe("SET_CONTROL_PROPERTY");
-            expect(actions[4].type).toBe("QUERY:TOGGLE_LAYER_FILTER");
-            expect(actions[5].type).toBe("CHANGE_LAYER_PROPERTIES");
+        testEpic(handleLayerFilterPanel, 6, action, ([featureTypeSelected, loadFilter, initLayerFilter, setControlProperty, toggleLayerFilter, changeLayerProperties]) => {
+            expect(featureTypeSelected.type).toBe("FEATURE_TYPE_SELECTED");
+            expect(featureTypeSelected.url).toBe("url");
+            expect(featureTypeSelected.typeName).toBe("topp:states");
+            expect(featureTypeSelected.fields).toEqual([{name: "STATE_NAME", type: "string", alias: "State Name"}]);
+
+            expect(loadFilter.type).toBe("QUERYFORM:LOAD_FILTER");
+            expect(initLayerFilter.type).toBe("LAYER_FILTER:INIT_LAYER_FILTER");
+            expect(setControlProperty.type).toBe("SET_CONTROL_PROPERTY");
+            expect(toggleLayerFilter.type).toBe("QUERY:TOGGLE_LAYER_FILTER");
+            expect(changeLayerProperties.type).toBe("CHANGE_LAYER_PROPERTIES");
             done();
 
         }, state);
+    });
+    it('handleLayerFilterPanel with fields', () => {
+
     });
     it("restoreSavedFilter throws correct action", (done) => {
         let action = discardCurrentFilter();

--- a/web/client/epics/__tests__/wfsquery-test.js
+++ b/web/client/epics/__tests__/wfsquery-test.js
@@ -386,7 +386,12 @@ describe('wfsquery Epics', () => {
             name: 'poi',
             title: 'layer2 title',
             description: 'layer2 description',
-            type: 'wms'
+            type: 'wms',
+            fields: [{
+                name: "NAME",
+                alias: "Name Alias",
+                type: "string"
+            }]
         }];
         it('vector layer', (done) => {
             const mockState = {
@@ -447,7 +452,7 @@ describe('wfsquery Epics', () => {
             );
         });
 
-        it('featureTypeSelectedEpic', (done) => {
+        it('wms layer', (done) => {
             const mockState = {
                 query: {
                     data: {},
@@ -481,12 +486,12 @@ describe('wfsquery Epics', () => {
             const wfsResults = require('../../test-resources/wfs/describe-pois.json');
             mockAxios.onGet().reply(() => [200, wfsResults]);
             testEpic(featureTypeSelectedEpic, 2,
-                featureTypeSelected('/dummy', 'poi'), ([changeSpatialAttribute, featureTypeLoaded]) => {
+                featureTypeSelected('/dummy', 'poi', wmsLayer[0].fields), ([changeSpatialAttribute, featureTypeLoaded]) => {
                     try {
                         expect(featureTypeLoaded.type).toBe(FEATURE_TYPE_LOADED);
                         expect(changeSpatialAttribute.type).toBe(CHANGE_SPATIAL_ATTRIBUTE);
                         expect(featureTypeLoaded.featureType.attributes).toEqual([{
-                            label: "NAME",
+                            label: "Name Alias",
                             attribute: "NAME",
                             type: "string",
                             valueId: "id",

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -271,7 +271,7 @@ const createLoadPageFlow = (store) => ({page, size, reason} = {}) => {
     ));
 };
 
-const createInitialQueryFlow = (action$, store, {url, name, id} = {}) => {
+const createInitialQueryFlow = (action$, store, {url, name, id, fields} = {}) => {
     const filterObj = get(store.getState(), `featuregrid.advancedFilters["${id}"]`);
     const createInitialQuery = () => createQuery(url, filterObj || {
         featureTypeName: name,
@@ -279,7 +279,7 @@ const createInitialQueryFlow = (action$, store, {url, name, id} = {}) => {
         ogcVersion: '1.1.0'
     });
 
-    return Rx.Observable.of(featureTypeSelected(url, name)).merge(
+    return Rx.Observable.of(featureTypeSelected(url, name, fields)).merge(
         action$.ofType(FEATURE_TYPE_LOADED).filter(({typeName} = {}) => typeName === name)
             .map(createInitialQuery)
     );

--- a/web/client/epics/layerfilter.js
+++ b/web/client/epics/layerfilter.js
@@ -58,10 +58,10 @@ const addFilterToLayer = (layer, filter) => {
 export const handleLayerFilterPanel = (action$, {getState}) =>
     action$.ofType(OPEN_QUERY_BUILDER).switchMap(() => {
         const layer = getSelectedLayer(getState());
-        const {url, name, layerFilter} = layer || {};
+        const {url, name, layerFilter, fields} = layer || {};
         const searchUrl = layer && layer.search && layer.search.url;
         return Rx.Observable.of(
-            featureTypeSelected(searchUrl || url, name),
+            featureTypeSelected(searchUrl || url, name, fields),
             // Load the filter from the layer if it exist
             loadFilter(layerFilter),
             initLayerFilter(layerFilter),

--- a/web/client/utils/FeatureTypeUtils.js
+++ b/web/client/utils/FeatureTypeUtils.js
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { get } from 'lodash';
+import { get, find } from 'lodash';
 
 const types = {
     // string
@@ -67,11 +67,19 @@ const types = {
     'xsd:float': 'number',
     'xsd:array': 'array'
 };
-export const describeFeatureTypeToAttributes = (data) => get(data, "featureTypes[0].properties")
+
+/**
+ * Transforms the DescribeFeatureType response to an array of attributes.
+ * @param {object} data JSON response of DescribeFeatureType
+ * @param {object[]} [fields=[]] optional `fields` array of the layer, to get the alias of the attributes, for customize/localize labels.
+ * @returns {object[]} attributes with `label`, `attribute`, `type`, `valueId`, `valueLabel`, `values`.
+ */
+export const describeFeatureTypeToAttributes = (data, fields = []) => get(data, "featureTypes[0].properties")
     .filter((attribute) => attribute.type.indexOf('gml:') !== 0 && types[attribute.type])
     .map((attribute) => {
+        const field = find(fields, {name: attribute.name}) ?? {};
         return {
-            label: attribute.name,
+            label: field.alias ?? attribute.name,
             attribute: attribute.name,
             type: types[attribute.type],
             valueId: "id",

--- a/web/client/utils/__tests__/FeatureTypeUtils-test.js
+++ b/web/client/utils/__tests__/FeatureTypeUtils-test.js
@@ -1,0 +1,40 @@
+import expect from 'expect';
+import {describeFeatureTypeToAttributes} from '../FeatureTypeUtils';
+
+describe('Test the FeatureTypeUtils', () => {
+    const data1 = {
+        featureTypes: [{
+            properties: [{
+                name: "name",
+                type: "xsd:string"
+            }]
+        }]
+    };
+    it('describeFeatureTypeToAttributes', () => {
+
+        const fields = [{
+            name: "name",
+            alias: "alias"
+        }];
+        const attributes = describeFeatureTypeToAttributes(data1, fields);
+        expect(attributes).toEqual([{
+            label: "alias",
+            attribute: "name",
+            type: "string",
+            valueId: "id",
+            valueLabel: "name",
+            values: []
+        }]);
+    });
+    it('describeFeatureTypeToAttributes with no fields', () => {
+        const attributes = describeFeatureTypeToAttributes(data1);
+        expect(attributes).toEqual([{
+            label: "name",
+            attribute: "name",
+            type: "string",
+            valueId: "id",
+            valueLabel: "name",
+            values: []
+        }]);
+    });
+});


### PR DESCRIPTION
## Description

This PR provides support for alias in 

- [x] Query Panel
- [ ] Style Editor
- [ ] Widget builder

In order to make the review easier I organized the commits in : 
- General improvements to i18n utilities, used in the tools
- Support to LayerFilter Plugin
- Support to the other tools that use the query builder
- TODO: support to style editor
- TODO: support to widget editor. 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
