### PR TITLE
New URLs for basemap.at

### DIFF
--- a/web/client/utils/ConfigProvider.js
+++ b/web/client/utils/ConfigProvider.js
@@ -558,12 +558,11 @@ export default {
         }
     },
     BasemapAT: {
-        url: 'https://maps{s}.wien.gv.at/basemap/{variant}/normal/google3857/{z}/{y}/{x}.{format}',
+        url: 'https://mapsneu.wien.gv.at/basemap/{variant}/normal/google3857/{z}/{y}/{x}.{format}',
         options: {
             maxZoom: 19,
             maxNativeZoom: 19,
             attribution: 'Datenquelle: <a href="https://www.basemap.at">basemap.at</a>',
-            subdomains: ['', '1', '2', '3', '4'],
             format: 'png',
             bounds: [[46.358770, 8.782379], [49.037872, 17.189532]],
             variant: 'geolandbasemap'

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -623,7 +623,7 @@ describe('PrintUtils', () => {
                 const layerSpec = specCreators.tileprovider.map(testLayer, { projection: "EPSG:900913" });
                 expect(layerSpec.type).toEqual("xyz");
                 // string without subdomains or params
-                expect(layerSpec.baseURL).toEqual("https://maps.wien.gv.at/basemap/geolandbasemap/normal/google3857/");
+                expect(layerSpec.baseURL).toEqual("https://mapsneu.wien.gv.at/basemap/geolandbasemap/normal/google3857/");
                 // parameters should be passed in pathSpec
                 expect(layerSpec.baseURL.indexOf(/\{[x,y,z]\}/)).toBeLessThan(0);
                 expect(layerSpec.path_format).toBe("${z}/${y}/${x}.png"); // use the format of mapfish print for variables


### PR DESCRIPTION
## Description
According to information published at basemap.at, new URLs need to be used. Existing URLs will be decomissioned by end of 2023. See https://cdn.basemap.at/basemap.at_URL_Umstellung_2023.pdf for more information.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [X] Other... Please describe: Config change

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

