### PR TITLE
#9326 Fixed propertyName override

### DIFF
--- a/web/client/utils/ogc/Filter/FilterBuilder.js
+++ b/web/client/utils/ogc/Filter/FilterBuilder.js
@@ -67,6 +67,30 @@ const {castArray} = require('lodash');
  * // examples
  * property("p").equalTo("a")
  * ```
+ * @prop {function} valueReference `valueReference("P1")` -> `<ogc:PropertyName>P1</ogc:PropertyName>` or `<fes:ValueReference>P1</fes:ValueReference>` depending on the wfs version
+ * @prop {function} literal `literal('a')` -> `<ogc:Literal>a</ogc:Literal>`
+ * @prop {object} operations all the available operations (logical, spatial, comparison or custom):
+ * @prop {function} operations.func creates a function condition. Parameters can be passed as array or args list. E.g. `func("funcName", valueReference("propName"), literal('literal'))` -> `<ogc:Function name="funcName"><ogc:PropertyName>propName</ogc:PropertyName><ogc:Literal>literal</ogc:Literal></ogc:Function>`
+ * @prop {function} operations.and logic and. `and(...conditions)` -> `<ogc:And>...conditions</ogc:And>`
+ * @prop {function} operations.or logic or. `or(...conditions)` -> `<ogc:Or>...conditions</ogc:Or>`
+ * @prop {function} operations.not logic not. `not(condition)` -> `<ogc:Not>condition</ogc:Not>`
+ * @prop {function} operations.nor logic nor. `nor(...conditions)` -> `<ogc:Not><ogc:Or>...conditions</ogc:Or></ogc:Not>`
+ * @prop {function} operations.intersects spatial intersection. `intersects(valueReference('propName'), valueReference('geometry'))` -> `<ogc:Intersects><ogc:PropertyName>property</ogc:PropertyName>geometry</ogc:Intersects>`
+ * @prop {function} operations.within spatial within operation
+ * @prop {function} operations.bbox spatial bbox operation
+ * @prop {function} operations.dwithin spatial dwithin operation
+ * @prop {function} operations.contains spatial contains operation
+ * @prop {function} operations.equal comparison equal operation
+ * @prop {function} operations.greater comparison greater operation
+ * @prop {function} operations.less comparison less operation
+ * @prop {function} operations.greaterOrEqual comparison greaterOrEqual operation
+ * @prop {function} operations.lessOrEqual comparison lessOrEqual operation
+ * @prop {function} operations.notEqual comparison notEqual operation
+ * @prop {function} operations.between comparison between operation
+ * @prop {function} operations.like comparison like operation
+ * @prop {function} operations.ilike comparison ilike operation
+ * @prop {function} operations.isNull comparison isNull operation
+ * @prop {function} property Property is a function that returns an object with all the available operations for a property. When applied the operation, the final XML is generated. It is a quick shortcut to create filters.
  * @prop {function} property.equalTo `property("P1").equals("v1")`
  * @prop {function} property.greaterThen `property("P1").greaterThen(1)`
  * @prop {function} property.greaterThenOrEqualTo `property("P1").greaterThenOrEqualTo(1)`
@@ -113,9 +137,11 @@ module.exports = function({filterNS = "ogc", gmlVersion, wfsVersion = "1.1.0"} =
         not: logical.not.bind(null, filterNS),
         func: func.bind(null, filterNS),
         literal: getValue,
-        propertyName: (property) =>
+        // note: use valueReference method for filters and SortBy conditions. PropertyName is used in WFS 2.0 only for listing required attributes, while the rest uses ValueReference.
+        // this function already uses PropertyName or ValueReference depending of the wfsVersion passed.
+        valueReference: (property) =>
             castArray(property)
-                .map(p => propertyName(filterNS, p))
+                .map(p => propName(filterNS, p))
                 .join(""),
         property: function(name) {
             return {

--- a/web/client/utils/ogc/Filter/FilterBuilder.js
+++ b/web/client/utils/ogc/Filter/FilterBuilder.js
@@ -8,6 +8,7 @@
 const {logical, spatial, comparison, literal, propertyName, valueReference, distance, lower, upper, func} = require('./operators');
 const {filter, fidFilter} = require('./filter');
 const {processOGCGeometry} = require("../GML");
+const {castArray} = require('lodash');
 // const isValidXML = (value, {filterNS, gmlNS}) => value.indexOf(`<${filterNS}:` === 0) || value.indexOf(`<${gmlNS}:`) === 0;
 /**
  * Returns OGC Filter Builder. The FilterBuilder returns the method to compose the filter.
@@ -112,7 +113,10 @@ module.exports = function({filterNS = "ogc", gmlVersion, wfsVersion = "1.1.0"} =
         not: logical.not.bind(null, filterNS),
         func: func.bind(null, filterNS),
         literal: getValue,
-        propertyName: propName.bind(null, filterNS),
+        propertyName: (property) =>
+            castArray(property)
+                .map(p => propertyName(filterNS, p))
+                .join(""),
         property: function(name) {
             return {
                 equalTo: (value) => comparison.equal(filterNS, propName(filterNS, name), getValue(value)),

--- a/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
@@ -80,5 +80,12 @@ describe('FilterBuilder', () => {
             + `<ogc:And>${intersectsElem2}<ogc:Not>${intersectsElem1}</ogc:Not></ogc:And>`
             + `</ogc:Or>`);
     });
-
+    it('propertyName', () => {
+        const b = new FilterBuilder();
+        expect(b.propertyName("PROPERTY")).toBe("<ogc:PropertyName>PROPERTY</ogc:PropertyName>");
+    });
+    it('array of propertyNames translated into a sequesnce of propertyName tags', () => {
+        const b = new FilterBuilder();
+        expect(b.propertyName(["PROPERTY1", "PROPERTY2"])).toBe("<ogc:PropertyName>PROPERTY1</ogc:PropertyName><ogc:PropertyName>PROPERTY2</ogc:PropertyName>");
+    });
 });

--- a/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
@@ -80,12 +80,21 @@ describe('FilterBuilder', () => {
             + `<ogc:And>${intersectsElem2}<ogc:Not>${intersectsElem1}</ogc:Not></ogc:And>`
             + `</ogc:Or>`);
     });
-    it('propertyName', () => {
+
+    it('valueReference 1.1.0', () => {
         const b = new FilterBuilder();
-        expect(b.propertyName("PROPERTY")).toBe("<ogc:PropertyName>PROPERTY</ogc:PropertyName>");
+        expect(b.valueReference("PROPERTY")).toBe("<ogc:PropertyName>PROPERTY</ogc:PropertyName>");
     });
     it('array of propertyNames translated into a sequesnce of propertyName tags', () => {
         const b = new FilterBuilder();
-        expect(b.propertyName(["PROPERTY1", "PROPERTY2"])).toBe("<ogc:PropertyName>PROPERTY1</ogc:PropertyName><ogc:PropertyName>PROPERTY2</ogc:PropertyName>");
+        expect(b.valueReference(["PROPERTY1", "PROPERTY2"])).toBe("<ogc:PropertyName>PROPERTY1</ogc:PropertyName><ogc:PropertyName>PROPERTY2</ogc:PropertyName>");
+    });
+    it('valueReference wfs 2.0', () => {
+        const b = new FilterBuilder({wfsVersion: '2.0'});
+        expect(b.valueReference("PROPERTY")).toBe("<ogc:ValueReference>PROPERTY</ogc:ValueReference>");
+    });
+    it('func', () => {
+        const b = new FilterBuilder();
+        expect(b.func("funcName", b.valueReference('propName'), b.literal('value'))).toBe('<ogc:Function name="funcName"><ogc:PropertyName>propName</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:Function>');
     });
 });

--- a/web/client/utils/ogc/Filter/fromObject.js
+++ b/web/client/utils/ogc/Filter/fromObject.js
@@ -33,7 +33,7 @@ const fromObject = (filterBuilder = {}) => ({type, filters = [], args = [], name
         return filterBuilder.literal(value);
     }
     if (type === "property") {
-        return filterBuilder.propertyName(name);
+        return filterBuilder.valueReference(name);
     }
     if (includes(logical, type)) {
         return filterBuilder[type](

--- a/web/client/utils/ogc/WFS/__tests__/RequestBuilder-test.js
+++ b/web/client/utils/ogc/WFS/__tests__/RequestBuilder-test.js
@@ -76,4 +76,42 @@ describe('RequestBuilder Operators', () => {
             ), {outputFormat: "application/json"})
         ).toBe(expected3);
     });
+    it('test PropertyName and sortBy usage', () => {
+        const {filter, getFeature, property, query, propertyName, sortBy} = requestBuilder({wfsVersion: "2.0"});
+        const expected = '<wfs:GetFeature service="WFS" version="2.0"'
+            + ' xmlns:wfs="http://www.opengis.net/wfs/2.0"'
+            + ' xmlns:fes="http://www.opengis.net/fes/2.0"'
+            + ' xmlns:gml="http://www.opengis.net/gml/3.2"'
+            + ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd">'
+            + '<wfs:Query typeNames="ft_name_test" srsName="EPSG:4326">'
+                + '<wfs:SortBy>'
+                    + '<wfs:SortProperty>'
+                        + '<fes:PropertyName>highway_system</fes:PropertyName>'
+                        + '<wfs:SortOrder>A</wfs:SortOrder>'
+                    + '</wfs:SortProperty>'
+                + '</wfs:SortBy>'
+                + '<fes:PropertyName>highway_system</fes:PropertyName>'
+                + '<fes:PropertyName>name</fes:PropertyName>'
+                + '<fes:Filter>'
+                    + '<fes:PropertyIsEqualTo>'
+                        + '<fes:ValueReference>highway_system</fes:ValueReference>'
+                        + '<fes:Literal>state</fes:Literal>'
+                    + '</fes:PropertyIsEqualTo>'
+                + '</fes:Filter>'
+            + '</wfs:Query>'
+        + '</wfs:GetFeature>';
+        expect(
+            getFeature(query("ft_name_test",
+                [
+                    sortBy("highway_system", "A"),
+                    propertyName(["highway_system", "name"]),
+                    filter(property("highway_system").equalTo("state"))
+                ]
+
+            ))
+        ).toBe(
+            expected
+        );
+
+    });
 });

--- a/web/client/utils/ogc/WFS/__tests__/RequestBuilder-test.js
+++ b/web/client/utils/ogc/WFS/__tests__/RequestBuilder-test.js
@@ -76,7 +76,45 @@ describe('RequestBuilder Operators', () => {
             ), {outputFormat: "application/json"})
         ).toBe(expected3);
     });
-    it('test PropertyName and sortBy usage', () => {
+    it('test PropertyName and sortBy usage WFS 1.1.0', () => {
+        const {filter, getFeature, property, query, propertyName, sortBy} = requestBuilder({wfsVersion: "1.1.0"});
+        const expected = '<wfs:GetFeature service="WFS" version="1.1.0"'
+            + ' xmlns:gml="http://www.opengis.net/gml"'
+            + ' xmlns:wfs="http://www.opengis.net/wfs"'
+            + ' xmlns:ogc="http://www.opengis.net/ogc"'
+            + ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">'
+            + '<wfs:Query typeName="ft_name_test" srsName="EPSG:4326">'
+                + '<wfs:SortBy>'
+                    + '<wfs:SortProperty>'
+                        + '<ogc:PropertyName>highway_system</ogc:PropertyName>'
+                        + '<wfs:SortOrder>A</wfs:SortOrder>'
+                    + '</wfs:SortProperty>'
+                + '</wfs:SortBy>'
+                + '<ogc:PropertyName>highway_system</ogc:PropertyName>'
+                + '<ogc:PropertyName>name</ogc:PropertyName>'
+                + '<ogc:Filter>'
+                    + '<ogc:PropertyIsEqualTo>'
+                        + '<ogc:PropertyName>highway_system</ogc:PropertyName>'
+                        + '<ogc:Literal>state</ogc:Literal>'
+                    + '</ogc:PropertyIsEqualTo>'
+                + '</ogc:Filter>'
+            + '</wfs:Query>'
+        + '</wfs:GetFeature>';
+        expect(
+            getFeature(query("ft_name_test",
+                [
+                    sortBy("highway_system", "A"),
+                    propertyName(["highway_system", "name"]),
+                    filter(property("highway_system").equalTo("state"))
+                ]
+
+            ))
+        ).toBe(
+            expected
+        );
+
+    });
+    it('test PropertyName and sortBy usage WFS 2.0', () => {
         const {filter, getFeature, property, query, propertyName, sortBy} = requestBuilder({wfsVersion: "2.0"});
         const expected = '<wfs:GetFeature service="WFS" version="2.0"'
             + ' xmlns:wfs="http://www.opengis.net/wfs/2.0"'
@@ -86,7 +124,7 @@ describe('RequestBuilder Operators', () => {
             + '<wfs:Query typeNames="ft_name_test" srsName="EPSG:4326">'
                 + '<wfs:SortBy>'
                     + '<wfs:SortProperty>'
-                        + '<fes:PropertyName>highway_system</fes:PropertyName>'
+                        + '<fes:ValueReference>highway_system</fes:ValueReference>'
                         + '<wfs:SortOrder>A</wfs:SortOrder>'
                     + '</wfs:SortProperty>'
                 + '</wfs:SortBy>'
@@ -112,6 +150,5 @@ describe('RequestBuilder Operators', () => {
         ).toBe(
             expected
         );
-
     });
 });


### PR DESCRIPTION
## Description
The error was caused by the method `propertyName` created in filterBuilder that overrides the one created in `requestBuilder`, 
The overridden implementation supported the arrays, while the one in filter builder doesn't support it. 
Note that `PropertyName` is the correct tag for query body to exclude parmeters, while `ValueReference` will be used for the SortBy and for Filters values. (easy, isn't it? ...) 

The issue was fixed by:
- Renaming `propertyName` into `valueReference` to avoid ambiguity. The `valueReference` method of filterBuilder will use the tag `PropertyName` or `ValueReference` depending on the version of `wfs`. 
- Using `valueReference` method for SortBy
- Keep `propertyName` method in the WFS query option-
- supporting array as argument of propertyName of filter builder.

I added extensive tests and documentation. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #9326

**What is the new behavior?**
Now widget works, and every request with filter builder works too. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
