### PR TITLE
[Backport 2023.01.xx] Fix #9159 Map views mask is not working (#9160)

### DIFF
--- a/web/client/epics/__tests__/mapviews-test.js
+++ b/web/client/epics/__tests__/mapviews-test.js
@@ -89,6 +89,26 @@ describe('mapviews epics', () => {
                     UPDATE_ADDITIONAL_LAYER,
                     UPDATE_ADDITIONAL_LAYER
                 ]);
+
+                expect(actions[4].options.style).toBeTruthy();
+                expect(actions[4].options.style).toEqual({
+                    format: 'geostyler',
+                    body: {
+                        name: '',
+                        rules: [
+                            {
+                                name: '',
+                                symbolizers: [{
+                                    kind: 'Fill',
+                                    color: '#ffffff',
+                                    fillOpacity: 0,
+                                    msClampToGround: true,
+                                    msClassificationType: '3d'
+                                }]
+                            }
+                        ]
+                    }
+                });
             } catch (e) {
                 done(e);
             }

--- a/web/client/epics/mapviews.js
+++ b/web/client/epics/mapviews.js
@@ -180,7 +180,9 @@ export const updateMapViewsLayers = (action$, store) =>
                                                     symbolizers: [{
                                                         kind: 'Fill',
                                                         color: '#ffffff',
-                                                        fillOpacity: 0
+                                                        fillOpacity: 0,
+                                                        msClampToGround: true,
+                                                        msClassificationType: '3d'
                                                     }]
                                                 }
                                             ]


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds the correct style for the mask layer in the map views plugin

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9159

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The Mask option for Map Views is working

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
