### PR TITLE
#9335: Fix - Default permalink resource type is missing

### DIFF
--- a/web/client/components/permalink/Permalink.jsx
+++ b/web/client/components/permalink/Permalink.jsx
@@ -24,18 +24,20 @@ import LoadingSpinner from "../misc/LoadingSpinner";
 
 const FormControl = localizedProps("placeholder")(FC);
 
-const getPathinfo = (url = "") => {
+export const getPathinfo = (url = "") => {
     const [, path] = url?.split("#/") ?? [];
-    const pathInfos = path?.split("/") ?? [];
-    let [pathType] = pathInfos ?? [];
+    const [pathType] = path?.split("/") ?? [];
+    let pathLastIndex = path?.lastIndexOf("/");
+    pathLastIndex = pathLastIndex === -1 ? path?.length : pathLastIndex;
     let pathTemplate = pathType === "context"
         ? "context"
-        : (path?.substring(0, path?.lastIndexOf("/")) ?? "");
-    pathTemplate = `/${pathTemplate}/` + '${id}';
+        : (path?.substring(0, pathLastIndex) ?? "");
+    pathTemplate = `/${!isEmpty(pathTemplate) ? pathTemplate : "viewer"}/` + '${id}';
 
     let type;
     switch (pathType) {
     case "viewer":
+    case "map":
         type = "map";
         break;
     case "dashboard":
@@ -49,6 +51,7 @@ const getPathinfo = (url = "") => {
         pathTemplate = pathTemplate.replace("id", "name") + '?category=PERMALINK';
         break;
     default:
+        type = "map";
         break;
     }
     return {

--- a/web/client/components/permalink/__tests__/Permalink-test.jsx
+++ b/web/client/components/permalink/__tests__/Permalink-test.jsx
@@ -9,7 +9,7 @@
 import React from 'react';
 
 import ReactDOM from 'react-dom';
-import Permalink from '../Permalink';
+import Permalink, {getPathinfo} from '../Permalink';
 import expect from 'expect';
 import TestUtils from 'react-dom/test-utils';
 
@@ -72,6 +72,28 @@ describe('Permalink tests', () => {
         expect(args.resource.category).toBe('PERMALINK');
         expect(args.resource.attributes).toBeTruthy();
         expect(args.resource.attributes.pathTemplate).toBe("/context/${name}?category=PERMALINK");
+    });
+    it('test permalink - getPathinfo', () => {
+        let pathInfo = getPathinfo("/#/");
+        expect(pathInfo).toEqual({type: "map", pathTemplate: "/viewer/${id}"});
+        pathInfo = getPathinfo("/#/map");
+        expect(pathInfo).toEqual({type: "map", pathTemplate: "/map/${id}"});
+        pathInfo = getPathinfo("/#/map/12");
+        expect(pathInfo).toEqual({type: "map", pathTemplate: "/map/${id}"});
+        pathInfo = getPathinfo("/#/viewer/");
+        expect(pathInfo).toEqual({type: "map", pathTemplate: "/viewer/${id}"});
+        pathInfo = getPathinfo("/#/viewer/12");
+        expect(pathInfo).toEqual({type: "map", pathTemplate: "/viewer/${id}"});
+        pathInfo = getPathinfo("/#/dashboard/12");
+        expect(pathInfo).toEqual({type: "dashboard", pathTemplate: "/dashboard/${id}"});
+        pathInfo = getPathinfo("/#/geostory/12");
+        expect(pathInfo).toEqual({type: "geostory", pathTemplate: "/geostory/${id}"});
+        pathInfo = getPathinfo("/#/geostory/shared/12");
+        expect(pathInfo).toEqual({type: "geostory", pathTemplate: "/geostory/shared/${id}"});
+        pathInfo = getPathinfo("/#/context/12");
+        expect(pathInfo).toEqual({type: "context", pathTemplate: "/context/${name}?category=PERMALINK"});
+        pathInfo = getPathinfo("/#/context/cname/12");
+        expect(pathInfo).toEqual({type: "context", pathTemplate: "/context/${name}?category=PERMALINK"});
     });
     it('test show permalink link panel', () => {
         ReactDOM.render(<Permalink shareUrl="#/viewer/22" settings={{name: 1}} />, document.getElementById("container"));


### PR DESCRIPTION
## Description
This PR fixes the missing default resource type in permalink when not obtainable from the path

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9335

**What is the new behavior?**
Default path template is set to resource type obtained from path ex: `/viewer, /map` and also manages to set the path as `viewer` when missing, as certain applications uses mapviewer as root path

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
