### PR TITLE
Fix #9150. Support for alias in widgets

### DIFF
--- a/web/client/components/data/featuregrid/AttributeTable.jsx
+++ b/web/client/components/data/featuregrid/AttributeTable.jsx
@@ -11,7 +11,10 @@ import ReactDataGrid from 'react-data-grid';
 import { castArray, includes, uniqBy, isEmpty } from "lodash";
 
 import Message from '../../I18N/Message';
+import localizedProps from '../../misc/enhancers/localizedProps';
 import FormatEditor from "../../data/featuregrid/editors/FormatEditor";
+
+const DataGrid = localizedProps("columns", "name")(ReactDataGrid);
 
 // Update property name on row selection operation
 const updatePropertyName = (arr, names, hide) => {
@@ -28,17 +31,17 @@ const getEditor = (formatRegex) => <FormatEditor dataType="string" formatRegex={
 
 // Columns for configuring table options
 const columns = [{
-    name: 'Name',
-    key: 'attribute',
+    name: 'widgets.builder.wizard.attributeEditorColumns.name',
+    key: 'label',
     width: 120
 }, {
-    name: 'Title',
+    name: 'widgets.builder.wizard.attributeEditorColumns.title',
     key: 'title',
     editor: getEditor("^[-@.\\/\#&+\\w\\s*]{0,100}$"),
     width: 120,
     editable: (rowData) => !rowData?.hide
 }, {
-    name: 'Description',
+    name: 'widgets.builder.wizard.attributeEditorColumns.tooltip',
     key: 'description',
     editor: getEditor("^[-@.,\\/\#&+\\w\\s*]{0,200}$"),
     width: 150,
@@ -70,7 +73,7 @@ export default ({
 
     return (<div className="bg-body data-attribute-selector" style={style}>
         <h4 className="text-center"><strong><Message msgId={titleMsg}/></strong></h4>
-        <ReactDataGrid
+        <DataGrid
             rowKey="id"
             columns={columns}
             enableCellSelect

--- a/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
@@ -311,7 +311,7 @@ export default ({
                                 onChange("autoColorOptions.classification", formatAutoColorOptions(newClassification, attributeType) || []);
                             }
                         }}
-                        options={typedOptions}
+                        options={typedOptions.filter(item => item.type === 'string' || item.type === 'number')}
                         placeHolder={placeHolder}
                         classification={classification}
                         rangeClassification={rangeClassification}

--- a/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
@@ -106,7 +106,6 @@ export default ({
     data = { options: {}, autoColorOptions: {} },
     onChange = () => { },
     options = [],
-    typedOptions = [],
     showTitle = true,
     formOptions = {
         showGroupBy: true,
@@ -311,7 +310,7 @@ export default ({
                                 onChange("autoColorOptions.classification", formatAutoColorOptions(newClassification, attributeType) || []);
                             }
                         }}
-                        options={typedOptions.filter(item => item.type === 'string' || item.type === 'number')}
+                        options={options.filter(item => item.type === 'string' || item.type === 'number')}
                         placeHolder={placeHolder}
                         classification={classification}
                         rangeClassification={rangeClassification}

--- a/web/client/components/widgets/builder/wizard/common/__tests__/wfsChartOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/common/__tests__/wfsChartOptions-test.jsx
@@ -156,4 +156,59 @@ describe('wfsChartOptions enhancer', () => {
             checkOptions({ aggregationAttribute: "DateTime" }, props => expect(props.aggregationOptions.every(({ value }) => NO_NUM_OPS.includes(value))).toBeTruthy(), done);
         });
     });
+    describe('check options (with fields)', () => {
+        const fields = [{
+            name: "itemWithAlias",
+            alias: "itemWithAliasAlias"
+        }, {
+            name: "itemWithAliasLocalized",
+            alias: {
+                "default": "itemWithAliasLocalizedAliasDefault"
+            }
+        }];
+        const checkOptions = (options, check = () => {}, done) => {
+            const data = {
+                options
+            };
+            const Sink = wfsChartOptions(createSink(props => {
+                check(props);
+                done();
+            }));
+            ReactDOM.render(<Sink data={data} featureTypeProperties={featureTypeProperties} layer={{fields}} />, document.getElementById("container"));
+        };
+        const featureTypeProperties2 = [{
+            "name": "itemWithAlias",
+            "maxOccurs": 1,
+            "minOccurs": 0,
+            "nillable": true,
+            "type": "xsd:string",
+            "localType": "string"
+        }, {
+            "name": "itemWithAliasLocalized",
+            "maxOccurs": 1,
+            "minOccurs": 0,
+            "nillable": true,
+            "type": "xsd:string",
+            "localType": "string"
+        }];
+        it('item with alias', (done) => {
+            checkOptions(featureTypeProperties2, props => {
+                props.options.forEach(({ value, label }) => {
+                    if (value === "itemWithAlias") {
+                        expect(label).toBe("itemWithAliasAlias");
+                    }
+                });
+            }, done);
+        });
+        it('item with alias (localized)', (done) => {
+            checkOptions(featureTypeProperties2, props => {
+                props.options.forEach(({ value, label }) => {
+                    if (value === "itemWithAliasLocalized") {
+                        expect(label).toBe("itemWithAliasLocalizedAliasDefault");
+                    }
+                });
+            }, done);
+        });
+    });
+
 });

--- a/web/client/components/widgets/builder/wizard/common/wfsChartOptions.js
+++ b/web/client/components/widgets/builder/wizard/common/wfsChartOptions.js
@@ -11,13 +11,8 @@ import localizedProps from '../../../../misc/enhancers/localizedProps';
 import { getDefaultAggregationOperations } from '../../../../../utils/WidgetsUtils';
 import {find} from 'lodash';
 
-const propsToOptions = props => props.filter(({type} = {}) => type.indexOf("gml:") !== 0)
-    .map( ({name} = {}) => ({label: name, value: name}));
-
-/** custom color-coded charts currently support string and number types only */
-const propsToTypedOptions = props => props.filter(({type} = {}) => type.indexOf("gml:") !== 0)
-    .map(({name, localType} = {}) => ({ label: name, value: name, type: localType }))
-    .filter(item => item.type === 'string' || item.type === 'number');
+const propsToOptions = (props, fields = []) => props.filter(({type} = {}) => type.indexOf("gml:") !== 0)
+    .map( ({name, localType} = {}) => ({label: find(fields, {name})?.alias ?? name, value: name, type: localType}));
 
 const getAllowedAggregationOptions = (propertyName, featureTypeProperties = []) => {
     const prop = find(featureTypeProperties, {name: propertyName});
@@ -28,13 +23,13 @@ const getAllowedAggregationOptions = (propertyName, featureTypeProperties = []) 
 };
 
 export default compose(
-    withProps(({featureTypeProperties = [], data = {}} = {}) => ({
-        options: propsToOptions(featureTypeProperties),
-        typedOptions: propsToTypedOptions(featureTypeProperties),
+    withProps(({featureTypeProperties = [], data = {}, layer} = {}) => ({
+        options: propsToOptions(featureTypeProperties, layer?.fields),
+        /** custom color-coded charts currently support string and number types only */
         aggregationOptions:
             (data?.widgetType !== "counter" ? [{ value: "None", label: "widgets.operations.NONE" }] : [])
                 .concat(getAllowedAggregationOptions(data.options && data.options.aggregationAttribute, featureTypeProperties))
     })),
+    localizedProps("options", "label", "object"),
     localizedProps("aggregationOptions")
-
 );

--- a/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
@@ -16,6 +16,7 @@ import Message from '../../../../I18N/Message';
 import StepHeader from '../../../../misc/wizard/StepHeader';
 import noAttributes from '../common/noAttributesEmptyView';
 import Button from '../../../../misc/Button';
+import localizedProps from '../../../../misc/enhancers/localizedProps';
 
 const AttributeSelector = compose(
     withProps(({options = {}})=>({
@@ -25,15 +26,16 @@ const AttributeSelector = compose(
         }
     })),
     withProps(
-        ({ attributes = [], options = {}} = {}) => ({ // TODO manage hide condition
+        ({ attributes = [], options = {}, layer = {}} = {}) => ({ // TODO manage hide condition
             attributes: attributes
                 .filter(a => !isGeometryType(a))
                 .map( a => {
                     const propertyNames = options?.propertyName?.map(p => p.name);
                     const currPropertyName = options?.propertyName?.find(p => p.name === a.name);
+                    const field = layer.fields?.find(f => f.name === a.name);
                     return {
                         ...a,
-                        label: a.name,
+                        label: field?.alias || a.name,
                         attribute: a.name,
                         hide: propertyNames?.indexOf( a.name ) < 0,
                         title: currPropertyName?.title || '',
@@ -41,11 +43,12 @@ const AttributeSelector = compose(
                     };
                 })
         })),
+    localizedProps("attributes", "label", "object"),
     noAttributes(({ attributes = []}) => attributes.length === 0)
 )(AttributeTable);
 
 
-export default ({ data = { options: {} }, onChange = () => { }, featureTypeProperties, sampleChart}) => (<Row>
+export default ({ data = { options: {} }, onChange = () => { }, featureTypeProperties, sampleChart, layer}) => (<Row>
     <StepHeader title={<Message msgId={`widgets.builder.wizard.configureTableOptions`} />} />
     <Col xs={12}>
         <div >
@@ -55,6 +58,7 @@ export default ({ data = { options: {} }, onChange = () => { }, featureTypePrope
     <Col xs={12}>
         <Form className="chart-options-form" horizontal>
             <AttributeSelector
+                layer={layer}
                 options={data.options}
                 onChange={onChange}
                 attributes={featureTypeProperties}/>

--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -33,7 +33,6 @@ export default pure(({
     widgets = [],
     layouts,
     dependencies,
-    verticalCompact = false,
     compactMode,
     useDefaultWidthProvider = true,
     measureBeforeMount,
@@ -72,7 +71,6 @@ export default pure(({
         className={`widget-container ${className} ${canEdit ? '' : 'no-drag'}`}
         rowHeight={rowHeight}
         autoSize
-        verticalCompact={verticalCompact}
         compactMode={compactMode}
         breakpoints={breakpoints}
         cols={cols}

--- a/web/client/components/widgets/widget/TableWidget.jsx
+++ b/web/client/components/widgets/widget/TableWidget.jsx
@@ -43,6 +43,7 @@ export default getWidgetFilterRenderers(({
     filterRenderers,
     columnSettings,
     features,
+    layer,
     size,
     pages,
     error,
@@ -86,6 +87,7 @@ export default getWidgetFilterRenderers(({
                 virtualScroll={virtualScroll}
                 enableColumnFilters={enableColumnFilters}
                 filterRenderers={filterRenderers}
+                fields={layer?.fields}
                 features={features}
                 pages={pages}
                 error={error}

--- a/web/client/epics/__tests__/widgets-test.js
+++ b/web/client/epics/__tests__/widgets-test.js
@@ -380,6 +380,39 @@ describe('widgets Epics', () => {
                 }
             });
     });
+    it('changeLayerPropertiesEpic triggers updateWidgetLayer on fields change', (done) => {
+        const checkActions = actions => {
+            expect(actions.length).toBe(1);
+            expect(actions[0].type).toBe(UPDATE_LAYER);
+            expect(actions[0].layer).toEqual({
+                id: "1",
+                name: "layer"
+            });
+            done();
+        };
+        testEpic(updateLayerOnLayerPropertiesChange,
+            1,
+            [changeLayerProperties(
+                "1",
+                {fields: [{name: "field1", type: "string", alias: "Field 1"}]}
+            )],
+            checkActions,
+            {
+                layers: {
+                    flat: [{
+                        id: "1",
+                        name: "layer"
+                    }, {
+                        id: "2",
+                        name: "layer2",
+                        fields: [{name: "field1", type: "string", alias: "Field 1"}]
+                    }, {
+                        id: "3",
+                        name: "layer3"
+                    }]
+                }
+            });
+    });
     it('changeLayerPropertiesEpic does not triger updateWidgetLayer on visibility change', (done) => {
         const action = changeLayerProperties("1", {visibility: false});
         const state = {

--- a/web/client/epics/__tests__/widgetsbuilder-test.js
+++ b/web/client/epics/__tests__/widgetsbuilder-test.js
@@ -221,6 +221,11 @@ describe('widgetsbuilder epic', () => {
                     }
                     break;
                 case FEATURE_TYPE_SELECTED:
+                    expect(action.fields).toEqual([{
+                        name: "x",
+                        type: "string",
+                        alias: "X alias"
+                    }]);
                     break;
                 case LOAD_FILTER:
                     break;
@@ -241,6 +246,11 @@ describe('widgetsbuilder epic', () => {
                 builder: {
                     editor: {
                         layer: {
+                            fields: [{
+                                name: "x",
+                                type: "string",
+                                alias: "X alias"
+                            }],
                             search: {
                                 url: "test"
                             }

--- a/web/client/epics/widgets.js
+++ b/web/client/epics/widgets.js
@@ -249,9 +249,11 @@ export const updateLayerOnLayerPropertiesChange = (action$, store) =>
         .switchMap(({layer, newProperties}) => {
             const state = store.getState();
             const flatLayer = getLayerFromId(state, layer);
-            return Rx.Observable.of(
-                ...(has(newProperties, "layerFilter") && flatLayer ? [updateWidgetLayer(flatLayer)] : [])
-            );
+            const shouldUpdate = flatLayer && (has(newProperties, "layerFilter") || has(newProperties, "fields"));
+            if (shouldUpdate) {
+                return Rx.Observable.of(updateWidgetLayer(flatLayer));
+            }
+            return Rx.Observable.empty();
         });
 
 /**

--- a/web/client/epics/widgetsbuilder.js
+++ b/web/client/epics/widgetsbuilder.js
@@ -31,7 +31,7 @@ const getFTSelectedArgs = (state) => {
     let layer = getWidgetLayer(state);
     let url = layer.search && layer.search.url;
     let typeName = layer.name;
-    return [url, typeName];
+    return [url, typeName, layer.fields];
 };
 
 export const openWidgetEditor = (action$, {getState = () => {}} = {}) => action$.ofType(NEW, EDIT, NEW_CHART)

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1911,6 +1911,11 @@
                     "errorChart": "Mindestens ein Diagramm ist ungültig",
                     "backToTableOptions": "Zurück zu den Tabellenoptionen",
                     "configureTableOptions": "Konfigurieren Sie die Tabellenoptionen",
+                    "attributeEditorColumns": {
+                      "name": "Name",
+                      "title": "Titel",
+                      "tooltip": "Tooltip"
+                    },
                     "resetColumnsSizes": "Setzen Sie alle Änderungen an den Spaltengrößen zurück",
                     "updateWidget": "Aktualisieren Sie das Widget",
                     "addTheWidget": "Hinzufügen des Widget",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1874,6 +1874,11 @@
                     "errorChart": "One or more chart(s) is invalid",
                     "backToTableOptions": "Back to table options",
                     "configureTableOptions": "Configure table options",
+                    "attributeEditorColumns": {
+                      "name": "Name",
+                      "title": "Title",
+                      "tooltip": "Tooltip"
+                    },
                     "resetColumnsSizes": "Reset all changes to the column sizes",
                     "updateWidget": "Update the widget",
                     "addTheWidget": "Add the widget",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1873,6 +1873,11 @@
                     "errorChart": "Uno o más gráficos no son válidos",
                     "backToTableOptions": "Volver a las opciones de tabla",
                     "configureTableOptions": "Configurar opciones de tabla",
+                    "attributeEditorColumns": {
+                      "name": "Nombre",
+                      "title": "Título",
+                      "tooltip": "Tooltip"
+                    },
                     "resetColumnsSizes": "Restablecer todos los cambios en los tamaños de columna",
                     "updateWidget": "Actualiza el widget",
                     "addTheWidget": "Agrega el widget",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1874,6 +1874,11 @@
                     "errorChart": "Un ou plusieurs graphiques ne sont pas valides",
                     "backToTableOptions": "Retour à l'option de table",
                     "configureTableOptions": "Configurer les options de table",
+                    "attributeEditorColumns": {
+                      "name": "Nom",
+                      "title": "Titre",
+                      "tooltip": "Info-bulle"
+                    },
                     "resetColumnsSizes": "Réinitialiser toutes les modifications de taille des colonnes",
                     "updateWidget": "Mettre à jour le widget",
                     "addTheWidget": "Ajouter le widget",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1873,6 +1873,11 @@
                     "errorChart": "Uno o più grafici non sono validi",
                     "backToTableOptions": "Torna alle opzioni della tabella",
                     "configureTableOptions": "Configura le opzioni della tabella",
+                    "attributeEditorColumns": {
+                      "name": "Nome",
+                      "title": "Titolo",
+                      "tooltip": "Tooltip"
+                    },
                     "resetColumnsSizes": "Reimposta larghezza automatica delle colonne",
                     "updateWidget": "Aggiorna il widget",
                     "addTheWidget": "Aggiungi il widget",


### PR DESCRIPTION
## Description
Fix #9150. Support for alias in widgets. 
I also added : 
-  A few simplification in functions to avoid duplications
- Localization of columns in table widget configuration step (I noticed they where not localized)

For chart widget I didn't support the legend / tooltip yet in this PR (still to investigate if it is feasable and how, because it is a little more related to the chart itself).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9150 missing

**What is the new behavior?**
#9150 fixed 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
