### PR TITLE
#9287 Fix terser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     ]
   },
   "devDependencies": {
+    "terser": "5.18.1",
     "@babel/core": "7.8.7",
     "@babel/plugin-proposal-class-properties": "7.8.3",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
@@ -275,7 +276,7 @@
     "react-swipeable-views": "0.12.2",
     "react-textfit": "1.1.0",
     "react-widgets": "3.5.0",
-    "recharts": "0.22.4",
+    "recharts": "0.22.5",
     "recompose": "0.24.0",
     "redux": "3.6.0",
     "redux-logger": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
     "react-swipeable-views": "0.12.2",
     "react-textfit": "1.1.0",
     "react-widgets": "3.5.0",
-    "recharts": "0.22.5",
+    "recharts": "0.22.4",
     "recompose": "0.24.0",
     "redux": "3.6.0",
     "redux-logger": "3.0.6",


### PR DESCRIPTION
## Description
From local testings updating terser library seems to fix the JS heap out of memory problem.

Some other libs can cause the same fix. Investigating on this, anyway at least this seems to work.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #9287

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
