### PR TITLE
[Backport 2023.02.xx] Fix #9147 Issue in chart creation from feature grid. (#9214)

### DIFF
--- a/web/client/epics/__tests__/widgetsbuilder-test.js
+++ b/web/client/epics/__tests__/widgetsbuilder-test.js
@@ -178,14 +178,24 @@ describe('widgetsbuilder epic', () => {
     });
     it('initEditorOnNewChart', (done) => {
         const startActions = [createChart()];
-        testEpic(initEditorOnNewChart, 2, startActions, actions => {
-            expect(actions.length).toBe(2);
+        const NUMBER_OF_ACTIONS = 3;
+        testEpic(initEditorOnNewChart, NUMBER_OF_ACTIONS, startActions, actions => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
             actions.map((action) => {
                 switch (action.type) {
                 case EDIT_NEW:
                     expect(action.widget).toExist();
                     // verify default mapSync
                     expect(action.widget.mapSync).toBe(true);
+                    expect(action.widget.widgetType).toBe('chart');
+                    expect(action.widget.charts.length).toBe(1);
+                    expect(action.widget.charts[0].chartId).toBe(action.widget.selectedChartId);
+                    expect(action.widget.charts[0].type).toBe('bar');
+                    expect(action.widget.charts[0].name).toBe('Chart-1');
+                    break;
+                case EDITOR_CHANGE:
+                    expect(action.key).toBe('returnToFeatureGrid');
+                    expect(action.value).toBe(true);
                     break;
                 case CLOSE_FEATURE_GRID:
                     expect(action.type).toBe(CLOSE_FEATURE_GRID);

--- a/web/client/epics/widgetsbuilder.js
+++ b/web/client/epics/widgetsbuilder.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import Rx from 'rxjs';
-
+import uuid from 'uuid';
 import {
     NEW,
     INSERT,
@@ -56,17 +56,32 @@ export const initEditorOnNew = (action$, {getState = () => {}} = {}) => action$.
     }, {step: 0})));
 export const initEditorOnNewChart = (action$, {getState = () => {}} = {}) => action$.ofType(NEW_CHART)
     .filter(() => widgetBuilderAvailable(getState()))
-    .switchMap((w) => Rx.Observable.of(closeFeatureGrid(), editNewWidget({
-        legend: false,
-        mapSync: true,
-        cartesian: true,
-        yAxis: true,
-        widgetType: "chart",
-        filter: wfsFilter(getState()),
-        ...w,
-        // override action's type
-        type: undefined
-    }, {step: 0}), onEditorChange("returnToFeatureGrid", true)));
+    .switchMap(() => {
+        const chartId = uuid();
+        const state = getState();
+        const layer = getWidgetLayer(state);
+        return Rx.Observable.of(
+            closeFeatureGrid(),
+            editNewWidget({
+                mapSync: true,
+                selectedChartId: chartId,
+                widgetType: 'chart',
+                charts: [
+                    {
+                        name: 'Chart-1',
+                        chartId,
+                        type: 'bar',
+                        legend: false,
+                        cartesian: true,
+                        yAxis: true,
+                        layer,
+                        filter: wfsFilter(state)
+                    }
+                ]
+            }, {step: 0}),
+            onEditorChange("returnToFeatureGrid", true)
+        );
+    });
 /**
  * Manages interaction with QueryPanel and widgetBuilder
  */


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes the initialization of charts from the feature grid. The feature grids widget button was not creating an array of charts.

This PR should solve also #9202

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9147
#9202

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Restored the creation of chart widgets from the feature grid

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
