### PR TITLE
Fix #9025 Available tile grids popup always reports mismatch in geostories and dashboards

### DIFF
--- a/web/client/components/widgets/builder/wizard/map/NodeEditor.jsx
+++ b/web/client/components/widgets/builder/wizard/map/NodeEditor.jsx
@@ -12,6 +12,7 @@ import { NavItem as BSNavItem, Col, Glyphicon, Nav, Row } from 'react-bootstrap'
 
 import Message from '../../../../I18N/Message';
 import tooltip from '../../../../misc/enhancers/tooltip';
+import { VisualizationModes } from '../../../../../utils/MapTypeUtils';
 
 const NavItem = tooltip(BSNavItem);
 
@@ -48,6 +49,8 @@ export default ({
                     settings={settings}
                     retrieveLayerData={onRetrieveLayerData}
                     isLocalizedLayerStylesEnabled={isLocalizedLayerStylesEnabled}
+                    projection={props.map?.projection}
+                    isCesiumActive={props.map?.visualizationMode === VisualizationModes._3D}
                     onChange={(key, value) => isObject(key) ? onUpdateParams(key, realtimeUpdate) : onUpdateParams({ [key]: value }, realtimeUpdate)} />
             ))}</Col>
     </Row>);

--- a/web/client/components/widgets/builder/wizard/map/__tests__/NodeEditor-test.jsx
+++ b/web/client/components/widgets/builder/wizard/map/__tests__/NodeEditor-test.jsx
@@ -10,8 +10,11 @@ import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {createSink} from 'recompose';
-
+import { Simulate } from 'react-dom/test-utils';
+import { VisualizationModes } from '../../../../../../utils/MapTypeUtils';
 import NodeEditor from '../NodeEditor';
+import nodeEditor from '../enhancers/nodeEditor';
+const EnhancedNodeEditor = nodeEditor(NodeEditor);
 describe('NodeEditor component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -35,5 +38,101 @@ describe('NodeEditor component', () => {
         // search the icon rendered
         const el = container.querySelector('.glyphicon-wrench');
         expect(el).toExist();
+    });
+    it('cache options should show info with matching with the map projection with nodeEditor(NodeEditor)', () => {
+        const layer = {
+            id: 'layer-01',
+            type: 'wms',
+            name: 'workspace:layer',
+            group: 'group-01',
+            url: '/geoserver/wms',
+            tileGridStrategy: 'custom',
+            tileGrids: [
+                {
+                    id: 'EPSG:32122x2',
+                    crs: 'EPSG:32122',
+                    scales: [2557541.55271451, 1278770.776357255, 639385.3881786275],
+                    origins: [[403035.4105968763, 414783], [403035.4105968763, 414783], [403035.4105968763, 323121]],
+                    tileSize: [512, 512]
+                },
+                {
+                    id: 'EPSG:900913',
+                    crs: 'EPSG:900913',
+                    scales: [559082263.9508929, 279541131.97544646, 139770565.98772323],
+                    origin: [-20037508.34, 20037508],
+                    tileSize: [256, 256]
+                }
+            ]
+        };
+        ReactDOM.render(<EnhancedNodeEditor
+            map={{ projection: 'EPSG:3857', groups: [{ id: layer.group }], layers: [layer] }}
+            nodes={[{ id: layer.group, nodes: [layer]}]}
+            layers={[layer]}
+            editNode={layer.id}
+        />, document.getElementById("container"));
+
+        const tabs = document.querySelectorAll('.nav-tabs > li > a');
+        expect(tabs.length).toBe(3);
+
+        Simulate.click(tabs[1]);
+
+        const info = document.querySelector('.glyphicon-info-sign');
+        expect(info).toBeTruthy();
+        expect(info.getAttribute('class')).toBe('text-success glyphicon glyphicon-info-sign');
+
+        let table = document.querySelector('table');
+        expect(table).toBeFalsy();
+
+        Simulate.mouseOver(info);
+
+        table = document.querySelector('table');
+        expect(table).toBeTruthy();
+
+        const tableRows = table.querySelectorAll('tbody > tr');
+        expect([...tableRows].map((row) => row.innerText)).toEqual([
+            'EPSG:32122x2\tEPSG:32122\t512',
+            'EPSG:900913\tEPSG:900913\t256'
+        ]);
+        const alert = document.querySelector('.alert');
+        expect(alert.innerText).toBe('layerProperties.tileGridInUse');
+    });
+    it('should not shows the cache options for 3D maps with nodeEditor(NodeEditor)', () => {
+        const layer = {
+            id: 'layer-01',
+            type: 'wms',
+            name: 'workspace:layer',
+            group: 'group-01',
+            url: '/geoserver/wms',
+            tileGridStrategy: 'custom',
+            tileGrids: [
+                {
+                    id: 'EPSG:32122x2',
+                    crs: 'EPSG:32122',
+                    scales: [2557541.55271451, 1278770.776357255, 639385.3881786275],
+                    origins: [[403035.4105968763, 414783], [403035.4105968763, 414783], [403035.4105968763, 323121]],
+                    tileSize: [512, 512]
+                },
+                {
+                    id: 'EPSG:900913',
+                    crs: 'EPSG:900913',
+                    scales: [559082263.9508929, 279541131.97544646, 139770565.98772323],
+                    origin: [-20037508.34, 20037508],
+                    tileSize: [256, 256]
+                }
+            ]
+        };
+        ReactDOM.render(<EnhancedNodeEditor
+            map={{ visualizationMode: VisualizationModes._3D, projection: 'EPSG:3857', groups: [{ id: layer.group }], layers: [layer] }}
+            nodes={[{ id: layer.group, nodes: [layer]}]}
+            layers={[layer]}
+            editNode={layer.id}
+        />, document.getElementById("container"));
+
+        const tabs = document.querySelectorAll('.nav-tabs > li > a');
+        expect(tabs.length).toBe(3);
+
+        Simulate.click(tabs[1]);
+        const cacheOptionsNode = document.querySelector('.ms-wms-cache-options-toolbar');
+        expect(cacheOptionsNode).toBeFalsy();
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes a bug reported in this comment https://github.com/geosolutions-it/MapStore2/pull/9184#issuecomment-1564053808

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9025

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The WMS cache info message reports correctly the state of the matching with remote configuration

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
