### PR TITLE
#9139: Fix - New WFS layers no longer visible in dashboards

### DIFF
--- a/web/client/plugins/widgetbuilder/enhancers/__tests__/handleMapZoomLayer-test.js
+++ b/web/client/plugins/widgetbuilder/enhancers/__tests__/handleMapZoomLayer-test.js
@@ -101,5 +101,36 @@ describe('handleMapZoomLayer enhancer', function() {
         }));
         ReactDOM.render(<Provider store={store}><Sink editorData={editorData} selectedNodes={selectedNodes}  /></Provider>, document.getElementById("container"));
     });
+    it('test zoom map and epsgSupported with boundingBox', (done) => {
+        const editorData = {
+            selectedMapId: 'MAP_ID',
+            maps: [{
+                mapId: 'MAP_ID',
+                size: {
+                    width: 518,
+                    height: 351
+                },
+                layers: [{
+                    id: "layer.id1",
+                    boundingBox: {
+                        crs: 'EPSG:4326',
+                        bounds: {
+                            minx: -12,
+                            miny: 24,
+                            maxx: -66,
+                            maxy: 49
+                        }
+                    }
+                }]
+            }]
+        };
+        const selectedNodes = ["layer.id1"];
+        const Sink = handleMapZoomLayer(createSink(props => {
+            props.zoomTo(selectedNodes);
+            expect(props.isEpsgSupported()).toBeTruthy();
+            done();
+        }));
+        ReactDOM.render(<Provider store={store}><Sink editorData={editorData} selectedNodes={selectedNodes}  /></Provider>, document.getElementById("container"));
+    });
 });
 

--- a/web/client/plugins/widgetbuilder/enhancers/__tests__/layerSelector-test.js
+++ b/web/client/plugins/widgetbuilder/enhancers/__tests__/layerSelector-test.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import expect from 'expect';
+import { addSearchObservable } from '../layerSelector';
+
+
+describe('layerSelector enhancer', function() {
+
+    it('test addSearchObservable with addSearch', () => {
+        expect(addSearchObservable({
+            type: "wms",
+            name: "test-layer"
+        }, {
+            type: "wms"
+        }).value).toBeFalsy();
+    });
+    it('test addSearchObservable skip addSearch', () => {
+        expect(addSearchObservable({
+            type: "wfs",
+            name: "test-layer"
+        }, {
+            type: "wfs"
+        }).value).toBeTruthy();
+    });
+
+});
+

--- a/web/client/plugins/widgetbuilder/enhancers/handleMapZoomLayer.js
+++ b/web/client/plugins/widgetbuilder/enhancers/handleMapZoomLayer.js
@@ -45,6 +45,10 @@ const toBoundsArray = extent => {
     }
     return null;
 };
+const getBbox = l => l.bbox || l.boundingBox;
+const getLayersBbox = (layers) => {
+    return layers?.filter(getBbox).map(getBbox) ?? [];
+};
 
 const enhancer = compose(
     connect(() => ({}), {
@@ -54,7 +58,7 @@ const enhancer = compose(
         isEpsgSupported: ({ editorData = {}, selectedNodes = [] }) => () => {
             const layers = editorData.maps?.find(m => m.mapId === editorData.selectedMapId)?.layers || [];
             const selectedLayers = selectedNodes.map(nodeId => layers.find(layer => layer.id === nodeId)).filter(l => l);
-            const layersBbox = selectedLayers.filter(l => l.bbox).map(l => l.bbox);
+            const layersBbox = getLayersBbox(selectedLayers);
             const uniqueCRS = layersBbox.length > 0 ? layersBbox.reduce((a, b) => a.crs === b.crs ? a : { crs: 'differentCRS' }) : { crs: 'differentCRS' };
             const currentEPSG = !!head(layersBbox) && uniqueCRS.crs !== 'differentCRS' && uniqueCRS.crs;
             return currentEPSG && Proj4js.defs(currentEPSG);
@@ -63,7 +67,7 @@ const enhancer = compose(
             const map = editorData.maps?.find(m => m.mapId === editorData.selectedMapId) || {};
             const layers = map.layers || [];
             const selectedLayers = selectedNodes.map(nodeId => layers.find(layer => layer.id === nodeId)).filter(l => l);
-            const layersBbox = selectedLayers.filter(l => l.bbox).map(l => l.bbox);
+            const layersBbox = getLayersBbox(selectedLayers);
             const bbox = layersBbox.length > 1 ? layersBbox.reduce((a, b) => {
                 return {
                     bounds: {

--- a/web/client/plugins/widgetbuilder/enhancers/layerSelector.js
+++ b/web/client/plugins/widgetbuilder/enhancers/layerSelector.js
@@ -18,8 +18,8 @@ export const toLayer = (r, service) => ["tms", "wfs"].includes(service?.type) //
     // the type wms is default (for csw and wms), wmts have to be passed. // TODO: improve and centralize more
     : API[service?.type || 'wms'].getLayerFromRecord(r, { service });
 
-// checks for tms wmts in order to addSearch() to skip addSearch
-export const addSearchObservable = (selected, service) => ["tms", "wmts"].includes(service?.type) ? Rx.Observable.of(toLayer(selected, service)) : addSearch(toLayer(selected, service));
+// checks for tms, wmts & wfs, in order to skip addSearch
+export const addSearchObservable = (selected, service) => ["tms", "wmts", "wfs"].includes(service?.type) ? Rx.Observable.of(toLayer(selected, service)) : addSearch(toLayer(selected, service));
 
 /**
  * enhancer for CompactCatalog (or a container) to validate a selected record,


### PR DESCRIPTION
## Description
This PR fixes the following
- Zoom to layer is not enabled on WFS layer
- DescribeLayer call on WFS service layer

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9139 

**What is the new behavior?**
- User can zoom in on WFS layer added
- Skip addSearch WFS when layer is selected

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
