### PR TITLE
#9313 Error when 3D Tiles layer are not visible

### DIFF
--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -1262,7 +1262,8 @@ describe('Cesium layer', () => {
             />, document.getElementById('container'));
         expect(cmp).toBeTruthy();
         expect(cmp.layer).toBeTruthy();
-        expect(cmp.layer.getTileSet).toBeFalsy();
+        expect(cmp.layer.getTileSet).toBeTruthy();
+        expect(cmp.layer.getTileSet()).toBe(undefined);
     });
     it('should create a 3d tiles layer with and offset applied to the height', (done) => {
         const options = {

--- a/web/client/components/map/cesium/plugins/ThreeDTilesLayer.js
+++ b/web/client/components/map/cesium/plugins/ThreeDTilesLayer.js
@@ -161,6 +161,7 @@ Layers.registerType('3dtiles', {
         }
         return {
             detached: true,
+            getTileSet: () => undefined,
             remove: () => {},
             setVisible: () => {}
         };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds the `.getTileSet` returning undefined method to 3D Tiles not visible

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9313

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Now the application works when a 3D Tiles has been initialized with visibility false

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
