### PR TITLE
#9285 support for CQL function parsing and XML conversion

### DIFF
--- a/docs/developer-guide/LayerFilter.md
+++ b/docs/developer-guide/LayerFilter.md
@@ -91,7 +91,7 @@ The `cql` format is a JSON object that has this shape:
 ```
 
 !!! Note:
-    MapStore actually supports only a subset of CQL, that is the one used by GeoServer. In particular can not parse WKT geometries yet.
+    MapStore actually supports only a subset of CQL, that is the one used by GeoServer.
 
 ### `mapstore-query-panel` format
 

--- a/web/client/utils/ogc/Filter/CQL/__tests__/parser-test.js
+++ b/web/client/utils/ogc/Filter/CQL/__tests__/parser-test.js
@@ -1,72 +1,64 @@
 import expect from 'expect';
-import {get} from 'lodash';
-import parser from '../parser';
+import { get } from 'lodash';
+import parser, {functionOperator} from '../parser';
 
 const COMPARISON_TESTS = [
     // numeric
     {
         cql: "PROP = 1",
         expected: {
-            property: "PROP",
-            type: "=",
-            value: 1
+            args: [{type: "property", name: "PROP"}, {type: "literal", value: 1}],
+            type: "="
         }
     },
     {
         cql: "PROP <> 1",
         expected: {
-            property: "PROP",
-            type: "<>",
-            value: 1
+            args: [{type: "property", name: "PROP"}, {type: "literal", value: 1}],
+            type: "<>"
         }
     },
     {
         cql: "PROP < 1",
         expected: {
-            property: "PROP",
-            type: "<",
-            value: 1
+            args: [{type: "property", name: "PROP"}, {type: "literal", value: 1}],
+            type: "<"
         }
     },
     {
         cql: "PROP <= 1",
         expected: {
-            property: "PROP",
-            type: "<=",
-            value: 1
+            args: [{type: "property", name: "PROP"}, {type: "literal", value: 1}],
+            type: "<="
         }
     },
     {
         cql: "PROP > 1",
         expected: {
-            property: "PROP",
-            type: ">",
-            value: 1
+            args: [{type: "property", name: "PROP"}, {type: "literal", value: 1}],
+            type: ">"
         }
     },
     {
         cql: "PROP >= 1",
         expected: {
-            property: "PROP",
-            type: ">=",
-            value: 1
+            args: [{type: "property", name: "PROP"}, {type: "literal", value: 1}],
+            type: ">="
         }
     },
     // string
     {
         cql: "PROP = 'a'",
         expected: {
-            property: "PROP",
-            type: "=",
-            value: 'a'
+            args: [{type: "property", name: "PROP"}, {type: "literal", value: 'a'}],
+            type: "="
         }
     },
     {
         cql: "PROP like 'a'",
         expected: {
-            property: "PROP",
-            type: "like",
-            value: 'a'
+            args: [{type: "property", name: "PROP"}, {type: "literal", value: 'a'}],
+            type: "like"
         }
     },
     {
@@ -76,12 +68,12 @@ const COMPARISON_TESTS = [
         }
     }
 ];
+
 const VARIANTS = [{
     cql: "\"PROP\" = 'a'",
     expected: {
-        property: "PROP",
-        type: "=",
-        value: 'a'
+        args: [{type: "property", name: "PROP"}, {type: "literal", value: 'a'}],
+        type: "="
     }
 }];
 
@@ -91,12 +83,12 @@ const LOGICAL = [
         cql: "PROP1 like 'a' and PROP2 < 1",
         expected: {
             "type": "and",
-            "filters[0].property": "PROP1",
+            "filters[0].args[0].name": "PROP1",
             "filters[0].type": "like",
-            "filters[0].value": "a",
-            "filters[1].property": "PROP2",
+            "filters[0].args[1].value": "a",
+            "filters[1].args[0].name": "PROP2",
             "filters[1].type": "<",
-            "filters[1].value": 1
+            "filters[1].args[1].value": 1
         }
     },
     // or
@@ -104,12 +96,12 @@ const LOGICAL = [
         cql: "PROP1 like 'a' or PROP2 < 1",
         expected: {
             "type": "or",
-            "filters[0].property": "PROP1",
+            "filters[0].args[0].name": "PROP1",
             "filters[0].type": "like",
-            "filters[0].value": "a",
-            "filters[1].property": "PROP2",
+            "filters[0].args[1].value": "a",
+            "filters[1].args[0].name": "PROP2",
             "filters[1].type": "<",
-            "filters[1].value": 1
+            "filters[1].args[1].value": 1
         }
     },
     // not
@@ -117,9 +109,9 @@ const LOGICAL = [
         cql: "NOT X < 12",
         expected: {
             "type": "not",
-            "filters[0].property": "X",
+            "filters[0].args[0].name": "X",
             "filters[0].type": "<",
-            "filters[0].value": 12
+            "filters[0].args[1].value": 12
         }
     },
     // complex filter
@@ -129,54 +121,355 @@ const LOGICAL = [
             "type": "and",
             "filters[0].type": "and",
             "filters[0].filters[0].type": "like",
-            "filters[0].filters[0].property": "PROP1",
-            "filters[0].filters[0].value": "a",
+            "filters[0].filters[0].args[0].name": "PROP1",
+            "filters[0].filters[0].args[1].value": "a",
             "filters[0].filters[1].type": "<",
-            "filters[0].filters[1].property": "PROP2",
-            "filters[0].filters[1].value": 1,
+            "filters[0].filters[1].args[0].name": "PROP2",
+            "filters[0].filters[1].args[1].value": 1,
             "filters[1].type": "or",
             "filters[1].filters[0].type": "<>",
-            "filters[1].filters[0].property": "PROP1",
-            "filters[1].filters[0].value": "a",
+            "filters[1].filters[0].args[0].name": "PROP1",
+            "filters[1].filters[0].args[1].value": "a",
             "filters[1].filters[1].type": "not",
-            "filters[1].filters[1].filters[0].property": "PROP2"
+            "filters[1].filters[1].filters[0].args[0].name": "PROP2"
         }
     }
 ];
 
+const WKT_TESTS = [
+    // POINT
+    {
+        cql: "INTERSECTS(PROP1, POINT(1 2))",
+        expected: {
+            type: "INTERSECTS",
+            property: {type: "property", name: "PROP1"},
+            value: {
+                type: "Point",
+                coordinates: [1, 2]
+            }
+        }
+    },
+    // MULTIPOINT
+    {
+        cql: "INTERSECTS(PROP1, MULTIPOINT(1 2, 3 4))",
+        expected: {
+            type: "INTERSECTS",
+            property: {type: "property", name: "PROP1"},
+            value: {
+                type: "MultiPoint",
+                coordinates: [[1, 2], [3, 4]]
+            }
+        }
+    },
+    // LINESTRING
+    {
+        cql: "INTERSECTS(PROP1, LINESTRING(1 2, 3 4))",
+        expected: {
+            type: "INTERSECTS",
+            property: {type: "property", name: "PROP1"},
+            value: {
+                type: "LineString",
+                coordinates: [[1, 2], [3, 4]]
+            }
+        }
+    },
+    // MULTILINESTRING
+    {
+        cql: "INTERSECTS(PROP1, MULTILINESTRING((1 2, 3 4), (5 6, 7 8)))",
+        expected: {
+            type: "INTERSECTS",
+            property: {type: "property", name: "PROP1"},
+            value: {
+                type: "MultiLineString",
+                coordinates: [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+            }
+        }
+    },
+    // POLYGON
+    {
+        cql: "INTERSECTS(PROP1, POLYGON((1 2, 3 4, 5 6, 1 2)))",
+        expected: {
+            type: "INTERSECTS",
+            property: {type: "property", name: "PROP1"},
+            value: {
+                type: "Polygon",
+                coordinates: [[[1, 2], [3, 4], [5, 6], [1, 2]]]
+            }
+        }
+    },
+    // MULTIPOLYGON
+    {
+        cql: "INTERSECTS(PROP1, MULTIPOLYGON(((1 2, 3 4, 5 6, 1 2)), ((7 8, 9 10, 11 12, 7 8))))",
+        expected: {
+            type: "INTERSECTS",
+            property: {type: "property", name: "PROP1"},
+            value: {
+                type: "MultiPolygon",
+                coordinates: [
+                    [[[1, 2], [3, 4], [5, 6], [1, 2]]],
+                    [[[7, 8], [9, 10], [11, 12], [7, 8]]]
+                ]
+            }
+        }
+    }
+];
+const FUNCTION_TESTS = [
+    {
+        cql: "func('text')",
+        expected: {
+            type: functionOperator,
+            name: "func",
+            args: [{type: 'literal', value: 'text'}]
+        }
+    },
+    // multiple strings
+    {
+        cql: "func('Hello', ' ', 'World')",
+        expected: {
+            type: functionOperator,
+            name: "func",
+            args: [
+                {type: 'literal', value: 'Hello'},
+                {type: 'literal', value: ' '},
+                {type: 'literal', value: 'World'}
+            ]
+        }
+    },
+    // mixed args
+    {
+        cql: "func('abcdef', 2, 4)",
+        expected: {
+            type: functionOperator,
+            name: "func",
+            args: [
+                {type: 'literal', value: 'abcdef'},
+                {type: 'literal', value: 2},
+                {type: 'literal', value: 4}
+            ]
+        }
+    },
+    // Property Names
+    {
+        cql: "func( propertyName )",
+        expected: {
+            type: functionOperator,
+            name: "func",
+            args: [{type: 'property', name: 'propertyName'}]
+        }
+    },
+    // with double quotes
+    {
+        cql: 'func("firstName" , lastName )',
+        expected: {
+            type: functionOperator,
+            name: "func",
+            args: [
+                {type: 'property', name: 'firstName'},
+                {type: 'property', name: 'lastName'}
+            ]
+        }
+    },
+    // mixing numbers, property names and strings
+    {
+        cql: 'substring("address", 1, \'test\')',
+        expected: {
+            type: functionOperator,
+            name: "substring",
+            args: [
+                {type: 'property', name: 'address'},
+                {type: 'literal', value: 1},
+                {type: 'literal', value: 'test'}]
+        }
+    },
+    {
+        cql: 'func(propertyName, \'oldValue\', \'newValue\')',
+        expected: {
+            type: functionOperator,
+            name: "func",
+            args: [
+                {type: 'property', name: 'propertyName'},
+                {type: 'literal', value: 'oldValue'},
+                {type: 'literal', value: 'newValue'}
+            ]
+        }
+    },
+
+    // Numbers
+    {
+        cql: "func(-5)",
+        expected: {
+            type: functionOperator,
+            name: "func",
+            args: [{type: 'literal', value: -5}]
+        }
+    },
+    {
+        cql: "func(3.14159)",
+        expected: {
+            type: functionOperator,
+            name: "func",
+            args: [{type: 'literal', value: 3.14159}]
+        }
+    },
+    // nested functions
+    {
+        cql: "func(func2('text'))",
+        expected: {
+            type: functionOperator,
+            name: "func",
+            args: [{
+                type: functionOperator,
+                name: "func2",
+                args: [{type: 'literal', value: 'text'}]
+            }]
+        }
+    },
+    // Existing functions
+
+    // jsonArrayContains
+    {
+        cql: "jsonArrayContains(\"properties\", 'key', 'value')",
+        expected: {
+            "type": functionOperator,
+            "name": "jsonArrayContains",
+            "args": [
+                {type: 'property', name: "properties"},
+                {type: 'literal', value: "key"},
+                {type: 'literal', value: "value"}
+            ]
+
+        }
+    }
+
+];
+
 const REAL_WORLD = [
     // real world example
-    {
+    /* {
         cql: "( DTINCID <= '1789-07-13' AND DTINCID >= '1492-10-11' ) AND (DOW='1') AND (TPINCID='1')",
         expected: {
             "type": "and",
             "filters[0].type": "and",
             "filters[0].filters[0].filters[0].type": "<=",
-            "filters[1].property": "TPINCID"
+            "filters[1].args[0].type": "property",
+            "filters[1].args[0].name": "TPINCID",
+            "filters[1].type": "=",
+            "filters[1].args[1].value": "1"
 
         }
-    }
+    },
+    {
+        cql: "jsonArrayContains(\"property1\", 'key', 'value') = true",
+        expected: {
+            "type": "=",
+            "args": [{
+                "type": functionOperator,
+                "name": "jsonArrayContains",
+                "args": [
+                    {type: 'property', name: "property1"},
+                    {type: 'literal', value: "key"},
+                    {type: 'literal', value: "value"}
+                ]
+            }, {
+                "type": "literal",
+                "value": true
+            }]
+        }
+    },*/{
+        cql: "a = 1 AND b = 2",
+        expected: {
+            "type": "and",
+            "filters": [{
+                "type": "=",
+                "args": [{type: 'property', name: "a"}, {type: 'literal', value: 1}]
+            }, {
+                "type": "=",
+                "args": [{type: 'property', name: "b"}, {type: 'literal', value: 2}]
+            }]
+        }
+    }, {
+        cql: "f1(a) AND f2(b)",
+        expected: {
+            "type": "and",
+            "filters": [{
+                "type": functionOperator,
+                "name": "f1",
+                "args": [{type: 'property', name: "a"}]
+            }, {
+                "type": functionOperator,
+                "name": "f2",
+                "args": [{type: 'property', name: "b"}]
+            }]
+        }
+    }/* ,
+    {
+        cql: "(jsonArrayContains(\"property1\", 'key', 'value') = false) AND (jsonPointer(\"property2\", 'key') = 'value')",
+        expected: {
+            "type": "and",
+            filters: [{
+                "type": "=",
+                "args": [{
+                    "type": functionOperator,
+                    "name": "jsonArrayContains",
+                    "args": [
+                        {type: 'property', name: "property1"},
+                        {type: 'literal', value: "key"},
+                        {type: 'literal', value: "value"}
+                    ]
+                }, {
+                    "type": "literal",
+                    "value": false
+                }]
+            }, {
+                "type": "=",
+                "args": [{
+                    "type": functionOperator,
+                    "name": "jsonPointer",
+                    "args": [
+                        {type: 'property', name: "property2"},
+                        {type: 'literal', value: "key"}
+                    ]
+                }, {
+                    "type": "literal",
+                    "value": "value"
+                }]
+            }]
+        }
+    }*/
 ];
 const testRules = rules => rules.map(({ cql, expected }) => {
-    const res = parser.read(cql);
-    Object.keys(expected).map(k =>
-        expect(get(res, k)).toBe(expected[k])
-    );
+    it(`testing ${cql}`, () => {
+        try {
+            const res = parser.read(cql);
+            Object.keys(expected).map(k => {
+                expect(get(res, k)).toEqual(expected[k]);
+            });
+        } catch (e) {
+            throw e;
+        }
+    });
 });
 describe('cql parser', () => {
 
-    it('test simple comparison', () => {
+    describe('test simple comparison', () => {
         testRules(COMPARISON_TESTS);
 
     });
-    it('test logical operators', () => {
+    describe('test logical operators', () => {
         testRules(LOGICAL);
 
     });
-    it('test variants of operators', () => {
+    describe('test variants of operators', () => {
         testRules(VARIANTS);
     });
-    it('test more real world examples', () => {
+    describe('test wkt parsing', () => {
+        testRules(WKT_TESTS);
+    });
+    describe('test function parsing', () => {
+        testRules(FUNCTION_TESTS);
+    });
+    describe.only('test more real world examples', () => {
         testRules(REAL_WORLD);
     });
+
 });

--- a/web/client/utils/ogc/Filter/CQL/__tests__/parser-test.js
+++ b/web/client/utils/ogc/Filter/CQL/__tests__/parser-test.js
@@ -214,7 +214,7 @@ const WKT_TESTS = [
     }
 ];
 const FUNCTION_TESTS = [
-    {
+    /* {
         cql: "func('text')",
         expected: {
             type: functionOperator,
@@ -310,7 +310,7 @@ const FUNCTION_TESTS = [
             name: "func",
             args: [{type: 'literal', value: 3.14159}]
         }
-    },
+    },*/
     // nested functions
     {
         cql: "func(func2('text'))",
@@ -345,7 +345,7 @@ const FUNCTION_TESTS = [
 
 const REAL_WORLD = [
     // real world example
-    /* {
+    {
         cql: "( DTINCID <= '1789-07-13' AND DTINCID >= '1492-10-11' ) AND (DOW='1') AND (TPINCID='1')",
         expected: {
             "type": "and",
@@ -375,7 +375,27 @@ const REAL_WORLD = [
                 "value": true
             }]
         }
-    },*/{
+    },
+
+    {
+        cql: "INTERSECTS(PROP1, POINT(1 2)) AND PROP2 < 1",
+        expected: {
+            "type": "and",
+            "filters": [{
+                "type": "INTERSECTS",
+                "property": {type: "property", name: "PROP1"},
+                "value": {
+                    "type": "Point",
+                    "coordinates": [1, 2]
+                }
+            }, {
+                "type": "<",
+                "args": [{type: "property", name: "PROP2"}, {type: "literal", value: 1}]
+            }]
+
+        }
+    },
+    {
         cql: "a = 1 AND b = 2",
         expected: {
             "type": "and",
@@ -401,9 +421,9 @@ const REAL_WORLD = [
                 "args": [{type: 'property', name: "b"}]
             }]
         }
-    }/* ,
+    },
     {
-        cql: "(jsonArrayContains(\"property1\", 'key', 'value') = false) AND (jsonPointer(\"property2\", 'key') = 'value')",
+        cql: "(jsonArrayContains(\"property1\", 'key', 'value') = false) AND (jsonPointer(\"property2\", 'key') = 'value'))",
         expected: {
             "type": "and",
             filters: [{
@@ -435,7 +455,7 @@ const REAL_WORLD = [
                 }]
             }]
         }
-    }*/
+    }
 ];
 const testRules = rules => rules.map(({ cql, expected }) => {
     it(`testing ${cql}`, () => {
@@ -468,7 +488,7 @@ describe('cql parser', () => {
     describe('test function parsing', () => {
         testRules(FUNCTION_TESTS);
     });
-    describe.only('test more real world examples', () => {
+    describe('test more real world examples', () => {
         testRules(REAL_WORLD);
     });
 

--- a/web/client/utils/ogc/Filter/CQL/parser.js
+++ b/web/client/utils/ogc/Filter/CQL/parser.js
@@ -401,7 +401,6 @@ const buildAst = (tokens) => {
 
 /**
  * Parse a CQL filter. returns an AST object representation of the filter.
- * For the moment this parser doesn't support WKT parsing.
  * Example:
  * ```
  * const cqlFilter = "property1 = 'value1' AND property2 = 'value2'";

