### PR TITLE
#9269 fix issue of correct map embed url in sharing map

### DIFF
--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web/client/components/share/__tests__', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web/client/components/share/__tests__', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -106,8 +106,8 @@ class SharePanel extends React.Component {
         modal: false,
         draggable: true,
         onClose: () => {},
-        shareUrlRegex: "(h[^#]*)#\/viewer\/([^\/]*\/[A-Za-z0-9]*|[A-Za-z0-9]*)",
-        shareUrlReplaceString: "$1embedded.html#/$2",       // $2 points to the 2nd caputred group in the above regEx [here the words/id after viewer/]
+        shareUrlRegex: "(h[^#]*)#\\/viewer\\/([A-Za-z0-9]*)",
+        shareUrlReplaceString: "$1embedded.html#/$2",
         embedPanel: true,
         embedOptions: {},
         showAPI: true,

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -106,8 +106,8 @@ class SharePanel extends React.Component {
         modal: false,
         draggable: true,
         onClose: () => {},
-        shareUrlRegex: "(h[^#]*)#\\/viewer\\/([^\\/]*)\\/([A-Za-z0-9]*)",
-        shareUrlReplaceString: "$1embedded.html#/$3",
+        shareUrlRegex: "(h[^#]*)#\/viewer\/([^\/]*\/[A-Za-z0-9]*|[A-Za-z0-9]*)",
+        shareUrlReplaceString: "$1embedded.html#/$2",       // $2 points to the 2nd caputred group in the above regEx [here the words/id after viewer/]
         embedPanel: true,
         embedOptions: {},
         showAPI: true,

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -106,8 +106,8 @@ class SharePanel extends React.Component {
         modal: false,
         draggable: true,
         onClose: () => {},
-        shareUrlRegex: "(h[^#]*)#\/viewer\/([^\/]*\/[A-Za-z0-9]*|[A-Za-z0-9]*)",
-        shareUrlReplaceString: "$1embedded.html#/$2",       // $2 points to the 2nd caputred group in the above regEx [here the words/id after viewer/]
+        shareUrlRegex: "(h[^#]*)#\\/viewer\\/([^\\/]*)\\/([A-Za-z0-9]*)",
+        shareUrlReplaceString: "$1embedded.html#/$3",
         embedPanel: true,
         embedOptions: {},
         showAPI: true,

--- a/web/client/components/share/__tests__/SharePanel-test.jsx
+++ b/web/client/components/share/__tests__/SharePanel-test.jsx
@@ -49,7 +49,7 @@ describe("The SharePanel component", () => {
         const cmpSharePanelDom = ReactDOM.findDOMNode(cmpSharePanel);
         expect(cmpSharePanelDom).toBeFalsy();
     });
-    it.only('test regex parsing for shareEmbeddedUrl generation', () => {
+    it('test regex parsing for shareEmbeddedUrl generation', () => {
         const cmpSharePanel = ReactDOM.render(<SharePanel selectedTab="embed" getCount={()=>0} shareUrlRegex=".*" shareUrlReplaceString="ABC" shareUrl="www.geo-solutions.it" isVisible={false} />, document.getElementById("container"));
         expect(cmpSharePanel).toExist();
         const parsed = cmpSharePanel.generateUrl("TEST", "(TE)ST", "$1");

--- a/web/client/components/share/__tests__/SharePanel-test.jsx
+++ b/web/client/components/share/__tests__/SharePanel-test.jsx
@@ -49,7 +49,7 @@ describe("The SharePanel component", () => {
         const cmpSharePanelDom = ReactDOM.findDOMNode(cmpSharePanel);
         expect(cmpSharePanelDom).toBeFalsy();
     });
-    it.n('test regex parsing for shareEmbeddedUrl generation', () => {
+    it('test regex parsing for shareEmbeddedUrl generation', () => {
         const cmpSharePanel = ReactDOM.render(<SharePanel selectedTab="embed" getCount={()=>0} shareUrlRegex=".*" shareUrlReplaceString="ABC" shareUrl="www.geo-solutions.it" isVisible={false} />, document.getElementById("container"));
         expect(cmpSharePanel).toExist();
         const parsed = cmpSharePanel.generateUrl("TEST", "(TE)ST", "$1");

--- a/web/client/components/share/__tests__/SharePanel-test.jsx
+++ b/web/client/components/share/__tests__/SharePanel-test.jsx
@@ -49,11 +49,15 @@ describe("The SharePanel component", () => {
         const cmpSharePanelDom = ReactDOM.findDOMNode(cmpSharePanel);
         expect(cmpSharePanelDom).toBeFalsy();
     });
-    it('test regex parsing for shareEmbeddedUrl generation', () => {
+    it.only('test regex parsing for shareEmbeddedUrl generation', () => {
         const cmpSharePanel = ReactDOM.render(<SharePanel selectedTab="embed" getCount={()=>0} shareUrlRegex=".*" shareUrlReplaceString="ABC" shareUrl="www.geo-solutions.it" isVisible={false} />, document.getElementById("container"));
         expect(cmpSharePanel).toExist();
         const parsed = cmpSharePanel.generateUrl("TEST", "(TE)ST", "$1");
+        const embedMap1 = cmpSharePanel.generateUrl("http://localhost:8081/#/viewer/shared/44asd", "(h[^#]*)#\/viewer\/([^\/]*\/[A-Za-z0-9]*|[A-Za-z0-9]*)", "$2");
+        const embedMap2 = cmpSharePanel.generateUrl("http://localhost:8081/#/viewer/44asd", "(h[^#]*)#\/viewer\/([^\/]*\/[A-Za-z0-9]*|[A-Za-z0-9]*)", "$2");
         expect(parsed).toBe("TE");
+        expect(embedMap1).toBe("shared/44asd");
+        expect(embedMap2).toBe("44asd");
     });
     it('test showAPI flag', () => {
         let cmpSharePanel = ReactDOM.render(<SharePanel selectedTab="embed" showAPI={false} getCount={()=>0} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));

--- a/web/client/components/share/__tests__/SharePanel-test.jsx
+++ b/web/client/components/share/__tests__/SharePanel-test.jsx
@@ -49,15 +49,13 @@ describe("The SharePanel component", () => {
         const cmpSharePanelDom = ReactDOM.findDOMNode(cmpSharePanel);
         expect(cmpSharePanelDom).toBeFalsy();
     });
-    it('test regex parsing for shareEmbeddedUrl generation', () => {
+    it.n('test regex parsing for shareEmbeddedUrl generation', () => {
         const cmpSharePanel = ReactDOM.render(<SharePanel selectedTab="embed" getCount={()=>0} shareUrlRegex=".*" shareUrlReplaceString="ABC" shareUrl="www.geo-solutions.it" isVisible={false} />, document.getElementById("container"));
         expect(cmpSharePanel).toExist();
         const parsed = cmpSharePanel.generateUrl("TEST", "(TE)ST", "$1");
-        const embedMap1 = cmpSharePanel.generateUrl("http://localhost:8081/#/viewer/shared/44asd", "(h[^#]*)#\/viewer\/([^\/]*\/[A-Za-z0-9]*|[A-Za-z0-9]*)", "$2");
-        const embedMap2 = cmpSharePanel.generateUrl("http://localhost:8081/#/viewer/44asd", "(h[^#]*)#\/viewer\/([^\/]*\/[A-Za-z0-9]*|[A-Za-z0-9]*)", "$2");
+        const embedMap = cmpSharePanel.generateUrl("http://localhost:8081/#/viewer/44asd", "(h[^#]*)#\/viewer\/([^\/]*\/[A-Za-z0-9]*|[A-Za-z0-9]*)", "$2");
         expect(parsed).toBe("TE");
-        expect(embedMap1).toBe("shared/44asd");
-        expect(embedMap2).toBe("44asd");
+        expect(embedMap).toBe("44asd");
     });
     it('test showAPI flag', () => {
         let cmpSharePanel = ReactDOM.render(<SharePanel selectedTab="embed" showAPI={false} getCount={()=>0} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));


### PR DESCRIPTION
## Description
In sharing map, if user select the Embed tab, the map embed link was pointing to "/#/viewer/{mapId}" instead of "/embedded.html#/{mapId}" and this was because of something wrong in the used regExp.
So I fixed the RegExp that corrects the embed map link. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
## Issue

**What is the current behavior?**
#9269 

**What is the new behavior?**
if user gos to the homepage or inside a map, clicks on the share button of the map card or from the side bar inside the map viewer, select the embed tab, user will get the correct embed url that points to /embedded.html#/{mapId}.
The embed url should point to the correct html page

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No


## Other useful information
