### PR TITLE
Fix #9172 add flag to always select first layer in toc in identify results

### DIFF
--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -38,7 +38,7 @@ export default props => {
         onClose = () => {},
         responses = [],
         index,
-        ignorePerformances,
+        showAllResponses,
         viewerOptions = {},
         format,
         dock = true,
@@ -134,7 +134,7 @@ export default props => {
                         <LayerSelector
                             responses={responses}
                             index={index}
-                            ignorePerformances={ignorePerformances}
+                            showAllResponses={showAllResponses}
                             loaded={loaded}
                             setIndex={setIndex}
                             missingResponses={missingResponses}

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -38,6 +38,7 @@ export default props => {
         onClose = () => {},
         responses = [],
         index,
+        ignorePerformances,
         viewerOptions = {},
         format,
         dock = true,
@@ -133,6 +134,7 @@ export default props => {
                         <LayerSelector
                             responses={responses}
                             index={index}
+                            ignorePerformances={ignorePerformances}
                             loaded={loaded}
                             setIndex={setIndex}
                             missingResponses={missingResponses}

--- a/web/client/components/data/identify/LayerSelector.jsx
+++ b/web/client/components/data/identify/LayerSelector.jsx
@@ -13,7 +13,7 @@ import {isEmpty} from 'lodash';
 import localizedProps from '../../misc/enhancers/localizedProps';
 const SelectLocalized = localizedProps(['placeholder', 'clearValueText', 'noResultsText'])(Select);
 
-const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, emptyResponses, validator, format}) => {
+const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, emptyResponses, validator, format, ignorePerformances = false}) => {
     const selectProps = {clearable: false, isSearchable: true};
     const [options, setOptions] = useState([]);
     const [title, setTitle] = useState("");
@@ -22,9 +22,16 @@ const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, e
         if (!isEmpty(responses)) {
             setOptions(responses.map((opt, idx)=> {
                 const value = opt?.layerMetadata?.title;
-                // Display only valid responses in the drop down
+                // Display only valid responses in the drop down if ignorePerformances is false,
+                // otherwise all response are visible and the first layer in toc is present in here
                 const valid = !!validator(format)?.getValidResponses([opt]).length;
-                return {label: value, value, idx, style: {display: valid ? 'block' : 'none'}};
+                return {
+                    label: value,
+                    value,
+                    idx,
+                    style: {
+                        display: ignorePerformances ? 'block' : (valid ? 'block' : 'none')
+                    }};
             }));
         }
     }, [responses]);

--- a/web/client/components/data/identify/LayerSelector.jsx
+++ b/web/client/components/data/identify/LayerSelector.jsx
@@ -13,7 +13,7 @@ import {isEmpty} from 'lodash';
 import localizedProps from '../../misc/enhancers/localizedProps';
 const SelectLocalized = localizedProps(['placeholder', 'clearValueText', 'noResultsText'])(Select);
 