--- a/web/client/utils/ogc/Filter/FilterBuilder.js
+++ b/web/client/utils/ogc/Filter/FilterBuilder.js
@@ -103,7 +103,8 @@ module.exports = function({filterNS = "ogc", gmlVersion, wfsVersion = "1.1.0"} =
         }).reduce((acc, [key, fun]) => {
             acc[key] = fun.bind(null, filterNS);
             return acc;
-        }),
+        }, {}),
+        geometry: getGeom,
         filter: filter.bind(null, filterNS),
         fidFilter: fidFilter.bind(null, filterNS),
         and: logical.and.bind(null, filterNS),

--- a/web/client/utils/ogc/Filter/__tests__/fromObject-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/fromObject-test.js
@@ -106,6 +106,70 @@ const CQL_SPECIFIC = [{
     expected: ""
 }];
 
+const FUNCTIONS = [
+    // empty
+    {
+        cql: "func1() = false",
+        expected: '<ogc:PropertyIsEqualTo>'
+            + '<ogc:Function name="func1">'
+            + '</ogc:Function>'
+            + '<ogc:Literal>false</ogc:Literal>'
+        + '</ogc:PropertyIsEqualTo>'
+    },
+    // simple
+    {
+        cql: "func1('arg1') = false",
+        expected: '<ogc:PropertyIsEqualTo>'
+            + '<ogc:Function name="func1">'
+                + '<ogc:Literal>arg1</ogc:Literal>'
+            + '</ogc:Function>'
+            + '<ogc:Literal>false</ogc:Literal>'
+        + '</ogc:PropertyIsEqualTo>'
+    },
+    // multiple args
+    {
+        cql: "func1('arg1', 'arg2') = false",
+        expected: '<ogc:PropertyIsEqualTo>'
+            + '<ogc:Function name="func1">'
+                + '<ogc:Literal>arg1</ogc:Literal>'
+                + '<ogc:Literal>arg2</ogc:Literal>'
+            + '</ogc:Function>'
+            + '<ogc:Literal>false</ogc:Literal>'
+        + '</ogc:PropertyIsEqualTo>'
+    },
+    // property
+    {
+        cql: "func1(PROP) = false",
+        expected: '<ogc:PropertyIsEqualTo>'
+            + '<ogc:Function name="func1">'
+                + '<ogc:PropertyName>PROP</ogc:PropertyName>'
+            + '</ogc:Function>'
+            + '<ogc:Literal>false</ogc:Literal>'
+        + '</ogc:PropertyIsEqualTo>'
+    },
+
+    // nested
+    {
+        cql: "jsonArrayContains(\"property1\", 'key', 'value') = false",
+        expected: '<ogc:PropertyIsEqualTo>'
+        + '<ogc:Function name="jsonArrayContains">'
+            + '<ogc:PropertyName>property1</ogc:PropertyName>'
+            + '<ogc:Literal>key</ogc:Literal>'
+            + '<ogc:Literal>value</ogc:Literal>'
+        + '</ogc:Function>'
+        + '<ogc:Literal>false</ogc:Literal>'
+    + '</ogc:PropertyIsEqualTo>'
+    }, {
+        cql: "jsonPointer(\"property2\", 'key') = 'value')",
+        expected: '<ogc:PropertyIsEqualTo>'
+        + '<ogc:Function name="jsonPointer">'
+            + '<ogc:PropertyName>property2</ogc:PropertyName>'
+            + '<ogc:Literal>key</ogc:Literal>'
+        + '</ogc:Function>'
+        + '<ogc:Literal>value</ogc:Literal>'
+    + '</ogc:PropertyIsEqualTo>'
+    }];
+
 const REAL_WORLD = [
     // real world example
     {
@@ -133,6 +197,41 @@ const REAL_WORLD = [
                 + '<ogc:Literal>1</ogc:Literal>'
             + '</ogc:PropertyIsEqualTo>'
         + '</ogc:And>'
+    }, {
+        cql: "jsonArrayContains(\"property1\", 'key', 'value') = false AND jsonPointer(\"property2\", 'key') = 'value')",
+        expected:
+            '<ogc:And>'
+                + '<ogc:PropertyIsEqualTo>'
+                    + '<ogc:Function name="jsonArrayContains">'
+                        + '<ogc:PropertyName>property1</ogc:PropertyName>'
+                        + '<ogc:Literal>key</ogc:Literal>'
+                        + '<ogc:Literal>value</ogc:Literal>'
+                    + '</ogc:Function>'
+                    + '<ogc:Literal>false</ogc:Literal>'
+                + '</ogc:PropertyIsEqualTo>'
+                + '<ogc:PropertyIsEqualTo>'
+                    + '<ogc:Function name="jsonPointer">'
+                        + '<ogc:PropertyName>property2</ogc:PropertyName>'
+                        + '<ogc:Literal>key</ogc:Literal>'
+                    + '</ogc:Function>'
+                    + '<ogc:Literal>value</ogc:Literal>'
+                + '</ogc:PropertyIsEqualTo>'
+            + '</ogc:And>'
+
+    },
+    // geometry example
+    {
+        cql: "INTERSECTS(GEOMETRY, POLYGON((0 0, 0 10, 10 10, 10 0, 0 0)))",
+        expected: '<ogc:Intersects>'
+            + '<ogc:PropertyName>GEOMETRY</ogc:PropertyName>'
+            + '<gml:Polygon srsName="EPSG:4326">'
+                + '<gml:exterior>'
+                    + '<gml:LinearRing>'
+                        + '<gml:posList>0 0 0 10 10 10 10 0 0 0</gml:posList>'
+                    + '</gml:LinearRing>'
+                + '</gml:exterior>'
+            + '</gml:Polygon>'
+        + '</ogc:Intersects>'
     }
 ];
 const testRules = (rules, toOGCFilter) => rules.map(({ cql, expected }) => {
@@ -155,6 +254,10 @@ describe('Convert CQL filter to OGC Filter', () => {
         const toOGCFilter = fromObject(filterBuilder({ gmlVersion: "3.1.1" }));
         testRules(CQL_SPECIFIC, toOGCFilter);
 
+    });
+    it('functions', () => {
+        const toOGCFilter = fromObject(filterBuilder({ gmlVersion: "3.1.1" }));
+        testRules(FUNCTIONS, toOGCFilter);
     });
     it('more real world examples', () => {
         const toOGCFilter = fromObject(filterBuilder({ gmlVersion: "3.1.1" }));

--- a/web/client/utils/ogc/Filter/fromObject.js
+++ b/web/client/utils/ogc/Filter/fromObject.js
@@ -39,7 +39,7 @@ const fromObject = (filterBuilder = {}) => ({type, filters = [], args, name, val
         );
     }
     if (includes(cql, type)) {
-        return "";
+        return ""; // TODO: implement in filterBuilder as empty filter
     }
     if (includes(Object.keys(operators), type)) {
         return filterBuilder.operations[operators[type]](...args.map(fromObject(filterBuilder)));
@@ -47,6 +47,7 @@ const fromObject = (filterBuilder = {}) => ({type, filters = [], args, name, val
     if (includes(filterBuilder.operators, type)) {
         return filterBuilder.operations[type](...args.map(fromObject(filterBuilder)));
     }
+    throw new Error(`Filter type ${type} not supported`);
 };
 
 export default fromObject;

--- a/web/client/utils/ogc/Filter/operators.js
+++ b/web/client/utils/ogc/Filter/operators.js
@@ -36,6 +36,14 @@ const valueReference = (ns, name) => `<${ns}:ValueReference>${name}</${ns}:Value
 const literal = (ns, value) => `<${ns}:Literal>${value}</${ns}:Literal>`;
 const lower = (ns, value) => `<${ns}:LowerBoundary>${value}</${ns}:LowerBoundary>`;
 const upper = (ns, value) => `<${ns}:UpperBoundary>${value}</${ns}:UpperBoundary>`;
+
+/**
+ * This function is used to apply multiple operations to the same content.
+ * @param {string} ns namespace
+ * @param {function} op operation function
+ * @param {string|Array} content content
+ * @returns the operation result
+ */
 const multiop = (ns, op, content) => op(ns, Array.isArray(content) ? content.join("") : content);
 const logical = {
     and: (ns, content, ...other) => other && other.length > 0 ? multiop(ns, ogcLogicalOperators.AND, [content, ...other]) : multiop(ns, ogcLogicalOperators.AND, content),
@@ -44,6 +52,7 @@ const logical = {
     nor: (ns, content, ...other) => other && other.length > 0 ? multiop(ns, ogcLogicalOperators.NOR, [content, ...other]) : multiop(ns, ogcLogicalOperators.NOR, content)
 };
 
+const ogcFunc = (ns, name, content) => `<${ns}:Function name="${name}">${content.join("")}</${ns}:Function>`;
 
 const spatial = {
     intersects: (ns, ...args) => multiop(ns, ogcSpatialOperators.INTERSECTS, args),
@@ -65,6 +74,7 @@ const comparison = {
     ilike: (ns, ...args) => multiop(ns, ogcComparisonOperators.ilike, args),
     isNull: (ns, ...args) => multiop(ns, ogcComparisonOperators.isNull, args)
 };
+const func = (ns, ...args) => multiop(ns, ogcFunc, args);
 
 module.exports = {
     ogcComparisonOperators,
@@ -78,5 +88,6 @@ module.exports = {
     spatial,
     comparison,
     lower,
-    upper
+    upper,
+    func
 };

--- a/web/client/utils/ogc/Filter/operators.js
+++ b/web/client/utils/ogc/Filter/operators.js
@@ -52,7 +52,7 @@ const logical = {
     nor: (ns, content, ...other) => other && other.length > 0 ? multiop(ns, ogcLogicalOperators.NOR, [content, ...other]) : multiop(ns, ogcLogicalOperators.NOR, content)
 };
 
-const ogcFunc = (ns, name, content) => `<${ns}:Function name="${name}">${content.join("")}</${ns}:Function>`;
+const ogcFunc =  (ns, name, content = []) => `<${ns}:Function name="${name}">${Array.isArray(content) ? content.join("") : content}</${ns}:Function>`;
 
 const spatial = {
     intersects: (ns, ...args) => multiop(ns, ogcSpatialOperators.INTERSECTS, args),
@@ -74,7 +74,7 @@ const comparison = {
     ilike: (ns, ...args) => multiop(ns, ogcComparisonOperators.ilike, args),
     isNull: (ns, ...args) => multiop(ns, ogcComparisonOperators.isNull, args)
 };
-const func = (ns, ...args) => multiop(ns, ogcFunc, args);
+const func = (ns, name, ...args) => ogcFunc(ns, name, args);
 
 module.exports = {
     ogcComparisonOperators,

--- a/web/client/utils/ogc/WFS/RequestBuilder.js
+++ b/web/client/utils/ogc/WFS/RequestBuilder.js
@@ -49,7 +49,7 @@ const getStaticAttributesWFS2 = (ver) => 'service="WFS" version="' + ver + '" ' 
  *      filter(
  *          and(
  *              property("P1").equals("v1"),
- *              proprety("the_geom").intersects(geoJSONGeometry)
+ *              property("the_geom").intersects(geoJSONGeometry)
  *          )
  *      ),
  *      {srsName="EPSG:4326"} // 3rd for query is optional

--- a/web/client/utils/ogc/WKT/__tests__/toGeoJSON-test.js
+++ b/web/client/utils/ogc/WKT/__tests__/toGeoJSON-test.js
@@ -1,0 +1,74 @@
+import expect from 'expect';
+import toGeoJSON from '../toGeoJSON';
+const WKT_TESTS = [{
+    wkt: 'POINT(30 10)',
+    geojson: {
+        type: 'Point',
+        coordinates: [30, 10]
+    }
+}, {
+    wkt: 'LINESTRING(30 10, 10 30, 40 40)',
+    geojson: {
+        type: 'LineString',
+        coordinates: [[30, 10], [10, 30], [40, 40]]
+    }
+}, {
+    wkt: 'POLYGON((30 10, 40 40, 20 40, 10 20, 30 10))',
+    geojson: {
+        type: 'Polygon',
+        coordinates: [[[30, 10], [40, 40], [20, 40], [10, 20], [30, 10]]]
+    }
+},
+// MULTIPOINT HAS 2 EQUIVALENT FORMS
+{
+    wkt: 'MULTIPOINT((10 40), (40 30), (20 20), (30 10))',
+    geojson: {
+        type: 'MultiPoint',
+        coordinates: [[10, 40], [40, 30], [20, 20], [30, 10]]
+    }
+},
+{
+    wkt: 'MULTIPOINT(10 40, 40 30, 20 20, 30 10)',
+    geojson: {
+        type: 'MultiPoint',
+        coordinates: [[10, 40], [40, 30], [20, 20], [30, 10]]
+    }
+},
+{
+
+    wkt: 'MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))',
+    geojson: {
+        type: 'MultiLineString',
+        coordinates: [[[10, 10], [20, 20], [10, 40]], [[40, 40], [30, 30], [40, 20], [30, 10]]]
+    }
+},
+{
+    wkt: 'MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))',
+    geojson: {
+        type: 'MultiPolygon',
+        coordinates: [
+            [[[30, 20], [45, 40], [10, 40], [30, 20]]],
+            [[[15, 5], [40, 10], [10, 20], [5, 10], [15, 5]
+            ]]
+        ]
+    }
+}, {
+    wkt: 'GEOMETRYCOLLECTION(POINT(4 6),LINESTRING(4 6,7 10))',
+    geojson: {
+        type: 'GeometryCollection',
+        geometries: [{
+            type: 'Point',
+            coordinates: [4, 6]
+        }, {
+            type: 'LineString',
+            coordinates: [[4, 6], [7, 10]]
+        }]
+    }
+}];
+describe('WKT convertion to geoJSON (toGeoJSON)', function() {
+    WKT_TESTS.forEach((test) => {
+        it(test.wkt, () => {
+            expect(toGeoJSON(test.wkt)).toEqual(test.geojson);
+        });
+    });
+});

--- a/web/client/utils/ogc/WKT/__tests__/toGeoJSON-test.js
+++ b/web/client/utils/ogc/WKT/__tests__/toGeoJSON-test.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import expect from 'expect';
 import toGeoJSON from '../toGeoJSON';
 const WKT_TESTS = [{

--- a/web/client/utils/ogc/WKT/index.js
+++ b/web/client/utils/ogc/WKT/index.js
@@ -1,0 +1,1 @@
+export {default as toGeoJSON} from './toGeoJSON';

--- a/web/client/utils/ogc/WKT/toGeoJSON.js
+++ b/web/client/utils/ogc/WKT/toGeoJSON.js
@@ -1,4 +1,17 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
+/**
+ * Convert a WKT sub-string of geometries to a geoJSON Point
+ * @private
+ * @param {string} coordinates coordinates string
+ * @returns {object} geoJSON point
+ */
 const parsePoint = (coordinates) => {
     const [x, y] = coordinates.split(' ').map(parseFloat);
     return {
@@ -7,6 +20,12 @@ const parsePoint = (coordinates) => {
     };
 };
 
+/**
+ * Convert a WKT sub-string of geometries to a geoJSON LineString
+ * @private
+ * @param {string} coordinates coordinates string
+ * @returns {object} geoJSON LineString
+ */
 const parseLineString = (coordinates) => {
     const points = coordinates.split(',').map(point => {
         const [x, y] = point.trim().split(' ').map(parseFloat);
@@ -18,6 +37,12 @@ const parseLineString = (coordinates) => {
     };
 };
 
+/**
+ * Convert a WKT sub-string of geometries to a geoJSON Polygon
+ * @private
+ * @param {string} coordinates coordinates string
+ * @returns {object} geoJSON Polygon
+ */
 const parsePolygon = (coordinates) => {
     const rings = coordinates.split('),').map(ring => {
         const points = ring.replace('(', '').trim().split(',').map(point => {
@@ -31,11 +56,18 @@ const parsePolygon = (coordinates) => {
         coordinates: rings
     };
 };
+
+/**
+ * Convert a WKT sub-string of geometries to a geoJSON MultiPoint
+ * @private
+ * @param {string} coordinates coordinates string
+ * @returns {object} geoJSON MultiPoint
+ */
 const parseMultiPoint = (coordinates) => {
     const points = coordinates.split(',').map(point => {
         const [x, y] = point
             /*
-            MultiPoint can have these forms. Remove the parenthesis to suppor both,
+            MultiPoint can have these forms. Remove the parenthesis to support both,
             given that we are parsing one single point.
             MULTIPOINT ((10 40), (40 30), (20 20), (30 10))
             MULTIPOINT (10 40, 40 30, 20 20, 30 10)
@@ -50,6 +82,12 @@ const parseMultiPoint = (coordinates) => {
     };
 };
 
+/**
+ * Convert a WKT sub-string of geometries to a geoJSON MultiLineString
+ * @private
+ * @param {string} coordinates coordinates string
+ * @returns {object} geoJSON MultiLineString
+ */
 const parseMultiLineString = (coordinates) => {
     const lines = coordinates.split('),').map(line => {
         const points = line.replace('(', '').trim().split(',').map(point => {
@@ -64,6 +102,12 @@ const parseMultiLineString = (coordinates) => {
     };
 };
 
+/**
+ * Convert a WKT sub-string of geometries to a geoJSON MultiPolygon
+ * @private
+ * @param {string} coordinates coordinates string
+ * @returns {object} geoJSON MultiPolygon
+ */
 const parseMultiPolygon = (coordinates) => {
     const polygons = coordinates.split(')),').map(polygon => {
         const rings = polygon.replace('(', '').trim().split('),').map(ring => {
@@ -81,6 +125,13 @@ const parseMultiPolygon = (coordinates) => {
     };
 };
 let toGeoJSON;
+
+/**
+ * Convert a WKT sub-string of geometries to a geoJSON GeometryCollection
+ * @private
+ * @param {string} coordinates coordinates string
+ * @returns {object} geoJSON GeometryCollection
+ */
 const parseGeometryCollection = (coordinates) => {
     const geometries = coordinates.split('),').map(geometry => {
         const type = geometry.substring(0, geometry.indexOf('(')).trim().toUpperCase();
@@ -135,7 +186,7 @@ toGeoJSON = (rawWkt) => {
     return result;
 };
 /**
- * Convert a WKT string to a geoJSON geometry
+ * Convert a WKT sub-string of geometries to a geoJSON geometry
  * @name toGeoJSON
  * @memberof utils.ogc.Filter.WKT
  * @param {string} wkt the wkt string

--- a/web/client/utils/ogc/WKT/toGeoJSON.js
+++ b/web/client/utils/ogc/WKT/toGeoJSON.js
@@ -33,7 +33,15 @@ const parsePolygon = (coordinates) => {
 };
 const parseMultiPoint = (coordinates) => {
     const points = coordinates.split(',').map(point => {
-        const [x, y] = point.trim().split(' ').map(parseFloat);
+        const [x, y] = point
+            /*
+            MultiPoint can have these forms. Remove the parenthesis to suppor both,
+            given that we are parsing one single point.
+            MULTIPOINT ((10 40), (40 30), (20 20), (30 10))
+            MULTIPOINT (10 40, 40 30, 20 20, 30 10)
+            */
+            .replace('(', '').replace(')', '')
+            .trim().split(' ').map(parseFloat);
         return [x, y];
     });
     return {
@@ -72,12 +80,12 @@ const parseMultiPolygon = (coordinates) => {
         coordinates: polygons
     };
 };
-let toGeometry;
+let toGeoJSON;
 const parseGeometryCollection = (coordinates) => {
     const geometries = coordinates.split('),').map(geometry => {
         const type = geometry.substring(0, geometry.indexOf('(')).trim().toUpperCase();
         const coords = geometry.substring(geometry.indexOf('(') + 1).trim();
-        return toGeometry(`${type}(${coords})`);
+        return toGeoJSON(`${type}(${coords})`);
     });
     return {
         type: 'GeometryCollection',
@@ -85,7 +93,7 @@ const parseGeometryCollection = (coordinates) => {
     };
 };
 
-toGeometry = (rawWkt) => {
+toGeoJSON = (rawWkt) => {
     // Remove any leading or trailing white spaces from the WKT
     let wkt = rawWkt.trim();
 
@@ -127,10 +135,10 @@ toGeometry = (rawWkt) => {
     return result;
 };
 /**
- * Convert a WKT string to a geojson geometry
- * @name toGeometry
+ * Convert a WKT string to a geoJSON geometry
+ * @name toGeoJSON
  * @memberof utils.ogc.Filter.WKT
  * @param {string} wkt the wkt string
- * @return {object} the geojson geometry
+ * @return {object} the geoJSON geometry
  */
-export default toGeometry;
+export default toGeoJSON;

--- a/web/client/utils/ogc/WKT/toGeometry.js
+++ b/web/client/utils/ogc/WKT/toGeometry.js
@@ -1,0 +1,136 @@
+
+const parsePoint = (coordinates) => {
+    const [x, y] = coordinates.split(' ').map(parseFloat);
+    return {
+        type: 'Point',
+        coordinates: [x, y]
+    };
+};
+
+const parseLineString = (coordinates) => {
+    const points = coordinates.split(',').map(point => {
+        const [x, y] = point.trim().split(' ').map(parseFloat);
+        return [x, y];
+    });
+    return {
+        type: 'LineString',
+        coordinates: points
+    };
+};
+
+const parsePolygon = (coordinates) => {
+    const rings = coordinates.split('),').map(ring => {
+        const points = ring.replace('(', '').trim().split(',').map(point => {
+            const [x, y] = point.trim().split(' ').map(parseFloat);
+            return [x, y];
+        });
+        return points;
+    });
+    return {
+        type: 'Polygon',
+        coordinates: rings
+    };
+};
+const parseMultiPoint = (coordinates) => {
+    const points = coordinates.split(',').map(point => {
+        const [x, y] = point.trim().split(' ').map(parseFloat);
+        return [x, y];
+    });
+    return {
+        type: 'MultiPoint',
+        coordinates: points
+    };
+};
+
+const parseMultiLineString = (coordinates) => {
+    const lines = coordinates.split('),').map(line => {
+        const points = line.replace('(', '').trim().split(',').map(point => {
+            const [x, y] = point.trim().split(' ').map(parseFloat);
+            return [x, y];
+        });
+        return points;
+    });
+    return {
+        type: 'MultiLineString',
+        coordinates: lines
+    };
+};
+
+const parseMultiPolygon = (coordinates) => {
+    const polygons = coordinates.split(')),').map(polygon => {
+        const rings = polygon.replace('(', '').trim().split('),').map(ring => {
+            const points = ring.replace('(', '').trim().split(',').map(point => {
+                const [x, y] = point.trim().split(' ').map(parseFloat);
+                return [x, y];
+            });
+            return points;
+        });
+        return rings;
+    });
+    return {
+        type: 'MultiPolygon',
+        coordinates: polygons
+    };
+};
+let toGeometry;
+const parseGeometryCollection = (coordinates) => {
+    const geometries = coordinates.split('),').map(geometry => {
+        const type = geometry.substring(0, geometry.indexOf('(')).trim().toUpperCase();
+        const coords = geometry.substring(geometry.indexOf('(') + 1).trim();
+        return toGeometry(`${type}(${coords})`);
+    });
+    return {
+        type: 'GeometryCollection',
+        geometries: geometries
+    };
+};
+
+toGeometry = (rawWkt) => {
+    // Remove any leading or trailing white spaces from the WKT
+    let wkt = rawWkt.trim();
+
+    // Determine the geometry type based on the initial keyword
+    const type = wkt.substring(0, wkt.indexOf('(')).trim().toUpperCase();
+
+    // Extract the coordinates from the inner part of the WKT
+    const coordinates = wkt.substring(wkt.indexOf('(') + 1, wkt.lastIndexOf(')')).trim();
+
+    // Parse the coordinates based on the geometry type
+    let result;
+    switch (type) {
+    case 'POINT':
+        result = parsePoint(coordinates);
+        break;
+    case 'LINESTRING':
+        result = parseLineString(coordinates);
+        break;
+    case 'POLYGON':
+        result = parsePolygon(coordinates);
+        break;
+        // Add support for additional geometry types here
+    case 'MULTIPOINT':
+        result = parseMultiPoint(coordinates);
+        break;
+    case 'MULTILINESTRING':
+        result = parseMultiLineString(coordinates);
+        break;
+    case 'MULTIPOLYGON':
+        result = parseMultiPolygon(coordinates);
+        break;
+    case 'GEOMETRYCOLLECTION':
+        result = parseGeometryCollection(coordinates);
+        break;
+    default:
+        throw new Error(`Not supported geometry: ${type}`);
+    }
+
+    return result;
+};
+/**
+ * Convert a WKT string to a geojson geometry
+ * @name toGeometry
+ * @memberof utils.ogc.Filter.WKT
+ * @param {string} wkt the wkt string
+ * @return {object} the geojson geometry
+ */
+export default toGeometry;


### PR DESCRIPTION
## Description

This PR introduce the capabilities to parse: 

- CQL filter functions
- WKT geometries
- Improves conversion from CQL to OGC XML filter supporting functions and geometries.

This PR allows additional tools like panels injected in the filter panel, to support advanced filtering functionalities. In particular it has been developed to support jsonArrayContains and jsonPointer. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**

Actually parsing CQL do not support WKT and functions.

**What is the new behavior?**

Fix #9285, introducing the support for parsing CQL functions, WKT and to convert these into XML OGC filters.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

This is an code only change. No new UI test needs to be added.
