### PR TITLE
#9346 ensure the zoom is always round before using it as index

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -579,7 +579,7 @@ class CesiumMap extends React.Component {
                     roll: this.map.camera.roll
                 }
             },
-            getResolutions()[zoom]
+            getResolutions()[Math.round(zoom)]
         );
     };
 

--- a/web/client/components/map/leaflet/Layer.jsx
+++ b/web/client/components/map/leaflet/Layer.jsx
@@ -127,8 +127,9 @@ class LeafletLayer extends React.Component {
             maxResolution = Infinity,
             disableResolutionLimits
         } = options || {};
-        if (!disableResolutionLimits && !isNil(resolutions[zoom])) {
-            const resolution = resolutions[zoom];
+        const zoomRound = Math.round(zoom);
+        if (!disableResolutionLimits && !isNil(resolutions[zoomRound])) {
+            const resolution = resolutions[zoomRound];
             // use similar approach of ol
             // maxResolution is exclusive
             // minResolution is inclusive

--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -463,7 +463,7 @@ class LeafletMap extends React.Component {
             this.props.id,
             this.props.projection,
             viewerOptions, // viewerOptions
-            this.getResolutions()[zoom] // resolution
+            this.getResolutions()[Math.round(zoom)] // resolution
         );
     };
 

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -912,7 +912,7 @@ export function calculateExtent(center = {x: 0, y: 0, crs: "EPSG:3857"}, resolut
 
 export const reprojectZoom = (zoom, mapProjection, printProjection) => {
     const multiplier = METERS_PER_UNIT[getUnits(mapProjection)] / METERS_PER_UNIT[getUnits(printProjection)];
-    const mapResolution = getResolutions(mapProjection)[zoom] * multiplier;
+    const mapResolution = getResolutions(mapProjection)[Math.round(zoom)] * multiplier;
     const printResolutions = getResolutions(printProjection);
 
     const printResolution = printResolutions.reduce((nearest, current) => {

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -40,7 +40,8 @@ import {
     addRootParentGroup,
     mapUpdated,
     getZoomFromResolution,
-    getResolutionObject
+    getResolutionObject,
+    reprojectZoom
 } from '../MapUtils';
 import { VisualizationModes } from '../MapTypeUtils';
 
@@ -2131,6 +2132,10 @@ describe('Test the MapUtils', () => {
     it('addRootParentGroup', () => {
         const resolution = 1000; // ~zoom 7 in Web Mercator
         expect(getZoomFromResolution(resolution)).toBe(7);
+    });
+    it('reprojectZoom', () => {
+        expect(reprojectZoom(5, 'EPSG:3857', 'EPSG:4326')).toBe(4);
+        expect(reprojectZoom(5.2, 'EPSG:3857', 'EPSG:4326')).toBe(4);
     });
     describe("getResolutionObject tests", () => {
         const resolutions =  [156543, 78271, 39135, 19567, 9783, 4891, 2445, 1222];

--- a/web/client/utils/grids/MapGridsUtils.js
+++ b/web/client/utils/grids/MapGridsUtils.js
@@ -408,7 +408,7 @@ export function getGridGeoJson({
     pixelRatio = devicePixelRatio,
     frameSize = 0.0
 }) {
-    const resolution = (resolutions ?? getResolutions(mapProjection))[zoom];
+    const resolution = (resolutions ?? getResolutions(mapProjection))[Math.round(zoom)];
     const mapToGrid = proj4(mapProjection, gridProjection).forward;
     const gridToMap = proj4(gridProjection, mapProjection).forward;
     const projectionCenter = mapToGrid(getCenter(getProjection(gridProjection).extent));

--- a/web/client/utils/grids/__tests__/MapGridsUtils-test.js
+++ b/web/client/utils/grids/__tests__/MapGridsUtils-test.js
@@ -245,12 +245,12 @@ describe("getGridGeoJson", () => {
         expect(geoJson.features[5].geometry.coordinates).toEqual([[-180, -90], [180, -90]]);
         expect(geoJson.features[7].geometry.coordinates).toEqual([[-180, 90], [180, 90]]);
     });
-    it("map and grid in EPSG:4326 and zoom 5, no labels", () => {
+    it("map and grid in EPSG:4326 and zoom 5.2, no labels", () => {
         const geoJson = getGridGeoJson({
             mapProjection: "EPSG:4326",
             gridProjection: "EPSG:4326",
             extent: [5, 40, 10, 44],
-            zoom: 5
+            zoom: 5.2
         });
         expect(geoJson.type).toBe("FeatureCollection");
         expect(geoJson.features.length).toBe(7);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Sometimes the zoom level is to round also inside 2D map, with this PR we ensure the zoom is round when it is used as array index. The Print plugin was using reprojectZoom that was failing when the zoom level had decimals

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9346

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Print plugin is working also after zoom in or out

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

see https://github.com/geosolutions-it/MapStore2/issues/9346#issuecomment-1688337975