### PR TITLE
#9154 Fixed map crash when expanding timeline with time intervals

### DIFF
--- a/web/client/epics/__tests__/timeline-test.js
+++ b/web/client/epics/__tests__/timeline-test.js
@@ -781,6 +781,67 @@ describe('timeline Epics', () => {
             });
         });
     });
+    it("setRangeOnInit when the values stored are intervals", (done) => {
+        testEpic(setRangeOnInit, 3, initializeRange(), ([action1, action2, action3]) => {
+            try {
+                const { time, type } = action1;
+                const { offsetTime, type: typeOff} = action2;
+                const { type: typeRange, start, end } = action3;
+                expect(time).toBeTruthy();
+                expect(offsetTime).toBeTruthy();
+                expect(type).toBe(SET_CURRENT_TIME);
+                expect(typeOff).toBe(SET_OFFSET_TIME);
+                expect(typeRange).toBe(RANGE_CHANGED);
+                expect(start).toBe("2001-01-01T00:00:00.000Z");
+                expect(end).toBe("2001-12-31T00:00:00.000Z");
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }, {
+            timeline: {
+                selectedLayer: "TEST_LAYER",
+                settings: {
+                    initialMode: 'range',
+                    initialSnap: 'fullRange'
+                }
+            },
+            dimension: {
+                currentTime: "2000-01-01T00:00:00.000Z",
+                offsetTime: "2001-12-31T00:00:00.000Z",
+                data: {
+                    time: {
+                        TEST_LAYER: {
+                            name: "time",
+                            domain: "2001-01-01T00:00:00.000Z/2001-12-31T00:00:00.000Z"
+                        }
+                    }
+                }
+            },
+            layers: {
+                flat: [{
+                    id: 'TEST_LAYER',
+                    name: 'TEST_LAYER',
+                    type: 'wms',
+                    visibility: true,
+                    url: 'base/web/client/test-resources/wmts/DomainIntervalValues.xml',
+                    dimensions: [
+                        {
+                            source: {
+                                type: 'multidim-extension',
+                                url: 'base/web/client/test-resources/wmts/DomainIntervalValues.xml'
+                            },
+                            name: 'time'
+                        }
+                    ],
+                    params: {
+                        time: '2000-06-08T00:00:00.000Z'
+                    }
+                }]
+            }
+        });
+    });
+
     it("updateTimelineDataOnMapLoad", (done) =>{
         const config = {
             timelineData: {

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -224,7 +224,8 @@ const updateRangeOnInit = (state, value, currentTime) => {
     } else {
         values = value;
     }
-
+    // if values are intervals (separated by /) spread them in the array
+    values = values.reduce((acc, v) => acc.concat(v.split('/')), []);
     if (values.length > 2) {
         values = [values[0], values[values.length - 1]]; // more than 2 values, start and end are the first and last values
     }


### PR DESCRIPTION
## Description
This PR fixes the issue by getting a single value from time intervals, when returned by getDomainValues

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9154 

**What is the new behavior?**
Fix #9154 , not crashing anymore.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
