### PR TITLE
#9250: Share plugin - Permalink functionality

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -95,11 +95,15 @@ The old spring maven repositories that do not exist anymore have been removed fr
 
 ### New Permalink plugin
 
-As part this release, permalink plugin is added to MS.
+As part this release, permalink plugin is added to MapStore. The new plugin is already configured in standard MapStore application, but if you are working on a project or if you customized the configuration files, you may need to update them to introduce the new plugin.
 
-#### Add permalink to localConfig.json
+In any case on an existing installation you **must** update the database adding the category to make the plugin work.
 
-- Update `localConfig.json` and add "Permalink" plugin to the "desktop", "dashboard" and "geostory" section
+#### Add Permalink plugin to localConfig.json
+
+In the case you customized your `configs/localConfig.json` file in your project/installation, to add the permalink plugin you will have to update it as following:
+
+- Add the "Permalink" plugin to the pages you want to use this plugin. Pages plugins are in the `plugins` section in the root of `localConfig.json`,  so you have to add "Permalink" entry to `desktop`, `dashboard` and `geostory` arrays, like this:
 
 ```json
 {
@@ -121,7 +125,7 @@ As part this release, permalink plugin is added to MS.
 }
 ```
 
-- Add new "permalink" section as shown below
+- To activate the functionality, you must add a new `permalink` section to `plugins` root object of `localConfig.json`, as shown below
 
 ```json
 {
@@ -134,10 +138,10 @@ As part this release, permalink plugin is added to MS.
 
 #### Using Permalink in new contexts
 
-Contents of your `pluginsConfig.json` need to be reviewed to allow usage of new "Peramlink" in new contexts.
-Existing contexts need to be updated separately.
+The plugins available for contexts are listed in the file `configs/pluginsConfig.json`. In your project/installation, you may need to edit this configuration to make the plugin selectable for your context.
+Existing contexts need to be updated separately, after applying these changes
 
-- Find "Share" plugin configuration in `pluginsConfig.json` and modify as shown below:
+- Find the "Share" plugin configuration in the `plugins` array in the root of  `pluginsConfig.json` configuration file and modify it as shown below (adding `children` and `autoEnableChildren` sections:
 
 ```json
     {
@@ -157,15 +161,14 @@ Existing contexts need to be updated separately.
     }
 ```
 
-- Add "Permalink" plugin configuration to `pluginsConfig.json`
+- Add "Permalink" plugin configuration to the `plugins` array in the root of `pluginsConfig.json`
 
 ```json
     {
       "name": "Permalink",
       "glyph": "link",
       "title": "plugins.Permalink.title",
-      "description": "plugins.Permalink.description",
-      "denyUserSelection": true
+      "description": "plugins.Permalink.description"
     },
 ```
 

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -93,6 +93,107 @@ The old spring maven repositories that do not exist anymore have been removed fr
 -        </repository>
 ```
 
+### New Permalink plugin
+
+As part this release, permalink plugin is added to MS.
+
+#### Add permalink to localConfig.json
+
+- Update `localConfig.json` and add "Permalink" plugin to the "desktop", "dashboard" and "geostory" section
+
+```json
+{
+    "desktop": [
+        ...
+        "Permalink",
+        ...
+    ],
+    "dashboard": [
+        ...
+        "Permalink",
+        ...
+    ],
+    "geostory": [
+        ...
+        "Permalink",
+        ...
+    ]
+}
+```
+
+- Add new "permalink" section as shown below
+
+```json
+{
+    "permalink": [
+        "Permalink",
+        "FeedbackMask"
+    ]
+}
+```
+
+#### Using Permalink in new contexts
+
+Contents of your `pluginsConfig.json` need to be reviewed to allow usage of new "Peramlink" in new contexts.
+Existing contexts need to be updated separately.
+
+- Find "Share" plugin configuration in `pluginsConfig.json` and modify as shown below:
+
+```json
+    {
+      "name": "Share",
+      "glyph": "share",
+      "title": "plugins.Share.title",
+      "description": "plugins.Share.description",
+      "dependencies": [
+        "SidebarMenu"
+      ],
+      "children": [
+        "Permalink"
+      ],
+      "autoEnableChildren": [
+        "Permalink"
+      ]
+    }
+```
+
+- Add "Permalink" plugin configuration to `pluginsConfig.json`
+
+```json
+    {
+      "name": "Permalink",
+      "glyph": "link",
+      "title": "plugins.Permalink.title",
+      "description": "plugins.Permalink.description",
+      "denyUserSelection": true
+    },
+```
+
+#### Database Update
+
+Add new category `PERMALINK` to `gs_category` table. To update your database you need to apply this SQL scripts to your database
+
+##### PostgreSQL
+
+```sql
+-- New PERMALINK category
+INSERT INTO geostore.gs_category(id, name) VALUES (nextval('geostore.hibernate_sequence'), 'PERMALINK') ON CONFLICT DO NOTHING;
+```
+
+##### H2
+
+```sql
+-- New PERMALINK category
+INSERT INTO gs_category(name) VALUES ('PERMALINK');
+```
+
+##### Oracle
+
+```sql
+-- New PERMALINK category
+INSERT INTO gs_category(id, name) VALUES (hibernate_sequence.nextval, ‘PERMALINK');
+```
+
 ## Migration from 2022.02.02 to 2023.01.00
 
 ### Log4j update to Log4j2

--- a/java/web/src/main/resources/sample_categories.xml
+++ b/java/web/src/main/resources/sample_categories.xml
@@ -24,4 +24,7 @@
     <Category>
         <name>USERSESSION</name>
     </Category>
+    <Category>
+        <name>PERMALINK</name>
+    </Category>
 </CategoryList>

--- a/project/standard/templates/configs/pluginsConfig.json
+++ b/project/standard/templates/configs/pluginsConfig.json
@@ -152,7 +152,20 @@
       "description": "plugins.Share.description",
       "dependencies": [
         "SidebarMenu"
+      ],
+      "children": [
+        "Permalink"
+      ],
+      "autoEnableChildren": [
+        "Permalink"
       ]
