### PR TITLE
#8999 Included missing reducer in search plugin

### DIFF
--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -424,6 +424,6 @@ export default {
     reducers: {
         search: searchReducers,
         mapInfo: mapInfoReducers,
-        searchconfig: searchconfigReducer
+        searchconfig: searchconfigReducer // required to load configuration even if the SearchServicesConfig plugin is not included (e.g. in mobile)
     }
 };


### PR DESCRIPTION
## Description

Including the reducer inside the search plugin, so the alternative configurations can be loaded even if the SearchServicesConfig is not defined.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8999

**What is the new behavior?**
Now the configurations are loaded on mobile too.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
