### PR TITLE
#9310 fixing issue of hiding annotation plugin in a context with sidebar menu

### DIFF
--- a/web/client/configs/pluginsConfig.json
+++ b/web/client/configs/pluginsConfig.json
@@ -177,7 +177,7 @@
       "title": "plugins.Annotations.title",
       "description": "plugins.Annotations.description",
       "dependencies": [
-        "SidebarMenu"
+        "TOC"
       ]
     },
     {

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -354,16 +354,6 @@ export default createPlugin('Annotations', {
                 }
                 return false;
             })
-        },
-        BurgerMenu: {
-            name: 'annotations',
-            position: 40,
-            text: <Message msgId="annotationsbutton"/>,
-            tooltip: "annotations.tooltip",
-            icon: <Glyphicon glyph="comment"/>,
-            action: conditionalToggle,
-            priority: 2,
-            doNotHide: true
         }
     },
     reducers: {


### PR DESCRIPTION

## Description
This PR fixes issue #9310 of not showing annotation plugin in creating a context with sidebar menu. In this PR annotation plugin if added in a context it will be appeared in the TOC.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#9310 

**What is the new behavior?**
Annotation plugin if added in a context it will be appeared only in the TOC

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No


## Other useful information