+    },
+    {
+      "name": "Permalink",
+      "glyph": "link",
+      "title": "plugins.Permalink.title",
+      "description": "plugins.Permalink.description",
+      "denyUserSelection": true
     },
     {
       "name": "BackgroundSelector",

--- a/project/standard/templates/web/src/main/resources/sample_categories.xml
+++ b/project/standard/templates/web/src/main/resources/sample_categories.xml
@@ -24,4 +24,7 @@
     <Category>
         <name>USERSESSION</name>
     </Category>
+    <Category>
+        <name>PERMALINK</name>
+    </Category>
 </CategoryList>

--- a/web/client/actions/__tests__/permalink-test.js
+++ b/web/client/actions/__tests__/permalink-test.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from "expect";
+
+import {
+    LOAD_PERMALINK,
+    LOAD_PERMALINK_ERROR,
+    PERMALINK_LOADED,
+    LOADING,
+    RESET,
+    SAVE_PERMALINK,
+    UPDATE_SETTINGS,
+    loadPermalink,
+    loadPermalinkError,
+    permalinkLoaded,
+    permalinkLoading,
+    resetPermalink,
+    savePermalink,
+    updatePermalinkSettings
+} from "../permalink";
+
+describe("Test correctness of the permalink actions", () => {
+    it("loadPermalink", () => {
+        const action = loadPermalink("test");
+        expect(action.type).toBe(LOAD_PERMALINK);
+        expect(action.id).toBe("test");
+    });
+    it("loadPermalinkError", () => {
+        const error = {message: "error"};
+        const action = loadPermalinkError(error);
+        expect(action.type).toBe(LOAD_PERMALINK_ERROR);
+        expect(action.error).toEqual(error);
+    });
+    it("permalinkLoaded", () => {
+        const action = permalinkLoaded();
+        expect(action.type).toBe(PERMALINK_LOADED);
+    });
+    it("permalinkLoading", () => {
+        const action = permalinkLoading(true);
+        expect(action.type).toBe(LOADING);
+        expect(action.loading).toBeTruthy();
+    });
+    it("resetPermalink", () => {
+        const action = resetPermalink();
+        expect(action.type).toBe(RESET);
+    });
+    it("savePermalink", () => {
+        const saveObj = {name: "test"};
+        const action = savePermalink(saveObj);
+        expect(action.type).toBe(SAVE_PERMALINK);
+        expect(action.value).toEqual(saveObj);
+    });
+    it("updatePermalinkSettings", () => {
+        const settings = {title: "test"};
+        const action = updatePermalinkSettings(settings);
+        expect(action.type).toBe(UPDATE_SETTINGS);
+        expect(action.settings).toEqual(settings);
+    });
+});

--- a/web/client/actions/permalink.js
+++ b/web/client/actions/permalink.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+export const LOAD_PERMALINK = "PERMALINK:LOAD";
+export const PERMALINK_LOADED = "PERMALINK:LOADED";
+export const LOAD_PERMALINK_ERROR = "PERMALINK:LOAD_ERROR";
+export const SAVE_PERMALINK = "PERMALINK:SAVE";
+export const UPDATE_SETTINGS = "PERMALINK:UPDATE_SETTINGS";
+export const LOADING = "PERMALINK:LOADING";
+export const RESET = "PERMALINK:RESET";
+
+/**
+ * Load permalink
+ * @param {string} id
+ * @memberof actions.permalink
+*/
+export const loadPermalink = (id) => ({
+    type: LOAD_PERMALINK,
+    id
+});
+
+/**
+ * Trigger on permalink loaded
+ * @memberof actions.permalink
+*/
+export const permalinkLoaded = () => ({
+    type: PERMALINK_LOADED
+});
+
+/**
+ * Trigger on permalink load error
+ * @param {Object} error
+ * @memberof actions.permalink
+*/
+export const loadPermalinkError = (error) => ({
+    type: LOAD_PERMALINK_ERROR,
+    error
+});
+
+/**
+ * Trigger on save permalink
+ * @param {Object} value
+ * @memberof actions.permalink
+*/
+export const savePermalink = (value) => ({
+    type: SAVE_PERMALINK,
+    value
+});
+
+/**
+ * Trigger on update permalink settings
+ * @param {Object} settings
+ * @memberof actions.permalink
+*/
+export const updatePermalinkSettings = (settings) => ({
+    type: UPDATE_SETTINGS,
+    settings
+});
+
+/**
+ * Trigger on loading a permalink
+ * @param {boolean} loading
+ * @memberof actions.permalink
+*/
+export const permalinkLoading = (loading) => ({
+    type: LOADING,
+    loading
+});
+
+/**
+ * Trigger on permalink reset
+ * @memberof actions.permalink
+*/
+export const resetPermalink = () => ({
+    type: RESET
+});

--- a/web/client/components/permalink/Permalink.jsx
+++ b/web/client/components/permalink/Permalink.jsx
@@ -101,13 +101,13 @@ export default ({
         <div id="permalink">
             {settings.name ? (
                 <>
-                    <ShareLink shareTitle="share.permalink.shareLinkTitle" shareUrl={getPermalinkUrl(settings.name)} />
-                    <span className="subtitle">Share the resource using the generated address</span>
+                    <ShareLink shareTitle="permalink.shareLinkTitle" shareUrl={getPermalinkUrl(settings.name)} />
+                    <span className="subtitle"><Message msgId={"permalink.subtitle"}/></span>
 
                     <ShareQRCode shareUrl={getPermalinkUrl(settings.name)} />
                     <div className="create-new">
                         <Button bsStyle="primary" onClick={onReset}>
-                            <Message msgId={"share.permalink.create"}/>
+                            <Message msgId={"permalink.create"}/>
                         </Button>
                     </div>
                 </>
@@ -115,7 +115,7 @@ export default ({
                 <>
                     <FormGroup>
                         <ControlLabel>
-                            <Message msgId={"share.permalink.titleLabel"} />*
+                            <Message msgId={"permalink.titleLabel"} />*
                         </ControlLabel>
                         <FormControl
                             key="permalinkTitle"
@@ -123,13 +123,13 @@ export default ({
                             value={settings.title || ""}
                             name="title"
                             onChange={onChange}
-                            placeholder={"share.permalink.titlePlaceholder"}
+                            placeholder={"permalink.titlePlaceholder"}
                         />
                     </FormGroup>
                     <FormGroup>
                         <ControlLabel>
                             <Message
-                                msgId={"share.permalink.descriptionLabel"}
+                                msgId={"permalink.descriptionLabel"}
                             />
                         </ControlLabel>
                         <FormControl
@@ -139,7 +139,7 @@ export default ({
                             name="description"
                             onChange={onChange}
                             placeholder={
-                                "share.permalink.descriptionPlaceholder"
+                                "permalink.descriptionPlaceholder"
                             }
                         />
                     </FormGroup>
@@ -149,7 +149,7 @@ export default ({
                             checked={settings.allowAllUser}
                             onChange={onChange}
                         >
-                            <Message msgId="share.permalink.accessible" />
+                            <Message msgId="permalink.accessible" />
                         </Checkbox>
                     </FormGroup>
                     <div className="permalink-save">
@@ -158,7 +158,7 @@ export default ({
                             disabled={loading || isEmpty(settings.title)}
                             onClick={onClickSave}
                         >
-                            <Message msgId="share.permalink.generate" />
+                            <Message msgId="permalink.generate" />
                             {loading && <LoadingSpinner />}
                         </Button>
                     </div>

--- a/web/client/components/permalink/Permalink.jsx
+++ b/web/client/components/permalink/Permalink.jsx
@@ -103,10 +103,13 @@ export default ({
                 <>
                     <ShareLink shareTitle="share.permalink.shareLinkTitle" shareUrl={getPermalinkUrl(settings.name)} />
                     <span className="subtitle">Share the resource using the generated address</span>
-                    <Button className="create-new" bsStyle="primary" onClick={onReset}>
-                        <Message msgId={"share.permalink.create"}/>
-                    </Button>
+
                     <ShareQRCode shareUrl={getPermalinkUrl(settings.name)} />
+                    <div className="create-new">
+                        <Button bsStyle="primary" onClick={onReset}>
+                            <Message msgId={"share.permalink.create"}/>
+                        </Button>
+                    </div>
                 </>
             ) : (
                 <>
@@ -155,7 +158,7 @@ export default ({
                             disabled={loading || isEmpty(settings.title)}
                             onClick={onClickSave}
                         >
-                            <Message msgId="share.permalink.save" />
+                            <Message msgId="share.permalink.generate" />
                             {loading && <LoadingSpinner />}
                         </Button>
                     </div>

--- a/web/client/components/permalink/Permalink.jsx
+++ b/web/client/components/permalink/Permalink.jsx
@@ -46,7 +46,7 @@ const getPathinfo = (url = "") => {
         break;
     case "context":
         type = "context";
-        pathTemplate = pathTemplate.replace("id", "name");
+        pathTemplate = pathTemplate.replace("id", "name") + '?category=PERMALINK';
         break;
     default:
         break;
@@ -98,14 +98,15 @@ export default ({
     }, []);
 
     return (
-        <div id="permalink" style={{padding: 4}}>
-            {settings.id ? (
+        <div id="permalink">
+            {settings.name ? (
                 <>
-                    <ShareLink shareUrl={getPermalinkUrl(settings.id)} />
-                    <Button bsStyle="primary" onClick={onReset}>
+                    <ShareLink shareTitle="share.permalink.shareLinkTitle" shareUrl={getPermalinkUrl(settings.name)} />
+                    <span className="subtitle">Share the resource using the generated address</span>
+                    <Button className="create-new" bsStyle="primary" onClick={onReset}>
                         <Message msgId={"share.permalink.create"}/>
                     </Button>
-                    <ShareQRCode shareUrl={getPermalinkUrl(settings.id)} />
+                    <ShareQRCode shareUrl={getPermalinkUrl(settings.name)} />
                 </>
             ) : (
                 <>
@@ -148,14 +149,16 @@ export default ({
                             <Message msgId="share.permalink.accessible" />
                         </Checkbox>
                     </FormGroup>
-                    <Button
-                        style={{ display: "flex", alignItems: "center", "float": "right" }}
-                        disabled={loading || isEmpty(settings.title)}
-                        onClick={onClickSave}
-                    >
-                        <Message msgId="share.permalink.save" />
-                        {loading && <LoadingSpinner />}
-                    </Button>
+                    <div className="permalink-save">
+                        <Button
+                            className={loading ? "loading" : ''}
+                            disabled={loading || isEmpty(settings.title)}
+                            onClick={onClickSave}
+                        >
+                            <Message msgId="share.permalink.save" />
+                            {loading && <LoadingSpinner />}
+                        </Button>
+                    </div>
                 </>
             )}
         </div>

--- a/web/client/components/permalink/Permalink.jsx
+++ b/web/client/components/permalink/Permalink.jsx
@@ -28,11 +28,11 @@ const getPathinfo = (url = "") => {
     const [, path] = url?.split("#/") ?? [];
     const pathInfos = path?.split("/") ?? [];
     let [pathType] = pathInfos ?? [];
-    const pathTemplate =
-        (pathType === "context" && pathInfos?.length === 3)
-        || pathType !== "context"
-            ? path?.substring(0, path?.lastIndexOf("/")) ?? ""
-            : path;
+    let pathTemplate = pathType === "context"
+        ? "context"
+        : (path?.substring(0, path?.lastIndexOf("/")) ?? "");
+    pathTemplate = `/${pathTemplate}/` + '${id}';
+
     let type;
     switch (pathType) {
     case "viewer":
@@ -46,13 +46,14 @@ const getPathinfo = (url = "") => {
         break;
     case "context":
         type = "context";
+        pathTemplate = pathTemplate.replace("id", "name");
         break;
     default:
         break;
     }
     return {
         type,
-        pathTemplate: `/${pathTemplate}/` + '${id}'
+        pathTemplate
     };
 };
 

--- a/web/client/components/permalink/Permalink.jsx
+++ b/web/client/components/permalink/Permalink.jsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useEffect } from "react";
+import uuid from 'uuid';
+import isEmpty from 'lodash/isEmpty';
+import {
+    Checkbox,
+    ControlLabel,
+    FormControl as FC,
+    FormGroup
+} from "react-bootstrap";
+import localizedProps from "../misc/enhancers/localizedProps";
+import ShareLink from "../share/ShareLink";
+import Button from "../misc/Button";
+import Message from "../I18N/Message";
+import ShareQRCode from "../share/ShareQRCode";
+import LoadingSpinner from "../misc/LoadingSpinner";
+
+const FormControl = localizedProps("placeholder")(FC);
+
+const getPathinfo = (url = "") => {
+    const [, path] = url?.split("#/") ?? [];
+    const pathInfos = path?.split("/") ?? [];
+    let [pathType] = pathInfos ?? [];
+    const pathTemplate =
+        (pathType === "context" && pathInfos?.length === 3)
+        || pathType !== "context"
+            ? path?.substring(0, path?.lastIndexOf("/")) ?? ""
+            : path;
+    let type;
+    switch (pathType) {
+    case "viewer":
+        type = "map";
+        break;
+    case "dashboard":
+        type = "dashboard";
+        break;
+    case "geostory":
+        type = "geostory";
+        break;
+    case "context":
+        type = "context";
+        break;
+    default:
+        break;
+    }
+    return {
+        type,
+        pathTemplate: `/${pathTemplate}/` + '${id}'
+    };
+};
+
+export default ({
+    loading = false,
+    settings = {},
+    shareUrl = "",
+    onSave = () => {},
+    onReset = () => {},
+    onUpdateSettings = () => {}
+}) => {
+    const onChange = (event) => {
+        const { value, name, checked } = event?.target || {};
+        onUpdateSettings({
+            [name]: name === "allowAllUser" ? checked : value
+        });
+    };
+    const getPermalinkUrl = (id) => {
+        const url = location.href?.split("#")[0];
+        return url + `#/permalink/${id}`;
+    };
+
+    const onClickSave = () => {
+        const pathInfo = getPathinfo(shareUrl);
+        onSave({
+            permalinkType: pathInfo.type,
+            resource: {
+                category: "PERMALINK",
+                metadata: {name: uuid()},
+                attributes: {
+                    ...pathInfo,
+                    title: settings.title,
+                    description: settings.description
+                }
+            },
+            allowAllUser: settings.allowAllUser
+        });
+    };
+
+    useEffect(() => {
+        return () => onReset();
+    }, []);
+
+    return (
+        <div id="permalink" style={{padding: 4}}>
+            {settings.id ? (
+                <>
+                    <ShareLink shareUrl={getPermalinkUrl(settings.id)} />
+                    <Button bsStyle="primary" onClick={onReset}>
+                        <Message msgId={"share.permalink.create"}/>
+                    </Button>
+                    <ShareQRCode shareUrl={getPermalinkUrl(settings.id)} />
+                </>
+            ) : (
+                <>
+                    <FormGroup>
+                        <ControlLabel>
+                            <Message msgId={"share.permalink.titleLabel"} />*
+                        </ControlLabel>
+                        <FormControl
+                            key="permalinkTitle"
+                            type="text"
+                            value={settings.title || ""}
+                            name="title"
+                            onChange={onChange}
+                            placeholder={"share.permalink.titlePlaceholder"}
+                        />
+                    </FormGroup>
+                    <FormGroup>
+                        <ControlLabel>
+                            <Message
+                                msgId={"share.permalink.descriptionLabel"}
+                            />
+                        </ControlLabel>
+                        <FormControl
+                            key="permalinkDescription"
+                            type="text"
+                            value={settings.description || ""}
+                            name="description"
+                            onChange={onChange}
+                            placeholder={
+                                "share.permalink.descriptionPlaceholder"
+                            }
+                        />
+                    </FormGroup>
+                    <FormGroup>
+                        <Checkbox
+                            name="allowAllUser"
+                            checked={settings.allowAllUser}
+                            onChange={onChange}
+                        >
+                            <Message msgId="share.permalink.accessible" />
+                        </Checkbox>
+                    </FormGroup>
+                    <Button
+                        style={{ display: "flex", alignItems: "center", "float": "right" }}
+                        disabled={loading || isEmpty(settings.title)}
+                        onClick={onClickSave}
+                    >
+                        <Message msgId="share.permalink.save" />
+                        {loading && <LoadingSpinner />}
+                    </Button>
+                </>
+            )}
+        </div>
+    );
+};

--- a/web/client/components/permalink/__tests__/Permalink-test.jsx
+++ b/web/client/components/permalink/__tests__/Permalink-test.jsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+import ReactDOM from 'react-dom';
+import Permalink from '../Permalink';
+import expect from 'expect';
+import TestUtils from 'react-dom/test-utils';
+
+describe('Permalink tests', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates the component with defaults', () => {
+        ReactDOM.render(<Permalink />, document.getElementById("container"));
+        expect(document.getElementById('permalink')).toBeTruthy();
+    });
+    it('test form fields of the component', () => {
+        ReactDOM.render(<Permalink />, document.getElementById("container"));
+        expect(document.getElementById('permalink')).toBeTruthy();
+        const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBe(3);
+        const buttons = document.querySelectorAll('button');
+        expect(buttons.length).toBe(1);
+    });
+    it('test onSave of Permalink', () => {
+        const actions = {
+            onSave: () => {}
+        };
+
+        const onSaveSpy = expect.spyOn(actions, 'onSave');
+        ReactDOM.render(<Permalink onSave={actions.onSave} shareUrl="#/viewer/22" settings={{title: "name"}} />, document.getElementById("container"));
+        expect(document.getElementById('permalink')).toBeTruthy();
+        const button = document.querySelector('button');
+        TestUtils.Simulate.click(button);
+        expect(onSaveSpy).toHaveBeenCalled();
+        const args = onSaveSpy.calls[0].arguments[0];
+        expect(args.permalinkType).toBe('map');
+        expect(args.resource.category).toBe('PERMALINK');
+        expect(args.resource.attributes).toBeTruthy();
+        expect(args.resource.attributes.pathTemplate).toBe("/viewer/${id}");
+    });
+    it('test onSave of Permalink - context', () => {
+        const actions = {
+            onSave: () => {}
+        };
+
+        const onSaveSpy = expect.spyOn(actions, 'onSave');
+        ReactDOM.render(<Permalink onSave={actions.onSave} shareUrl="#/context/22" settings={{title: "name"}} />, document.getElementById("container"));
+        expect(document.getElementById('permalink')).toBeTruthy();
+        const button = document.querySelector('button');
+        TestUtils.Simulate.click(button);
+        expect(onSaveSpy).toHaveBeenCalled();
+        const args = onSaveSpy.calls[0].arguments[0];
+        expect(args.permalinkType).toBe('context');
+        expect(args.resource.category).toBe('PERMALINK');
+        expect(args.resource.attributes).toBeTruthy();
+        expect(args.resource.attributes.pathTemplate).toBe("/context/${name}");
+    });
+    it('test show permalink link panel', () => {
+        ReactDOM.render(<Permalink shareUrl="#/viewer/22" settings={{id: 1}} />, document.getElementById("container"));
+        expect(document.getElementById('permalink')).toBeTruthy();
+        expect(document.getElementsByClassName('qr-code')[0]).toBeTruthy();
+    });
+});

--- a/web/client/components/permalink/__tests__/Permalink-test.jsx
+++ b/web/client/components/permalink/__tests__/Permalink-test.jsx
@@ -69,10 +69,10 @@ describe('Permalink tests', () => {
         expect(args.permalinkType).toBe('context');
         expect(args.resource.category).toBe('PERMALINK');
         expect(args.resource.attributes).toBeTruthy();
-        expect(args.resource.attributes.pathTemplate).toBe("/context/${name}");
+        expect(args.resource.attributes.pathTemplate).toBe("/context/${name}?category=PERMALINK");
     });
     it('test show permalink link panel', () => {
-        ReactDOM.render(<Permalink shareUrl="#/viewer/22" settings={{id: 1}} />, document.getElementById("container"));
+        ReactDOM.render(<Permalink shareUrl="#/viewer/22" settings={{name: 1}} />, document.getElementById("container"));
         expect(document.getElementById('permalink')).toBeTruthy();
         expect(document.getElementsByClassName('qr-code')[0]).toBeTruthy();
     });

--- a/web/client/components/resources/ResourceCard.jsx
+++ b/web/client/components/resources/ResourceCard.jsx
@@ -174,7 +174,7 @@ class ResourceCard extends React.Component {
 
         return (
             <div>
-                <GridCard className="map-thumb" style={this.getCardStyle()} header={this.props.resource.title || this.props.resource.name}
+                <GridCard className="map-thumb" style={this.getCardStyle()} header={this.props.resource.name || this.props.resource.title}
                     actions={availableAction} onClick={this.onClick}
                 >
                     <div className="map-thumb-description">{this.props.resource.description}</div>

--- a/web/client/components/resources/enhancers/__tests__/withShareTool-test.js
+++ b/web/client/components/resources/enhancers/__tests__/withShareTool-test.js
@@ -69,7 +69,7 @@ describe('withShareTool enhancer', () => {
             expect(directLink).toExist('directLink doesn\'t exist');
             expect(directLink.value).toBe(FAKE_RESOURCE_URL);
             expect(directLink.value).toBe("http://some-location/mapstore/#/FAKE_RESOURCE_PATH"); // double check
-            document.getElementById('sharePanel-tabs-tab-3').click();
+            document.getElementById('sharePanel-tabs-tab-4').click();
             const codeBlock = document.getElementsByTagName('code')[0];
             expect(codeBlock).toExist();
             const iframeCode = codeBlock.innerText;
@@ -86,7 +86,7 @@ describe('withShareTool enhancer', () => {
             />, document.getElementById("container"));
             const sharePanel = document.querySelector('#sharePanel-tabs');
             expect(sharePanel).toExist('Share panel doesn\'t exist');
-            document.getElementById('sharePanel-tabs-tab-3').click();
+            document.getElementById('sharePanel-tabs-tab-4').click();
             // check if the showTOC is enabled by deafult
             let showTOC = document.querySelector('#sharePanel-tabs .input-link-tools input[type=checkbox]');
             expect(showTOC).toExist();
@@ -97,7 +97,7 @@ describe('withShareTool enhancer', () => {
                 editedResource={{}}
                 getShareUrl={() => FAKE_RESOURCE_PATH}
             />, document.getElementById("container"));
-            document.getElementById('sharePanel-tabs-tab-3').click();
+            document.getElementById('sharePanel-tabs-tab-4').click();
             showTOC = document.querySelector('#sharePanel-tabs .input-link-tools input[type=checkbox]');
             // verify the embedOptions.showTOCToggle has effect on "show TOC" checkbox hiding it
             expect(showTOC).toNotExist();
@@ -114,7 +114,7 @@ describe('withShareTool enhancer', () => {
             />, document.getElementById("container"));
             const sharePanel = document.querySelector('#sharePanel-tabs');
             expect(sharePanel).toExist('Share panel doesn\'t exist');
-            document.getElementById('sharePanel-tabs-tab-3').click();
+            document.getElementById('sharePanel-tabs-tab-4').click();
             // check if the showTOC is enabled by deafult
             let showTOC = document.querySelector('#sharePanel-tabs .input-link-tools input[type=checkbox]');
             expect(showTOC).toExist();
@@ -125,7 +125,7 @@ describe('withShareTool enhancer', () => {
                 editedResource={{}}
                 getShareUrl={() => FAKE_RESOURCE_PATH}
             />, document.getElementById("container"));
-            document.getElementById('sharePanel-tabs-tab-3').click();
+            document.getElementById('sharePanel-tabs-tab-4').click();
             const codeAPI = document.querySelectorAll("code")[1];
             const code = codeAPI.innerText;
             const index = code.indexOf("dist/ms2-api.js?VERSION");

--- a/web/client/components/resources/enhancers/__tests__/withShareTool-test.js
+++ b/web/client/components/resources/enhancers/__tests__/withShareTool-test.js
@@ -69,7 +69,7 @@ describe('withShareTool enhancer', () => {
             expect(directLink).toExist('directLink doesn\'t exist');
             expect(directLink.value).toBe(FAKE_RESOURCE_URL);
             expect(directLink.value).toBe("http://some-location/mapstore/#/FAKE_RESOURCE_PATH"); // double check
-            document.getElementById('sharePanel-tabs-tab-4').click();
+            document.getElementById('sharePanel-tabs-tab-3').click();
             const codeBlock = document.getElementsByTagName('code')[0];
             expect(codeBlock).toExist();
             const iframeCode = codeBlock.innerText;
@@ -86,7 +86,7 @@ describe('withShareTool enhancer', () => {
             />, document.getElementById("container"));
             const sharePanel = document.querySelector('#sharePanel-tabs');
             expect(sharePanel).toExist('Share panel doesn\'t exist');
-            document.getElementById('sharePanel-tabs-tab-4').click();
+            document.getElementById('sharePanel-tabs-tab-3').click();
             // check if the showTOC is enabled by deafult
             let showTOC = document.querySelector('#sharePanel-tabs .input-link-tools input[type=checkbox]');
             expect(showTOC).toExist();
@@ -97,7 +97,7 @@ describe('withShareTool enhancer', () => {
                 editedResource={{}}
                 getShareUrl={() => FAKE_RESOURCE_PATH}
             />, document.getElementById("container"));
-            document.getElementById('sharePanel-tabs-tab-4').click();
+            document.getElementById('sharePanel-tabs-tab-3').click();
             showTOC = document.querySelector('#sharePanel-tabs .input-link-tools input[type=checkbox]');
             // verify the embedOptions.showTOCToggle has effect on "show TOC" checkbox hiding it
             expect(showTOC).toNotExist();
@@ -114,7 +114,7 @@ describe('withShareTool enhancer', () => {
             />, document.getElementById("container"));
             const sharePanel = document.querySelector('#sharePanel-tabs');
             expect(sharePanel).toExist('Share panel doesn\'t exist');
-            document.getElementById('sharePanel-tabs-tab-4').click();
+            document.getElementById('sharePanel-tabs-tab-3').click();
             // check if the showTOC is enabled by deafult
             let showTOC = document.querySelector('#sharePanel-tabs .input-link-tools input[type=checkbox]');
             expect(showTOC).toExist();
@@ -125,7 +125,7 @@ describe('withShareTool enhancer', () => {
                 editedResource={{}}
                 getShareUrl={() => FAKE_RESOURCE_PATH}
             />, document.getElementById("container"));
-            document.getElementById('sharePanel-tabs-tab-4').click();
+            document.getElementById('sharePanel-tabs-tab-3').click();
             const codeAPI = document.querySelectorAll("code")[1];
             const code = codeAPI.innerText;
             const index = code.indexOf("dist/ms2-api.js?VERSION");

--- a/web/client/components/resources/forms/Metadata.jsx
+++ b/web/client/components/resources/forms/Metadata.jsx
@@ -73,6 +73,7 @@ class Metadata extends React.Component {
     }
 
     render() {
+        const title = get(this.props.resource, 'attributes.title', "");
         return (<form ref="metadataForm" onSubmit={this.handleSubmit}>
             <FormGroup>
                 <ControlLabel>{this.props.nameFieldText}</ControlLabel>
@@ -85,7 +86,7 @@ class Metadata extends React.Component {
                     defaultValue={this.props.resource ? this.props.resource.name : ""}
                     value={this.props.resource && this.props.resource.metadata && this.props.resource.metadata.name || ""} />
             </FormGroup>
-            <FormGroup>
+            {!!title && <FormGroup>
                 <ControlLabel>{this.props.titleFieldText}</ControlLabel>
                 <FormControl
                     key="mapTitle"
@@ -93,9 +94,9 @@ class Metadata extends React.Component {
                     onChange={this.changeTitle}
                     disabled={this.props.resource.saving}
                     placeholder={this.props.titlePlaceholderText}
-                    defaultValue={get(this.props.resource, 'attributes.title', "")}
-                    value={get(this.props.resource, 'attributes.title', "")} />
-            </FormGroup>
+                    defaultValue={title}
+                    value={title} />
+            </FormGroup>}
             <FormGroup>
                 <ControlLabel>{this.props.descriptionFieldText}</ControlLabel>
                 <FormControl

--- a/web/client/components/resources/forms/Metadata.jsx
+++ b/web/client/components/resources/forms/Metadata.jsx
@@ -17,6 +17,7 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormControl as BFormControl, ControlLabel, FormGroup } from 'react-bootstrap';
+import get from 'lodash/get';
 
 import ConfigUtils from '../../../utils/ConfigUtils';
 import localizedProps from '../../misc/enhancers/localizedProps';
@@ -34,10 +35,12 @@ class Metadata extends React.Component {
 
         // I18N
         nameFieldText: PropTypes.node,
+        titleFieldText: PropTypes.node,
         descriptionFieldText: PropTypes.node,
         nameFieldFilter: PropTypes.func,
         namePlaceholderText: PropTypes.string,
         descriptionPlaceholderText: PropTypes.string,
+        titlePlaceholderText: PropTypes.string,
         createdAtFieldText: PropTypes.string,
         modifiedAtFieldText: PropTypes.string
     };
@@ -83,6 +86,17 @@ class Metadata extends React.Component {
                     value={this.props.resource && this.props.resource.metadata && this.props.resource.metadata.name || ""} />
             </FormGroup>
             <FormGroup>
+                <ControlLabel>{this.props.titleFieldText}</ControlLabel>
+                <FormControl
+                    key="mapTitle"
+                    type="text"
+                    onChange={this.changeTitle}
+                    disabled={this.props.resource.saving}
+                    placeholder={this.props.titlePlaceholderText}
+                    defaultValue={get(this.props.resource, 'attributes.title', "")}
+                    value={get(this.props.resource, 'attributes.title', "")} />
+            </FormGroup>
+            <FormGroup>
                 <ControlLabel>{this.props.descriptionFieldText}</ControlLabel>
                 <FormControl
                     key="mapDescription"
@@ -114,6 +128,10 @@ class Metadata extends React.Component {
 
     changeDescription = (e) => {
         this.props.onChange('metadata.description', e.target.value);
+    };
+
+    changeTitle = (e) => {
+        this.props.onChange('attributes.title', e.target.value);
     };
 }
 

--- a/web/client/components/resources/forms/__tests__/Metadata-test.jsx
+++ b/web/client/components/resources/forms/__tests__/Metadata-test.jsx
@@ -26,7 +26,7 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata />, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
-        expect(el.length).toBe(3);
+        expect(el.length).toBe(2);
     });
     it('Metadata rendering with meta-data', () => {
         const resource = {
@@ -41,9 +41,9 @@ describe('Metadata component', () => {
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
         const labels = container.querySelectorAll('label');
-        expect(labels.length).toBe(7);
+        expect(labels.length).toBe(6);
         expect(el[0].value).toBe("NAME");
-        expect(el[2].value).toBe("DESCRIPTION");
+        expect(el[1].value).toBe("DESCRIPTION");
     });
     it('Metadata rendering with attributes', () => {
         const resource = {
@@ -70,7 +70,7 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata resource={resource}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const labels = container.querySelectorAll('label');
-        expect(labels.length).toBe(3);
+        expect(labels.length).toBe(2);
     });
 
     it('Test Metadata onChange', () => {
@@ -110,9 +110,8 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata resource={resource} titleFieldText="Title" createdAtFieldText="Created" modifiedAtFieldText="Modified"/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const labels = container.querySelectorAll('label');
-        expect(labels.length).toBe(7);
-        expect(labels[1].innerText).toBe('Title');
-        expect(labels[3].innerText).toBe('Created');
-        expect(labels[5].innerText).toBe('Modified');
+        expect(labels.length).toBe(6);
+        expect(labels[2].innerText).toBe('Created');
+        expect(labels[4].innerText).toBe('Modified');
     });
 });

--- a/web/client/components/resources/forms/__tests__/Metadata-test.jsx
+++ b/web/client/components/resources/forms/__tests__/Metadata-test.jsx
@@ -26,7 +26,7 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata />, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
-        expect(el.length).toBe(2);
+        expect(el.length).toBe(3);
     });
     it('Metadata rendering with meta-data', () => {
         const resource = {
@@ -41,9 +41,24 @@ describe('Metadata component', () => {
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
         const labels = container.querySelectorAll('label');
-        expect(labels.length).toBe(6);
+        expect(labels.length).toBe(7);
         expect(el[0].value).toBe("NAME");
-        expect(el[1].value).toBe("DESCRIPTION");
+        expect(el[2].value).toBe("DESCRIPTION");
+    });
+    it('Metadata rendering with attributes', () => {
+        const resource = {
+            modifiedAt: new Date(),
+            createdAt: new Date(),
+            attributes: {
+                title: "TITLE"
+            }
+        };
+        ReactDOM.render(<Metadata resource={resource}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelectorAll('input');
+        const labels = container.querySelectorAll('label');
+        expect(labels.length).toBe(7);
+        expect(el[1].value).toBe("TITLE");
     });
     it('Metadata rendering without timestamp', () => {
         const resource = {
@@ -55,7 +70,7 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata resource={resource}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const labels = container.querySelectorAll('label');
-        expect(labels.length).toBe(2);
+        expect(labels.length).toBe(3);
     });
 
     it('Test Metadata onChange', () => {
@@ -92,11 +107,12 @@ describe('Metadata component', () => {
                 description: "DESCRIPTION"
             }
         };
-        ReactDOM.render(<Metadata resource={resource} createdAtFieldText="Created" modifiedAtFieldText="Modified"/>, document.getElementById("container"));
+        ReactDOM.render(<Metadata resource={resource} titleFieldText="Title" createdAtFieldText="Created" modifiedAtFieldText="Modified"/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const labels = container.querySelectorAll('label');
-        expect(labels.length).toBe(6);
-        expect(labels[2].innerText).toBe('Created');
-        expect(labels[4].innerText).toBe('Modified');
+        expect(labels.length).toBe(7);
+        expect(labels[1].innerText).toBe('Title');
+        expect(labels[3].innerText).toBe('Created');
+        expect(labels[5].innerText).toBe('Modified');
     });
 });

--- a/web/client/components/resources/modals/fragments/MainForm.jsx
+++ b/web/client/components/resources/modals/fragments/MainForm.jsx
@@ -67,12 +67,14 @@ class MainForm extends React.Component {
                     onChange={onUpdate}
                     resource={resource}
                     nameFieldText={<Message msgId="saveDialog.name" />}
+                    titleFieldText={<Message msgId="saveDialog.titleInput" />}
                     descriptionFieldText={<Message msgId="saveDialog.description" />}
                     nameFieldFilter={nameFieldFilter}
                     createdAtFieldText={<Message msgId="saveDialog.createdAt" />}
                     modifiedAtFieldText={<Message msgId="saveDialog.modifiedAt" />}
                     namePlaceholderText={"saveDialog.namePlaceholder"}
                     descriptionPlaceholderText={"saveDialog.descriptionPlaceholder"}
+                    titlePlaceholderText={"saveDialog.titlePlaceholder"}
                 />
             </Col>
         </Row>);

--- a/web/client/components/share/ShareLink.jsx
+++ b/web/client/components/share/ShareLink.jsx
@@ -20,7 +20,12 @@ import { FormControl } from 'react-bootstrap';
 class ShareLink extends React.Component {
 
     static propTypes = {
-        shareUrl: PropTypes.string
+        shareUrl: PropTypes.string,
+        shareTitle: PropTypes.string
+    };
+
+    static defaultProps = {
+        shareTitle: "share.directLinkTitle"
     };
 
     state = {
@@ -32,7 +37,7 @@ class ShareLink extends React.Component {
             <div className="input-link">
                 <div className="input-link-head">
                     <h4>
-                        <Message msgId="share.directLinkTitle"/>
+                        <Message msgId={this.props.shareTitle}/>
                     </h4>
                     <ShareCopyToClipboard
                         copied={this.state.copied}

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -233,6 +233,33 @@ class SharePanel extends React.Component {
         return orig;
     };
 
+    getEmbedEventKey = (itemTabs = []) => {
+        return itemTabs.length + 3; // 2 Default panels (direct, social)
+    }
+
+    getShareTabs = (itemTabs = []) => {
+        return  {
+            ...SHARE_TABS,
+            ...itemTabs?.map(({tabName} = {}, index) => ({[tabName]: 2 + (index + 1)})).reduce((f, c) => ({...f, ...c}), {}),
+            embed: this.getEmbedEventKey(itemTabs)
+        };
+    }
+
+    getHideIntabs = (itemTabs = []) => {
+        return [
+            this.props?.advancedSettings?.hideInTab,
+            ...itemTabs?.map(({tabName, hideAdvancedSettingsInTab} = {}) => hideAdvancedSettingsInTab ? tabName : "")
+        ];
+    }
+
+    getCurrenTab = (itemTabs = []) => {
+        const embedEventKey = this.getEmbedEventKey(itemTabs);
+        return (
+            (!this.props.embedPanel && this.state.eventKey === embedEventKey)
+            || (isEmpty(itemTabs) && this.state.eventKey > (this.props.embedPanel ? 3 : 2))
+        ) ? 1 : this.state.eventKey; // fallback to tab link if embed is disabled and selected at the same time
+    }
+
     render() {
         // ************************ CHANGE URL PARAMETER FOR EMBED CODE ****************************
         /* if the property shareUrl is not defined it takes the url from location.href */
@@ -242,22 +269,31 @@ class SharePanel extends React.Component {
         if (this.props.shareUrlRegex && this.props.shareUrlReplaceString) {
             shareEmbeddedUrl = this.generateUrl(shareEmbeddedUrl, this.props.shareUrlRegex, this.props.shareUrlReplaceString);
         }
-        const {component: Permalink} = this.props.items?.find(({name} = {}) => name === "Permalink") ?? {};
-        const permalink = Permalink ? <Permalink shareUrl={shareUrl}/> : null;
-        const currentTab = ((!this.props.embedPanel && this.state.eventKey === 4) || (!permalink && this.state.eventKey === 3)) ? 1 : this.state.eventKey; // fallback to tab link if embed|permalink is disabled and selected at the same time
+
+        const itemTabs = this.props.items?.filter(({target} = {}) => target === 'tabs') ?? [];
+        const embedEventKey = this.getEmbedEventKey(itemTabs);
+        const currentTab = this.getCurrenTab(itemTabs);
         const shareApiUrl = this.props.shareApiUrl || cleanShareUrl || location.href;
         const social = <ShareSocials sharedTitle={this.props.sharedTitle} shareUrl={shareUrl} getCount={this.props.getCount}/>;
         const direct = <div><ShareLink shareUrl={shareUrl} bbox={this.props.bbox}/><ShareQRCode shareUrl={shareUrl}/></div>;
         const code = (<div><ShareEmbed shareUrl={shareEmbeddedUrl} {...this.props.embedOptions} />
             {this.props.showAPI ? <ShareApi baseUrl={shareApiUrl} shareUrl={shareUrl} shareConfigUrl={this.props.shareConfigUrl} version={this.props.version}/> : null}</div>);
 
+        const SHARE_TABS_UPDATED = this.getShareTabs(itemTabs);
         const tabs = (<Tabs defaultActiveKey={currentTab} id="sharePanel-tabs" onSelect={(eventKey) => this.setState({ eventKey })}>
             <Tab eventKey={1} title={<Message msgId="share.direct" />}>{currentTab === 1 && direct}</Tab>
             <Tab eventKey={2} title={<Message msgId="share.social" />}>{currentTab === 2 && social}</Tab>
-            {permalink ? <Tab eventKey={3} title={<Message msgId="share.permalink.title" />}>{currentTab === 3 && permalink}</Tab> : null}
-            {this.props.embedPanel ? <Tab eventKey={4} title={<Message msgId="share.code" />}>{currentTab === 4 && code}</Tab> : null}
+            {!isEmpty(itemTabs)
+                ? itemTabs.map(({title, component: Component}, index) => {
+                    const eventKey = 2 + (index + 1);
+                    return <Tab eventKey={eventKey} title={title}>{currentTab === eventKey && <Component shareUrl={shareUrl} />}</Tab>;
+                })
+                : null
+            }
+            {/* Keep embed panel at the last */}
+            {this.props.embedPanel ? <Tab eventKey={embedEventKey} title={<Message msgId="share.code" />}>{currentTab === embedEventKey && code}</Tab> : null}
         </Tabs>);
-        const hideInTabs = [this.props?.advancedSettings?.hideInTab, "permalink"];
+        const hideInTabs = this.getHideIntabs(itemTabs);
         let sharePanel =
             (<ResizableModal
                 id={this.props.modal ? "share-panel-dialog-modal" : "share-panel-dialog"}
@@ -271,7 +307,7 @@ class SharePanel extends React.Component {
                 <div role="body" className="share-panels">
                     {tabs}
                     {!isEmpty(this.props.advancedSettings)
-                        && hideInTabs.every(hideInTab => currentTab !== SHARE_TABS[hideInTab])
+                        && hideInTabs.every(hideInTab => currentTab !== SHARE_TABS_UPDATED[hideInTab])
                         && this.renderAdvancedSettings()
                     }
                 </div>

--- a/web/client/components/share/__tests__/SharePanel-test.jsx
+++ b/web/client/components/share/__tests__/SharePanel-test.jsx
@@ -66,17 +66,17 @@ describe("The SharePanel component", () => {
     });
     it('test hide embedPanel option remove the panel', () => {
         let panel = ReactDOM.render(<SharePanel showAPI={false} getCount={() => 0} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
-        const fourthTab = document.getElementById('sharePanel-tabs-tab-4');
-        ReactTestUtils.Simulate.click(fourthTab);
-        expect(panel.state.eventKey).toBe(4);
+        const thirdTab = document.getElementById('sharePanel-tabs-tab-3');
+        ReactTestUtils.Simulate.click(thirdTab);
+        expect(panel.state.eventKey).toBe(3);
         let liTags = document.querySelectorAll('li');
 
         expect(liTags.length).toBe(3);
         expect(document.querySelectorAll('h4')[1].innerHTML).toBe("<span>share.embeddedLinkTitle</span>");
 
         panel = ReactDOM.render(<SharePanel embedPanel={false} showAPI={false} getCount={() => 0} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
-        expect(document.getElementById('sharePanel-tabs-tab-4')).toNotExist();
-        expect(panel.state.eventKey).toBe(4);
+        expect(document.getElementById('sharePanel-tabs-tab-3')).toNotExist();
+        expect(panel.state.eventKey).toBe(3);
         liTags = document.querySelectorAll('li');
         expect(document.querySelectorAll('h4')[1].innerHTML).toBe("<span>share.directLinkTitle</span>");
 
@@ -108,9 +108,9 @@ describe("The SharePanel component", () => {
         let advancedSettingsPanel = document.querySelector('.mapstore-switch-panel');
         expect(advancedSettingsPanel).toBeTruthy();
 
-        const embedTab = document.getElementById('sharePanel-tabs-tab-4');
+        const embedTab = document.getElementById('sharePanel-tabs-tab-3');
         ReactTestUtils.Simulate.click(embedTab);
-        expect(panel.state.eventKey).toBe(4);
+        expect(panel.state.eventKey).toBe(3);
         expect(document.querySelectorAll('h4')[1].innerHTML).toBe("<span>share.embeddedLinkTitle</span>");
         advancedSettingsPanel = document.querySelector('.mapstore-switch-panel');
         expect(advancedSettingsPanel).toBeFalsy();
@@ -160,7 +160,7 @@ describe("The SharePanel component", () => {
     });
     it('test permalink panel', () => {
         const panel = ReactDOM.render(
-            <SharePanel settings={{markerEnabled: false}} items={[{name: "Permalink", component: () => <div id="permalink">Permalink</div>}]} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
+            <SharePanel settings={{markerEnabled: false}} items={[{target: "tabs", title: <div>test</div>, component: () => <div id="permalink">Permalink</div>}]} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
         expect(panel).toBeTruthy();
         const thirdTab = document.getElementById('sharePanel-tabs-tab-3');
         ReactTestUtils.Simulate.click(thirdTab);

--- a/web/client/components/share/__tests__/SharePanel-test.jsx
+++ b/web/client/components/share/__tests__/SharePanel-test.jsx
@@ -66,17 +66,17 @@ describe("The SharePanel component", () => {
     });
     it('test hide embedPanel option remove the panel', () => {
         let panel = ReactDOM.render(<SharePanel showAPI={false} getCount={() => 0} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
-        const thirdTab = document.getElementById('sharePanel-tabs-tab-3');
-        ReactTestUtils.Simulate.click(thirdTab);
-        expect(panel.state.eventKey).toBe(3);
+        const fourthTab = document.getElementById('sharePanel-tabs-tab-4');
+        ReactTestUtils.Simulate.click(fourthTab);
+        expect(panel.state.eventKey).toBe(4);
         let liTags = document.querySelectorAll('li');
 
         expect(liTags.length).toBe(3);
         expect(document.querySelectorAll('h4')[1].innerHTML).toBe("<span>share.embeddedLinkTitle</span>");
 
         panel = ReactDOM.render(<SharePanel embedPanel={false} showAPI={false} getCount={() => 0} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
-        expect(document.getElementById('sharePanel-tabs-tab-3')).toNotExist();
-        expect(panel.state.eventKey).toBe(3);
+        expect(document.getElementById('sharePanel-tabs-tab-4')).toNotExist();
+        expect(panel.state.eventKey).toBe(4);
         liTags = document.querySelectorAll('li');
         expect(document.querySelectorAll('h4')[1].innerHTML).toBe("<span>share.directLinkTitle</span>");
 
@@ -108,9 +108,9 @@ describe("The SharePanel component", () => {
         let advancedSettingsPanel = document.querySelector('.mapstore-switch-panel');
         expect(advancedSettingsPanel).toBeTruthy();
 
-        const embedTab = document.getElementById('sharePanel-tabs-tab-3');
+        const embedTab = document.getElementById('sharePanel-tabs-tab-4');
         ReactTestUtils.Simulate.click(embedTab);
-        expect(panel.state.eventKey).toBe(3);
+        expect(panel.state.eventKey).toBe(4);
         expect(document.querySelectorAll('h4')[1].innerHTML).toBe("<span>share.embeddedLinkTitle</span>");
         advancedSettingsPanel = document.querySelector('.mapstore-switch-panel');
         expect(advancedSettingsPanel).toBeFalsy();
@@ -157,5 +157,14 @@ describe("The SharePanel component", () => {
         expect(spyOnUpdateSettings).toHaveBeenCalled();
         expect(spyOnUpdateSettings.calls[0].arguments[0]).toEqual({ markerEnabled: true, centerAndZoomEnabled: true, bboxEnabled: false });
         expect(spyAddMarker).toHaveBeenCalled();
+    });
+    it('test permalink panel', () => {
+        const panel = ReactDOM.render(
+            <SharePanel settings={{markerEnabled: false}} items={[{name: "Permalink", component: () => <div id="permalink">Permalink</div>}]} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
+        expect(panel).toBeTruthy();
+        const thirdTab = document.getElementById('sharePanel-tabs-tab-3');
+        ReactTestUtils.Simulate.click(thirdTab);
+        expect(panel.state.eventKey).toBe(3);
+        expect(document.getElementById('permalink')).toBeTruthy();
     });
 });

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -329,6 +329,7 @@
                 }
               }
             },
+            "Permalink",
             {
                 "name": "Identify",
                 "cfg": {
@@ -659,6 +660,10 @@
             "declineUrl" : "http://www.google.com"
           }
         }],
+        "permalink": [
+          "Permalink",
+          "FeedbackMask"
+        ],
         "dashboard": [
           "BurgerMenu",
           "Dashboard",
@@ -702,6 +707,7 @@
               }
             }
           },
+          "Permalink",
           {"name": "DashboardEditor",
             "cfg": {
               "selectedService": "GeoSolutions GeoServer CSW",
@@ -843,7 +849,8 @@
                 "sectionId": true
               }
             }
-          }
+          },
+          "Permalink"
         ],
         "context-creator": [
           {

--- a/web/client/configs/pluginsConfig.json
+++ b/web/client/configs/pluginsConfig.json
@@ -152,7 +152,20 @@
       "description": "plugins.Share.description",
       "dependencies": [
         "SidebarMenu"
+      ],
+      "children": [
+        "Permalink"
+      ],
+      "autoEnableChildren": [
+        "Permalink"
       ]
+    },
+    {
+      "name": "Permalink",
+      "glyph": "link",
+      "title": "plugins.Permalink.title",
+      "description": "plugins.Permalink.description",
+      "denyUserSelection": true
     },
     {
       "name": "BackgroundSelector",

--- a/web/client/configs/pluginsConfig.json
+++ b/web/client/configs/pluginsConfig.json
@@ -164,8 +164,7 @@
       "name": "Permalink",
       "glyph": "link",
       "title": "plugins.Permalink.title",
-      "description": "plugins.Permalink.description",
-      "denyUserSelection": true
+      "description": "plugins.Permalink.description"
     },
     {
       "name": "BackgroundSelector",

--- a/web/client/epics/__tests__/feedbackMask-test.js
+++ b/web/client/epics/__tests__/feedbackMask-test.js
@@ -14,7 +14,8 @@ import {
     updateGeoStoryFeedbackMaskVisibility,
     detectNewPage,
     feedbackMaskPromptLogin,
-    redirectUnauthorizedUserOnNewLoadError
+    redirectUnauthorizedUserOnNewLoadError,
+    updatePermalinkFeedbackMaskVisibility
 } from '../feedbackMask';
 
 import {
@@ -31,6 +32,7 @@ import { loadGeostory, geostoryLoaded, loadGeostoryError } from '../../actions/g
 import { LOGIN_REQUIRED } from '../../actions/security';
 import { onLocationChanged } from 'connected-react-router';
 import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
+import { loadPermalink, loadPermalinkError, permalinkLoaded } from '../../actions/permalink';
 
 describe('feedbackMask Epics', () => {
 
@@ -274,5 +276,34 @@ describe('feedbackMask Epics', () => {
         };
 
         testEpic(redirectUnauthorizedUserOnNewLoadError, 1, configureError({status: 403}), epicResponse, initState);
+    });
+    it('test updatePermalinkFeedbackMaskVisibility loaded', (done) => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(3);
+            const loadingAction = actions[0];
+            expect(loadingAction.type).toBe(FEEDBACK_MASK_LOADING);
+            const loadedAction = actions[1];
+            expect(loadedAction.type).toBe(FEEDBACK_MASK_LOADED);
+            const enabledAction = actions[2];
+            expect(enabledAction.type).toBe(FEEDBACK_MASK_ENABLED);
+            expect(enabledAction.enabled).toBe(false);
+            done();
+        };
+        testEpic(updatePermalinkFeedbackMaskVisibility, 3, [loadPermalink(), permalinkLoaded()], epicResult, {});
+    });
+
+    it('test updatePermalinkFeedbackMaskVisibility error', (done) => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(3);
+            const loadingAction = actions[0];
+            expect(loadingAction.type).toBe(FEEDBACK_MASK_LOADING);
+            const loadedAction = actions[1];
+            expect(loadedAction.type).toBe(FEEDBACK_MASK_LOADED);
+            const enabledAction = actions[2];
+            expect(enabledAction.type).toBe(FEEDBACK_MASK_ENABLED);
+            expect(enabledAction.enabled).toBe(true);
+            done();
+        };
+        testEpic(updatePermalinkFeedbackMaskVisibility, 3, [loadPermalink(), loadPermalinkError()], epicResult, {});
     });
 });

--- a/web/client/epics/__tests__/permalink-test.js
+++ b/web/client/epics/__tests__/permalink-test.js
@@ -19,7 +19,8 @@ const api = {
     createResource: () => Rx.Observable.of(10),
     getResource: () => Rx.Observable.of({name: "test", attributes: {type: "map", pathTemplate: "/viewer/${id}"}}),
     updateResource: () => Rx.Observable.of(10),
-    updateResourceAttribute: () =>  Rx.Observable.of(11)
+    updateResourceAttribute: () =>  Rx.Observable.of(11),
+    getResourceIdByName: () =>  Rx.Observable.of(10)
 };
 const state = {
     map: {
@@ -107,7 +108,7 @@ describe('Permalink Epics', () => {
                     case LOADING:
                         break;
                     case UPDATE_SETTINGS:
-                        expect(action.settings).toEqual({id: 10});
+                        expect(action.settings).toEqual({name: "test"});
                         break;
                     case SHOW_NOTIFICATION:
                         expect(action.id).toBe("PERMALINK_SAVE_SUCCESS");
@@ -144,7 +145,7 @@ describe('Permalink Epics', () => {
                     case LOADING:
                         break;
                     case UPDATE_SETTINGS:
-                        expect(action.settings).toEqual({id: 10});
+                        expect(action.settings).toEqual({name: "test"});
                         break;
                     case SHOW_NOTIFICATION:
                         expect(action.id).toBe("PERMALINK_SAVE_SUCCESS");
@@ -194,7 +195,7 @@ describe('Permalink Epics', () => {
                     case LOADING:
                         break;
                     case UPDATE_SETTINGS:
-                        expect(action.settings).toEqual({id: 10});
+                        expect(action.settings).toEqual({name: "test"});
                         break;
                     case SHOW_NOTIFICATION:
                         expect(action.id).toBe("PERMALINK_SAVE_SUCCESS");
@@ -234,7 +235,7 @@ describe('Permalink Epics', () => {
                     case LOADING:
                         break;
                     case UPDATE_SETTINGS:
-                        expect(action.settings).toEqual({id: 10});
+                        expect(action.settings).toEqual({name: "test"});
                         break;
                     case SHOW_NOTIFICATION:
                         expect(action.id).toBe("PERMALINK_SAVE_SUCCESS");
@@ -297,7 +298,7 @@ describe('Permalink Epics', () => {
             });
     });
     it("loadPermalinkEpic on load permalink - context", (done) => {
-        const getResource = () => Rx.Observable.of({name: "test", attributes: {type: "context", pathTemplate: "/context/${name}"}});
+        const getResource = () => Rx.Observable.of({name: "test", attributes: {type: "context", pathTemplate: "/context/${name}?category=PERMALINK"}});
         setApiGetResource(api, getResource);
         const NUMBER_OF_ACTIONS = 2;
         testEpic(
@@ -309,7 +310,7 @@ describe('Permalink Epics', () => {
                 actions.forEach((action)=>{
                     switch (action.type) {
                     case "@@router/CALL_HISTORY_METHOD":
-                        expect(action.payload.args).toEqual(["/context/test"]);
+                        expect(action.payload.args).toEqual(["/context/test?category=PERMALINK"]);
                         break;
                     case PERMALINK_LOADED:
                         break;

--- a/web/client/epics/__tests__/permalink-test.js
+++ b/web/client/epics/__tests__/permalink-test.js
@@ -19,6 +19,7 @@ import { loginSuccess } from '../../actions/security';
 
 const api = {
     createResource: () => Rx.Observable.of(10),
+    getResource: () => Rx.Observable.of({name: "test"}),
     updateResource: () => Rx.Observable.of(10),
     updateResourceAttribute: () =>  Rx.Observable.of(11)
 };
@@ -255,6 +256,29 @@ describe('Permalink Epics', () => {
                     switch (action.type) {
                     case "@@router/CALL_HISTORY_METHOD":
                         expect(action.payload.args).toEqual(["/viewer/10"]);
+                        break;
+                    case PERMALINK_LOADED:
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, {});
+    });
+    it("loadPermalinkEpic on load permalink - context", (done) => {
+        mockAxios.onGet().reply(200, {AttributeList: {Attribute: [{name: "pathTemplate", value: "/context/${name}"}, {name: "type", value: "context"}]}});
+        const NUMBER_OF_ACTIONS = 2;
+        testEpic(
+            loadPermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                loadPermalink(10)
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    switch (action.type) {
+                    case "@@router/CALL_HISTORY_METHOD":
+                        expect(action.payload.args).toEqual(["/context/test"]);
                         break;
                     case PERMALINK_LOADED:
                         break;

--- a/web/client/epics/__tests__/permalink-test.js
+++ b/web/client/epics/__tests__/permalink-test.js
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import Rx from 'rxjs';
+import MockAdapter from 'axios-mock-adapter';
+
+import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
+import { loadPermalinkEpic, savePermalinkEpic } from '../permalink';
+import { LOADING, LOAD_PERMALINK_ERROR, PERMALINK_LOADED, UPDATE_SETTINGS, loadPermalink, savePermalink } from '../../actions/permalink';
+import Persistence from '../../api/persistence';
+import { SHOW_NOTIFICATION } from '../../actions/notifications';
+import axios from '../../libs/ajax';
+import { loginSuccess } from '../../actions/security';
+
+const api = {
+    createResource: () => Rx.Observable.of(10),
+    updateResource: () => Rx.Observable.of(10),
+    updateResourceAttribute: () =>  Rx.Observable.of(11)
+};
+let mockAxios;
+const state = {
+    map: {
+        present: {
+            bbox: {}
+        }
+    },
+    context: {
+        resource: {
+            id: "context-id"
+        }
+    },
+    layers: {
+        groups: [{
+            expanded: true,
+            id: 'Default',
+            name: 'Default',
+            nodes: [ 'layer_01', 'layer_02' ],
+            title: 'Default'
+        }],
+        flat: [{
+            id: 'layer_01',
+            title: 'title_01'
+        }, {
+            id: 'layer_02',
+            title: 'title_02'
+        }]
+    }
+};
+describe('Permalink Epics', () => {
+    Persistence.addApi("testPermalink", api);
+    beforeEach(done => {
+        Persistence.setApi("testPermalink");
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+
+    afterEach(done => {
+        Persistence.setApi("geostore");
+        mockAxios.restore();
+        setTimeout(done);
+    });
+    it('test savePermalinkEpic with empty resource', (done) => {
+        const NUMBER_OF_ACTIONS = 1;
+        testEpic(
+            addTimeoutEpic(savePermalinkEpic, 10),
+            NUMBER_OF_ACTIONS, [
+                savePermalink()
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.map((action) => {
+                    expect(action.type).toBe(TEST_TIMEOUT);
+                });
+                done();
+            }, {});
+    });
+    it('savePermalinkEpic with map resource', (done) => {
+        const NUMBER_OF_ACTIONS = 4;
+        const permalinkObj = {
+            permalinkType: "map",
+            resource: {
+                category: "PERMALINK",
+                metadata: {name: "test"},
+                attributes: {
+                    title: "title",
+                    description: "description"
+                }
+            }
+        };
+
+        testEpic(
+            savePermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                savePermalink(permalinkObj)
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    switch (action.type) {
+                    case LOADING:
+                        break;
+                    case UPDATE_SETTINGS:
+                        expect(action.settings).toEqual({id: 10});
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(action.id).toBe("PERMALINK_SAVE_SUCCESS");
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, state);
+    });
+    it('savePermalinkEpic with context resource', (done) => {
+        const NUMBER_OF_ACTIONS = 4;
+        const permalinkObj = {
+            permalinkType: "context",
+            resource: {
+                category: "PERMALINK",
+                metadata: {name: "test"},
+                attributes: {
+                    title: "title",
+                    description: "description"
+                }
+            }
+        };
+
+        testEpic(
+            savePermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                savePermalink(permalinkObj)
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    switch (action.type) {
+                    case LOADING:
+                        break;
+                    case UPDATE_SETTINGS:
+                        expect(action.settings).toEqual({id: 10});
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(action.id).toBe("PERMALINK_SAVE_SUCCESS");
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, state);
+    });
+    it('savePermalinkEpic with dashboard resource', (done) => {
+        const _state = {
+            ...state,
+            widgets: {
+                containers: {
+                    floating: {
+                        widgets: {},
+                        layouts: {}
+                    }
+                }
+            },
+            dashboard: {
+                services: {}
+            }
+        };
+        const NUMBER_OF_ACTIONS = 4;
+        const permalinkObj = {
+            permalinkType: "dashboard",
+            resource: {
+                category: "PERMALINK",
+                metadata: {name: "test"},
+                attributes: {
+                    title: "title"
+                }
+            }
+        };
+
+        testEpic(
+            savePermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                savePermalink(permalinkObj)
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    switch (action.type) {
+                    case LOADING:
+                        break;
+                    case UPDATE_SETTINGS:
+                        expect(action.settings).toEqual({id: 10});
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(action.id).toBe("PERMALINK_SAVE_SUCCESS");
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, _state);
+    });
+    it('savePermalinkEpic with geostory resource', (done) => {
+        const _state = {
+            ...state,
+            geostory: {currentStory: {}}
+        };
+        const NUMBER_OF_ACTIONS = 4;
+        const permalinkObj = {
+            permalinkType: "geostory",
+            resource: {
+                category: "PERMALINK",
+                metadata: {name: "test"},
+                attributes: {
+                    title: "title"
+                }
+            }
+        };
+
+        testEpic(
+            savePermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                savePermalink(permalinkObj)
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    switch (action.type) {
+                    case LOADING:
+                        break;
+                    case UPDATE_SETTINGS:
+                        expect(action.settings).toEqual({id: 10});
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(action.id).toBe("PERMALINK_SAVE_SUCCESS");
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, _state);
+    });
+    it("loadPermalinkEpic on load permalink", (done) => {
+        mockAxios.onGet().reply(200, {AttributeList: {Attribute: [{name: "pathTemplate", value: "/viewer/${id}"}]}});
+        const NUMBER_OF_ACTIONS = 2;
+        testEpic(
+            loadPermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                loadPermalink(10)
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    switch (action.type) {
+                    case "@@router/CALL_HISTORY_METHOD":
+                        expect(action.payload.args).toEqual(["/viewer/10"]);
+                        break;
+                    case PERMALINK_LOADED:
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, {});
+    });
+    it("loadPermalinkEpic on login success", (done) => {
+        mockAxios.onGet().reply(200, {AttributeList: {Attribute: [{name: "pathTemplate", value: "/viewer/${id}"}]}});
+        const NUMBER_OF_ACTIONS = 2;
+        testEpic(
+            loadPermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                loginSuccess()
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    switch (action.type) {
+                    case "@@router/CALL_HISTORY_METHOD":
+                        expect(action.payload.args).toEqual(["/viewer/10"]);
+                        break;
+                    case PERMALINK_LOADED:
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, {
+                router: {
+                    location: {
+                        pathname: "/permalink/10"
+                    }
+                }
+            });
+    });
+    it("loadPermalinkEpic on error - not found", (done) => {
+        const ERROR_STATUS = 404;
+        mockAxios.onGet().reply(ERROR_STATUS);
+        const NUMBER_OF_ACTIONS = 2;
+        testEpic(
+            loadPermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                loginSuccess()
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    const permalinkDontExit = 'share.permalink.errors.loading.permalinkDoesNotExist';
+                    switch (action.type) {
+                    case LOAD_PERMALINK_ERROR:
+                        expect(action.error).toBeTruthy();
+                        expect(action.error.status).toBe(ERROR_STATUS);
+                        expect(action.error.messageId).toBe(permalinkDontExit);
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(action.title).toBe('share.permalink.errors.loading.title');
+                        expect(action.message).toBe(permalinkDontExit);
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, {});
+    });
+    it("loadPermalinkEpic on error forbidden and not logged in", (done) => {
+        const ERROR_STATUS = 403;
+        mockAxios.onGet().reply(ERROR_STATUS);
+        const NUMBER_OF_ACTIONS = 2;
+        testEpic(
+            loadPermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                loginSuccess()
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    const permalinkErrorLogin = 'share.permalink.errors.loading.pleaseLogin';
+                    switch (action.type) {
+                    case LOAD_PERMALINK_ERROR:
+                        expect(action.error).toBeTruthy();
+                        expect(action.error.status).toBe(ERROR_STATUS);
+                        expect(action.error.messageId).toBe(permalinkErrorLogin);
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(action.title).toBe('share.permalink.errors.loading.title');
+                        expect(action.message).toBe(permalinkErrorLogin);
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, {});
+    });
+    it("loadPermalinkEpic on error forbidden and logged in", (done) => {
+        const ERROR_STATUS = 403;
+        mockAxios.onGet().reply(ERROR_STATUS);
+        const NUMBER_OF_ACTIONS = 2;
+        testEpic(
+            loadPermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                loginSuccess()
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    const permalinkErrorLogin = 'share.permalink.errors.loading.permalinkNotAccessible';
+                    switch (action.type) {
+                    case LOAD_PERMALINK_ERROR:
+                        expect(action.error).toBeTruthy();
+                        expect(action.error.status).toBe(ERROR_STATUS);
+                        expect(action.error.messageId).toBe(permalinkErrorLogin);
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(action.title).toBe('share.permalink.errors.loading.title');
+                        expect(action.message).toBe(permalinkErrorLogin);
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, {
+                security: {
+                    user: {}
+                }
+            });
+    });
+    it("loadPermalinkEpic on error unknown", (done) => {
+        const ERROR_STATUS = 500;
+        mockAxios.onGet().reply(ERROR_STATUS);
+        const NUMBER_OF_ACTIONS = 2;
+        testEpic(
+            loadPermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                loginSuccess()
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                actions.forEach((action)=>{
+                    const permalinkErrorUnknown = 'share.permalink.errors.loading.unknownError';
+                    switch (action.type) {
+                    case LOAD_PERMALINK_ERROR:
+                        expect(action.error).toBeTruthy();
+                        expect(action.error.status).toBe(ERROR_STATUS);
+                        expect(action.error.messageId).toBe(permalinkErrorUnknown);
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(action.title).toBe('share.permalink.errors.loading.title');
+                        expect(action.message).toBe(permalinkErrorUnknown);
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            }, {
+                security: {
+                    user: {}
+                }
+            });
+    });
+});

--- a/web/client/epics/__tests__/permalink-test.js
+++ b/web/client/epics/__tests__/permalink-test.js
@@ -48,6 +48,11 @@ const state = {
             id: 'layer_02',
             title: 'title_02'
         }]
+    },
+    router: {
+        location: {
+            pathname: "/permalink/10"
+        }
     }
 };
 const setApiGetResource = (_api, getResource) => {
@@ -267,7 +272,7 @@ describe('Permalink Epics', () => {
                     }
                 });
                 done();
-            }, {});
+            }, state);
     });
     it("loadPermalinkEpic on login success", (done) => {
         const NUMBER_OF_ACTIONS = 2;
@@ -289,13 +294,7 @@ describe('Permalink Epics', () => {
                     }
                 });
                 done();
-            }, {
-                router: {
-                    location: {
-                        pathname: "/permalink/10"
-                    }
-                }
-            });
+            }, state);
     });
     it("loadPermalinkEpic on load permalink - context", (done) => {
         const getResource = () => Rx.Observable.of({name: "test", attributes: {type: "context", pathTemplate: "/context/${name}?category=PERMALINK"}});
@@ -319,7 +318,7 @@ describe('Permalink Epics', () => {
                     }
                 });
                 done();
-            }, {});
+            }, state);
     });
 
     it("loadPermalinkEpic on error - not found", (done) => {
@@ -350,7 +349,7 @@ describe('Permalink Epics', () => {
                     }
                 });
                 done();
-            }, {});
+            }, state);
     });
     it("loadPermalinkEpic on error forbidden and not logged in", (done) => {
         const getResource = () => Rx.Observable.throw({status: 403});
@@ -380,7 +379,7 @@ describe('Permalink Epics', () => {
                     }
                 });
                 done();
-            }, {});
+            }, state);
     });
     it("loadPermalinkEpic on error forbidden and logged in", (done) => {
         const getResource = () => Rx.Observable.throw({status: 403});
@@ -411,6 +410,7 @@ describe('Permalink Epics', () => {
                 });
                 done();
             }, {
+                ...state,
                 security: {
                     user: {}
                 }
@@ -445,6 +445,7 @@ describe('Permalink Epics', () => {
                 });
                 done();
             }, {
+                ...state,
                 security: {
                     user: {}
                 }

--- a/web/client/epics/context.js
+++ b/web/client/epics/context.js
@@ -23,7 +23,7 @@ import { wrapStartStop } from '../observables/epics';
 import ConfigUtils from '../utils/ConfigUtils';
 import {userSessionEnabledSelector, buildSessionName} from "../selectors/usersession";
 import merge from "lodash/merge";
-import { isPermalinkSelector } from '../selectors/permalink';
+import { searchSelector } from '../selectors/router';
 
 function MapError(error) {
     this.originalError = error;
@@ -138,8 +138,10 @@ const createSessionFlow = (mapId, contextName, resourceCategory, action$, getSta
  */
 export const loadContextAndMap = (action$, { getState = () => { } } = {}) =>
     action$.ofType(LOAD_CONTEXT).switchMap(({ mapId, contextName }) => {
-        const isPermalink = isPermalinkSelector(getState());
-        const resourceCategory = isPermalink ? 'PERMALINK' : 'CONTEXT';
+        const params = new URLSearchParams(searchSelector(getState()));
+        // When loading a permalink of type context, we lose the category type upon page reload.
+        // Hence the category is fetched from the param to provide correct category name to getResourceIdByName
+        const resourceCategory = params.get("category") || 'CONTEXT';
         const sessionsEnabled = userSessionEnabledSelector(getState());
         const flow = sessionsEnabled
             ? createSessionFlow(mapId, contextName, resourceCategory, action$, getState)

--- a/web/client/epics/feedbackMask.js
+++ b/web/client/epics/feedbackMask.js
@@ -161,7 +161,7 @@ export const updatePermalinkFeedbackMaskVisibility = action$ =>
         .switchMap(() => {
             const loadActions = [PERMALINK_LOADED, LOAD_PERMALINK_ERROR];
             const isEnabled = ({ type }) => type === LOAD_PERMALINK_ERROR;
-            const updateObservable = updateVisibility(action$, loadActions, isEnabled, "share.permalink");
+            const updateObservable = updateVisibility(action$, loadActions, isEnabled, "permalink");
             return Rx.Observable.merge(
                 updateObservable,
                 action$.ofType(LOGIN_SUCCESS, LOGOUT, LOCATION_CHANGE)

--- a/web/client/epics/feedbackMask.js
+++ b/web/client/epics/feedbackMask.js
@@ -25,6 +25,7 @@ import { LOGIN_SUCCESS, LOGOUT, LOGIN_PROMPT_CLOSED, loginRequired } from '../ac
 import { LOAD_DASHBOARD, DASHBOARD_LOADED, DASHBOARD_LOAD_ERROR } from '../actions/dashboard';
 import { LOAD_GEOSTORY, GEOSTORY_LOADED, LOAD_GEOSTORY_ERROR } from '../actions/geostory';
 import { LOAD_CONTEXT, LOAD_FINISHED, CONTEXT_LOAD_ERROR } from '../actions/context';
+import { LOAD_PERMALINK, LOAD_PERMALINK_ERROR, PERMALINK_LOADED } from '../actions/permalink';
 
 import {
     START_RESOURCE_LOAD as LOAD_CONTEXT_CONTEXTCREATOR,
@@ -150,6 +151,26 @@ export const updateContextFeedbackMaskVisibility = action$ =>
         });
 
 /**
+ * Enabled/disabled mask based on permalink load feedback, in case of error enable feedbackMask.
+ * @param {Observable} action$ stream of actions. Manages `LOAD_PERMALINK, `PERMALINK_LOADED`, `LOAD_PERMALINK_ERROR`, `LOGIN_SUCCESS`, `LOGOUT`, `LOCATION_CHANGE`
+ * @memberof epics.feedbackMask
+ * @return {Observable}
+ */
+export const updatePermalinkFeedbackMaskVisibility = action$ =>
+    action$.ofType(LOAD_PERMALINK)
+        .switchMap(() => {
+            const loadActions = [PERMALINK_LOADED, LOAD_PERMALINK_ERROR];
+            const isEnabled = ({ type }) => type === LOAD_PERMALINK_ERROR;
+            const updateObservable = updateVisibility(action$, loadActions, isEnabled, "share.permalink");
+            return Rx.Observable.merge(
+                updateObservable,
+                action$.ofType(LOGIN_SUCCESS, LOGOUT, LOCATION_CHANGE)
+                    .switchMap(() => updateObservable)
+                    .takeUntil(action$.ofType(DETECTED_NEW_PAGE))
+            );
+        });
+
+/**
  * Enabled/disabled mask based on context load feedback in context creator, in case of error enable feedbackMask.
  * @param {Observable} action$ stream of actions. Manages `LOAD_CONTEXT, `LOAD_FINISHED`, `CONTEXT_LOAD_ERROR`, `LOGIN_SUCCESS`, `LOGOUT`, `LOCATION_CHANGE`
  * @memberof epics.feedbackMask
@@ -196,12 +217,12 @@ export const detectNewPage = (action$, store) =>
  * @param {stream} action$ the action stream
  */
 export const feedbackMaskPromptLogin = (action$, store) => // TODO: separate login required logic (403) condition from feedback mask
-    action$.ofType(MAP_CONFIG_LOAD_ERROR, DASHBOARD_LOAD_ERROR, LOAD_GEOSTORY_ERROR, CONTEXT_LOAD_ERROR, CONTEXT_LOAD_ERROR_CONTEXTCREATOR)
+    action$.ofType(MAP_CONFIG_LOAD_ERROR, DASHBOARD_LOAD_ERROR, LOAD_GEOSTORY_ERROR, CONTEXT_LOAD_ERROR, CONTEXT_LOAD_ERROR_CONTEXTCREATOR, LOAD_PERMALINK_ERROR)
         .filter((action) => {
             const pathname = pathnameSelector(store.getState());
             return action.error
                 && action.error.status === 403
-                && pathname.indexOf("new") === -1 && !(pathname.match(/dashboard/) !== null && pathname.match(/dashboard\/[0-9]+/) === null); // new map geostory and dashboard has different handling (see redirectUnauthorizedUserOnNewLoadError, TODO: uniform different behaviour)
+                && pathname.indexOf("new") === -1 && !(pathname.match(/(dashboard|permalink)/) !== null && pathname.match(/(dashboard|permalink)\/[0-9]+/) === null); // new map geostory and dashboard has different handling (see redirectUnauthorizedUserOnNewLoadError, TODO: uniform different behaviour)
         })
         .filter(() => !isLoggedIn(store.getState()) && !isSharedStory(store.getState()))
         .exhaustMap(
@@ -238,5 +259,6 @@ export default {
     updateGeoStoryFeedbackMaskVisibility,
     detectNewPage,
     feedbackMaskPromptLogin,
-    redirectUnauthorizedUserOnNewLoadError
+    redirectUnauthorizedUserOnNewLoadError,
+    updatePermalinkFeedbackMaskVisibility
 };

--- a/web/client/epics/feedbackMask.js
+++ b/web/client/epics/feedbackMask.js
@@ -221,7 +221,7 @@ export const feedbackMaskPromptLogin = (action$, store) => // TODO: separate log
         .filter((action) => {
             const pathname = pathnameSelector(store.getState());
             return action.error
-                && action.error.status === ([LOAD_PERMALINK_ERROR].includes(action.type) ? 404 : 403)
+                && [403].concat([LOAD_PERMALINK_ERROR].includes(action.type) ? 404 : []).includes(action.error.status)
                 && pathname.indexOf("new") === -1 && !(pathname.match(/(dashboard)/) !== null && pathname.match(/(dashboard)\/[0-9]+/) === null); // new map geostory and dashboard has different handling (see redirectUnauthorizedUserOnNewLoadError, TODO: uniform different behaviour)
         })
         .filter(() => !isLoggedIn(store.getState()) && !isSharedStory(store.getState()))

--- a/web/client/epics/feedbackMask.js
+++ b/web/client/epics/feedbackMask.js
@@ -221,8 +221,8 @@ export const feedbackMaskPromptLogin = (action$, store) => // TODO: separate log
         .filter((action) => {
             const pathname = pathnameSelector(store.getState());
             return action.error
-                && action.error.status === 403
-                && pathname.indexOf("new") === -1 && !(pathname.match(/(dashboard|permalink)/) !== null && pathname.match(/(dashboard|permalink)\/[0-9]+/) === null); // new map geostory and dashboard has different handling (see redirectUnauthorizedUserOnNewLoadError, TODO: uniform different behaviour)
+                && action.error.status === ([LOAD_PERMALINK_ERROR].includes(action.type) ? 404 : 403)
+                && pathname.indexOf("new") === -1 && !(pathname.match(/(dashboard)/) !== null && pathname.match(/(dashboard)\/[0-9]+/) === null); // new map geostory and dashboard has different handling (see redirectUnauthorizedUserOnNewLoadError, TODO: uniform different behaviour)
         })
         .filter(() => !isLoggedIn(store.getState()) && !isSharedStory(store.getState()))
         .exhaustMap(

--- a/web/client/epics/permalink.js
+++ b/web/client/epics/permalink.js
@@ -160,22 +160,10 @@ export const loadPermalinkEpic = (action$, { getState = () => {} } = {}) =>
         .switchMap(({ id: pid } = {}) => {
             const state = getState();
             const id = pid ?? pathnameSelector(state)?.split("/")?.pop();
-            return Observable.forkJoin(
-                [
-                    getResource(id),
-                    Observable.defer(() => API.getResourceAttributes(id))
-                ]
-            ).switchMap(([resource, attributes]) => {
-                const resourceName = resource?.name;
-                let { value: pathTemplate } =
-                        attributes.find(
-                            ({ name } = {}) => name === "pathTemplate"
-                        ) ?? {};
-                const { value: type } =
-                        attributes.find(
-                            ({ name } = {}) => name === "type"
-                        ) ?? {};
-                pathTemplate = template(pathTemplate)(type === "context" ? {name: resourceName} : { id });
+            return getResource(id).switchMap((resource) => {
+                const { name, attributes } = resource ?? {};
+                let { type, pathTemplate } = attributes ?? {};
+                pathTemplate = template(pathTemplate)(type === "context" ? {name} : { id });
                 return Observable.of(push(pathTemplate), permalinkLoaded());
             }).catch((e) => {
                 const errorMsg = "share.permalink.errors.loading";

--- a/web/client/epics/permalink.js
+++ b/web/client/epics/permalink.js
@@ -159,6 +159,7 @@ export const savePermalinkEpic = (action$, { getState = () => {} }) =>
 export const loadPermalinkEpic = (action$, { getState = () => {} } = {}) =>
     action$
         .ofType(LOAD_PERMALINK, LOGIN_SUCCESS)
+        .filter(() => pathnameSelector(getState())?.split('/')?.[1] === "permalink")
         .switchMap(({ id: pid } = {}) => {
             const state = getState();
             const hash = pid ?? pathnameSelector(state)?.split("/")?.pop();

--- a/web/client/epics/permalink.js
+++ b/web/client/epics/permalink.js
@@ -71,7 +71,6 @@ const PERMALINK_RESOURCES = {
 
 };
 
-let categoryCreated = false;
 const permalinkErrorHandler = (state) =>
     (e, stream$) => {
         if (e.status === 404 && isString(e.data) && e.data.indexOf('Resource Category not found') > -1) {
@@ -79,8 +78,11 @@ const permalinkErrorHandler = (state) =>
                 // Create category when missing and role is ADMIN
                 return createCategory(PERMALINK)
                     .switchMap(() => {
-                        categoryCreated = true;
-                        return stream$.skip(1);
+                        return stream$.skip(1).concat(Observable.of(show({
+                            id: "PERMALINK_SAVE_SUCCESS",
+                            title: "notification.success",
+                            message: `permalink.createCategorySuccess`
+                        })));
                     })
                     .catch(() => Observable.of(error({
                         title: 'permalink.errors.save.title',
@@ -168,9 +170,9 @@ export const savePermalinkEpic = (action$, { getState = () => {} }) =>
                         show({
                             id: "PERMALINK_SAVE_SUCCESS",
                             title: "notification.success",
-                            message: `permalink.${categoryCreated ? 'createAndSaveSuccess' : 'success'}`
+                            message: "permalink.success"
                         })
-                    ).do(categoryCreated = false))
+                    ))
                 );
         }).let(
             wrapStartStop(

--- a/web/client/epics/permalink.js
+++ b/web/client/epics/permalink.js
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Observable } from "rxjs";
+import { push } from "connected-react-router";
+import pick from "lodash/pick";
+import template from "lodash/template";
+
+import API from "../api/GeoStoreDAO";
+import { error, show } from "../actions/notifications";
+import { LOGIN_SUCCESS } from "../actions/security";
+import {
+    LOAD_PERMALINK,
+    SAVE_PERMALINK,
+    loadPermalinkError,
+    permalinkLoaded,
+    permalinkLoading,
+    updatePermalinkSettings
+} from "../actions/permalink";
+
+import { createResource, updateResourceAttribute } from "../api/persistence";
+import { contextResourceSelector } from "../selectors/context";
+import { currentStorySelector } from "../selectors/geostory";
+import { mapSelector } from "../selectors/map";
+import { mapSaveSelector } from "../selectors/mapsave";
+import { isLoggedIn, userSelector } from "../selectors/security";
+import { widgetsConfig } from "../selectors/widgets";
+import { pathnameSelector } from "../selectors/router";
+import { wrapStartStop } from "../observables/epics";
+
+const PERMALINK_RESOURCES = {
+    map: (resource, state) => {
+        const mapConfig = mapSaveSelector(state);
+        const map = {
+            ...mapConfig,
+            map: {
+                ...mapConfig.map,
+                bbox: mapSelector(state)?.bbox
+            }
+        };
+        return { ...resource, data: map };
+    },
+    context: (resource, state) => {
+        const newResources = PERMALINK_RESOURCES.map(resource, state);
+        const contextId = contextResourceSelector(state)?.id;
+        return {
+            ...newResources,
+            attributes: {
+                ...newResources.attributes,
+                context: contextId
+            }
+        };
+    },
+    dashboard: (resource, state) => {
+        return { ...resource, data: widgetsConfig(state) };
+    },
+    geostory: (resource, state) => {
+        return {
+            ...resource,
+            data: currentStorySelector(state)
+        };
+    }
+
+};
+
+/**
+ * Save permalink by resource type
+ * @name epics.permalink
+ * @param {Observable} action$ stream of actions
+ * @param {object} store redux store
+ */
+export const savePermalinkEpic = (action$, { getState = () => {} }) =>
+    action$.ofType(SAVE_PERMALINK).switchMap(({ value } = {}) => {
+        const { resource, permalinkType, allowAllUser } = value ?? {};
+        if (!resource) {
+            return Observable.empty();
+        }
+        const state = getState();
+        let newResource = { ...resource };
+        newResource = PERMALINK_RESOURCES[permalinkType](newResource, state);
+
+        const user = userSelector(state);
+        return Observable.defer(() =>
+            allowAllUser
+                ? API.getAvailableGroups(user)
+                : Observable.of([])
+        ).switchMap((groups) => {
+            const publicGroup = groups.find(
+                ({groupName} = {}) => groupName === "everyone"
+            );
+            if (allowAllUser && publicGroup) {
+                const permission = [
+                    {
+                        canRead: true,
+                        canWrite: false,
+                        group: pick(publicGroup, ["id", "groupName"])
+                    }
+                ];
+                newResource = { ...newResource, permission };
+            }
+
+            let attributes = {...newResource.attributes};
+            attributes = pick(attributes, Object.keys(attributes).filter(key=> attributes[key]));
+
+            return createResource(newResource)
+                .switchMap((id) =>
+                    Observable.forkJoin(
+                        Object.keys(attributes).map(
+                            (attrName) =>
+                                updateResourceAttribute({
+                                    id,
+                                    name: attrName,
+                                    value: attributes[
+                                        attrName
+                                    ]
+                                })
+                        )
+                    ).switchMap(() =>
+                        Observable.of(
+                            updatePermalinkSettings({id}),
+                            show({
+                                id: "PERMALINK_SAVE_SUCCESS",
+                                title: "notification.success",
+                                message: "share.permalink.success"
+                            })
+                        )
+                    )
+                );
+        }).let(
+            wrapStartStop(
+                permalinkLoading(true),
+                permalinkLoading(false),
+                () =>
+                    Observable.of(
+                        error({
+                            title: "notification.error",
+                            message: "share.permalink.error",
+                            autoDismiss: 6,
+                            position: "tc"
+                        })
+                    )
+            )
+        );
+    });
+
+/**
+ * Load permalink
+ * @name epics.permalink
+ * @param {Observable} action$ stream of actions
+ * @param {object} store redux store
+ */
+export const loadPermalinkEpic = (action$, { getState = () => {} } = {}) =>
+    action$
+        .ofType(LOAD_PERMALINK, LOGIN_SUCCESS)
+        .switchMap(({ id: pid } = {}) => {
+            const state = getState();
+            const id = pid ?? pathnameSelector(state)?.split("/")?.pop();
+            return Observable.defer(() =>
+                API.getResourceAttributes(id)
+            ).switchMap((attributes) => {
+                let { value: pathTemplate } =
+                        attributes.find(
+                            ({ name } = {}) => name === "pathTemplate"
+                        ) ?? {};
+                pathTemplate = template(pathTemplate)({ id });
+                return Observable.of(push(pathTemplate), permalinkLoaded());
+            }).catch((e) => {
+                const errorMsg = "share.permalink.errors.loading";
+                let message = errorMsg + ".unknownError";
+                if (e.status === 403) {
+                    message = errorMsg + ".pleaseLogin";
+                    if (isLoggedIn(state)) {
+                        message = errorMsg + ".permalinkNotAccessible";
+                    }
+                }
+                if (e.status === 404) {
+                    message = errorMsg + ".permalinkDoesNotExist";
+                }
+                return Observable.of(
+                    error({
+                        title: errorMsg + ".title",
+                        message
+                    }),
+                    loadPermalinkError({ ...e, messageId: message })
+                );
+            });
+        });
+
+export default {
+    savePermalinkEpic,
+    loadPermalinkEpic
+};

--- a/web/client/plugins/Permalink.jsx
+++ b/web/client/plugins/Permalink.jsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { connect } from "react-redux";
+import { createSelector } from "reselect";
+
+import { createPlugin } from "../utils/PluginsUtils";
+import Permalink from "../components/permalink/Permalink";
+import { updatePermalinkSettings, savePermalink, resetPermalink } from '../actions/permalink';
+import permalink from '../reducers/permalink';
+import permalinkEpics from '../epics/permalink';
+import { permalinkLoadingSelector, permalinkSettingsSelector } from "../selectors/permalink";
+
+/**
+ * Permalink Component
+ */
+const PermalinkComponent = connect(
+    createSelector(
+        permalinkSettingsSelector,
+        permalinkLoadingSelector,
+        (settings, loading) => ({ settings, loading })
+    ),
+    {
+        onUpdateSettings: updatePermalinkSettings,
+        onSave: savePermalink,
+        onReset: resetPermalink
+    }
+)(Permalink);
+
+/**
+ * Permalink plugin
+ * Allows creating a copy of the resource's current state.
+ * Enabled only when user is authenticated
+ * @class PermalinkComponent
+ * @memberof plugins
+ * @static
+ */
+export default createPlugin('Permalink', {
+    component: () => null,
+    options: {
+        disablePluginIf: "{!state('userrole')}"
+    },
+    containers: {
+        Share: {
+            name: "Permalink",
+            component: PermalinkComponent
+        }
+    },
+    reducers: {
+        permalink
+    },
+    epics: permalinkEpics
+});

--- a/web/client/plugins/Permalink.jsx
+++ b/web/client/plugins/Permalink.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
+import React from 'react';
 import { connect } from "react-redux";
 import { createSelector } from "reselect";
 
@@ -15,6 +15,7 @@ import { updatePermalinkSettings, savePermalink, resetPermalink } from '../actio
 import permalink from '../reducers/permalink';
 import permalinkEpics from '../epics/permalink';
 import { permalinkLoadingSelector, permalinkSettingsSelector } from "../selectors/permalink";
+import Message from '../components/I18N/Message';
 
 /**
  * Permalink Component
@@ -47,7 +48,10 @@ export default createPlugin('Permalink', {
     },
     containers: {
         Share: {
-            name: "Permalink",
+            target: "tabs",
+            tabName: "permalink",
+            hideAdvancedSettingsInTab: true,
+            title: <Message msgId="share.permalink.title" />,
             component: PermalinkComponent
         }
     },

--- a/web/client/plugins/Permalink.jsx
+++ b/web/client/plugins/Permalink.jsx
@@ -51,7 +51,7 @@ export default createPlugin('Permalink', {
             target: "tabs",
             tabName: "permalink",
             hideAdvancedSettingsInTab: true,
-            title: <Message msgId="share.permalink.title" />,
+            title: <Message msgId="permalink.title" />,
             component: PermalinkComponent
         }
     },

--- a/web/client/plugins/__tests__/Permalink-test.jsx
+++ b/web/client/plugins/__tests__/Permalink-test.jsx
@@ -26,7 +26,8 @@ describe('PermalinkPlugin Plugin', () => {
         const { Plugin, containers } = getPluginForTest(PermalinkPlugin, {});
         ReactDOM.render(<Plugin />, document.getElementById("container"));
         expect(containers).toBeTruthy();
-        expect(containers.Share.name).toBe("Permalink");
+        expect(containers.Share.target).toBe("tabs");
+        expect(containers.Share.title).toBeTruthy();
         expect(containers.Share.component).toBeTruthy();
 
         const store = { dispatch: () => {}, subscribe: () => {}, getState: () => ({}) };

--- a/web/client/plugins/__tests__/Permalink-test.jsx
+++ b/web/client/plugins/__tests__/Permalink-test.jsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PermalinkPlugin from '../Permalink';
+import { getPluginForTest } from './pluginsTestUtils';
+import { Provider } from 'react-redux';
+
+describe('PermalinkPlugin Plugin', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="container"></div>';
+    });
+
+    afterEach(() => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+    });
+
+    it('test PermalinkPlugin with default configuration', () => {
+        const { Plugin, containers } = getPluginForTest(PermalinkPlugin, {});
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(containers).toBeTruthy();
+        expect(containers.Share.name).toBe("Permalink");
+        expect(containers.Share.component).toBeTruthy();
+
+        const store = { dispatch: () => {}, subscribe: () => {}, getState: () => ({}) };
+        const Component = containers.Share.component;
+        ReactDOM.render(<Provider store={store}><Component /></Provider>, document.getElementById("container"));
+        expect(document.getElementById('permalink')).toBeTruthy();
+    });
+});
+

--- a/web/client/product/appConfig.js
+++ b/web/client/product/appConfig.js
@@ -93,6 +93,11 @@ export default {
         name: "geostory",
         path: "/geostory/shared/:gid/section/:sectionId/column/:columnId",
         component: require('./pages/GeoStory').default
+    },
+    {
+        name: "permalink",
+        path: "/permalink/:pid",
+        component: require('./pages/Permalink').default
     }],
     initialState: {
         defaultState: {

--- a/web/client/product/pages/Permalink.jsx
+++ b/web/client/product/pages/Permalink.jsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PropTypes from "prop-types";
+import React from "react";
+import { connect } from "react-redux";
+import get from "lodash/get";
+
+import Page from "../../containers/Page";
+import { loadPermalink } from '../../actions/permalink';
+
+/**
+ * @name Peramlink
+ * @memberof pages
+ * @class
+ * @classdesc
+ * This is the main container page for permalink.
+ */
+class Permalink extends React.Component {
+    static propTypes = {
+        mode: PropTypes.string,
+        match: PropTypes.object,
+        reset: PropTypes.func,
+        plugins: PropTypes.object,
+        loaderComponent: PropTypes.func,
+        loadResource: PropTypes.func
+    };
+
+    static contextTypes = {
+        router: PropTypes.object
+    };
+
+    static defaultProps = {
+        mode: "desktop",
+        reset: () => {}
+    };
+
+    state = {};
+
+    onLoaded = (pluginsAreLoaded) => {
+        if (pluginsAreLoaded && !this.state.pluginsAreLoaded) {
+            this.setState({ pluginsAreLoaded: true }, () => {
+                const id = get(this.props, "match.params.pid");
+                if (id) {
+                    this.props.loadResource(id);
+                }
+            });
+        }
+    };
+
+    render() {
+        return (
+            <Page
+                id="permalink"
+                className="permalink"
+                onLoaded={this.onLoaded}
+                plugins={this.props.plugins}
+                params={this.props.match.params}
+                loaderComponent={this.props.loaderComponent}
+            />
+        );
+    }
+}
+
+export default connect((state) => {
+    return {
+        mode: "desktop",
+        messages: (state.locale && state.locale.messages) || {}
+    };
+}, {
+    loadResource: loadPermalink
+})(Permalink);

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -137,6 +137,7 @@ export const plugins = {
     SettingsPlugin: toModulePlugin('Settings', () => import(/* webpackChunkName: 'plugins/settings' */ '../plugins/Settings')),
     SidebarMenuPlugin: toModulePlugin('SidebarMenu', () => import(/* webpackChunkName: 'plugins/sidebarMenu' */ '../plugins/SidebarMenu')),
     SharePlugin: toModulePlugin('Share', () => import(/* webpackChunkName: 'plugins/share' */ '../plugins/Share')),
+    PermalinkPlugin: toModulePlugin('Permalink', () => import(/* webpackChunkName: 'plugins/permalink' */ '../plugins/Permalink')),
     SnapshotPlugin: toModulePlugin('Snapshot', () => import(/* webpackChunkName: 'plugins/snapshot' */ '../plugins/Snapshot')),
     StreetView: toModulePlugin('StreetView', () => import(/* webpackChunkName: 'plugins/streetView' */ '../plugins/StreetView')),
     StyleEditor: toModulePlugin('StyleEditor', () => import(/* webpackChunkName: 'plugins/styleEditor' */ '../plugins/StyleEditor')),

--- a/web/client/reducers/__tests__/permalink-test.js
+++ b/web/client/reducers/__tests__/permalink-test.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+
+import {
+    updatePermalinkSettings,
+    permalinkLoading,
+    resetPermalink
+} from '../../actions/permalink';
+import permalink from '../permalink';
+
+describe('permalink reducer', () => {
+    it('default permalink', () => {
+        const state = permalink();
+        expect(state).toBeTruthy();
+        expect(state.settings).toEqual({allowAllUser: true});
+    });
+    it('update permalink settings', () => {
+        const state = permalink({}, updatePermalinkSettings({title: "Test"}));
+        expect(state).toBeTruthy();
+        expect(state.settings).toBeTruthy();
+        expect(state.settings.title).toBe("Test");
+    });
+    it('loading permalink', () => {
+        const state = permalink({}, permalinkLoading(true));
+        expect(state).toBeTruthy();
+        expect(state.loading).toBeTruthy();
+    });
+    it('reset permalink', () => {
+        const state = permalink({}, resetPermalink());
+        expect(state).toBeTruthy();
+        expect(state.settings).toBeTruthy();
+        expect(state.settings.allowAllUser).toBeTruthy();
+    });
+});

--- a/web/client/reducers/__tests__/permalink-test.js
+++ b/web/client/reducers/__tests__/permalink-test.js
@@ -13,7 +13,6 @@ import {
     resetPermalink
 } from '../../actions/permalink';
 import permalink from '../permalink';
-import { loadFinished } from '../../actions/context';
 
 describe('permalink reducer', () => {
     it('default permalink', () => {
@@ -34,12 +33,6 @@ describe('permalink reducer', () => {
     });
     it('reset permalink', () => {
         const state = permalink({}, resetPermalink());
-        expect(state).toBeTruthy();
-        expect(state.settings).toBeTruthy();
-        expect(state.settings.allowAllUser).toBeTruthy();
-    });
-    it('reset permalink on loadfinished', () => {
-        const state = permalink({}, loadFinished());
         expect(state).toBeTruthy();
         expect(state.settings).toBeTruthy();
         expect(state.settings.allowAllUser).toBeTruthy();

--- a/web/client/reducers/__tests__/permalink-test.js
+++ b/web/client/reducers/__tests__/permalink-test.js
@@ -13,6 +13,7 @@ import {
     resetPermalink
 } from '../../actions/permalink';
 import permalink from '../permalink';
+import { loadFinished } from '../../actions/context';
 
 describe('permalink reducer', () => {
     it('default permalink', () => {
@@ -33,6 +34,12 @@ describe('permalink reducer', () => {
     });
     it('reset permalink', () => {
         const state = permalink({}, resetPermalink());
+        expect(state).toBeTruthy();
+        expect(state.settings).toBeTruthy();
+        expect(state.settings.allowAllUser).toBeTruthy();
+    });
+    it('reset permalink on loadfinished', () => {
+        const state = permalink({}, loadFinished());
         expect(state).toBeTruthy();
         expect(state.settings).toBeTruthy();
         expect(state.settings.allowAllUser).toBeTruthy();

--- a/web/client/reducers/permalink.js
+++ b/web/client/reducers/permalink.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { UPDATE_SETTINGS, LOADING, RESET } from "../actions/permalink";
+
+const initialState = {
+    settings: {
+        allowAllUser: true
+    }
+};
+export default (state = initialState, action = {}) => {
+    switch (action.type) {
+    case UPDATE_SETTINGS:
+        return {
+            ...state,
+            settings: {...state.settings, ...action.settings}
+        };
+    case LOADING:
+        return {
+            ...state,
+            loading: action.loading
+        };
+    case RESET: {
+        return initialState;
+    }
+    default:
+        return state;
+    }
+};

--- a/web/client/reducers/permalink.js
+++ b/web/client/reducers/permalink.js
@@ -5,8 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { UPDATE_SETTINGS, LOADING, RESET, LOAD_PERMALINK } from "../actions/permalink";
-import { LOAD_FINISHED } from "../actions/context";
+import { UPDATE_SETTINGS, LOADING, RESET } from "../actions/permalink";
 
 const initialState = {
     settings: {
@@ -25,13 +24,6 @@ export default (state = initialState, action = {}) => {
             ...state,
             loading: action.loading
         };
-
-    case LOAD_PERMALINK:
-        return {
-            ...state,
-            id: action.id
-        };
-    case LOAD_FINISHED:
     case RESET: {
         return initialState;
     }

--- a/web/client/reducers/permalink.js
+++ b/web/client/reducers/permalink.js
@@ -5,7 +5,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { UPDATE_SETTINGS, LOADING, RESET } from "../actions/permalink";
+import { UPDATE_SETTINGS, LOADING, RESET, LOAD_PERMALINK } from "../actions/permalink";
+import { LOAD_FINISHED } from "../actions/context";
 
 const initialState = {
     settings: {
@@ -24,6 +25,13 @@ export default (state = initialState, action = {}) => {
             ...state,
             loading: action.loading
         };
+
+    case LOAD_PERMALINK:
+        return {
+            ...state,
+            id: action.id
+        };
+    case LOAD_FINISHED:
     case RESET: {
         return initialState;
     }

--- a/web/client/selectors/__tests__/map-test.js
+++ b/web/client/selectors/__tests__/map-test.js
@@ -15,6 +15,7 @@ import {
     mapIdSelector,
     projectionDefsSelector,
     mapNameSelector,
+    mapInfoSelector,
     mapInfoDetailsUriFromIdSelector,
     configuredRestrictedExtentSelector,
     configuredExtentCrsSelector,
@@ -24,7 +25,8 @@ import {
     isMouseMoveActiveSelector,
     isMouseMoveCoordinatesActiveSelector,
     isMouseMoveIdentifyActiveSelector,
-    identifyFloatingToolSelector
+    identifyFloatingToolSelector,
+    mapInfoAttributesSelector
 } from '../map';
 
 const center = {x: 1, y: 1};
@@ -112,6 +114,10 @@ describe('Test map selectors', () => {
         const props = mapNameSelector({});
         expect(props).toBe('');
     });
+    it('test mapNameSelector with title', () => {
+        const props = mapNameSelector({map: {present: {info: { name: 'map name', attributes: {title: "map title"} }}}});
+        expect(props).toBe('map title');
+    });
     it('test configuredExtentSelectorCrs', () => {
         const props = configuredExtentCrsSelector({localConfig: {mapConstraints: {crs: 'EPSG:4326'}}});
         expect(props).toBe('EPSG:4326');
@@ -180,5 +186,16 @@ describe('Test map selectors', () => {
     it('test identifyFloatingToolSelector should non display mapPopUp data if identify is not enabled for pop up maps', () => {
         const renderValidOnly = identifyFloatingToolSelector({mapPopups: {popups: [{component: 'sampleComponent'}]}});
         expect(renderValidOnly).toBe(false);
+    });
+    it('test mapInfoSelector', () => {
+        const mapInfo = mapInfoSelector({map: {present: {info: {name: "test"}}}});
+        expect(mapInfo).toBeTruthy();
+        expect(mapInfo.name).toBe("test");
+    });
+    it('test mapInfoAttributesSelector', () => {
+        const attributes = {title: "test"};
+        const mapInfoAttributes = mapInfoAttributesSelector({map: {present: {info: {attributes}}}});
+        expect(mapInfoAttributes).toBeTruthy();
+        expect(mapInfoAttributes).toEqual(attributes);
     });
 });

--- a/web/client/selectors/__tests__/permalink-test.js
+++ b/web/client/selectors/__tests__/permalink-test.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+
+import {
+    permalinkSettingsSelector,
+    permalinkLoadingSelector
+} from "../permalink";
+
+describe('permalink selectors', () => {
+    it('permalinkSettingsSelector', () => {
+        const settings = {title: "test"};
+        const permalinkSettings = permalinkSettingsSelector({permalink: {settings}});
+        expect(permalinkSettings).toBeTruthy();
+        expect(permalinkSettings).toEqual(settings);
+    });
+    it('permalinkLoadingSelector', () => {
+        const permalinkLoading = permalinkLoadingSelector({permalink: {loading: true}});
+        expect(permalinkLoading).toBeTruthy();
+    });
+});

--- a/web/client/selectors/__tests__/permalink-test.js
+++ b/web/client/selectors/__tests__/permalink-test.js
@@ -9,8 +9,7 @@ import expect from 'expect';
 
 import {
     permalinkSettingsSelector,
-    permalinkLoadingSelector,
-    isPermalinkSelector
+    permalinkLoadingSelector
 } from "../permalink";
 
 describe('permalink selectors', () => {
@@ -23,9 +22,5 @@ describe('permalink selectors', () => {
     it('permalinkLoadingSelector', () => {
         const permalinkLoading = permalinkLoadingSelector({permalink: {loading: true}});
         expect(permalinkLoading).toBeTruthy();
-    });
-    it('isPermalinkSelector', () => {
-        const isPermalink = isPermalinkSelector({permalink: {id: 1}});
-        expect(isPermalink).toBeTruthy();
     });
 });

--- a/web/client/selectors/__tests__/permalink-test.js
+++ b/web/client/selectors/__tests__/permalink-test.js
@@ -9,7 +9,8 @@ import expect from 'expect';
 
 import {
     permalinkSettingsSelector,
-    permalinkLoadingSelector
+    permalinkLoadingSelector,
+    isPermalinkSelector
 } from "../permalink";
 
 describe('permalink selectors', () => {
@@ -22,5 +23,9 @@ describe('permalink selectors', () => {
     it('permalinkLoadingSelector', () => {
         const permalinkLoading = permalinkLoadingSelector({permalink: {loading: true}});
         expect(permalinkLoading).toBeTruthy();
+    });
+    it('isPermalinkSelector', () => {
+        const isPermalink = isPermalinkSelector({permalink: {id: 1}});
+        expect(isPermalink).toBeTruthy();
     });
 });

--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -43,6 +43,7 @@ export const mapIsEditableSelector = state => {
     }
     return mapInfoCanEdit;
 };
+export const mapInfoAttributesSelector = state => get(mapInfoSelector(state), 'attributes');
 
 // TODO: move these in selectors/localConfig.js or selectors/config.js
 export const projectionDefsSelector = (state) => state.localConfig && state.localConfig.projectionDefs || [];
@@ -94,7 +95,11 @@ export const mapVersionSelector = (state) => state.map && state.map.present && s
  * @param  {object} state the state
  * @return {string} name/title of the map
  */
-export const mapNameSelector = (state) => state.map && state.map.present && state.map.present.info && state.map.present.info.name || '';
+export const mapNameSelector = (state) => {
+    const mapInfo = mapInfoSelector(state);
+    const attributes = mapInfoAttributesSelector(state);
+    return attributes?.title || mapInfo?.name || '';
+};
 
 export const mapSizeSelector = (state) => state?.map?.present?.size ?? 0;
 

--- a/web/client/selectors/permalink.js
+++ b/web/client/selectors/permalink.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import get from 'lodash/get';
+
+export const permalinkSettingsSelector = (state) => get(state, 'permalink.settings', {});
+export const permalinkLoadingSelector = (state) => get(state, 'permalink.loading', false);

--- a/web/client/selectors/permalink.js
+++ b/web/client/selectors/permalink.js
@@ -10,3 +10,4 @@ import get from 'lodash/get';
 
 export const permalinkSettingsSelector = (state) => get(state, 'permalink.settings', {});
 export const permalinkLoadingSelector = (state) => get(state, 'permalink.loading', false);
+export const isPermalinkSelector = (state) => get(state, 'permalink.id');

--- a/web/client/selectors/permalink.js
+++ b/web/client/selectors/permalink.js
@@ -10,4 +10,3 @@ import get from 'lodash/get';
 
 export const permalinkSettingsSelector = (state) => get(state, 'permalink.settings', {});
 export const permalinkLoadingSelector = (state) => get(state, 'permalink.loading', false);
-export const isPermalinkSelector = (state) => get(state, 'permalink.id');

--- a/web/client/themes/default/less/mapstore.less
+++ b/web/client/themes/default/less/mapstore.less
@@ -90,3 +90,4 @@
 @import "user-extensions.less";
 @import "map-popup.less";
 @import "map-views.less";
+@import "permalink.less";

--- a/web/client/themes/default/less/permalink.less
+++ b/web/client/themes/default/less/permalink.less
@@ -1,0 +1,45 @@
+//
+// Copyright 2021, GeoSolutions Sas.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// **************
+// Theme
+// **************
+#ms-components-theme(@theme-vars) {}
+
+// **************
+// Layout
+// **************
+#permalink {
+    padding: 10px 4px;
+    display: flex;
+    flex-direction: column;
+    .subtitle {
+        font-size: 14px;
+    }
+    .create-new {
+        width: 100px;
+        margin-top: 10px;
+    }
+    .form-group {
+        margin-bottom: 10px;
+    }
+    .permalink-save {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: -10px;
+        button {
+            width: 50px;
+            display: flex;
+            align-items: center;
+            &.loading {
+                width: unset;
+            }
+            
+        }
+    }
+}

--- a/web/client/themes/default/less/permalink.less
+++ b/web/client/themes/default/less/permalink.less
@@ -16,14 +16,13 @@
 // **************
 #permalink {
     padding: 10px 4px;
-    display: flex;
-    flex-direction: column;
     .subtitle {
         font-size: 14px;
     }
     .create-new {
-        width: 100px;
         margin-top: 10px;
+        display: flex;
+        justify-content: flex-end;
     }
     .form-group {
         margin-bottom: 10px;
@@ -33,7 +32,6 @@
         justify-content: flex-end;
         margin-top: -10px;
         button {
-            width: 50px;
             display: flex;
             align-items: center;
             &.loading {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1423,7 +1423,7 @@
             "shareLinkTitle": "Permalink generiert",
             "accessible": "Öffentlich",
             "success": "Permalink wurde erfolgreich gespeichert",
-            "createAndSaveSuccess": "Die Kategorie \"PERMALINK\" wurde erstellt und der Permalink wurde erfolgreich gespeichert",
+            "createCategorySuccess": "Die Kategorie \"PERMALINK\" wurde erstellt und der Permalink wurde erfolgreich gespeichert",
             "descriptionLabel": "Beschreibung",
             "titleLabel": "Titel",
             "titlePlaceholder": "Geben Sie einen Titel ein",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1423,7 +1423,7 @@
             "shareLinkTitle": "Permalink generiert",
             "accessible": "Öffentlich",
             "success": "Permalink wurde erfolgreich gespeichert",
-            "createCategorySuccess": "Die Kategorie \"PERMALINK\" wurde erstellt und der Permalink wurde erfolgreich gespeichert",
+            "createCategorySuccess": "Die Kategorie \"PERMALINK\" fehlte und wurde daher erstellt",
             "descriptionLabel": "Beschreibung",
             "titleLabel": "Titel",
             "titlePlaceholder": "Geben Sie einen Titel ein",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1382,31 +1382,6 @@
             "social": "Social",
             "direct": "Link",
             "code": "Embed",
-            "permalink": {
-                "title": "Permalink",
-                "shareLinkTitle": "Permalink generiert",
-                "accessible": "Öffentlich",
-                "success": "Permalink wurde erfolgreich gespeichert",
-                "error": "Fehler beim Speichern des Permalinks",
-                "descriptionLabel": "Beschreibung",
-                "titleLabel": "Titel",
-                "titlePlaceholder": "Geben Sie einen Titel ein",
-                "descriptionPlaceholder": "Geben Sie eine Beschreibung ein",
-                "generate": "Permalink generieren",
-                "create": "Erstellen Sie einen neuen Permalink",
-                "loadingSpinner": "Permalink wird geladen",
-                "errors": {
-                    "loading": {
-                        "unknownError": "Beim Laden des Permalinks ist ein Fehler aufgetreten",
-                        "permalinkNotAccessible": "Sie haben keine Berechtigung, auf diesen Permalink zuzugreifen. Bitte wenden Sie sich an den Ressourceneigentümer",
-                        "permalinkDoesNotExist": "Der Permalink, auf den Sie zugreifen möchten, existiert nicht",
-                        "title": "Fehler beim Laden des Peramlinks",
-                        "pleaseLogin": "Dieser Permalink ist nicht öffentlich. Bitte versuchen Sie sich anzumelden",
-                        "notFound": "Permalink nicht gefunden",
-	                    "notAccessible": "Permalink nicht zugänglich"
-                    }
-                }
-            },
             "embeddedLinkTitle": "Über einen eingebetteten Code",
             "forceDrawer": "Inhaltsverzeichnis anzeigen",
             "apiLinkTitle": "API verwenden",
@@ -1441,6 +1416,38 @@
             "sizeOptions": {
                 "width": "Breite",
                 "height": "Höhe"
+            }
+        },
+        "permalink": {
+            "title": "Permalink",
+            "shareLinkTitle": "Permalink generiert",
+            "accessible": "Öffentlich",
+            "success": "Permalink wurde erfolgreich gespeichert",
+            "createAndSaveSuccess": "Die Kategorie \"PERMALINK\" wurde erstellt und der Permalink wurde erfolgreich gespeichert",
+            "descriptionLabel": "Beschreibung",
+            "titleLabel": "Titel",
+            "titlePlaceholder": "Geben Sie einen Titel ein",
+            "descriptionPlaceholder": "Geben Sie eine Beschreibung ein",
+            "generate": "Permalink generieren",
+            "create": "Erstellen Sie einen neuen Permalink",
+            "loadingSpinner": "Permalink wird geladen",
+            "subtitle": "Teilen Sie die Ressource mithilfe der generierten Adresse",
+            "errors": {
+                "loading": {
+                    "unknownError": "Beim Laden des Permalinks ist ein Fehler aufgetreten",
+                    "permalinkNotAccessible": "Sie haben keine Berechtigung, auf diesen Permalink zuzugreifen. Bitte wenden Sie sich an den Ressourceneigentümer",
+                    "permalinkDoesNotExist": "Der Permalink, auf den Sie zugreifen möchten, existiert nicht",
+                    "title": "Fehler beim Laden des Peramlinks",
+                    "pleaseLogin": "Dieser Permalink ist nicht öffentlich. Bitte versuchen Sie sich anzumelden",
+                    "notFound": "Permalink nicht gefunden",
+                    "notAccessible": "Permalink nicht zugänglich"
+                },
+                "save": {
+                    "title": "Die Permalink-Generierung ist fehlgeschlagen",
+                    "generic": "Fehler beim Speichern des Permalinks",
+                    "categoryErrorAdmin": "Das Erstellen der fehlenden Kategorie \"{categoryName}\" ist fehlgeschlagen",
+                    "categoryErrorNonAdmin": "Fehlende Kategorie \"{categoryName}\". Bitte wenden Sie sich an den Administrator, um die Kategorie zu erstellen"
+                }
             }
         },
         "snapshot": {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -213,6 +213,7 @@
             "update": "Aktualisierung",
             "warning": "Warnung",
             "success": "Erfolg",
+            "error": "Fehler",
             "backgroundLayerNotSupported": "Der zuvor gewählte Hintergrund wird nicht für diese Art von Karte unterstützt. Der erste verfügbare wird alternativ verwendet.",
             "noBackgroundLayerSupported": "Es gibt keine unterstützten Hintergrundebenen für diese Art von Karte.",
             "updateOldMap": "Dies ist eine alte Karte, daher können nicht alle Funktionen aktiviert werden. Klicken Sie auf die Schaltfläche Aktualisieren, um die Karte zu aktualisieren, oder schließen Sie diese Benachrichtigung einfach, wenn Sie sie nicht aktualisieren möchten.",
@@ -1381,6 +1382,30 @@
             "social": "Social",
             "direct": "Link",
             "code": "Embed",
+            "permalink": {
+                "title": "Permalink",
+                "accessible": "Öffentlich",
+                "success": "Permalink wurde erfolgreich gespeichert",
+                "error": "Fehler beim Speichern des Permalinks",
+                "descriptionLabel": "Beschreibung",
+                "titleLabel": "Titel",
+                "titlePlaceholder": "Geben Sie einen Titel ein",
+                "descriptionPlaceholder": "Geben Sie eine Beschreibung ein",
+                "save": "Speichern",
+                "create": "Erstelle neu",
+                "loadingSpinner": "Permalink wird geladen",
+                "errors": {
+                    "loading": {
+                        "unknownError": "Beim Laden des Permalinks ist ein Fehler aufgetreten",
+                        "permalinkNotAccessible": "Sie haben keine Berechtigung, auf diesen Permalink zuzugreifen. Bitte wenden Sie sich an den Ressourceneigentümer",
+                        "permalinkDoesNotExist": "Der Permalink, auf den Sie zugreifen möchten, existiert nicht",
+                        "title": "Fehler beim Laden des Peramlinks",
+                        "pleaseLogin": "Dieser Permalink ist nicht öffentlich. Bitte versuchen Sie sich anzumelden",
+                        "notFound": "Permalink nicht gefunden",
+	                    "notAccessible": "Permalink nicht zugänglich"
+                    }
+                }
+            },
             "embeddedLinkTitle": "Über einen eingebetteten Code",
             "forceDrawer": "Inhaltsverzeichnis anzeigen",
             "apiLinkTitle": "API verwenden",
@@ -2868,10 +2893,12 @@
             "title": "Eigenschaften bearbeiten",
             "name": "Name",
             "description": "Beschreibung",
+            "titleInput": "Titel",
             "createdAt": "Erstellt",
             "modifiedAt": "Geändert",
             "namePlaceholder": "Geben Sie einen Namen ein ...",
             "descriptionPlaceholder": "Geben Sie eine Beschreibung ein ...",
+            "titlePlaceholder": "Geben Sie einen Titel ein...",
             "confirmCloseText": "Es gibt ausstehende Änderungen, sind Sie sicher, dass Sie schließen möchten, ohne zu speichern?",
             "close": "Schließen",
             "cancel": "Abbrechen",
@@ -3112,6 +3139,10 @@
           "Share": {
             "description": "Ermöglicht das Teilen der Karte auf verschiedene Arten (Link, QR-Code, Einbettung, soziale Netzwerke ...)",
             "title": "Freigabe-Werkzeug"
+          },
+          "Permalink": {
+            "description": "Ermöglicht das Erstellen eines Permalinks der aktuell angezeigten Ressource",
+            "title": "Permalink"
           },
           "StreetView": {
             "title": "Street-View",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1384,6 +1384,7 @@
             "code": "Embed",
             "permalink": {
                 "title": "Permalink",
+                "shareLinkTitle": "Permalink generiert",
                 "accessible": "Öffentlich",
                 "success": "Permalink wurde erfolgreich gespeichert",
                 "error": "Fehler beim Speichern des Permalinks",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1392,8 +1392,8 @@
                 "titleLabel": "Titel",
                 "titlePlaceholder": "Geben Sie einen Titel ein",
                 "descriptionPlaceholder": "Geben Sie eine Beschreibung ein",
-                "save": "Speichern",
-                "create": "Erstelle neu",
+                "generate": "Permalink generieren",
+                "create": "Erstellen Sie einen neuen Permalink",
                 "loadingSpinner": "Permalink wird geladen",
                 "errors": {
                     "loading": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1384,7 +1384,7 @@
             "shareLinkTitle": "Permalink generated",
             "accessible": "Public",
             "success": "Permalink is saved successfully",
-            "createAndSaveSuccess": "\"PERMALINK\" category is created and the permalink is saved successfully",
+            "createCategorySuccess": "\"PERMALINK\" category was missing, so it has been created",
             "descriptionLabel": "Description",
             "titleLabel": "Title",
             "titlePlaceholder": "Enter a title",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1346,6 +1346,7 @@
             "code": "Embed",
             "permalink": {
                 "title": "Permalink",
+                "shareLinkTitle": "Permalink generated",
                 "accessible": "Public",
                 "success": "Permalink is saved successfully",
                 "error": "Error when saving permalink",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -213,6 +213,7 @@
             "update": "Update",
             "warning": "Warning",
             "success": "Success",
+            "error": "Error",
             "backgroundLayerNotSupported": "The previously selected background is not supported for this type of map. The first one available is then used.",
             "noBackgroundLayerSupported": "There are no supported background layers for this type of map.",
             "updateOldMap": "This is an old map, thus not all the functionalities can be enabled. Click on upgrade button in order to upgrade the map or simply dismiss this notification if you don't want to upgrade it.",
@@ -1343,6 +1344,30 @@
             "social": "Social",
             "direct": "Link",
             "code": "Embed",
+            "permalink": {
+                "title": "Permalink",
+                "accessible": "Public",
+                "success": "Permalink is saved successfully",
+                "error": "Error when saving permalink",
+                "descriptionLabel": "Description",
+                "titleLabel": "Title",
+                "titlePlaceholder": "Enter a title",
+                "descriptionPlaceholder": "Enter a description",
+                "save": "Save",
+                "create": "Create New",
+                "loadingSpinner": "Loading Permalink",
+                "errors": {
+                    "loading": {
+                        "unknownError": "There was an error loading the permalink",
+                        "permalinkNotAccessible": "You don't have permission to access this permalink. Please contact the resource owner",
+                        "permalinkDoesNotExist": "The permalink you are trying to access doesn't exist",
+                        "title": "Error loading peramlink",
+                        "pleaseLogin": "This permalink is not public. Please try to login",
+                        "notFound": "Permalink not found",
+	                    "notAccessible": "Permalink not accessible"
+                    }
+                }
+            },
             "forceDrawer": "Show TOC",
             "apiLinkTitle": "Using APIs",
             "QRCodeLinkTitle": "QR code",
@@ -2841,11 +2866,13 @@
         "saveDialog": {
             "title": "Edit properties",
             "name": "Name",
+            "titleInput": "Title",
             "description": "Description",
             "createdAt": "Created",
             "modifiedAt": "Modified",
             "namePlaceholder": "Type a name...",
             "descriptionPlaceholder": "Type a description...",
+            "titlePlaceholder": "Type a title...",
             "confirmCloseText": "There are pending changes, are you sure that you want to close without saving?",
             "close": "Close",
             "cancel": "Cancel",
@@ -3086,6 +3113,10 @@
           "Share": {
             "description": "Allows to share the map in various ways (link, QR-Code, embed, social networks...)",
             "title": "Share Tool"
+          },
+          "Permalink": {
+            "description": "Allows to create a permalink of the current resource in view",
+            "title": "Permalink"
           },
           "StreetView": {
             "title": "Street View",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1344,31 +1344,6 @@
             "social": "Social",
             "direct": "Link",
             "code": "Embed",
-            "permalink": {
-                "title": "Permalink",
-                "shareLinkTitle": "Permalink generated",
-                "accessible": "Public",
-                "success": "Permalink is saved successfully",
-                "error": "Error when saving permalink",
-                "descriptionLabel": "Description",
-                "titleLabel": "Title",
-                "titlePlaceholder": "Enter a title",
-                "descriptionPlaceholder": "Enter a description",
-                "generate": "Generate permalink",
-                "create": "Create a new permalink",
-                "loadingSpinner": "Loading Permalink",
-                "errors": {
-                    "loading": {
-                        "unknownError": "There was an error loading the permalink",
-                        "permalinkNotAccessible": "You don't have permission to access this permalink. Please contact the resource owner",
-                        "permalinkDoesNotExist": "The permalink you are trying to access doesn't exist",
-                        "title": "Error loading peramlink",
-                        "pleaseLogin": "This permalink is not public. Please try to login",
-                        "notFound": "Permalink not found",
-	                    "notAccessible": "Permalink not accessible"
-                    }
-                }
-            },
             "forceDrawer": "Show TOC",
             "apiLinkTitle": "Using APIs",
             "QRCodeLinkTitle": "QR code",
@@ -1402,6 +1377,38 @@
             "sizeOptions": {
                 "width": "width",
                 "height": "height"
+            }
+        },
+        "permalink": {
+            "title": "Permalink",
+            "shareLinkTitle": "Permalink generated",
+            "accessible": "Public",
+            "success": "Permalink is saved successfully",
+            "createAndSaveSuccess": "\"PERMALINK\" category is created and the permalink is saved successfully",
+            "descriptionLabel": "Description",
+            "titleLabel": "Title",
+            "titlePlaceholder": "Enter a title",
+            "descriptionPlaceholder": "Enter a description",
+            "generate": "Generate permalink",
+            "create": "Create a new permalink",
+            "loadingSpinner": "Loading Permalink",
+            "subtitle": "Share the resource using the generated address",
+            "errors": {
+                "loading": {
+                    "unknownError": "There was an error loading the permalink",
+                    "permalinkNotAccessible": "You don't have permission to access this permalink. Please contact the resource owner",
+                    "permalinkDoesNotExist": "The permalink you are trying to access doesn't exist",
+                    "title": "Error loading peramlink",
+                    "pleaseLogin": "This permalink is not public. Please try to login",
+                    "notFound": "Permalink not found",
+                    "notAccessible": "Permalink not accessible"
+                },
+                "save": {
+                    "title": "Permalink generation failed",
+                    "generic": "Error when saving permalink",
+                    "categoryErrorAdmin": "Creating missing category \"{categoryName}\" failed",
+                    "categoryErrorNonAdmin": "Missing category \"{categoryName}\", please contact administrator to create the category"
+                }
             }
         },
         "snapshot": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1354,8 +1354,8 @@
                 "titleLabel": "Title",
                 "titlePlaceholder": "Enter a title",
                 "descriptionPlaceholder": "Enter a description",
-                "save": "Save",
-                "create": "Create New",
+                "generate": "Generate permalink",
+                "create": "Create a new permalink",
                 "loadingSpinner": "Loading Permalink",
                 "errors": {
                     "loading": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1353,8 +1353,8 @@
                 "titleLabel": "Título",
                 "titlePlaceholder": "Introduce un título",
                 "descriptionPlaceholder": "Introduce una descripción",
-                "save": "Ahorrar",
-                "create": "Crear nuevo",
+                "generate": "Generar enlace permanente",
+                "create": "Crear un nuevo enlace permanente",
                 "loadingSpinner": "Cargando Enlace permanente",
                 "errors": {
                     "loading": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1384,7 +1384,7 @@
             "shareLinkTitle": "Enlace permanente generado",
             "accessible": "Público",
             "success": "El enlace permanente se guardó con éxito",
-            "createAndSaveSuccess": "Se crea la categoría \"PERMALINK\" y el enlace permanente se guarda correctamente",
+            "createCategorySuccess": "Faltaba la categoría \"PERMALINK\", por lo que se ha creado",
             "descriptionLabel": "Descripción",
             "titleLabel": "Título",
             "titlePlaceholder": "Introduce un título",
@@ -1409,7 +1409,7 @@
                     "categoryErrorAdmin": "Error al crear el enlace \"{categoryName}\" de la categoría faltante",
                     "categoryErrorNonAdmin": "Falta el enlace \"{categoryName}\" de la categoría, comuníquese con el administrador para crear la categoría"
                 }
-                
+
             }
         },
         "snapshot": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1343,31 +1343,6 @@
             "social": "Social",
             "direct": "Enlace",
             "code": "Embebido",
-            "permalink": {
-                "title": "Permalink",
-                "shareLinkTitle": "Enlace permanente generado",
-                "accessible": "Público",
-                "success": "El enlace permanente se guardó con éxito",
-                "error": "Error al guardar enlace permanente",
-                "descriptionLabel": "Descripción",
-                "titleLabel": "Título",
-                "titlePlaceholder": "Introduce un título",
-                "descriptionPlaceholder": "Introduce una descripción",
-                "generate": "Generar enlace permanente",
-                "create": "Crear un nuevo enlace permanente",
-                "loadingSpinner": "Cargando Enlace permanente",
-                "errors": {
-                    "loading": {
-                        "unknownError": "Hubo un error al cargar el enlace permanente",
-                        "permalinkNotAccessible": "No tienes permiso para acceder a este enlace permanente. Póngase en contacto con el propietario del recurso.",
-                        "permalinkDoesNotExist": "El enlace permanente al que intenta acceder no existe",
-                        "title": "Error al cargar el enlace permanente",
-                        "pleaseLogin": "Este enlace permanente no es público. Intente iniciar sesión",
-                        "notFound": "Enlace permanente no encontrado",
-	                    "notAccessible": "Enlace permanente no accesible"
-                    }
-                }
-            },
             "embeddedLinkTitle": "A través de código embebido",
             "forceDrawer": "Mostrar el contenido",
             "apiLinkTitle": "A través de APIs",
@@ -1402,6 +1377,39 @@
             "sizeOptions": {
                 "width": "ancho",
                 "height": "altura"
+            }
+        },
+        "permalink": {
+            "title": "Permalink",
+            "shareLinkTitle": "Enlace permanente generado",
+            "accessible": "Público",
+            "success": "El enlace permanente se guardó con éxito",
+            "createAndSaveSuccess": "Se crea la categoría \"PERMALINK\" y el enlace permanente se guarda correctamente",
+            "descriptionLabel": "Descripción",
+            "titleLabel": "Título",
+            "titlePlaceholder": "Introduce un título",
+            "descriptionPlaceholder": "Introduce una descripción",
+            "generate": "Generar enlace permanente",
+            "create": "Crear un nuevo enlace permanente",
+            "loadingSpinner": "Cargando Enlace permanente",
+            "subtitle": "Comparte el recurso usando la dirección generada",
+            "errors": {
+                "loading": {
+                    "unknownError": "Hubo un error al cargar el enlace permanente",
+                    "permalinkNotAccessible": "No tienes permiso para acceder a este enlace permanente. Póngase en contacto con el propietario del recurso.",
+                    "permalinkDoesNotExist": "El enlace permanente al que intenta acceder no existe",
+                    "title": "Error al cargar el enlace permanente",
+                    "pleaseLogin": "Este enlace permanente no es público. Intente iniciar sesión",
+                    "notFound": "Enlace permanente no encontrado",
+                    "notAccessible": "Enlace permanente no accesible"
+                },
+                "save": {
+                    "title": "La generación del enlace permanente falló",
+                    "generic": "Error al guardar enlace permanente",
+                    "categoryErrorAdmin": "Error al crear el enlace \"{categoryName}\" de la categoría faltante",
+                    "categoryErrorNonAdmin": "Falta el enlace \"{categoryName}\" de la categoría, comuníquese con el administrador para crear la categoría"
+                }
+                
             }
         },
         "snapshot": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1345,6 +1345,7 @@
             "code": "Embebido",
             "permalink": {
                 "title": "Permalink",
+                "shareLinkTitle": "Enlace permanente generado",
                 "accessible": "Público",
                 "success": "El enlace permanente se guardó con éxito",
                 "error": "Error al guardar enlace permanente",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -213,6 +213,7 @@
             "update": "Actualizar",
             "warning": "Aviso",
             "success": "Éxito",
+            "error": "Error",
             "backgroundLayerNotSupported": "El mapa de fondo seleccionado no está soportado para este tipo de mapa. Se usará el primero disponible.",
             "noBackgroundLayerSupported": "No hay capas de fondo soportadas para este tipo de mapa.",
             "updateOldMap": "Este es un mapa antiguo, de modo que no todas las funcionalidades pueden ser habilitadas. Pinche en el botón de actulizar el mapa o ignore este aviso si no quiere actualizarlo.",
@@ -1342,6 +1343,30 @@
             "social": "Social",
             "direct": "Enlace",
             "code": "Embebido",
+            "permalink": {
+                "title": "Permalink",
+                "accessible": "Público",
+                "success": "El enlace permanente se guardó con éxito",
+                "error": "Error al guardar enlace permanente",
+                "descriptionLabel": "Descripción",
+                "titleLabel": "Título",
+                "titlePlaceholder": "Introduce un título",
+                "descriptionPlaceholder": "Introduce una descripción",
+                "save": "Ahorrar",
+                "create": "Crear nuevo",
+                "loadingSpinner": "Cargando Enlace permanente",
+                "errors": {
+                    "loading": {
+                        "unknownError": "Hubo un error al cargar el enlace permanente",
+                        "permalinkNotAccessible": "No tienes permiso para acceder a este enlace permanente. Póngase en contacto con el propietario del recurso.",
+                        "permalinkDoesNotExist": "El enlace permanente al que intenta acceder no existe",
+                        "title": "Error al cargar el enlace permanente",
+                        "pleaseLogin": "Este enlace permanente no es público. Intente iniciar sesión",
+                        "notFound": "Enlace permanente no encontrado",
+	                    "notAccessible": "Enlace permanente no accesible"
+                    }
+                }
+            },
             "embeddedLinkTitle": "A través de código embebido",
             "forceDrawer": "Mostrar el contenido",
             "apiLinkTitle": "A través de APIs",
@@ -2830,10 +2855,12 @@
             "title": "Editar propiedades",
             "name": "Nombre",
             "description": "Descripción",
+            "titleInput": "Título",
             "createdAt": "Creado",
             "modifiedAt": "Modificado",
             "namePlaceholder": "Escriba un nombre ...",
             "descriptionPlaceholder": "Escriba una descripción ...",
+            "titlePlaceholder": "Escribe un título...",
             "confirmCloseText": "Hay cambios pendientes, ¿está seguro que quiere cerrar sin guardar?",
             "close": "Cerrar",
             "cancel": "Cancelar",
@@ -3074,6 +3101,10 @@
           "Share": {
             "description": "Permite compartir el mapa de varias maneras (enlace, código QR, incrustar, redes sociales ...)",
             "title": "Compartir herramienta"
+          },
+          "Permalink": {
+            "description": "Permite crear un enlace permanente del recurso actual a la vista",
+            "title": "Enlace permanente"
           },
           "StreetView": {
             "title": "Street View",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1385,7 +1385,7 @@
             "shareLinkTitle": "Permalien généré",
             "accessible": "Public",
             "success": "Le lien permanent a été enregistré avec succès",
-            "createAndSaveSuccess": "La catégorie \"PERMALINK\" est créée et le permalien est enregistré avec succès",
+            "createCategorySuccess": "La catégorie \"PERMALINK\" était manquante, elle a donc été créée",
             "descriptionLabel": "Description",
             "titleLabel": "Titre",
             "titlePlaceholder": "Entrez un titre",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1353,8 +1353,8 @@
                 "titleLabel": "Titre",
                 "titlePlaceholder": "Entrez un titre",
                 "descriptionPlaceholder": "Entrez une description",
-                "save": "Sauvegarder",
-                "create": "Créer un nouveau",
+                "generate": "Générer un permalien",
+                "create": "Créer un nouveau lien permanent",
                 "loadingSpinner": "Chargement du lien permanent",
                 "errors": {
                     "loading": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1343,31 +1343,6 @@
             "social": "Social",
             "direct": "Link",
             "code": "Embed",
-            "permalink": {
-                "title": "Permalink",
-                "shareLinkTitle": "Permalien généré",
-                "accessible": "Public",
-                "success": "Le lien permanent a été enregistré avec succès",
-                "error": "Erreur lors de l'enregistrement du permalien",
-                "descriptionLabel": "Description",
-                "titleLabel": "Titre",
-                "titlePlaceholder": "Entrez un titre",
-                "descriptionPlaceholder": "Entrez une description",
-                "generate": "Générer un permalien",
-                "create": "Créer un nouveau lien permanent",
-                "loadingSpinner": "Chargement du lien permanent",
-                "errors": {
-                    "loading": {
-                        "unknownError": "Une erreur s'est produite lors du chargement du permalien",
-                        "permalinkNotAccessible": "Vous n'êtes pas autorisé à accéder à ce permalien. Veuillez contacter le propriétaire de la ressource",
-                        "permalinkDoesNotExist": "Le permalien auquel vous essayez d'accéder n'existe pas",
-                        "title": "Erreur lors du chargement du lien permanent",
-                        "pleaseLogin": "Ce permalien n'est pas public. Veuillez essayer de vous connecter",
-                        "notFound": "Permalien introuvable",
-	                    "notAccessible": "Permalien inaccessible"
-                    }
-                }
-            },
             "embeddedLinkTitle": "Via le code intégré",
             "forceDrawer": "Afficher la liste des couches",
             "apiLinkTitle": "Via les APIs",
@@ -1403,6 +1378,38 @@
             "sizeOptions": {
                 "width": "largeur",
                 "height": "la taille"
+            }
+        },
+        "permalink": {
+            "title": "Permalink",
+            "shareLinkTitle": "Permalien généré",
+            "accessible": "Public",
+            "success": "Le lien permanent a été enregistré avec succès",
+            "createAndSaveSuccess": "La catégorie \"PERMALINK\" est créée et le permalien est enregistré avec succès",
+            "descriptionLabel": "Description",
+            "titleLabel": "Titre",
+            "titlePlaceholder": "Entrez un titre",
+            "descriptionPlaceholder": "Entrez une description",
+            "generate": "Générer un permalien",
+            "create": "Créer un nouveau lien permanent",
+            "loadingSpinner": "Chargement du lien permanent",
+            "subtitle": "Partager la ressource à l'aide de l'adresse générée",
+            "errors": {
+                "loading": {
+                    "unknownError": "Une erreur s'est produite lors du chargement du permalien",
+                    "permalinkNotAccessible": "Vous n'êtes pas autorisé à accéder à ce permalien. Veuillez contacter le propriétaire de la ressource",
+                    "permalinkDoesNotExist": "Le permalien auquel vous essayez d'accéder n'existe pas",
+                    "title": "Erreur lors du chargement du lien permanent",
+                    "pleaseLogin": "Ce permalien n'est pas public. Veuillez essayer de vous connecter",
+                    "notFound": "Permalien introuvable",
+                    "notAccessible": "Permalien inaccessible"
+                },
+                "save": {
+                    "title": "La génération du permalien a échoué",
+                    "generic": "Erreur lors de l'enregistrement du permalien",
+                    "categoryErrorAdmin": "La création de la catégorie manquante \"{categoryName}\" a échoué",
+                    "categoryErrorNonAdmin": "Catégorie manquante \"{categoryName}\", veuillez contacter l'administrateur pour créer la catégorie"
+                }
             }
         },
         "snapshot": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -213,6 +213,7 @@
             "update": "Mise à jour",
             "warning": "Avertissement",
             "success": "Réussi",
+            "error": "Erreur",
             "backgroundLayerNotSupported": "Le fond de plan précédemment sélectionné n'est pas pris en charge pour ce type de carte. Le premier disponible sera utilisé.",
             "noBackgroundLayerSupported": "Il n'y a pas de fond de plan supporté pour ce type de carte.",
             "updateOldMap": "Cette carte est à un ancien format. Certaines fonctionnalités peuvent donc ne pas fonctionner. Cliquez sur le bouton de mise à jour pour mettre à niveau la carte ou ne tenez pas compte de cet avertissement pour ne pas mettre à niveau la carte.",
@@ -1342,6 +1343,30 @@
             "social": "Social",
             "direct": "Link",
             "code": "Embed",
+            "permalink": {
+                "title": "Permalink",
+                "accessible": "Public",
+                "success": "Le lien permanent a été enregistré avec succès",
+                "error": "Erreur lors de l'enregistrement du permalien",
+                "descriptionLabel": "Description",
+                "titleLabel": "Titre",
+                "titlePlaceholder": "Entrez un titre",
+                "descriptionPlaceholder": "Entrez une description",
+                "save": "Sauvegarder",
+                "create": "Créer un nouveau",
+                "loadingSpinner": "Chargement du lien permanent",
+                "errors": {
+                    "loading": {
+                        "unknownError": "Une erreur s'est produite lors du chargement du permalien",
+                        "permalinkNotAccessible": "Vous n'êtes pas autorisé à accéder à ce permalien. Veuillez contacter le propriétaire de la ressource",
+                        "permalinkDoesNotExist": "Le permalien auquel vous essayez d'accéder n'existe pas",
+                        "title": "Erreur lors du chargement du lien permanent",
+                        "pleaseLogin": "Ce permalien n'est pas public. Veuillez essayer de vous connecter",
+                        "notFound": "Permalien introuvable",
+	                    "notAccessible": "Permalien inaccessible"
+                    }
+                }
+            },
             "embeddedLinkTitle": "Via le code intégré",
             "forceDrawer": "Afficher la liste des couches",
             "apiLinkTitle": "Via les APIs",
@@ -2832,10 +2857,12 @@
             "title": "Modifier les propriétés",
             "name": "Nom",
             "description": "Description",
+            "titleInput": "Titre",
             "createdAt": "Créé",
             "modifiedAt": "Modifié",
             "namePlaceholder": "Tapez un nom...",
             "descriptionPlaceholder": "Tapez une description...",
+            "titlePlaceholder": "Tapez un titre...",
             "confirmCloseText": "Des modifications sont en attente, êtes-vous sûr de vouloir fermer sans enregistrer ?",
             "close": "Fermer",
             "cancel": "Annuler",
@@ -3076,6 +3103,10 @@
           "Share": {
             "description": "Permet de partager la carte de diverses manières (lien, QR-Code, embarqué, réseaux sociaux ...)",
             "title": "Outil de partage"
+          },
+          "Permalink": {
+            "description": "Permet de créer un permalien de la ressource courante en vue",
+            "title": "Lien permanent"
           },
           "StreetView": {
             "title": "Street View",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1345,6 +1345,7 @@
             "code": "Embed",
             "permalink": {
                 "title": "Permalink",
+                "shareLinkTitle": "Permalien généré",
                 "accessible": "Public",
                 "success": "Le lien permanent a été enregistré avec succès",
                 "error": "Erreur lors de l'enregistrement du permalien",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -213,6 +213,7 @@
             "update": "Aggiorna",
             "warning": "Attenzione",
             "success": "Aggiornamento completo",
+            "error": "Errore",
             "backgroundLayerNotSupported": "Lo sfondo precedentemente caricato non è supportato per questo tipo di mappa. E' stato pertanto selezionato il primo disponibile.",
             "noBackgroundLayerSupported": "Non ci sono sfondi supportati per questo tipo di mappa.",
             "updateOldMap": "Questa è una vecchia mappa perciò non tutte le funzionalità sono abilitate. Clicca su Aggiorna per aggiornare la mappa o semplicemnte chiudi la notifica se non desideri aggiornarla",
@@ -1342,6 +1343,30 @@
             "social": "Social",
             "direct": "Link",
             "code": "Embed",
+            "permalink": {
+                "title": "Permalink",
+                "accessible": "Pubblico",
+                "success": "Il permalink è stato salvato con successo",
+                "error": "Errore durante il salvataggio del permalink",
+                "descriptionLabel": "Descrizione",
+                "titleLabel": "Titolo",
+                "titlePlaceholder": "Inserisci un titolo",
+                "descriptionPlaceholder": "Inserisci una descrizione",
+                "save": "Salva",
+                "create": "Creare nuovo",
+                "loadingSpinner": "Permalink in caricamento",
+                "errors": {
+                    "loading": {
+                        "unknownError": "Si è verificato un errore durante il caricamento del permalink",
+                        "permalinkNotAccessible": "Non sei autorizzato ad accedere a questo permalink. Contatta il proprietario della risorsa",
+                        "permalinkDoesNotExist": "Il permalink a cui stai tentando di accedere non esiste",
+                        "title": "Errore durante il caricamento di peramlink",
+                        "pleaseLogin": "Questo permalink non è pubblico. Si prega di provare ad accedere",
+                        "notFound": "Permalink non trovato",
+	                    "notAccessible": "Permalink non accessibile"
+                    }
+                }
+            },
             "embeddedLinkTitle": "Con il codice embedded",
             "forceDrawer": "Mostra l'indice dei livelli",
             "apiLinkTitle": "Usando le API",
@@ -2832,10 +2857,12 @@
             "title": "Modifica proprietà",
             "name": "Nome",
             "description": "Descrizione",
+            "titleInput": "Titolo",
             "createdAt": "Creata",
             "modifiedAt": "Modificata",
             "namePlaceholder": "Inserisci un nome..",
             "descriptionPlaceholder": "Inserisci una descrizione...",
+            "titlePlaceholder": "Digita un titolo...",
             "confirmCloseText": "Ci sono modifiche non salvate, sei sicuro di voler chiudere senza salvare?",
             "close": "Chiudi",
             "cancel": "Annulla",
@@ -3076,6 +3103,10 @@
           "Share": {
             "description": "Permette di condividere la mappa in diversi modi (link, QR-Code, embed, social network ...)",
             "title": "Strumento di condivisione"
+          },
+          "Permalink": {
+            "description": "Permette di creare un permalink della risorsa attualmente in vista",
+            "title": "Permalink"
           },
           "StreetView": {
             "title": "Street View",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1343,31 +1343,6 @@
             "social": "Social",
             "direct": "Link",
             "code": "Embed",
-            "permalink": {
-                "title": "Permalink",
-                "shareLinkTitle": "Permalink generato",
-                "accessible": "Pubblico",
-                "success": "Il permalink è stato salvato con successo",
-                "error": "Errore durante il salvataggio del permalink",
-                "descriptionLabel": "Descrizione",
-                "titleLabel": "Titolo",
-                "titlePlaceholder": "Inserisci un titolo",
-                "descriptionPlaceholder": "Inserisci una descrizione",
-                "generate": "Genera permalink",
-                "create": "Crea un nuovo permalink",
-                "loadingSpinner": "Permalink in caricamento",
-                "errors": {
-                    "loading": {
-                        "unknownError": "Si è verificato un errore durante il caricamento del permalink",
-                        "permalinkNotAccessible": "Non sei autorizzato ad accedere a questo permalink. Contatta il proprietario della risorsa",
-                        "permalinkDoesNotExist": "Il permalink a cui stai tentando di accedere non esiste",
-                        "title": "Errore durante il caricamento di peramlink",
-                        "pleaseLogin": "Questo permalink non è pubblico. Si prega di provare ad accedere",
-                        "notFound": "Permalink non trovato",
-	                    "notAccessible": "Permalink non accessibile"
-                    }
-                }
-            },
             "embeddedLinkTitle": "Con il codice embedded",
             "forceDrawer": "Mostra l'indice dei livelli",
             "apiLinkTitle": "Usando le API",
@@ -1402,6 +1377,38 @@
             "sizeOptions": {
                 "width": "larghezza",
                 "height": "altezza"
+            }
+        },
+        "permalink": {
+            "title": "Permalink",
+            "shareLinkTitle": "Permalink generato",
+            "accessible": "Pubblico",
+            "success": "Il permalink è stato salvato con successo",
+            "createAndSaveSuccess": "La categoria \"PERMALINK\" viene creata e il permalink viene salvato correttamente",
+            "descriptionLabel": "Descrizione",
+            "titleLabel": "Titolo",
+            "titlePlaceholder": "Inserisci un titolo",
+            "descriptionPlaceholder": "Inserisci una descrizione",
+            "generate": "Genera permalink",
+            "create": "Crea un nuovo permalink",
+            "loadingSpinner": "Permalink in caricamento",
+            "subtitle": "Condividi la risorsa utilizzando l'indirizzo generato",
+            "errors": {
+                "loading": {
+                    "unknownError": "Si è verificato un errore durante il caricamento del permalink",
+                    "permalinkNotAccessible": "Non sei autorizzato ad accedere a questo permalink. Contatta il proprietario della risorsa",
+                    "permalinkDoesNotExist": "Il permalink a cui stai tentando di accedere non esiste",
+                    "title": "Errore durante il caricamento di peramlink",
+                    "pleaseLogin": "Questo permalink non è pubblico. Si prega di provare ad accedere",
+                    "notFound": "Permalink non trovato",
+                    "notAccessible": "Permalink non accessibile"
+                },
+                "save": {
+                    "title": "Generazione del permalink non riuscita",
+                    "generic": "Errore durante il salvataggio del permalink",
+                    "categoryErrorAdmin": "Creazione della categoria mancante \"{categoryName}\" non riuscita",
+                    "categoryErrorNonAdmin": "Categoria mancante \"{categoryName}\", contattare l'amministratore per creare la categoria"
+                }
             }
         },
         "snapshot": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1384,7 +1384,7 @@
             "shareLinkTitle": "Permalink generato",
             "accessible": "Pubblico",
             "success": "Il permalink è stato salvato con successo",
-            "createAndSaveSuccess": "La categoria \"PERMALINK\" viene creata e il permalink viene salvato correttamente",
+            "createCategorySuccess": "La categoria \"PERMALINK\" mancava, quindi è stata creata",
             "descriptionLabel": "Descrizione",
             "titleLabel": "Titolo",
             "titlePlaceholder": "Inserisci un titolo",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1353,8 +1353,8 @@
                 "titleLabel": "Titolo",
                 "titlePlaceholder": "Inserisci un titolo",
                 "descriptionPlaceholder": "Inserisci una descrizione",
-                "save": "Salva",
-                "create": "Creare nuovo",
+                "generate": "Genera permalink",
+                "create": "Crea un nuovo permalink",
                 "loadingSpinner": "Permalink in caricamento",
                 "errors": {
                     "loading": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1345,6 +1345,7 @@
             "code": "Embed",
             "permalink": {
                 "title": "Permalink",
+                "shareLinkTitle": "Permalink generato",
                 "accessible": "Pubblico",
                 "success": "Il permalink è stato salvato con successo",
                 "error": "Errore durante il salvataggio del permalink",

--- a/web/client/utils/ShareUtils.js
+++ b/web/client/utils/ShareUtils.js
@@ -48,7 +48,8 @@ export const CONTEXT_DEFAULT_SHARE_OPTIONS = {
 export const SHARE_TABS = {
     link: 1,
     social: 2,
-    embed: 3
+    permalink: 3,
+    embed: 4
 };
 /**
  * Utility functions for Share tools.

--- a/web/client/utils/ShareUtils.js
+++ b/web/client/utils/ShareUtils.js
@@ -48,8 +48,7 @@ export const CONTEXT_DEFAULT_SHARE_OPTIONS = {
 export const SHARE_TABS = {
     link: 1,
     social: 2,
-    permalink: 3,
-    embed: 4
+    embed: 3
 };
 /**
  * Utility functions for Share tools.


### PR DESCRIPTION
## Description
This PR introduces permalink functionality to Share

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
- #9250 

**What is the new behavior?**
User can create permalink of the current state of the map, dashboard, geostory, context map. The permalink resources are saved as PERMALINK category and has unique resource id. The title attribute is shown in Save/SaveAs modal and TOC

<img width="507" alt="image" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/b7c40abe-6754-4988-8b7e-eff1182581a7">
<img width="509" alt="image" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/8e9d2518-1848-4ad9-aaad-a369e8cfab9d">


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
