### PR TITLE
 fix #8913 commit link in projects.

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -22,11 +22,43 @@ This is a list of things to check if you want to update from a previous version 
 
 ## Migration from 2023.01.xx to 2023.02.00
 
+### About plugin cfg changes
+
+Starting this release **2023.02.00** we have included a new *cfg* option the About plugin called **githubUrl**
+
+We suggest you to edit About plugin cfg of **localConfig.json** adding the following
+
+```diff
+{
+-    "name": "About"
++    "name": "About",
++    "cfg": {
++      "githubUrl": "https://github.com/GITHUB_USER/REPO_NAME/tree/"
++    }
+```
+
+inside `configs/pluginsConfig.json` you can add this to the About plugin definition
+
+```diff
+      "name": "About",
+      "glyph": "info-sign",
+      "title": "plugins.About.title",
+      "description": "plugins.About.description",
+      "dependencies": [
+        "SidebarMenu"
+-      ]
++      ],
++      "defaultConfig": {
++        "githubUrl": "https://github.com/geosolutions-it/MapStore2-C027/tree/"
++      }
+    },
+```
+
 ### NodeJS/NPM upgrade
 
-In this release we updated all our systems to use node 16/NPM 8. This because Node 12 is actually out of maintainance.
+In this release we updated all our systems to use node 16/NPM 8. This because Node 12 is actually out of maintenance.
 We are going to support soon more recent versions of NodeJS solving the related issues.
