### PR TITLE
Fix #9208 Timeline map sync does not update for time ranges visualization

### DIFF
--- a/web/client/epics/dimension.js
+++ b/web/client/epics/dimension.js
@@ -27,11 +27,6 @@ import { domainsToDimensionsObject } from '../utils/TimeUtils';
 import { pick, find, get, flatten } from 'lodash';
 import { expandLimitSelector } from '../selectors/timeline';
 
-const DESCRIBE_DOMAIN_OPTIONS = {
-    expandLimit: 10
-};
-
-
 const getTimeMultidimURL = (l = {}) => get(find(l.dimensions || [], d => d && d.source && d.source.type === "multidim-extension"), "source.url");
 
 
@@ -61,7 +56,7 @@ export const queryMultidimensionalAPIExtensionOnAddLayer = (action$, {getState =
         .map(({ layer = {} } = {}) => ({ layer, multidimURL: getMultidimURL(layer)}))
         // every add layer has it's own flow, this is why it uses
         .flatMap(({ layer = {}, multidimURL } = {}) =>
-            describeDomains(multidimURL, layer.name, undefined, { expandLimit: expandLimitSelector(getState()) || DESCRIBE_DOMAIN_OPTIONS.expandLimit })
+            describeDomains(multidimURL, layer.name, undefined, { expandLimit: expandLimitSelector(getState()) })
                 .switchMap( domains => {
                     const dimensions = domainsToDimensionsObject(domains, multidimURL) || [];
                     if (dimensions && dimensions.length > 0) {
@@ -106,7 +101,7 @@ export const updateLayerDimensionDataOnMapLoad = (action$, {getState = () => {}}
             .concat(Observable.from(layersWithMultidim)
                 // one flow for each dimension
                 .mergeMap(l =>
-                    describeDomains(getTimeMultidimURL(l), l.name, undefined, { expandLimit: expandLimitSelector(getState()) || DESCRIBE_DOMAIN_OPTIONS.expandLimit })
+                    describeDomains(getTimeMultidimURL(l), l.name, undefined, { expandLimit: expandLimitSelector(getState()) })
                         .switchMap( domains =>
                             Observable.from(flatten(domainsToDimensionsObject(domains, getTimeMultidimURL(l))
                                 .map(d => [

--- a/web/client/epics/dimension.js
+++ b/web/client/epics/dimension.js
@@ -25,10 +25,10 @@ import { layersWithTimeDataSelector, offsetTimeSelector, currentTimeSelector } f
 import { describeDomains, getMultidimURL } from '../api/MultiDim';
 import { domainsToDimensionsObject } from '../utils/TimeUtils';
 import { pick, find, get, flatten } from 'lodash';
-
+import { expandLimitSelector } from '../selectors/timeline';
 
 const DESCRIBE_DOMAIN_OPTIONS = {
-    expandLimit: 10 // TODO: increase this limit to max client allowed
+    expandLimit: 10
 };
 
 
@@ -50,7 +50,7 @@ export const updateLayerDimensionOnCurrentTimeSelection = (action$, { getState =
  * Check the presence of Multidimensional API extension, then setup layers properly.
  * Updates also current dimension state
  */
-export const queryMultidimensionalAPIExtensionOnAddLayer = (action$) =>
+export const queryMultidimensionalAPIExtensionOnAddLayer = (action$, {getState = () => {}} = {}) =>
     action$
         .ofType(ADD_LAYER)
         .filter(
@@ -61,7 +61,7 @@ export const queryMultidimensionalAPIExtensionOnAddLayer = (action$) =>
         .map(({ layer = {} } = {}) => ({ layer, multidimURL: getMultidimURL(layer)}))
         // every add layer has it's own flow, this is why it uses
         .flatMap(({ layer = {}, multidimURL } = {}) =>
-            describeDomains(multidimURL, layer.name, undefined, DESCRIBE_DOMAIN_OPTIONS)
+            describeDomains(multidimURL, layer.name, undefined, { expandLimit: expandLimitSelector(getState()) || DESCRIBE_DOMAIN_OPTIONS.expandLimit })
                 .switchMap( domains => {
                     const dimensions = domainsToDimensionsObject(domains, multidimURL) || [];
                     if (dimensions && dimensions.length > 0) {
@@ -106,7 +106,7 @@ export const updateLayerDimensionDataOnMapLoad = (action$, {getState = () => {}}
             .concat(Observable.from(layersWithMultidim)
                 // one flow for each dimension
                 .mergeMap(l =>
-                    describeDomains(getTimeMultidimURL(l), l.name, undefined, DESCRIBE_DOMAIN_OPTIONS)
+                    describeDomains(getTimeMultidimURL(l), l.name, undefined, { expandLimit: expandLimitSelector(getState()) || DESCRIBE_DOMAIN_OPTIONS.expandLimit })
                         .switchMap( domains =>
                             Observable.from(flatten(domainsToDimensionsObject(domains, getTimeMultidimURL(l))
                                 .map(d => [

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -427,11 +427,13 @@ export const updateRangeDataOnRangeChange = (action$, { getState = () => { } } =
         )
         .debounceTime(400)
         .merge(action$.ofType(UPDATE_LAYER_DIMENSION_DATA).debounceTime(50))
-        .switchMap( () => {
+        .switchMap( (action) => {
+            // we should force the range data update when we turn off the map sync
+            const resetMapSync = action.mapSync === false;
             const timeData = timeDataSelector(getState()) || {};
             const layerIds = Object.keys(timeData).filter(id => timeData[id] && timeData[id].domain
                 // when data is already fully downloaded, no need to refresh, except if the mapSync is active
-                && (isTimeDomainInterval(timeData[id].domain)) || isMapSync(getState()));
+                && (isTimeDomainInterval(timeData[id].domain)) || isMapSync(getState()) || resetMapSync);
             // update range data for every layer that need to sync with histogram/domain
             return Rx.Observable.merge(
                 ...layerIds.map(id =>

--- a/web/client/selectors/__tests__/timeline-test.js
+++ b/web/client/selectors/__tests__/timeline-test.js
@@ -19,7 +19,8 @@ import {
     multidimOptionsSelectorCreator,
     timelineLayersSelector,
     timelineLayersSetting,
-    timelineLayersParsedSettings
+    timelineLayersParsedSettings,
+    getTimeItems
 } from '../timeline';
 
 import { set, compose } from '../../utils/ImmutableUtils';
@@ -169,7 +170,40 @@ describe('timeline selector', () => {
         expect(timelayer[0].id).toEqual(TEST_LAYER_ID);
         expect(timelayer[0].hideInTimeline).toEqual(true);
     });
-
+    it('getTimeItems should give priority to rangeData', () => {
+        const data = {
+            source: {
+                type: 'multidim-extension',
+                version: '1.2',
+                url: '/geoserver/gwc/service/wmts'
+            },
+            name: 'time',
+            domain: '2022-06-01T00:00:00.000Z/2023-06-01T00:00:00.000Z,2023-01-01T00:00:00.000Z/2023-06-01T00:00:00.000Z,2023-01-01T00:00:00.000Z/2023-12-31T00:00:00.000Z'
+        };
+        const range = {
+            start: '2022-06-01T00:00:00.000Z',
+            end: '2024-01-09T11:07:53.218Z'
+        };
+        let timeItems = getTimeItems(data, range);
+        expect(timeItems.length).toBe(3);
+        const rangeData = {
+            range: {
+                start: '2022-06-01T00:00:00.000Z',
+                end: '2024-01-09T11:07:53.218Z'
+            },
+            histogram: {
+                values: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                domain: '2022-06-01T00:00:00.000Z/2023-06-01T00:00:00.000Z/PT704H'
+            },
+            domain: {
+                values: [
+                    '2022-06-01T00:00:00.000Z/2023-06-01T00:00:00.000Z'
+                ]
+            }
+        };
+        timeItems = getTimeItems(data, range, rangeData);
+        expect(timeItems.length).toBe(1);
+    });
     it('itemsSelector', () => {
         const histogramItems = itemsSelector(SAMPLE_STATE_HISTOGRAM);
         expect(histogramItems.length).toBe(31);

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -130,10 +130,14 @@ export const rangeDataToItems = (rangeData = {}, range) => {
  * @param {object} rangeData object that contains domain or histogram
  */
 export const getTimeItems = (data = {}, range, rangeData) => {
+    // rangeData populates when some changes ara applied with map sync
+    // we should use this when available
+    // because represent the latest updated value
+    if (rangeData?.domain || rangeData?.histogram) {
+        return rangeDataToItems(rangeData, range);
+    }
     if (data && data.values || data && data.domain && !isTimeDomainInterval(data.domain)) {
         return valuesToItems(data.values || data.domain.split(','), range);
-    } else if (rangeData && rangeData.histogram) {
-        return rangeDataToItems(rangeData, range);
     }
     return [];
 };

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -30,7 +30,7 @@ export const rangeDataSelector = state => get(state, 'timeline.rangeData');
  */
 export const settingsSelector = state => get(state, 'timeline.settings');
 const MAX_ITEMS = 50;
-export const expandLimitSelector = state => get(settingsSelector(state), 'expandLimit');
+export const expandLimitSelector = state => get(settingsSelector(state), 'expandLimit') || 10;
 
 export const isCollapsed = state => get(settingsSelector(state), 'collapsed');
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR improved the get time items selector to use the updated range data if provided

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9208

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

@tdipisa 
It seems there is a problem with the spatial filter of domains, here an example:

The following example shows a DescribeDomains request where we expect to get information of a single feature but instead we get two:

request: https://development.demo.geonode.org/geoserver/gwc/service/wmts?service=WMTS&REQUEST=DescribeDomains&version=1.0.0&layer=geonode:test_time&tileMatrixSet=EPSG:4326&bbox=829991.4716345865,5755211.389189923,1039581.8031925397,5899065.876422625,EPSG:3857&expandLimit=20&time=2022-06-01T00:00:00.000Z/2024-01-09T11:07:53.218Z

response: 
```xml
<Domains xmlns="http://demo.geo-solutions.it/share/wmts-multidim/wmts_multi_dimensional.xsd" xmlns:ows="http://www.opengis.net/ows/1.1" version="1.2">
<SpaceDomain>
<BoundingBox CRS="EPSG:4326" minx="2.021484375000004" miny="40.871987756697415" maxx="30.849609375000014" maxy="50.645977340713586"/>
</SpaceDomain>
<DimensionDomain>
<ows:Identifier>time</ows:Identifier>
<Domain>2023-01-01T00:00:00.000Z/2023-06-01T00:00:00.000Z,2023-01-01T00:00:00.000Z/2023-12-31T00:00:00.000Z</Domain>
<Size>2</Size>
</DimensionDomain>
</Domains>
```

Visual representation of bbox param (red) and returned space domain (orange)
![image](https://github.com/geosolutions-it/MapStore2/assets/19175505/13a0bcb8-cc4f-47e1-b201-6f8f4c3105d5)

Note: We are also applying the bbox param to GetDomainValues and GetHistogram so they could have the same problem

