### PR TITLE
[Backport 2023.01.xx] Fix #9176 Make Map Views tool progress bar more evident (#9187)

### DIFF
--- a/web/client/components/mapviews/MapViewsProgressBar.jsx
+++ b/web/client/components/mapviews/MapViewsProgressBar.jsx
@@ -7,21 +7,42 @@
  */
 
 import React from 'react';
+import tooltip from '../misc/enhancers/tooltip';
+
+const MapViewsProgressBarTick = tooltip(({
+    left,
+    active,
+    ...props
+}) => {
+    return (
+        <div
+            {...props}
+            className={`ms-map-view-progress-tick${active ? ' active' : ''}`}
+            style={{ left }}
+        />
+    );
+});
 
 function MapViewsProgressBar({
+    play,
     progress,
     segments,
-    totalLength
+    totalLength,
+    onSelect,
+    currentIndex
 }) {
     return (
-        <div className="ms-map-view-progress-container">
+        <div className={`ms-map-view-progress-container${play ? ' playing' : ''}`}>
             <div className="ms-map-view-progress-bar" style={{ width: `${progress}%` }}></div>
             {segments
-                ?.map((duration, idx) => (
-                    <div
+                ?.map(({ duration, view }, idx) => (
+                    <MapViewsProgressBarTick
                         key={idx}
-                        className="ms-map-view-progress-tick"
-                        style={{ left: `${Math.round(duration / totalLength * 100)}%` }}
+                        tooltip={view?.title}
+                        active={idx <= currentIndex}
+                        tooltipPosition="bottom"
+                        left={`${Math.round(duration / totalLength * 100)}%`}
+                        onClick={() => onSelect(view)}
                     />)
                 )}
         </div>

--- a/web/client/components/mapviews/MapViewsSupport.jsx
+++ b/web/client/components/mapviews/MapViewsSupport.jsx
@@ -73,11 +73,11 @@ const useMapViewsNavigation = ({
     const [play, setPlay] = useState(false);
     const [navigationProgress, setNavigationProgress] = useState(0);
     const viewsTimeTotalLength = computeDurationSum(views);
-    const viewsTimeSegments = views.map((view, idx) => computeDurationSum(views.filter((vw, jdx) => jdx < idx)));
+    const viewsTimeSegments = views.map((view, idx) => ({ view, duration: computeDurationSum(views.filter((vw, jdx) => jdx < idx)) }));
 
     useEffect(() => {
         if (!play) {
-            setNavigationProgress(Math.round((viewsTimeSegments[currentIndex] ?? 0) / viewsTimeTotalLength * 100));
+            setNavigationProgress(Math.round((viewsTimeSegments?.[currentIndex]?.duration ?? 0) / viewsTimeTotalLength * 100));
         }
     }, [currentIndex, play]);
 
@@ -94,7 +94,7 @@ const useMapViewsNavigation = ({
         if (play) {
             let startTime = Date.now();
             let index = currentIndex === -1 ? 0 : currentIndex;
-            let initialDelta = viewsTimeSegments[index];
+            let initialDelta = viewsTimeSegments?.[index]?.duration;
             let mainStartTime = startTime;
             let currentView = views[index >= views.length ? 0 : index];
             onInit(currentView);
@@ -408,9 +408,17 @@ function MapViewsSupport({
                     <div className="ms-map-views" onClick={(event) => event.stopPropagation()}>
                         <div className="ms-map-views-wrapper">
                             <MapViewsProgressBar
+                                play={play}
+                                currentIndex={currentIndex}
                                 progress={navigationProgress}
                                 segments={viewsTimeSegments}
                                 totalLength={viewsTimeTotalLength}
+                                onSelect={view => {
+                                    if (play) {
+                                        setPlay(false);
+                                    }
+                                    handleSelectView(view);
+                                }}
                             />
                             <div className="ms-map-views-header">
                                 {(selected?.description && !expanded) ?

--- a/web/client/components/mapviews/__tests__/MapViewsProgressBar-test.jsx
+++ b/web/client/components/mapviews/__tests__/MapViewsProgressBar-test.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import MapViewsProgressBar from '../MapViewsProgressBar';
 import expect from 'expect';
+import { Simulate } from 'react-dom/test-utils';
 
 describe('MapViewsProgressBar component', () => {
     beforeEach((done) => {
@@ -39,7 +40,7 @@ describe('MapViewsProgressBar component', () => {
     });
     it('should display ticks based on segments and totalLength props', () => {
         ReactDOM.render(<MapViewsProgressBar
-            segments={[0, 2000, 4000, 5000]}
+            segments={[{ duration: 0 }, { duration: 2000 }, { duration: 4000 }, { duration: 5000 }]}
             totalLength={10000}
         />, document.getElementById("container"));
         const tickNodes = [...document.querySelectorAll('.ms-map-view-progress-tick')];
@@ -50,5 +51,53 @@ describe('MapViewsProgressBar component', () => {
             '40%',
             '50%'
         ]);
+    });
+    it('should display tooltip on tick', () => {
+        ReactDOM.render(<MapViewsProgressBar
+            segments={[
+                { duration: 0, view: { title: 'Title 01' } },
+                { duration: 2000, view: { title: 'Title 02' } },
+                { duration: 4000, view: { title: 'Title 03' } },
+                { duration: 5000, view: { title: 'Title 04' } }
+            ]}
+            totalLength={10000}
+        />, document.getElementById("container"));
+        const tickNodes = [...document.querySelectorAll('.ms-map-view-progress-tick')];
+        expect(tickNodes.length).toBeTruthy(4);
+        Simulate.mouseOver(tickNodes[0]);
+        const tooltipInner = document.querySelector('.tooltip-inner');
+        expect(tooltipInner.innerText).toBe('Title 01');
+    });
+    it('should trigger on select by clicking on tick', (done) => {
+        ReactDOM.render(<MapViewsProgressBar
+            segments={[
+                { duration: 0, view: { title: 'Title 01' } },
+                { duration: 2000, view: { title: 'Title 02' } },
+                { duration: 4000, view: { title: 'Title 03' } },
+                { duration: 5000, view: { title: 'Title 04' } }
+            ]}
+            totalLength={10000}
+            onSelect={(view) => {
+                expect(view).toEqual({ title: 'Title 01' });
+                done();
+            }}
+        />, document.getElementById("container"));
+        const tickNodes = [...document.querySelectorAll('.ms-map-view-progress-tick')];
+        expect(tickNodes.length).toBeTruthy(4);
+        Simulate.click(tickNodes[0]);
+    });
+    it('should apply active class to tick with index less and equal to the current one', () => {
+        ReactDOM.render(<MapViewsProgressBar
+            currentIndex={2}
+            segments={[
+                { duration: 0, view: { title: 'Title 01' } },
+                { duration: 2000, view: { title: 'Title 02' } },
+                { duration: 4000, view: { title: 'Title 03' } },
+                { duration: 5000, view: { title: 'Title 04' } }
+            ]}
+            totalLength={10000}
+        />, document.getElementById("container"));
+        const tickNodes = [...document.querySelectorAll('.active')];
+        expect(tickNodes.length).toBeTruthy(3);
     });
 });

--- a/web/client/themes/default/less/map-views.less
+++ b/web/client/themes/default/less/map-views.less
@@ -51,11 +51,28 @@
 
     .ms-map-view-progress-container {
         .background-color-var(@theme-vars[main-variant-bg]);
+        .border-bottom-color-var(@theme-vars[main-border-color]);
+        &.playing {
+            .ms-map-view-progress-bar {
+                .background-color-var(@theme-vars[success]);
+            }
+            .ms-map-view-progress-tick {
+                .border-color-var(@theme-vars[success]);
+                .background-color-var(@theme-vars[success-contrast]);
+            }
+        }
         .ms-map-view-progress-bar {
             .background-color-var(@theme-vars[primary]);
         }
         .ms-map-view-progress-tick {
-            .background-color-var(@theme-vars[main-variant-color]);
+            .border-color-var(@theme-vars[primary]);
+            .background-color-var(@theme-vars[primary-contrast]);
+            &:not(.active) {
+                .border-color-var(@theme-vars[main-border-color]);
+                &:hover {
+                    .border-color-var(@theme-vars[main-color]);
+                }
+            }
         }
     }
 }
@@ -326,16 +343,27 @@
 }
 .ms-map-view-progress-container {
     width: 100%;
-    height: 4px;
+    font-size: 8px;
+    height: 1em;
     position: relative;
+    border-bottom: 0.125em solid transparent;
+    overflow: hidden;
     .ms-map-view-progress-bar {
-        height: 4px;
+        height: 1em;
         transition: 0.3s width;
+        opacity: 0.5;
     }
     .ms-map-view-progress-tick {
         top: 0;
         position: absolute;
-        width: 1px;
-        height: 100%;
+        cursor: pointer;
+        width: 1em;
+        height: 1em;
+        border-radius: 50%;
+        transition: 0.3s all;
+        border: 0.25em solid transparent;
+        & + .ms-map-view-progress-tick {
+            transform: translateX(-50%);
+        }
     }
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR is including following improvements:

- different style for active ticks
- different color to loading bar when the play button is active
- allow click on ticks to select a specific view
- add tooltip with view title to each tick

https://github.com/geosolutions-it/MapStore2/assets/19175505/8279c211-2cde-40ba-a5d3-763155ee11b7

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9176

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Improved styles and interactions of the MapViews progress bar

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
