### PR TITLE
#9205: Fix - Map details on context map intermittently disappears

### DIFF
--- a/web/client/epics/__tests__/maptemplates-test.js
+++ b/web/client/epics/__tests__/maptemplates-test.js
@@ -13,7 +13,9 @@ import MockAdapter from 'axios-mock-adapter';
 import { testEpic } from './epicTestUtils';
 
 import {
+    mergeTemplateEpic,
     openMapTemplatesPanelEpic,
+    replaceTemplateEpic,
     setAllowedTemplatesEpic
 } from '../maptemplates';
 
@@ -21,12 +23,17 @@ import {
     openMapTemplatesPanel,
     setAllowedTemplates,
     SET_TEMPLATES,
-    SET_MAP_TEMPLATES_LOADED
+    SET_MAP_TEMPLATES_LOADED,
+    mergeTemplate,
+    SET_TEMPLATE_LOADING,
+    SET_TEMPLATE_DATA,
+    replaceTemplate
 } from '../../actions/maptemplates';
 
 import {
     SET_CONTROL_PROPERTY
 } from '../../actions/controls';
+import { MAP_CONFIG_LOADED, MAP_INFO_LOADED } from '../../actions/config';
 
 let mockAxios;
 
@@ -121,6 +128,138 @@ describe('maptemplates epics', () => {
                 }
             },
             maptemplates: {}
+        }, done);
+    });
+    it('mergeTemplateEpic with map data', (done) => {
+        mockAxios.onGet().reply(200, {
+            map: {}
+        });
+        testEpic(mergeTemplateEpic, 5, mergeTemplate("1"), actions => {
+            expect(actions.length).toBe(5);
+            expect(actions[0].type).toBe(SET_TEMPLATE_LOADING);
+            expect(actions[0].id).toBe("1");
+            expect(actions[0].loadingValue).toBeTruthy();
+            expect(actions[1].type).toBe(SET_TEMPLATE_DATA);
+            expect(actions[1].id).toBe("1");
+            expect(actions[1].data).toBeTruthy();
+            expect(actions[2].type).toBe(MAP_CONFIG_LOADED);
+            expect(actions[2].config).toBeTruthy();
+            expect(actions[2].legacy).toBeTruthy();
+            expect(actions[2].mapId).toBe("map1");
+            expect(actions[3].type).toBe(MAP_INFO_LOADED);
+            expect(actions[3].info).toEqual({id: "map1"});
+            expect(actions[3].mapId).toBe("map1");
+            expect(actions[4].type).toBe(SET_TEMPLATE_LOADING);
+            expect(actions[4].id).toBe("1");
+            expect(actions[4].loadingValue).toBeFalsy();
+        }, {
+            map: {
+                present: {
+                    zoom: 1,
+                    info: {
+                        id: "map1"
+                    }
+                }
+            },
+            layers: {
+                flat: [{
+                    id: "1",
+                    visibility: true,
+                    name: "test"
+                }],
+                groups: [{
+                    id: "Default",
+                    name: "Default",
+                    title: "Default",
+                    nodes: ["1"]
+                }]
+            },
+            maptemplates: {templates: [{id: "1"}]}
+        }, done);
+    });
+    it('mergeTemplateEpic - set setTemplateData when no map data in response', (done) => {
+        mockAxios.onGet().reply(200, {});
+        testEpic(mergeTemplateEpic, 3, mergeTemplate("1"), actions => {
+            expect(actions.length).toBe(3);
+            expect(actions[0].type).toBe(SET_TEMPLATE_LOADING);
+            expect(actions[0].id).toBe("1");
+            expect(actions[0].loadingValue).toBeTruthy();
+            expect(actions[1].type).toBe(SET_TEMPLATE_DATA);
+            expect(actions[1].id).toBe("1");
+            expect(actions[1].data).toBeTruthy();
+            expect(actions[2].type).toBe(SET_TEMPLATE_LOADING);
+            expect(actions[2].id).toBe("1");
+            expect(actions[2].loadingValue).toBeFalsy();
+        }, {
+            map: {
+                present: {
+                    zoom: 1,
+                    info: {
+                        id: "map1"
+                    }
+                }
+            },
+            layers: {
+                flat: [{
+                    id: "1",
+                    visibility: true,
+                    name: "test"
+                }],
+                groups: [{
+                    id: "Default",
+                    name: "Default",
+                    title: "Default",
+                    nodes: ["1"]
+                }]
+            },
+            maptemplates: {templates: [{id: "1"}]}
+        }, done);
+    });
+    it('replaceTemplateEpic', (done) => {
+        mockAxios.onGet().reply(200, {
+            map: {}
+        });
+        testEpic(replaceTemplateEpic, 5, replaceTemplate("1"), actions => {
+            expect(actions.length).toBe(5);
+            expect(actions[0].type).toBe(SET_TEMPLATE_LOADING);
+            expect(actions[0].id).toBe("1");
+            expect(actions[0].loadingValue).toBeTruthy();
+            expect(actions[1].type).toBe(SET_TEMPLATE_DATA);
+            expect(actions[1].id).toBe("1");
+            expect(actions[1].data).toBeTruthy();
+            expect(actions[2].type).toBe(MAP_CONFIG_LOADED);
+            expect(actions[2].config).toBeTruthy();
+            expect(actions[2].legacy).toBeTruthy();
+            expect(actions[2].mapId).toBe("map1");
+            expect(actions[3].type).toBe(MAP_INFO_LOADED);
+            expect(actions[3].info).toEqual({id: "map1"});
+            expect(actions[3].mapId).toBe("map1");
+            expect(actions[4].type).toBe(SET_TEMPLATE_LOADING);
+            expect(actions[4].id).toBe("1");
+            expect(actions[4].loadingValue).toBeFalsy();
+        }, {
+            map: {
+                present: {
+                    zoom: 1,
+                    info: {
+                        id: "map1"
+                    }
+                }
+            },
+            layers: {
+                flat: [{
+                    id: "1",
+                    visibility: true,
+                    name: "test"
+                }],
+                groups: [{
+                    id: "Default",
+                    name: "Default",
+                    title: "Default",
+                    nodes: ["1"]
+                }]
+            },
+            maptemplates: {templates: [{id: "1"}]}
         }, done);
     });
 });