-So make you sure to use the correct verison of NodeJS/NPM to build things correctly. See the [requirements](../requirements/#debug-build) section of the document for the details.
+So make you sure to use the correct version of NodeJS/NPM to build things correctly. See the [requirements](../requirements/#debug-build) section of the document for the details.
 
 ### Visualization mode in map configuration
 

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -49,7 +49,7 @@ inside `configs/pluginsConfig.json` you can add this to the About plugin definit
 -      ]
 +      ],
 +      "defaultConfig": {
-+        "githubUrl": "https://github.com/geosolutions-it/MapStore2-C027/tree/"
++        "githubUrl": "https://github.com/GITHUB_USER/REPO_NAME/tree/"
 +      }
     },
 ```

--- a/project/standard/templates/configs/pluginsConfig.json
+++ b/project/standard/templates/configs/pluginsConfig.json
@@ -351,7 +351,10 @@
       "description": "plugins.About.description",
       "dependencies": [
         "SidebarMenu"
-      ]
+      ],
+      "defaultConfig": {
+        "githubUrl": "https://github.com/geosolutions-it/MapStore2/tree/"
+      }
     },
     {
       "name": "MousePosition",

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -189,7 +189,10 @@
                     }
                 }
             }, {
-              "name": "About"
+              "name": "About",
+              "cfg": {
+                "githubUrl": "https://github.com/geosolutions-it/MapStore2/tree/"
+              }
             }, "DrawerMenu",
             {
                 "name": "BackgroundSelector",
@@ -407,7 +410,10 @@
                     "wrap": true
                 }
             }, {
-              "name": "About"
+              "name": "About",
+              "cfg": {
+                "githubUrl": "https://github.com/geosolutions-it/MapStore2/tree/"
+              }
             },
             {
               "name": "MousePosition",
@@ -670,7 +676,10 @@
           "Notifications",
           "Login",
           {
-            "name": "About"
+            "name": "About",
+            "cfg": {
+                "githubUrl": "https://github.com/geosolutions-it/MapStore2/tree/"
+              }
           },
           "Language",
           "NavMenu",
@@ -796,7 +805,10 @@
           "Login",
           "BurgerMenu",
           {
-            "name": "About"
+            "name": "About",
+            "cfg": {
+                "githubUrl": "https://github.com/geosolutions-it/MapStore2/tree/"
+              }
           },
           "Language",
           "NavMenu",

--- a/web/client/configs/pluginsConfig.json
+++ b/web/client/configs/pluginsConfig.json
@@ -350,7 +350,10 @@
       "description": "plugins.About.description",
       "dependencies": [
         "SidebarMenu"
-      ]
+      ],
+      "defaultConfig": {
+        "githubUrl": "https://github.com/geosolutions-it/MapStore2/tree/"
+      }
     },
     {
       "name": "MousePosition",

--- a/web/client/product/components/viewer/about/VersionInfo.jsx
+++ b/web/client/product/components/viewer/about/VersionInfo.jsx
@@ -57,9 +57,11 @@ class VersionInfo extends React.Component {
                             <Message msgId="version.commit"/>
                         </div>
                         <div className="v_commit">
-                            <a href={this.props.githubUrl} target="_blank" className="v_githubUrl">
-                                {this.props.commit}
-                            </a>
+                            {
+                                this.props.githubUrl ? <a href={this.props.githubUrl + __COMMITHASH__} target="_blank" className="v_githubUrl">
+                                    {this.props.commit}
+                                </a> : this.props.commit
+                            }
                         </div>
                     </div>
                     <div className="version-info">

--- a/web/client/product/components/viewer/about/VersionInfo.jsx
+++ b/web/client/product/components/viewer/about/VersionInfo.jsx
@@ -58,9 +58,11 @@ class VersionInfo extends React.Component {
                         </div>
                         <div className="v_commit">
                             {
-                                this.props.githubUrl ? <a href={this.props.githubUrl + __COMMITHASH__} target="_blank" className="v_githubUrl">
-                                    {this.props.commit}
-                                </a> : this.props.commit
+                                this.props.githubUrl ?
+                                    <a href={this.props.githubUrl + this.props.commit} target="_blank" className="v_githubUrl">
+                                        {this.props.commit}
+                                    </a> :
+                                    this.props.commit
                             }
                         </div>
                     </div>

--- a/web/client/product/components/viewer/about/__tests__/VersionInfo-test.js
+++ b/web/client/product/components/viewer/about/__tests__/VersionInfo-test.js
@@ -63,7 +63,7 @@ describe("The VersionInfo component", () => {
         expect(versionValue.textContent.trim()).toBe(version);
         expect(messageValue.textContent.trim()).toBe(message);
         expect(commitValue.textContent.trim()).toBe(commit);
-        expect(commitValue.innerHTML.trim()).toBe(`<a href="https://github.com/geosolutions-it/MapStore/tree/${__COMMITHASH__}" target="_blank" class="v_githubUrl">${__COMMITHASH__}</a>`);
+        expect(commitValue.innerHTML.trim()).toBe(`<a href="https://github.com/geosolutions-it/MapStore/tree/${commit}" target="_blank" class="v_githubUrl">${commit}</a>`);
         expect(dateValue.textContent.trim()).toBe(date);
         expect(githubUrlValue.textContent.trim()).toBe(commit);
     });

--- a/web/client/product/components/viewer/about/__tests__/VersionInfo-test.js
+++ b/web/client/product/components/viewer/about/__tests__/VersionInfo-test.js
@@ -33,7 +33,7 @@ describe("The VersionInfo component", () => {
         const message = "#7934 refactor code and resolve eslint error";
         const commit = "01046133761de880aebce08a7bf11dd858117837";
         const date = "Thu, 23 Jun 2022 20:00:02 +0300";
-        const githubUrl = "https://github.com/geosolutions-it/MapStore/tree/sha_commit";
+        const githubUrl = "https://github.com/geosolutions-it/MapStore/tree/";
 
         const vd = ReactDOM.render(
             <VersionInfo
@@ -63,7 +63,7 @@ describe("The VersionInfo component", () => {
         expect(versionValue.textContent.trim()).toBe(version);
         expect(messageValue.textContent.trim()).toBe(message);
         expect(commitValue.textContent.trim()).toBe(commit);
-        expect(commitValue.innerHTML.trim()).toBe('<a href="https://github.com/geosolutions-it/MapStore/tree/sha_commit" target="_blank" class="v_githubUrl">01046133761de880aebce08a7bf11dd858117837</a>');
+        expect(commitValue.innerHTML.trim()).toBe(`<a href="https://github.com/geosolutions-it/MapStore/tree/${__COMMITHASH__}" target="_blank" class="v_githubUrl">${__COMMITHASH__}</a>`);
         expect(dateValue.textContent.trim()).toBe(date);
         expect(githubUrlValue.textContent.trim()).toBe(commit);
     });

--- a/web/client/product/plugins/About.jsx
+++ b/web/client/product/plugins/About.jsx
@@ -18,7 +18,6 @@ import version from '../../reducers/version';
 import { aboutSelector } from '../../selectors/controls';
 import {
     versionSelector,
-    githubUrlSelector,
     commitSelector,
     messageSelector,
     dateSelector
@@ -26,7 +25,6 @@ import {
 
 const About = connect((state) => ({
     version: versionSelector(state),
-    githubUrl: githubUrlSelector(state),
     commit: commitSelector(state),
     message: messageSelector(state),
     date: dateSelector(state),
@@ -42,6 +40,14 @@ const About = connect((state) => ({
  * @name About
  * @class
  * @memberof plugins
+ * @prop {string} cfg.githubUrl base url to the github tree project, default is "". It will generate a url like "https://github.com/GITHUB_USER/REPO_NAME/tree/COMMIT_SHA"
+ *
+ * @example
+ * {
+ *   "cfg" : {
+ *     githubUrl: "https://github.com/GITHUB_USER/REPO_NAME/tree/"
+ *   }
+ * }
  */
 export default {
     AboutPlugin: assign(About,

--- a/web/client/reducers/version.js
+++ b/web/client/reducers/version.js
@@ -27,8 +27,7 @@ function version(state = {
     splitData,
     message: splitData.find((x)=> x.includes('Message:')).split('Message: ')[1],
     commit: splitData.find((x)=> x.includes('Commit:')).split('Commit: ')[1],
-    date: splitData.find((x)=> x.includes('Date:')).split('Date: ')[1],
-    githubUrl: "https://github.com/geosolutions-it/MapStore2/tree/" + __COMMITHASH__
+    date: splitData.find((x)=> x.includes('Date:')).split('Date: ')[1]
 }, action) {
     switch (action.type) {
     case CHANGE_VERSION: {

--- a/web/client/selectors/version.js
+++ b/web/client/selectors/version.js
@@ -7,7 +7,6 @@
 */
 
 export const versionSelector = (state) => state.version && state.version.current || '';
-export const githubUrlSelector = (state) => state.version && state.version.githubUrl || '';
 export const commitSelector = (state) => state.version && state.version.commit || '';
 export const messageSelector = (state) => state.version && state.version.message || '';
 export const dateSelector = (state) => state.version && state.version.date || '';


### PR DESCRIPTION
fix #8913 commit link in projects.

now a property githubUrl is mandatory to show it as url otherwise commit will not be clickable

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8913

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
