### PR TITLE
#9274 Fixed highlight layer style

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -34,6 +34,7 @@ import catalog from "../epics/catalog";
 import backgroundSelector from "../epics/backgroundselector";
 import API from '../api/catalog';
 import { MapLibraries } from '../utils/MapTypeUtils';
+import {getHighlightLayerOptions} from "../utils/HighlightUtils";
 
 /**
  * The Map plugin allows adding mapping library dependent functionality using support tools.
@@ -306,10 +307,21 @@ class MapPlugin extends React.Component {
 
     getHighlightLayer = (projection, index, env) => {
         const plugins = this.state.plugins;
-        return (<plugins.Layer type="vector" srs={projection} position={index} key="highlight" options={{name: "highlight"}} env={env}>
-            {this.props.features.map( (feature) => {
+        const {features, ...options} = getHighlightLayerOptions({features: this.props.features});
+        return (<plugins.Layer type="vector"
+            srs={projection}
+            position={index}
+            key="highlight"
+            env={env}
+            options={{
+                name: "highlight",
+                ...options,
+                features
+            }} >
+            {features.map( (feature) => {
                 return (<plugins.Feature
                     msId={feature.id}
+                    properties={feature.properties}
                     key={feature.id}
                     crs={projection}
                     type={feature.type}

--- a/web/client/utils/HighlightUtils.js
+++ b/web/client/utils/HighlightUtils.js
@@ -1,0 +1,83 @@
+
+export const GEOMETRY_PROPERTY  = '__geometry__type__';
+export const HIGH_LIGHT_STYLE = {
+    format: 'geostyler',
+    body: {
+        name: "highlight",
+        rules: [{
+            name: 'Default Polygon Style',
+            ruleId: "defaultPolygon",
+            filter: ['||',
+                ['==', GEOMETRY_PROPERTY, 'Polygon'],
+                ['==', GEOMETRY_PROPERTY, 'MultiPolygon']
+            ],
+            symbolizers: [
+                {
+                    kind: 'Fill',
+                    color: '#f2f2f2',
+                    fillOpacity: 0.3,
+                    outlineColor: '#3075e9',
+                    outlineOpacity: 1,
+                    outlineWidth: 2
+                }
+            ]
+        }, {
+            name: 'Default Line Style',
+            ruleId: "defaultLine",
+            filter: ['||',
+                ['==', GEOMETRY_PROPERTY, 'LineString'],
+                ['==', GEOMETRY_PROPERTY, 'MultiLineString']
+            ],
+            symbolizers: [
+                {
+                    kind: 'Line',
+                    color: '#3075e9',
+                    opacity: 1,
+                    width: 2
+                }
+            ]
+        }, {
+            name: 'Default Point Style',
+            ruleId: "defaultPoint",
+            filter: ['||',
+                ['==', GEOMETRY_PROPERTY, 'Point'],
+                ['==', GEOMETRY_PROPERTY, 'MultiPoint']
+            ],
+            symbolizers: [{
+                kind: 'Mark',
+                color: '#f2f2f2',
+                fillOpacity: 0.3,
+                strokeColor: '#3075e9',
+                strokeOpacity: 1,
+                strokeWidth: 2,
+                radius: 10,
+                wellKnownName: 'Circle',
+                msBringToFront: true
+            }]
+        }]
+    }
+};
+
+/**
+ * Add the the proper options to the highlight layer:
+ * - `visibility`: `true`
+ * - `features`: the features to highlight should be enhanced with the geometry type in properties, to allow the default style to work
+ * - `style`: the default style applies a different style for each geometry type. The geometry type is extracted from the geometry type and added to the feature properties
+ * @param {options} base options
+ * @returns the new options with the highlight layer
+ */
+export const getHighlightLayerOptions = ({features, ...options}) => {
+    return {
+        ...options,
+        visibility: true, // required by cesium
+        features: features?.map(feature => ({
+            ...feature,
+            properties: {
+                ...(feature?.properties || {}),
+                [GEOMETRY_PROPERTY]: feature?.geometry?.type // there is not actually a function to determine the geometry type from the feature. This is a workaround to automatically apply the default style
+            }
+
+        })),
+        style: HIGH_LIGHT_STYLE
+    };
+};

--- a/web/client/utils/__tests__/HighlightUtils-test.js
+++ b/web/client/utils/__tests__/HighlightUtils-test.js
@@ -1,0 +1,35 @@
+import expect from 'expect';
+import {getHighlightLayerOptions, GEOMETRY_PROPERTY, HIGH_LIGHT_STYLE} from '../HighlightUtils';
+
+describe('HighlightUtils', () => {
+    it('getHighlightLayerOptions', () => {
+        // adds standard options
+        const options = getHighlightLayerOptions({
+            features: [{
+                type: 'Feature',
+                properties: {
+                    id: '1'
+                },
+                geometry: {
+                    type: 'Point',
+                    coordinates: [0, 0]
+                }
+            }]
+        });
+        expect(options).toEqual({
+            visibility: true, // required by cesium
+            features: [{
+                type: 'Feature',
+                properties: {
+                    id: '1',
+                    [GEOMETRY_PROPERTY]: 'Point' // required by default style
+                },
+                geometry: {
+                    type: 'Point',
+                    coordinates: [0, 0]
+                }
+            }],
+            style: HIGH_LIGHT_STYLE
+        });
+    });
+});


### PR DESCRIPTION
## Description

This PR Fix #9274 by introducing a default style and adding some fake geometry type to properties in order to allow the filter to recognize the geometry type.
Now we do not have a filter to allow the geometry type to be recognized, so we can not allow the customization of the highlight style at all, as suggested in the PR. 
Anyway if required, this functionality can be a little customized to add this feature (e.g. by passing a something in the options).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9274

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Fix #9274

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
