### PR TITLE
Fix #9164 Map views clipping throws error with geometry preview

### DIFF
--- a/web/client/utils/MapViewsUtils.js
+++ b/web/client/utils/MapViewsUtils.js
@@ -107,7 +107,15 @@ export const formatClippingFeatures = (features) => {
     return features
         ? features
             .filter(({ geometry }) => geometry.type === 'Polygon')
-            .map((feature, idx) => ({ ...feature, id: isNumber(feature?.id) ? `Feature ${feature?.id}` : feature?.id || `Feature ${idx + 1}` }))
+            .map((feature, idx) => ({
+                ...feature,
+                geometry: {
+                    type: 'Polygon',
+                    // remove height because is not needed for clipping
+                    coordinates: feature.geometry.coordinates.map((rings) => rings.map(([lng, lat]) => [lng, lat]))
+                },
+                id: isNumber(feature?.id) ? `Feature ${feature?.id}` : feature?.id || `Feature ${idx + 1}`
+            }))
         : undefined;
 };
 

--- a/web/client/utils/__tests__/MapViewsUtils-test.js
+++ b/web/client/utils/__tests__/MapViewsUtils-test.js
@@ -116,6 +116,79 @@ describe('Test MapViewsUtils', () => {
         };
         expect(formatClippingFeatures([feature])[0].id).toEqual('feature.01');
     });
+    it('formatClippingFeatures should remove height from coordinates', () => {
+        const feature = {
+            type: 'Feature',
+            id: 'feature.01',
+            geometry: {
+                type: 'Polygon',
+                coordinates: [
+                    [
+                        [
+                            8.931329125577776,
+                            44.40689401356852,
+                            10
+                        ],
+                        [
+                            8.931329125577776,
+                            44.40035268585416,
+                            20
+                        ],
+                        [
+                            8.939979994731459,
+                            44.40035268585416,
+                            15
+                        ],
+                        [
+                            8.939979994731459,
+                            44.40689401356852,
+                            7
+                        ],
+                        [
+                            8.931329125577776,
+                            44.40689401356852,
+                            2
+                        ]
+                    ]
+                ]
+            },
+            properties: {}
+        };
+        expect(formatClippingFeatures([feature])).toEqual([
+            {
+                type: 'Feature',
+                id: 'feature.01',
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [
+                        [
+                            [
+                                8.931329125577776,
+                                44.40689401356852
+                            ],
+                            [
+                                8.931329125577776,
+                                44.40035268585416
+                            ],
+                            [
+                                8.939979994731459,
+                                44.40035268585416
+                            ],
+                            [
+                                8.939979994731459,
+                                44.40689401356852
+                            ],
+                            [
+                                8.931329125577776,
+                                44.40689401356852
+                            ]
+                        ]
+                    ]
+                },
+                properties: {}
+            }
+        ]);
+    });
     it('getZoomFromHeight', () => {
         expect(Math.round(getZoomFromHeight(1000))).toBe(17);
     });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The PR improves the mapping of clipping geometries of map view to remove the height value not needed to generate clipping planes. The height was causing problem in the conversion of geometry to primitive polyline in the preview visualization

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9164

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

It's possible to preview also polygon clipping geometry that contains the height

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
