### PR TITLE
set resolve.fallback.http/https/zlib to false in webpack extension build config

### DIFF
--- a/build/createExtensionWebpackConfig.js
+++ b/build/createExtensionWebpackConfig.js
@@ -35,6 +35,9 @@ module.exports = ({ prod = true, name, exposes, sharedLibrariesEager = true, ali
     resolve: {
         fallback: {
             path: false,
+            http: false,
+            https: false,
+            zlib: false,
             timers: false,
             stream: false
         },


### PR DESCRIPTION
- follows what was done in e9e38832bc for other webpack build configs
- fixes external extension building after cesium update in #9267
- cf georchestra/mapstore2-cadastrapp#182

## Description
when trying to update ms2 submodule in ms2-cadastrapp extension, it fails to build
```
ERROR in ./node_modules/@cesium/engine/Source/Core/Resource.js 2043:30-44
Module not found: Error: Can't resolve 'zlib' in '/data/src/georchestra/mapstore2-cadastrapp/node_modules/@cesium/engine/Source/Core'
ERROR in ./node_modules/@cesium/engine/Source/Core/Resource.js 2050:39-54
Module not found: Error: Can't resolve 'https' in '/data/src/georchestra/mapstore2-cadastrapp/node_modules/@cesium/engine/Source/Core'
ERROR in ./node_modules/@cesium/engine/Source/Core/Resource.js 2050:57-71
Module not found: Error: Can't resolve 'http' in '/data/src/georchestra/mapstore2-cadastrapp/node_modules/@cesium/engine/Source/Core'
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "http": require.resolve("stream-http") }'
        - install 'stream-http'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "http": false }
```

that's probably related to the cesium update in #9267

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
georchestra/mapstore2-cadastrapp#182

**What is the new behavior?**
build of the external extension succeeds

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information