### PR TITLE
#9166 Add search plugin to context creator map

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -205,6 +205,7 @@ export default class ContextCreator extends React.Component {
             "TOCItemsSettings",
             "DrawerMenu",
             "OmniBar",
+            "Search",
             "BurgerMenu",
             "AddGroup",
             "Notifications",


### PR DESCRIPTION
## Description
Fix #9166. Adds search plugin to context creator. The default configuration fits well ( no bookmark, no search services editor that may confuse users). 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**

#9166

**What is the new behavior?**

Fix #9166

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
