### PR TITLE
#9142 Support for alias in visual style editor

### DIFF
--- a/web/client/components/styleeditor/MultiInput.jsx
+++ b/web/client/components/styleeditor/MultiInput.jsx
@@ -13,7 +13,7 @@ import localizedProps from '../misc/enhancers/localizedProps';
 import Message from '../I18N/Message';
 import DebouncedFormControl from '../misc/DebouncedFormControl';
 
-const ReactSelect = localizedProps(['placeholder', 'noResultsText'])(Select);
+const ReactSelect = localizedProps('options', 'label', "object")(localizedProps(['placeholder', 'noResultsText'])(Select));
 
 function MultiInput({
     label,

--- a/web/client/components/styleeditor/RulesEditor.jsx
+++ b/web/client/components/styleeditor/RulesEditor.jsx
@@ -268,7 +268,7 @@ const RulesEditor = forwardRef(({
                     // before to look if the current selected attribute is of type number
                     // the attribute select of the classification rule changes the disabled attribute based on type
                     const isCustomNumber =  isArray(attributes)
-                        ? (attributes.find(({ label }) => label === rule?.attribute) || {})?.type === 'number'
+                        ? (attributes.find(({ attribute }) => attribute === rule?.attribute) || {})?.type === 'number'
                         : false;
                     return (
                         <Rule
@@ -348,7 +348,7 @@ const RulesEditor = forwardRef(({
                                     attributes={attributes && attributes.map((attribute) => ({
                                         ...attribute,
                                         ...( rule.method === "customInterval"
-                                            ? { disabled: isCustomNumber ? attribute.type !== 'number' : attribute.label !== rule.attribute }
+                                            ? { disabled: isCustomNumber ? attribute.type !== 'number' : attribute.attribute !== rule.attribute }
                                             : rule.method !== "uniqueInterval" && { disabled: attribute.type !== 'number' }
                                         )
                                     }))}

--- a/web/client/components/styleeditor/SelectInput.jsx
+++ b/web/client/components/styleeditor/SelectInput.jsx
@@ -13,8 +13,8 @@ import Message from '../I18N/Message';
 import Select from 'react-select';
 import localizedProps from '../misc/enhancers/localizedProps';
 
-const ReactSelect = localizedProps(['placeholder', 'noResultsText'])(Select);
-const ReactSelectCreatable = localizedProps(['placeholder', 'noResultsText'])(Select.Creatable);
+const ReactSelect = localizedProps('options', 'label', 'object')(localizedProps(['placeholder', 'noResultsText'])(Select));
+const ReactSelectCreatable = localizedProps('options', 'label', 'object')(localizedProps(['placeholder', 'noResultsText'])(Select.Creatable));
 
 function SelectInput({
     label,

--- a/web/client/components/styleeditor/__tests__/MultiInput-test.jsx
+++ b/web/client/components/styleeditor/__tests__/MultiInput-test.jsx
@@ -53,6 +53,31 @@ describe('MultiInput component', () => {
         const selectNode = document.querySelector('.Select');
         expect(selectNode).toBeTruthy();
     });
+    it('should render localized labels in select', () => {
+        const INITIAL_OPTION_VALUE = 'original_option_value';
+        const config = {
+            initialOptionValue: INITIAL_OPTION_VALUE,
+            getSelectOptions: () => [
+                { label: {"default": "Localized"}, value: 'height' },
+                { label: 'Id', value: 'id' },
+                { label: 'Original value', value: INITIAL_OPTION_VALUE }
+            ]
+        };
+        ReactDOM.render(<MultiInput value={{ type: 'attributes', name: 'height' }} config={config} />, document.getElementById("container"));
+        const selectNode = document.querySelector('.Select');
+        const selectInputNode = selectNode.querySelector('input');
+        act(() => {
+
+            Simulate.focus(selectInputNode);
+            Simulate.keyDown(selectInputNode, { key: 'ArrowDown', keyCode: 40 });
+            Simulate.keyDown(selectInputNode, { key: 'Enter', keyCode: 13 });
+        });
+        const selectMenuOptionNodes = selectNode.querySelectorAll('.Select-option');
+        expect(selectMenuOptionNodes.length).toBe(3);
+        expect(selectMenuOptionNodes[0].textContent).toBe('Localized');
+        expect(selectMenuOptionNodes[1].textContent).toBe('Id');
+        expect(selectMenuOptionNodes[2].textContent).toBe('Original value');
+    });
 
     it('should handle onChange', (done) => {
         act(() => {

--- a/web/client/components/styleeditor/__tests__/SelectInput-test.jsx
+++ b/web/client/components/styleeditor/__tests__/SelectInput-test.jsx
@@ -57,4 +57,31 @@ describe('SelectInput component', () => {
         expect(selectInputOptions.length).toBe(3);
         expect([...selectInputOptions].map((node) => node.innerHTML)).toEqual([ 'a', '1', '2' ]);
     });
+    it('should support localized labels in getOptions', () => {
+        act(() => {
+            ReactDOM.render(<SelectInput
+                value={'a'}
+                config={{
+                    getOptions: () => [{ value: '1', label: '1' }]
+                }}
+            />, document.getElementById("container"));
+        });
+        let selectInputControlNode = document.querySelector('.Select-control');
+        expect(selectInputControlNode).toBeTruthy();
+        act(() => {
+            ReactDOM.render(<SelectInput
+                value={'a'}
+                config={{
+                    getOptions: () => [{ value: '1', label: '1' }, { value: '2', label: {"default": '2-localized'} }]
+                }}
+            />, document.getElementById("container"));
+        });
+        selectInputControlNode = document.querySelector('.Select-control');
+        act(() => {
+            Simulate.keyDown(selectInputControlNode, { keyCode: 40 });
+        });
+        const selectInputOptions = document.querySelectorAll('.Select-option');
+        expect(selectInputOptions.length).toBe(3);
+        expect([...selectInputOptions].map((node) => node.innerHTML)).toEqual([ 'a', '1', '2-localized' ]);
+    });
 });

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -441,7 +441,7 @@ const getBlocks = ({
                     getOptions: ({ attributes }) => {
                         return attributes?.map((option) => ({
                             value: '{{' + option.attribute + '}}',
-                            label: option.attribute
+                            label: option.label || option.attribute
                         })) || [];
                     }
                 }),
@@ -561,7 +561,7 @@ const getBlocks = ({
                         getOptions: ({ attributes }) => {
                             return attributes?.map((option) => ({
                                 value: option.attribute,
-                                label: option.attribute,
+                                label: option.label || option.attribute,
                                 disabled: option.disabled
                             }));
                         }

--- a/web/client/plugins/styleeditor/StyleCodeEditor.jsx
+++ b/web/client/plugins/styleeditor/StyleCodeEditor.jsx
@@ -60,9 +60,9 @@ const styleUpdateTypes = {
     'classification-raster': classificationRaster
 };
 
-function getAttributesFromHintProperties(hintProperties, geometryType) {
+function getAttributesFromHintProperties(hintProperties, geometryType, fields) {
     return hintProperties && geometryType !== 'raster'
-        ? getAttributes(hintProperties)
+        ? getAttributes(hintProperties, fields)
         : [];
 }
 
@@ -84,7 +84,7 @@ const ConnectedVisualStyleEditor = connect(
             code,
             mode: getEditorMode(format),
             bands: isArray(hintProperties) && geometryType === 'raster' && hintProperties || [],
-            attributes: getAttributesFromHintProperties(hintProperties, geometryType),
+            attributes: getAttributesFromHintProperties(hintProperties, geometryType, layer?.fields),
             error: error.edit || null,
             loading,
             format,

--- a/web/client/utils/StyleEditorUtils.js
+++ b/web/client/utils/StyleEditorUtils.js
@@ -593,7 +593,14 @@ export function detectStyleCodeChanges({ metadata = {}, format, code } = {}) {
         });
 }
 
-export function getAttributes(properties) {
+/**
+ * Internal function for handling attributes in the style editor.
+ * Parses the properties object (that maps for each attribute name the information about hte type) and checks the type of each property (if it is a string or a number)
+ * @param {object} properties object with properties (`{key: {localType: "..."}}`)
+ * @param {object[]} [fields=[]] optional array of fields to get the alias from. If not provided, the alias will be the key
+ * @returns {object[]} returns an array of attributes (`{attribute: key, label: alias, type: 'string' | 'number'}`) where `alias` is the alias of the field if present, otherwise the key
+ */
+export function getAttributes(properties, fields = []) {
     const stringTypeToCheck = [ 'string'];
     const numberTypeToCheck = ['integer', 'long', 'double', 'float', 'bigdecimal', 'decimal', 'number', 'int'];
     return Object.keys(properties)
@@ -601,9 +608,10 @@ export function getAttributes(properties) {
             .indexOf(properties[key].localType.toLowerCase()) !== -1)
         .map((key) => {
             const { localType } = properties[key];
+            const field = fields.find(f => f.name === key) || {};
             return {
                 attribute: key,
-                label: key,
+                label: field?.alias ?? key,
                 type: numberTypeToCheck
                     .indexOf(localType.toLowerCase()) !== -1
                     ? 'number'
@@ -635,7 +643,7 @@ export function getVectorLayerAttributes(layer) {
         return attributes;
     }
     if (layer?.type === 'wfs') {
-        return getAttributes(layer.properties);
+        return getAttributes(layer.properties, layer?.fields);
     }
     if (layer?.type === 'vector') {
         const propertiesKeys = Object.keys(layer.properties || {});

--- a/web/client/utils/__tests__/StyleEditorUtils-test.js
+++ b/web/client/utils/__tests__/StyleEditorUtils-test.js
@@ -1269,5 +1269,10 @@ describe('StyleEditorUtils test', () => {
             { attribute: 'name', label: 'name', type: 'string' },
             { attribute: 'count', label: 'count', type: 'number' }
         ]);
+        // support for optionals fields for alias
+        expect(getAttributes(properties, [{"name": "name", "alias": "alias"}])).toEqual([
+            { attribute: 'name', label: 'alias', type: 'string' },
+            { attribute: 'count', label: 'count', type: 'number' }
+        ]);
     });
 });


### PR DESCRIPTION
## Description
This PR fixes #9142 introducing the support for alias in visual style editor.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9142 missing


**What is the new behavior?**

Now support for #9142 is implemented 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
