### PR TITLE
#9250: Error handler updated for missing category

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -178,6 +178,25 @@ Existing contexts need to be updated separately, after applying these changes
     },
 ```
 
+- the app pages inside a MapStore project must be updated with a new entry, only for projects using permalink feature, here an example:
+
+```js
+import Permalink from '@mapstore/product/pages/Permalink';
+import productAppConfig from "@mapstore/product/appConfig";
+
+const appConfig = {
+    ...productAppConfig,
+    pages: [
+        // my custom pages ...,
+        {
+            name: "permalink",
+            path: "/permalink/:pid",
+            component: Permalink
+        }
+    ]
+};
+```
+
 #### Database Update
 
 Add new category `PERMALINK` to `gs_category` table. To update your database you need to apply this SQL scripts to your database

--- a/web/client/epics/permalink.js
+++ b/web/client/epics/permalink.js
@@ -10,7 +10,6 @@ import { Observable } from "rxjs";
 import { push } from "connected-react-router";
 import pick from "lodash/pick";
 import get from "lodash/get";
-import isString from "lodash/isString";
 import template from "lodash/template";
 
 import API from "../api/GeoStoreDAO";
@@ -73,7 +72,7 @@ const PERMALINK_RESOURCES = {
 
 const permalinkErrorHandler = (state) =>
     (e, stream$) => {
-        if (e.status === 404 && isString(e.data) && e.data.indexOf('Resource Category not found') > -1) {
+        if (e.status === 404) { // Upon saving a permalink, the only instance when a 404 can happen is in the case of missing category
             if (isAdminUserSelector(state)) {
                 // Create category when missing and role is ADMIN
                 return createCategory(PERMALINK)
@@ -104,7 +103,7 @@ const permalinkErrorHandler = (state) =>
         }
         return Observable.of(
             error({
-                title: 'notifcation.error',
+                title: 'notification.error',
                 message: 'permalink.errors.save.generic',
                 autoDismiss: 6,
                 position: "tc"


### PR DESCRIPTION
## Description
This PR updates error handler for permalink when category is missing
- Application like geOrchestra for example can give different error message when category is missing. Hence updated the handler to listen to status 404 alone

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- https://github.com/geosolutions-it/MapStore2/issues/9250#issuecomment-1660233042

**What is the new behavior?**
The category permalink is created when status 404 on trying to create a permalink resource 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