--- a/web/client/epics/details.js
+++ b/web/client/epics/details.js
@@ -7,27 +7,22 @@
 */
 
 import Rx from 'rxjs';
-import { find } from 'lodash';
 
 import {
     OPEN_DETAILS_PANEL,
     CLOSE_DETAILS_PANEL,
     NO_DETAILS_AVAILABLE,
     updateDetails,
-    detailsLoaded,
-    openDetailsPanel,
     closeDetailsPanel
 } from '../actions/details';
-import { MAP_INFO_LOADED } from '../actions/config';
 import { toggleControl, setControlProperty } from '../actions/controls';
 
 import {
-    mapIdSelector, mapInfoDetailsUriFromIdSelector
+    mapInfoDetailsUriFromIdSelector
 } from '../selectors/map';
 
 import GeoStoreApi from '../api/GeoStoreDAO';
 
-import { EMPTY_RESOURCE_VALUE } from '../utils/MapInfoUtils';
 import { getIdFromUri } from '../utils/MapUtils';
 import { basicError } from '../utils/NotificationUtils';
 import { VISUALIZATION_MODE_CHANGED } from '../actions/maptype';
@@ -59,38 +54,6 @@ export const closeDetailsPanelEpic = (action$) =>
             setControlProperty("details", "enabled", false)
         ])
         );
-
-export const storeDetailsInfoEpic = (action$, store) =>
-    action$.ofType(MAP_INFO_LOADED)
-        .switchMap(() => {
-            const mapId = mapIdSelector(store.getState());
-            const isTutorialRunning = store.getState()?.tutorial?.run;
-            return !mapId ?
-                Rx.Observable.empty() :
-                Rx.Observable.fromPromise(
-                    GeoStoreApi.getResourceAttributes(mapId)
-                )
-                    .switchMap((attributes) => {
-                        let details = find(attributes, {name: 'details'});
-                        const detailsSettingsAttribute = find(attributes, {name: 'detailsSettings'});
-                        let detailsSettings = {};
-
-                        if (!details || details.value === EMPTY_RESOURCE_VALUE) {
-                            return Rx.Observable.empty();
-                        }
-
-                        try {
-                            detailsSettings = JSON.parse(detailsSettingsAttribute.value);
-                        } catch (e) {
-                            detailsSettings = {};
-                        }
-
-                        return Rx.Observable.of(
-                            detailsLoaded(mapId, details.value, detailsSettings),
-                            ...(detailsSettings.showAtStartup && !isTutorialRunning ? [openDetailsPanel()] : [])
-                        );
-                    });
-        });
 
 export const closeDetailsPanelOn3DToggle = (action$) =>
     action$.ofType(VISUALIZATION_MODE_CHANGED)


### PR DESCRIPTION
## Description
This PR fixes the details plugin intermittently disappearing when loading context map with details linked resource and map template replacing the original map's details

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9205 

**What is the new behavior?**
- Context map with details always loads correctly
- Context map with details is retained between map template replacement and merge activity

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