-const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, emptyResponses, validator, format, ignorePerformances = false}) => {
+const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, emptyResponses, validator, format, showAllResponses = false}) => {
     const selectProps = {clearable: false, isSearchable: true};
     const [options, setOptions] = useState([]);
     const [title, setTitle] = useState("");
@@ -22,7 +22,7 @@ const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, e
         if (!isEmpty(responses)) {
             setOptions(responses.map((opt, idx)=> {
                 const value = opt?.layerMetadata?.title;
-                // Display only valid responses in the drop down if ignorePerformances is false,
+                // Display only valid responses in the drop down if showAllResponses is false,
                 // otherwise all response are visible and the first layer in toc is present in here
                 const valid = !!validator(format)?.getValidResponses([opt]).length;
                 return {
@@ -30,7 +30,7 @@ const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, e
                     value,
                     idx,
                     style: {
-                        display: ignorePerformances ? 'block' : (valid ? 'block' : 'none')
+                        display: showAllResponses ? 'block' : (valid ? 'block' : 'none')
                     }};
             }));
         }

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -71,6 +71,7 @@ export const identifyLifecycle = compose(
                 enabled,
                 showInMapPopup,
                 maxItems,
+                ignorePerformances,
                 changeMousePointer = () => {},
                 disableCenterToMarker,
                 enableInfoForSelectedLayers = true,
@@ -85,7 +86,8 @@ export const identifyLifecycle = compose(
                 enableInfoForSelectedLayers,
                 configuration: {
                     maxItems
-                }
+                },
+                ignorePerformances
             });
 
             if (enabled || showInMapPopup) {

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -71,7 +71,7 @@ export const identifyLifecycle = compose(
                 enabled,
                 showInMapPopup,
                 maxItems,
-                ignorePerformances,
+                showAllResponses,
                 changeMousePointer = () => {},
                 disableCenterToMarker,
                 enableInfoForSelectedLayers = true,
@@ -87,7 +87,7 @@ export const identifyLifecycle = compose(
                 configuration: {
                     maxItems
                 },
-                ignorePerformances
+                showAllResponses
             });
 
             if (enabled || showInMapPopup) {

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -199,7 +199,7 @@ const identifyDefaultProps = defaultProps({
  * @prop cfg.viewerOptions.container {expression} the container of the viewer, expression from the context
  * @prop cfg.viewerOptions.header {expression} the header of the viewer, expression from the context{expression}
  * @prop cfg.disableCenterToMarker {bool} disable zoom to marker action
- * @prop cfg.ignorePerformances {bool} if true it will include invalid/empty responses and it will always select the first request/layer
+ * @prop cfg.showAllResponses {bool} if true it will include invalid/empty responses and it will always select the first request/layer
  * @prop cfg.zIndex {number} component z index order
  * @prop cfg.showInMapPopup {boolean} if true show the identify as popup
  * @prop cfg.maxItems {number} the number of features returned by this tool

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -174,7 +174,7 @@ const identifyDefaultProps = defaultProps({
 });
 
 /**
- * This plugin allows get informations about clicked point. It can be configured to have a mobile or a desktop flavor.
+ * This plugin allows get information about clicked point. It can be configured to have a mobile or a desktop flavor.
  *
  * You can configure some of the features of this plugin by setting up the initial mapInfo state, then you need to update the "initialState.defaultState", or by the plugin configuration
  * ```
@@ -182,7 +182,7 @@ const identifyDefaultProps = defaultProps({
  *   "enabled": true, // enabled by default
  *   "disabledAlwaysOn": false, // if true, disable always on setup
  *   "configuration": {
- *     "showEmptyMessageGFI": false // allow or deny the visiibility of message when you have no results from identify request
+ *     "showEmptyMessageGFI": false // allow or deny the visibility of message when you have no results from identify request
  *     "infoFormat": "text/plain" // default infoformat value, other values are "text/html" for text only or "application/json" for properties
  *   }
  * }
@@ -199,6 +199,7 @@ const identifyDefaultProps = defaultProps({
  * @prop cfg.viewerOptions.container {expression} the container of the viewer, expression from the context
  * @prop cfg.viewerOptions.header {expression} the header of the viewer, expression from the context{expression}
  * @prop cfg.disableCenterToMarker {bool} disable zoom to marker action
+ * @prop cfg.ignorePerformances {bool} if true it will include invalid/empty responses and it will always select the first request/layer
  * @prop cfg.zIndex {number} component z index order
  * @prop cfg.showInMapPopup {boolean} if true show the identify as popup
  * @prop cfg.maxItems {number} the number of features returned by this tool

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -125,7 +125,7 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[1].layerMetadata).toBe("meta");
         expect(state.index).toBe(1);
     });
-    it('creates a feature info data from successful request, with ignorePerformances true', () => {
+    it('creates a feature info data from successful request, with showAllResponses true', () => {
         let testAction = {
             type: 'LOAD_FEATURE_INFO',
             data: "data",
@@ -144,7 +144,7 @@ describe('Test the mapInfo reducer', () => {
                 {reqId: 11, request: "test1"},
                 {reqId: 3, request: "test3"}
             ],
-            ignorePerformances: true
+            showAllResponses: true
         }, testAction);
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(2);
@@ -164,7 +164,7 @@ describe('Test the mapInfo reducer', () => {
                 {reqId: 11, request: "test1"},
                 {reqId: 3, request: "test3"}
             ],
-            ignorePerformances: true
+            showAllResponses: true
         }, {...testAction, reqId: 3, layerMetadata: "meta3"});
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(3);

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -7,9 +7,10 @@
  */
 
 import expect from 'expect';
+import assign from 'object-assign';
+import 'babel-polyfill';
 
 import mapInfo from '../mapInfo';
-
 import {
     featureInfoClick,
     toggleEmptyMessageGFI,
@@ -22,11 +23,8 @@ import {
     onInitPlugin
 } from '../../actions/mapInfo';
 import {changeVisualizationMode} from '../../actions/maptype';
-
 import { MAP_CONFIG_LOADED } from '../../actions/config';
 import { VisualizationModes } from '../../utils/MapTypeUtils';
-import assign from 'object-assign';
-import 'babel-polyfill';
 
 describe('Test the mapInfo reducer', () => {
     const appState = {
@@ -34,7 +32,11 @@ describe('Test the mapInfo reducer', () => {
             infoFormat: 'text/plain'
         },
         responses: [],
-        requests: [{reqId: 10, request: "test"}, {reqId: 11, request: "test1"}]};
+        requests: [
+            {reqId: 10, request: "test"},
+            {reqId: 11, request: "test1"},
+            {reqId: 3, request: "test3"}
+        ]};
 
     it('returns original state on unrecognized action', () => {
         let state = mapInfo(1, {type: 'UNKNOWN'});
@@ -123,6 +125,59 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[1].layerMetadata).toBe("meta");
         expect(state.index).toBe(1);
     });
+    it('creates a feature info data from successful request, with ignorePerformances true', () => {
+        let testAction = {
+            type: 'LOAD_FEATURE_INFO',
+            data: "data",
+            requestParams: "params",
+            layerMetadata: "meta",
+            reqId: 11
+        };
+
+        let state = mapInfo({
+            configuration: {
+                infoFormat: 'text/plain'
+            },
+            responses: [],
+            requests: [
+                {reqId: 10, request: "test"},
+                {reqId: 11, request: "test1"},
+                {reqId: 3, request: "test3"}
+            ],
+            ignorePerformances: true
+        }, testAction);
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(2);
+        expect(state.loaded).toBe(true);
+        expect(state.responses[1].response).toBe("data");
+        expect(state.responses[1].queryParams).toBe("params");
+        expect(state.responses[1].layerMetadata).toBe("meta");
+        expect(state.index).toBe(0);
+
+        state = mapInfo({
+            configuration: {
+                infoFormat: 'text/plain'
+            },
+            responses: [{response: "test"}, {response: "test1"}],
+            requests: [
+                {reqId: 10, request: "test"},
+                {reqId: 11, request: "test1"},
+                {reqId: 3, request: "test3"}
+            ],
+            ignorePerformances: true
+        }, {...testAction, reqId: 3, layerMetadata: "meta3"});
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(3);
+        expect(state.responses[0].response).toBe("test");
+        expect(state.responses[0]).toBeTruthy();
+        expect(state.responses[1].response).toBe("test1");
+        expect(state.responses[1]).toBeTruthy();
+        expect(state.responses[2]).toBeTruthy();
+        expect(state.responses[2].queryParams).toBe("params");
+        expect(state.responses[2].layerMetadata).toBe("meta3");
+        expect(state.loaded).toBe(true);
+        expect(state.index).toBe(0);
+    });
     it('creates a feature info data from successful request on showInMapPopup', () => {
         let testAction = {
             type: 'LOAD_FEATURE_INFO',
@@ -176,6 +231,15 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[1].response).toBe("");
         expect(state.responses[1].queryParams).toBe("params");
         expect(state.responses[1].layerMetadata).toBe("meta");
+
+        state = mapInfo(assign({}, appState, {responses: [{response: "test"}, {response: "test"}]}), {...testAction, layerMetadata: "meta3", reqId: 3});
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(3);
+        expect(state.responses[0]).toBeTruthy();
+        expect(state.responses[0].response).toBe("test");
+        expect(state.responses[1].response).toBe("test");
+        expect(state.responses[2].queryParams).toBe("params");
+        expect(state.responses[2].layerMetadata).toBe("meta3");
         expect(state.index).toBe(undefined);
         expect(state.loaded).toBe(true);
     });
@@ -241,7 +305,7 @@ describe('Test the mapInfo reducer', () => {
 
         state = mapInfo( appState, {type: 'NEW_MAPINFO_REQUEST', reqId: 1, request: "request"});
         expect(state.requests).toExist();
-        expect(state.requests.length).toBe(3);
+        expect(state.requests.length).toBe(4);
         expect(state.requests.filter((req) => req.reqId === 10)[0].request).toBe("test");
         expect(state.requests.filter((req) => req.reqId === 1)[0].request).toBe("request");
     });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -5,12 +5,13 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
 import assign from 'object-assign';
-import { findIndex, isUndefined, isEmpty } from 'lodash';
 import buffer from 'turf-buffer';
 import intersect from 'turf-intersect';
+import { findIndex, isUndefined, isEmpty } from 'lodash';
 
+import { MAP_CONFIG_LOADED } from '../actions/config';
+import { RESET_CONTROLS } from '../actions/controls';
 import {
     ERROR_FEATURE_INFO,
     EXCEPTIONS_FEATURE_INFO,
@@ -39,9 +40,6 @@ import {
     SET_SHOW_IN_MAP_POPUP,
     INIT_PLUGIN
 } from '../actions/mapInfo';
-
-import { MAP_CONFIG_LOADED } from '../actions/config';
-import { RESET_CONTROLS } from '../actions/controls';
 import { VISUALIZATION_MODE_CHANGED } from '../actions/maptype';
 
 import { getValidator } from '../utils/MapInfoUtils';
@@ -111,7 +109,7 @@ function receiveResponse(state, action, type) {
         }
 
         let indexObj;
-        if (isHover) {
+        if (isHover || state.ignorePerformances) {
             indexObj = {loaded: true, index: 0};
         } else if (!isHover && isIndexValid(state, responses, requestIndex, isVector)) {
             indexObj = {loaded: true, index: requestIndex};

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -109,7 +109,7 @@ function receiveResponse(state, action, type) {
         }
 
         let indexObj;
-        if (isHover || state.ignorePerformances) {
+        if (isHover || state.showAllResponses) {
             indexObj = {loaded: true, index: 0};
         } else if (!isHover && isIndexValid(state, responses, requestIndex, isVector)) {
             indexObj = {loaded: true, index: requestIndex};


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9172

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

when ignorePerformances is set to true this value is edited from cfg, then the first request/layer is selected no matter the validity/presence of the data in the response.

and all layers are listed in the layer selector field

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
