### PR TITLE
#9346 Print plugin is not showing the printable area

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -392,9 +392,10 @@ export default {
                     };
                     getPreviewResolution = (zoom, projection) => {
                         const dpu = dpi2dpu(DEFAULT_SCREEN_DPI, projection);
+                        const roundZoom = Math.round(zoom);
                         const scale = this.props.useFixedScales
-                            ? getPrintScales(this.props.capabilities)[zoom]
-                            : this.props.scales[zoom];
+                            ? getPrintScales(this.props.capabilities)[roundZoom]
+                            : this.props.scales[roundZoom];
                         return scale / dpu;
                     };
                     getLayout = (props) => {

--- a/web/client/plugins/__tests__/Print-test.jsx
+++ b/web/client/plugins/__tests__/Print-test.jsx
@@ -441,4 +441,45 @@ describe('Print Plugin', () => {
             }
         });
     });
+
+    it("test configuration with not round zoom level", (done) => {
+        const actions = {
+            onPrint: () => {}
+        };
+        let spy = expect.spyOn(actions, "onPrint");
+        getPrintPlugin({
+            layers: [
+                {visibility: true, type: "osm"},
+                {id: "test", url: "/test", name: "test", type: "wms", visibility: true, maxResolution: 500000}
+            ],
+            projection: "EPSG:4326",
+            state: {
+                ...initialState,
+                map: {
+                    ...initialState.map,
+                    zoom: 5.1
+                }
+            }
+        }).then(({ Plugin }) => {
+            try {
+                ReactDOM.render(<Plugin
+                    pluginCfg={{
+                        onPrint: actions.onPrint
+                    }}
+                    defaultBackground={["osm", "empty"]}
+                />, document.getElementById("container"));
+                const submit = document.getElementsByClassName("print-submit").item(0);
+                expect(submit).toExist();
+                ReactTestUtils.Simulate.click(submit);
+                setTimeout(() => {
+                    expect(spy.calls.length).toBe(1);
+                    expect(spy.calls[0].arguments[1].layers.length).toBe(1);
+                    expect(spy.calls[0].arguments[1].layers[0].layers).toEqual(["test"]);
+                    done();
+                }, 0);
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds a fix to round the zoom level before computing the print preview resolutions. It seems that sometimes while switching between 2D/3D the zoom is not round and it causing the blank preview

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9346

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Print preview is not blank

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
