### PR TITLE
Fix - WPS - Convert the ROI geometry to WKT to download spatial filter

### DIFF
--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -7,6 +7,7 @@
  */
 
 import Rx from 'rxjs';
+import wk from 'wellknown';
 import { get, find, findIndex, pick, toPairs, castArray } from 'lodash';
 import { saveAs } from 'file-saver';
 import { parseString } from 'xml2js';
@@ -332,8 +333,8 @@ export const startFeatureExportDownload = (action$, store) =>
                 ROI: cropToROI ? {
                     type: 'TEXT',
                     data: {
-                        mimeType: 'application/json',
-                        data: JSON.stringify(bboxToFeatureGeometry(mapBbox.bounds))
+                        mimeType: 'application/wkt',
+                        data: wk.stringify(bboxToFeatureGeometry(mapBbox.bounds))
                     }
                 } : undefined,
                 roiCRS: cropToROI ? (mapBbox.crs || 'EPSG:4326') : undefined,


### PR DESCRIPTION
## Description
This PR attempts to fix JSON geometries are not parsed in Geoserver by converting ROI geometry to WKT

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9332

**What is the new behavior?**
WPS download with ROI works as expected

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
