### PR TITLE
[Backport 2023.01.xx] Fix #9197 Disable apply media editor button while loading a selected item (#9198)

### DIFF
--- a/web/client/selectors/__tests__/mediaEditor-test.js
+++ b/web/client/selectors/__tests__/mediaEditor-test.js
@@ -27,7 +27,8 @@ import {
     getCurrentMediaResourcesParams,
     getCurrentMediaResourcesTotalCount,
     getLoadingSelectedMedia,
-    getLoadingMediaList
+    getLoadingMediaList,
+    disableApplyMapMedia
 } from "../mediaEditor";
 
 describe('mediaEditor selectors', () => {
@@ -291,5 +292,17 @@ describe('mediaEditor selectors', () => {
                 loadingList: true
             }
         })).toBe(true);
+    });
+    it('disableApplyMapMedia', () => {
+        expect(disableApplyMapMedia({
+            mediaEditor: {
+                loadingSelected: true
+            }
+        })).toBe(true);
+        expect(disableApplyMapMedia({
+            mediaEditor: {
+                loadingSelected: false
+            }
+        })).toBe(false);
     });
 });

--- a/web/client/selectors/mediaEditor.js
+++ b/web/client/selectors/mediaEditor.js
@@ -62,6 +62,8 @@ export const disabledMediaTypeSelector = state => get(state, "mediaEditor.disabl
 /**
  * Disable `apply` on empty selection for map media editor when geostory section is GeoCarousel,
  * here disable media type value is available only in GeoCarousel section
+ * The apply button should be disabled also when a selected item is loading
  */
 export const disableApplyMapMedia = (state) =>
-    disabledMediaTypeSelector(state).length && !selectedItemSelector(state) && currentMediaTypeSelector(state) === 'map';
+    (disabledMediaTypeSelector(state).length && !selectedItemSelector(state) && currentMediaTypeSelector(state) === 'map')
+    || getLoadingSelectedMedia(state);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds an additional selector to disable the apply button of Media Editor while a selected item is loading

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9197

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The apply button is disabled when a resource is loading

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
