### PR TITLE
#9180: Layer setting - Feature editing option with permission

### DIFF
--- a/web/client/components/TOC/fragments/settings/General.jsx
+++ b/web/client/components/TOC/fragments/settings/General.jsx
@@ -40,7 +40,8 @@ class General extends React.Component {
         showTooltipOptions: PropTypes.bool,
         allowNew: PropTypes.bool,
         enableLayerNameEditFeedback: PropTypes.bool,
-        currentLocale: PropTypes.string
+        currentLocale: PropTypes.string,
+        canEditMap: PropTypes.bool
     };
 
     static contextTypes = {
@@ -166,7 +167,7 @@ class General extends React.Component {
                             </Col>
                         </div>
                     }
-                    {supportsFeatureEditing(this.props.element) && <FormGroup>
+                    {supportsFeatureEditing(this.props.element) && this.props.canEditMap && <FormGroup>
                         <Checkbox
                             data-qa="general-read-only-attribute"
                             key="disableFeaturesEditing"

--- a/web/client/components/TOC/fragments/settings/General.jsx
+++ b/web/client/components/TOC/fragments/settings/General.jsx
@@ -41,7 +41,7 @@ class General extends React.Component {
         allowNew: PropTypes.bool,
         enableLayerNameEditFeedback: PropTypes.bool,
         currentLocale: PropTypes.string,
-        canEditMap: PropTypes.bool
+        mapInfo: PropTypes.object
     };
 
     static contextTypes = {
@@ -167,7 +167,7 @@ class General extends React.Component {
                             </Col>
                         </div>
                     }
-                    {supportsFeatureEditing(this.props.element) && this.props.canEditMap && <FormGroup>
+                    {supportsFeatureEditing(this.props.element) && this.canEditFeature() && <FormGroup>
                         <Checkbox
                             data-qa="general-read-only-attribute"
                             key="disableFeaturesEditing"
@@ -188,6 +188,10 @@ class General extends React.Component {
     updateEntry = (key, event) => isObject(key) ? this.props.onChange(key) : this.props.onChange(key, event.target.value);
     updateTitle = (title) => this.props.onChange("title", title);
 
+    canEditFeature = () => {
+        const {id, canEdit} = this.props.mapInfo ?? {};
+        return id ? canEdit : true;
+    }
 
     findGroupLabel = () => {
         const wholeGroups = this.props.groups && flattenGroups(this.props.groups, 0, true);

--- a/web/client/components/TOC/fragments/settings/__tests__/General-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/General-test.jsx
@@ -65,7 +65,7 @@ describe('test  Layer Properties General module component', () => {
         expect(comp).toExist();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toExist();
-        expect(inputs.length).toBe(5);
+        expect(inputs.length).toBe(6);
     });
     it('tests Layer Properties Display component events', () => {
         const l = {
@@ -89,7 +89,7 @@ describe('test  Layer Properties General module component', () => {
         expect(comp).toExist();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toExist();
-        expect(inputs.length).toBe(5);
+        expect(inputs.length).toBe(6);
         ReactTestUtils.Simulate.change(inputs[0]);
         ReactTestUtils.Simulate.blur(inputs[1]);
         expect(spy.calls.length).toBe(1);
@@ -118,7 +118,7 @@ describe('test  Layer Properties General module component', () => {
         expect(comp).toExist();
         const forms = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "form-group" );
         expect(forms).toExist();
-        expect(forms.length).toBe(4);
+        expect(forms.length).toBe(5);
     });
 
     it('TEST showTooltipOptions = true', () => {
@@ -224,6 +224,7 @@ describe('test  Layer Properties General module component', () => {
         const settings = {
             options: {opacity: 0.7}
         };
+        const mapInfo = {canEdit: true, id: "1"};
         const layer = {
             name: 'layer00',
             title: 'Layer',
@@ -232,12 +233,26 @@ describe('test  Layer Properties General module component', () => {
             type: 'wms',
             url: 'fakeurl'
         };
-        const comp = ReactDOM.render(<General onChange={handlers.onChange} pluginCfg={{}} element={layer} settings={settings} canEditMap/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<General onChange={handlers.onChange} pluginCfg={{}} element={layer} settings={settings} mapInfo={mapInfo}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const disableFeaturesEditing = document.querySelector('[data-qa="general-read-only-attribute"]');
         ReactTestUtils.Simulate.change(disableFeaturesEditing, { "target": { "checked": true }});
         expect(spyOn).toHaveBeenCalled();
         expect(spyOn.calls[0].arguments).toEqual([ 'disableFeaturesEditing', true ]);
+    });
+    it('tests read only attribute field on new map', () => {
+        const layer = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const comp = ReactDOM.render(<General pluginCfg={{}} element={layer}  />, document.getElementById("container"));
+        expect(comp).toBeTruthy();
+        const disableFeaturesEditing = document.querySelector('[data-qa="general-read-only-attribute"]');
+        expect(disableFeaturesEditing).toBeTruthy();
     });
     it('tests read only attribute field without permission', () => {
         const layer = {
@@ -248,7 +263,8 @@ describe('test  Layer Properties General module component', () => {
             type: 'wms',
             url: 'fakeurl'
         };
-        const comp = ReactDOM.render(<General pluginCfg={{}} element={layer} canEditMap={false}  />, document.getElementById("container"));
+        const mapInfo = {canEdit: false, id: "1"};
+        const comp = ReactDOM.render(<General pluginCfg={{}} element={layer} mapInfo={mapInfo}  />, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const disableFeaturesEditing = document.querySelector('[data-qa="general-read-only-attribute"]');
         expect(disableFeaturesEditing).toBeFalsy();

--- a/web/client/components/TOC/fragments/settings/__tests__/General-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/General-test.jsx
@@ -65,7 +65,7 @@ describe('test  Layer Properties General module component', () => {
         expect(comp).toExist();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toExist();
-        expect(inputs.length).toBe(6);
+        expect(inputs.length).toBe(5);
     });
     it('tests Layer Properties Display component events', () => {
         const l = {
@@ -89,7 +89,7 @@ describe('test  Layer Properties General module component', () => {
         expect(comp).toExist();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toExist();
-        expect(inputs.length).toBe(6);
+        expect(inputs.length).toBe(5);
         ReactTestUtils.Simulate.change(inputs[0]);
         ReactTestUtils.Simulate.blur(inputs[1]);
         expect(spy.calls.length).toBe(1);
@@ -118,7 +118,7 @@ describe('test  Layer Properties General module component', () => {
         expect(comp).toExist();
         const forms = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "form-group" );
         expect(forms).toExist();
-        expect(forms.length).toBe(5);
+        expect(forms.length).toBe(4);
     });
 
     it('TEST showTooltipOptions = true', () => {
@@ -232,11 +232,25 @@ describe('test  Layer Properties General module component', () => {
             type: 'wms',
             url: 'fakeurl'
         };
-        const comp = ReactDOM.render(<General onChange={handlers.onChange} pluginCfg={{}} element={layer} settings={settings}/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<General onChange={handlers.onChange} pluginCfg={{}} element={layer} settings={settings} canEditMap/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const disableFeaturesEditing = document.querySelector('[data-qa="general-read-only-attribute"]');
         ReactTestUtils.Simulate.change(disableFeaturesEditing, { "target": { "checked": true }});
         expect(spyOn).toHaveBeenCalled();
         expect(spyOn.calls[0].arguments).toEqual([ 'disableFeaturesEditing', true ]);
+    });
+    it('tests read only attribute field without permission', () => {
+        const layer = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const comp = ReactDOM.render(<General pluginCfg={{}} element={layer} canEditMap={false}  />, document.getElementById("container"));
+        expect(comp).toBeTruthy();
+        const disableFeaturesEditing = document.querySelector('[data-qa="general-read-only-attribute"]');
+        expect(disableFeaturesEditing).toBeFalsy();
     });
 });

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -29,7 +29,7 @@ import {
 import { createPlugin } from '../utils/PluginsUtils';
 import defaultSettingsTabs from './tocitemssettings/defaultSettingsTabs';
 import { isCesium } from '../selectors/maptype';
-import { mapIsEditableSelector } from "../selectors/map";
+import { mapInfoSelector } from "../selectors/map";
 
 const tocItemsSettingsSelector = createSelector([
     layerSettingSelector,
@@ -42,8 +42,8 @@ const tocItemsSettingsSelector = createSelector([
     elementSelector,
     isLocalizedLayerStylesEnabledSelector,
     isCesium,
-    mapIsEditableSelector
-], (settings, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, activeTab, element, isLocalizedLayerStylesEnabled, isCesiumActive, canEditMap) => ({
+    mapInfoSelector
+], (settings, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, activeTab, element, isLocalizedLayerStylesEnabled, isCesiumActive, mapInfo) => ({
     settings,
     element,
     groups,
@@ -54,7 +54,7 @@ const tocItemsSettingsSelector = createSelector([
     activeTab,
     isLocalizedLayerStylesEnabled,
     isCesiumActive,
-    canEditMap
+    mapInfo
 }));
 
 /**

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -29,6 +29,7 @@ import {
 import { createPlugin } from '../utils/PluginsUtils';
 import defaultSettingsTabs from './tocitemssettings/defaultSettingsTabs';
 import { isCesium } from '../selectors/maptype';
+import { mapIsEditableSelector } from "../selectors/map";
 
 const tocItemsSettingsSelector = createSelector([
     layerSettingSelector,
@@ -40,8 +41,9 @@ const tocItemsSettingsSelector = createSelector([
     activeTabSettingsSelector,
     elementSelector,
     isLocalizedLayerStylesEnabledSelector,
-    isCesium
-], (settings, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, activeTab, element, isLocalizedLayerStylesEnabled, isCesiumActive) => ({
+    isCesium,
+    mapIsEditableSelector
+], (settings, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, activeTab, element, isLocalizedLayerStylesEnabled, isCesiumActive, canEditMap) => ({
     settings,
     element,
     groups,
@@ -51,7 +53,8 @@ const tocItemsSettingsSelector = createSelector([
     isAdmin,
     activeTab,
     isLocalizedLayerStylesEnabled,
-    isCesiumActive
+    isCesiumActive,
+    canEditMap
 }));
 
 /**

--- a/web/client/plugins/__tests__/TOCItemsSettings-test.jsx
+++ b/web/client/plugins/__tests__/TOCItemsSettings-test.jsx
@@ -75,7 +75,7 @@ describe('TOCItemsSettings Plugin', () => {
         const tabIndexes = document.querySelectorAll(TAB_INDEX_SELECTOR);
         expect(tabIndexes.length).toBe(4);
         expect(tabIndexes[0].className).toBe("active"); // general tab active
-        expect(document.querySelectorAll(`${TAB_CONTENT_SELECTOR} div.form-group`).length).toBe(4); // check content is general settings tab.
+        expect(document.querySelectorAll(`${TAB_CONTENT_SELECTOR} div.form-group`).length).toBe(5); // check content is general settings tab.
 
     });
     it('display panel', () => {

--- a/web/client/plugins/__tests__/TOCItemsSettings-test.jsx
+++ b/web/client/plugins/__tests__/TOCItemsSettings-test.jsx
@@ -75,7 +75,7 @@ describe('TOCItemsSettings Plugin', () => {
         const tabIndexes = document.querySelectorAll(TAB_INDEX_SELECTOR);
         expect(tabIndexes.length).toBe(4);
         expect(tabIndexes[0].className).toBe("active"); // general tab active
-        expect(document.querySelectorAll(`${TAB_CONTENT_SELECTOR} div.form-group`).length).toBe(5); // check content is general settings tab.
+        expect(document.querySelectorAll(`${TAB_CONTENT_SELECTOR} div.form-group`).length).toBe(4); // check content is general settings tab.
 
     });
     it('display panel', () => {


### PR DESCRIPTION
## Description
This PR adds validation to layer setting `disableFeaturesEditing` option. The option is shown only if the user has write permission to map/context.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
- https://github.com/geosolutions-it/MapStore2/issues/9180#issuecomment-1593179308

**What is the new behavior?**
The option is visible only when user has write permission to map/context

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
