### PR TITLE
#9325 enhancement: support for 'isNull' logical operator on date field in layer filter

### DIFF
--- a/web/client/components/data/query/DateField.jsx
+++ b/web/client/components/data/query/DateField.jsx
@@ -94,9 +94,10 @@ class DateField extends React.Component {
                         onChange={(date) => this.updateValueState({startDate: startdate, endDate: date})}/>
                 </div>
             </div>)
-            : this.props.operator === "isNull" ? '' : (<div>
+            : (<div>
                 {this.props.showLabels && <Message msgId="queryform.date"/>}
                 <UTCDateTimePicker
+                    disabled={this.props.operator === "isNull"}
                     type={this.props.attType}
                     defaultValue={startdate}
                     value={startdate}

--- a/web/client/components/data/query/DateField.jsx
+++ b/web/client/components/data/query/DateField.jsx
@@ -94,8 +94,7 @@ class DateField extends React.Component {
                         onChange={(date) => this.updateValueState({startDate: startdate, endDate: date})}/>
                 </div>
             </div>)
-            :
-            (<div>
+            : this.props.operator === "isNull" ? '' : (<div>
                 {this.props.showLabels && <Message msgId="queryform.date"/>}
                 <UTCDateTimePicker
                     type={this.props.attType}

--- a/web/client/components/data/query/FilterField.jsx
+++ b/web/client/components/data/query/FilterField.jsx
@@ -96,7 +96,7 @@ class FilterField extends React.Component {
                         comboFilter={"contains"}/>
                 </div>
                 <div className="filter-field-operator">{selectedAttribute ? this.renderOperatorField() : null}</div>
-                <div className="filter-field-value">{this.props.filterField?.operator === 'isNull' ? null : selectedAttribute && this.props.filterField.operator ? this.renderValueField(selectedAttribute) : null}</div>
+                <div className="filter-field-value">{selectedAttribute && this.props.filterField.operator ? this.renderValueField(selectedAttribute) : null}</div>
                 {this.props.deleteButton ? <div className="filter-field-tools">{this.props.deleteButton}</div> : null}
             </div>
         );

--- a/web/client/components/data/query/FilterField.jsx
+++ b/web/client/components/data/query/FilterField.jsx
@@ -96,7 +96,7 @@ class FilterField extends React.Component {
                         comboFilter={"contains"}/>
                 </div>
                 <div className="filter-field-operator">{selectedAttribute ? this.renderOperatorField() : null}</div>
-                <div className="filter-field-value">{selectedAttribute && this.props.filterField.operator ? this.renderValueField(selectedAttribute) : null}</div>
+                <div className="filter-field-value">{this.props.filterField?.operator === 'isNull' ? null : selectedAttribute && this.props.filterField.operator ? this.renderValueField(selectedAttribute) : null}</div>
                 {this.props.deleteButton ? <div className="filter-field-tools">{this.props.deleteButton}</div> : null}
             </div>
         );

--- a/web/client/components/data/query/GroupField.jsx
+++ b/web/client/components/data/query/GroupField.jsx
@@ -87,7 +87,7 @@ class GroupField extends React.Component {
         stringOperators: ["=", "<>", "like", "ilike", "isNull"],
         arrayOperators: ["contains"],
         booleanOperators: ["="],
-        defaultOperators: ["=", ">", "<", ">=", "<=", "<>", "><"],
+        defaultOperators: ["=", ">", "<", ">=", "<=", "<>", "><", "isNull"],
         textFieldTooltipMessageId: 'queryform.attributefilter.tooltipTextField'
     };
 
@@ -130,9 +130,6 @@ class GroupField extends React.Component {
         }
         case "array": {
             return this.props.arrayOperators;
-        }
-        case "date": {
-            return [...this.props.defaultOperators, "isNull"];
         }
         default:
             return this.props.defaultOperators;

--- a/web/client/components/data/query/GroupField.jsx
+++ b/web/client/components/data/query/GroupField.jsx
@@ -131,6 +131,9 @@ class GroupField extends React.Component {
         case "array": {
             return this.props.arrayOperators;
         }
+        case "date": {
+            return [...this.props.defaultOperators, "isNull"];
+        }
         default:
             return this.props.defaultOperators;
         }

--- a/web/client/components/data/query/NumberField.jsx
+++ b/web/client/components/data/query/NumberField.jsx
@@ -76,6 +76,7 @@ class NumberField extends React.Component {
                 <div className="query-field-value">
                     {lowLabel}
                     <NumberPicker
+                        disabled={this.props.operator === "isNull"}
                         style={style}
                         value={this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : null}
                         onChange={(value) => !isNaN(value) && this.changeNumber({lowBound: value, upBound: this.props.fieldValue && (this.props.fieldValue.upBound !== null && this.props.fieldValue.upBound !== undefined ) ? this.props.fieldValue.upBound : null})}
@@ -85,6 +86,7 @@ class NumberField extends React.Component {
                 <div className="query-field-value">
                     {upLabel}
                     <NumberPicker
+                        disabled={this.props.operator === "isNull"}
                         style={style}
                         value={this.props.fieldValue && (this.props.fieldValue.upBound !== null && this.props.fieldValue.upBound !== undefined ) ? this.props.fieldValue.upBound : null}
                         onChange={(value) => !isNaN(value) && this.changeNumber({upBound: value, lowBound: this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : null})}
@@ -96,6 +98,7 @@ class NumberField extends React.Component {
             <div>
                 {label}
                 <NumberPicker
+                    disabled={this.props.operator === "isNull"}
                     style={style}
                     value={this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : this.props.fieldValue}
                     onChange={(value) => !isNaN(value) && this.changeNumber(value)}
@@ -111,7 +114,7 @@ class NumberField extends React.Component {
             style = {...this.props.style, borderColor: "#FF0000"};
         }
         return (
-            this.props.operator === "isNull" ? null : <OverlayTrigger placement="bottom"
+            <OverlayTrigger placement="bottom"
                 overlay={this.props.fieldException ?
                     <Tooltip id={this.props.fieldRowId + "_tooltip"}>
                         <strong>

--- a/web/client/components/data/query/NumberField.jsx
+++ b/web/client/components/data/query/NumberField.jsx
@@ -111,7 +111,7 @@ class NumberField extends React.Component {
             style = {...this.props.style, borderColor: "#FF0000"};
         }
         return (
-            <OverlayTrigger placement="bottom"
+            this.props.operator === "isNull" ? null : <OverlayTrigger placement="bottom"
                 overlay={this.props.fieldException ?
                     <Tooltip id={this.props.fieldRowId + "_tooltip"}>
                         <strong>

--- a/web/client/components/data/query/__tests__/FilterField-test.jsx
+++ b/web/client/components/data/query/__tests__/FilterField-test.jsx
@@ -227,6 +227,79 @@ describe('FilterField', () => {
 
     });
 
+    it('creates the FilterField component with date type and isNull operator', () => {
+        const filterField = {
+            rowId: 200,
+            attribute: "Attribute1",
+            operator: "isNull",
+            value: null,
+            exception: null
+        };
+
+        const attributes = [
+            {
+                attribute: "Attribute1",
+                label: "Attribute1",
+                type: "list",
+                values: [
+                    {id: "attribute1", name: "attribute1"},
+                    {id: "Attribute2", name: "attribute2"},
+                    {id: "attribute3", name: "attribute3"},
+                    {id: "attribute4", name: "attribute4"},
+                    {id: "attribute5", name: "attribute5"}
+                ],
+                valueId: "id",
+                valueLabel: "name",
+                fieldOptions: {"style": {display: "none"}}
+            }
+        ];
+
+        const filterfield = ReactDOM.render(
+            <FilterField
+                attributes={attributes}
+                filterField={filterField}>
+                <ComboField
+                    attType="list"
+                    valueField={'id'}
+                    textField={'name'}
+                    fieldOptions={attributes[0] && attributes[0].type === "list" ? [null, ...attributes[0].values] : null}/>
+                <DateField
+                    attType="date"
+                    operator={filterField.operator}/>
+            </FilterField>,
+            document.getElementById("container"));
+
+        expect(filterfield).toExist();
+
+        expect(filterfield.props.children).toExist();
+        expect(filterfield.props.children.length).toBe(2);
+
+        expect(filterfield.props.attributes).toExist();
+        expect(filterfield.props.attributes.length).toBe(1);
+
+        expect(filterfield.props.filterField).toExist();
+
+        const filterFieldDOMNode = expect(ReactDOM.findDOMNode(filterfield));
+
+        expect(filterFieldDOMNode).toExist();
+
+        let childNodes = filterFieldDOMNode.actual.childNodes;
+
+        expect(childNodes.length).toBe(3);
+
+        const inputFields = filterFieldDOMNode.actual.getElementsByClassName('rw-input');
+        expect(inputFields.length).toBe(2);
+
+        const attributeSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[0];
+        expect(attributeSelect.childNodes[0].nodeValue).toBe("Attribute1");
+
+        const operatorSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[1];
+        expect(operatorSelect.childNodes[0].nodeValue).toBe("isNull");
+
+        const valueSelectContainer = filterFieldDOMNode.actual.getElementsByClassName('filter-field-value')[0];
+        expect(valueSelectContainer.innerHTML).toBe('');
+
+    });
     it('tests the FilterField actions', () => {
 
         const actions = {

--- a/web/client/components/data/query/__tests__/FilterField-test.jsx
+++ b/web/client/components/data/query/__tests__/FilterField-test.jsx
@@ -15,6 +15,7 @@ import FilterField, {AttributeNameField} from '../FilterField.jsx';
 import ComboField from '../ComboField.jsx';
 import DateField from '../DateField.jsx';
 import expect from 'expect';
+import NumberField from '../NumberField';
 
 describe('FilterField', () => {
 
@@ -230,7 +231,7 @@ describe('FilterField', () => {
     it('creates the FilterField component with date type and isNull operator', () => {
         const filterField = {
             rowId: 200,
-            attribute: "Attribute1",
+            attribute: "Date",
             operator: "isNull",
             value: null,
             exception: null
@@ -238,19 +239,12 @@ describe('FilterField', () => {
 
         const attributes = [
             {
-                attribute: "Attribute1",
-                label: "Attribute1",
-                type: "list",
-                values: [
-                    {id: "attribute1", name: "attribute1"},
-                    {id: "Attribute2", name: "attribute2"},
-                    {id: "attribute3", name: "attribute3"},
-                    {id: "attribute4", name: "attribute4"},
-                    {id: "attribute5", name: "attribute5"}
-                ],
+                attribute: "Date",
+                label: "Date",
+                type: "date",
+                values: [],
                 valueId: "id",
-                valueLabel: "name",
-                fieldOptions: {"style": {display: "none"}}
+                valueLabel: "name"
             }
         ];
 
@@ -291,12 +285,226 @@ describe('FilterField', () => {
         expect(inputFields.length).toBe(2);
 
         const attributeSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[0];
-        expect(attributeSelect.childNodes[0].nodeValue).toBe("Attribute1");
+        expect(attributeSelect.childNodes[0].nodeValue).toBe("Date");
 
         const operatorSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[1];
         expect(operatorSelect.childNodes[0].nodeValue).toBe("isNull");
 
         const valueSelectContainer = filterFieldDOMNode.actual.getElementsByClassName('filter-field-value')[0];
+
+        expect(valueSelectContainer).toExist();
+
+
+        expect(valueSelectContainer.innerHTML).toBe('');
+
+    });
+    it('creates the FilterField component with time type and isNull operator', () => {
+        const filterField = {
+            rowId: 200,
+            attribute: "Time",
+            operator: "isNull",
+            value: null,
+            exception: null
+        };
+
+        const attributes = [
+            {
+                attribute: "Time",
+                label: "Time",
+                type: "time",
+                values: [],
+                valueId: "id",
+                valueLabel: "name"
+            }
+        ];
+
+        const filterfield = ReactDOM.render(
+            <FilterField
+                attributes={attributes}
+                filterField={filterField}>
+                <ComboField
+                    attType="list"
+                    valueField={'id'}
+                    textField={'name'}
+                    fieldOptions={attributes[0] && attributes[0].type === "list" ? [null, ...attributes[0].values] : null}/>
+                <DateField
+                    attType="time"
+                    operator={filterField.operator}/>
+            </FilterField>,
+            document.getElementById("container"));
+
+        expect(filterfield).toExist();
+
+        expect(filterfield.props.children).toExist();
+        expect(filterfield.props.children.length).toBe(2);
+
+        expect(filterfield.props.attributes).toExist();
+        expect(filterfield.props.attributes.length).toBe(1);
+
+        expect(filterfield.props.filterField).toExist();
+
+        const filterFieldDOMNode = expect(ReactDOM.findDOMNode(filterfield));
+
+        expect(filterFieldDOMNode).toExist();
+
+        let childNodes = filterFieldDOMNode.actual.childNodes;
+
+        expect(childNodes.length).toBe(3);
+
+        const inputFields = filterFieldDOMNode.actual.getElementsByClassName('rw-input');
+        expect(inputFields.length).toBe(2);
+
+        const attributeSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[0];
+        expect(attributeSelect.childNodes[0].nodeValue).toBe("Time");
+
+        const operatorSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[1];
+        expect(operatorSelect.childNodes[0].nodeValue).toBe("isNull");
+
+        const valueSelectContainer = filterFieldDOMNode.actual.getElementsByClassName('filter-field-value')[0];
+
+        expect(valueSelectContainer).toExist();
+
+
+        expect(valueSelectContainer.innerHTML).toBe('');
+
+    });
+    it('creates the FilterField component with date-time type and isNull operator', () => {
+        const filterField = {
+            rowId: 200,
+            attribute: "TimeDate",
+            operator: "isNull",
+            value: null,
+            exception: null
+        };
+
+        const attributes = [
+            {
+                attribute: "TimeDate",
+                label: "TimeDate",
+                type: "date-time",
+                values: [],
+                valueId: "id",
+                valueLabel: "name"
+            }
+        ];
+
+        const filterfield = ReactDOM.render(
+            <FilterField
+                attributes={attributes}
+                filterField={filterField}>
+                <ComboField
+                    attType="list"
+                    valueField={'id'}
+                    textField={'name'}
+                    fieldOptions={attributes[0] && attributes[0].type === "list" ? [null, ...attributes[0].values] : null}/>
+                <DateField
+                    attType="date-time"
+                    operator={filterField.operator}/>
+            </FilterField>,
+            document.getElementById("container"));
+
+        expect(filterfield).toExist();
+
+        expect(filterfield.props.children).toExist();
+        expect(filterfield.props.children.length).toBe(2);
+
+        expect(filterfield.props.attributes).toExist();
+        expect(filterfield.props.attributes.length).toBe(1);
+
+        expect(filterfield.props.filterField).toExist();
+
+        const filterFieldDOMNode = expect(ReactDOM.findDOMNode(filterfield));
+
+        expect(filterFieldDOMNode).toExist();
+
+        let childNodes = filterFieldDOMNode.actual.childNodes;
+
+        expect(childNodes.length).toBe(3);
+
+        const inputFields = filterFieldDOMNode.actual.getElementsByClassName('rw-input');
+        expect(inputFields.length).toBe(2);
+
+        const attributeSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[0];
+        expect(attributeSelect.childNodes[0].nodeValue).toBe("TimeDate");
+
+        const operatorSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[1];
+        expect(operatorSelect.childNodes[0].nodeValue).toBe("isNull");
+
+        const valueSelectContainer = filterFieldDOMNode.actual.getElementsByClassName('filter-field-value')[0];
+
+        expect(valueSelectContainer).toExist();
+
+
+        expect(valueSelectContainer.innerHTML).toBe('');
+
+    });
+    it('creates the FilterField component with number type and isNull operator', () => {
+        const filterField = {
+            rowId: 200,
+            attribute: "Number",
+            operator: "isNull",
+            value: null,
+            exception: null
+        };
+
+        const attributes = [
+            {
+                attribute: "Number",
+                label: "Number",
+                type: "number",
+                values: [],
+                valueId: "id",
+                valueLabel: "name"
+            }
+        ];
+
+        const filterfield = ReactDOM.render(
+            <FilterField
+                attributes={attributes}
+                filterField={filterField}>
+                <ComboField
+                    attType="list"
+                    valueField={'id'}
+                    textField={'name'}
+                    fieldOptions={attributes[0] && attributes[0].type === "list" ? [null, ...attributes[0].values] : null}/>
+                <NumberField
+                    attType="number"
+                    operator={filterField.operator}/>
+            </FilterField>,
+            document.getElementById("container"));
+
+        expect(filterfield).toExist();
+
+        expect(filterfield.props.children).toExist();
+        expect(filterfield.props.children.length).toBe(2);
+
+        expect(filterfield.props.attributes).toExist();
+        expect(filterfield.props.attributes.length).toBe(1);
+
+        expect(filterfield.props.filterField).toExist();
+
+        const filterFieldDOMNode = expect(ReactDOM.findDOMNode(filterfield));
+
+        expect(filterFieldDOMNode).toExist();
+
+        let childNodes = filterFieldDOMNode.actual.childNodes;
+
+        expect(childNodes.length).toBe(3);
+
+        const inputFields = filterFieldDOMNode.actual.getElementsByClassName('rw-input');
+        expect(inputFields.length).toBe(2);
+
+        const attributeSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[0];
+        expect(attributeSelect.childNodes[0].nodeValue).toBe("Number");
+
+        const operatorSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[1];
+        expect(operatorSelect.childNodes[0].nodeValue).toBe("isNull");
+
+        const valueSelectContainer = filterFieldDOMNode.actual.getElementsByClassName('filter-field-value')[0];
+
+        expect(valueSelectContainer).toExist();
+
+
         expect(valueSelectContainer.innerHTML).toBe('');
 
     });

--- a/web/client/components/data/query/__tests__/FilterField-test.jsx
+++ b/web/client/components/data/query/__tests__/FilterField-test.jsx
@@ -282,7 +282,7 @@ describe('FilterField', () => {
         expect(childNodes.length).toBe(3);
 
         const inputFields = filterFieldDOMNode.actual.getElementsByClassName('rw-input');
-        expect(inputFields.length).toBe(2);
+        expect(inputFields.length).toBe(3);
 
         const attributeSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[0];
         expect(attributeSelect.childNodes[0].nodeValue).toBe("Date");
@@ -290,12 +290,9 @@ describe('FilterField', () => {
         const operatorSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[1];
         expect(operatorSelect.childNodes[0].nodeValue).toBe("isNull");
 
-        const valueSelectContainer = filterFieldDOMNode.actual.getElementsByClassName('filter-field-value')[0];
-
+        const valueSelectContainer = inputFields[2];
         expect(valueSelectContainer).toExist();
-
-
-        expect(valueSelectContainer.innerHTML).toBe('');
+        expect(valueSelectContainer.disabled).toBe(true);
 
     });
     it('creates the FilterField component with time type and isNull operator', () => {
@@ -352,7 +349,7 @@ describe('FilterField', () => {
         expect(childNodes.length).toBe(3);
 
         const inputFields = filterFieldDOMNode.actual.getElementsByClassName('rw-input');
-        expect(inputFields.length).toBe(2);
+        expect(inputFields.length).toBe(3);
 
         const attributeSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[0];
         expect(attributeSelect.childNodes[0].nodeValue).toBe("Time");
@@ -360,12 +357,9 @@ describe('FilterField', () => {
         const operatorSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[1];
         expect(operatorSelect.childNodes[0].nodeValue).toBe("isNull");
 
-        const valueSelectContainer = filterFieldDOMNode.actual.getElementsByClassName('filter-field-value')[0];
-
+        const valueSelectContainer = inputFields[2];
         expect(valueSelectContainer).toExist();
-
-
-        expect(valueSelectContainer.innerHTML).toBe('');
+        expect(valueSelectContainer.disabled).toBe(true);
 
     });
     it('creates the FilterField component with date-time type and isNull operator', () => {
@@ -422,7 +416,7 @@ describe('FilterField', () => {
         expect(childNodes.length).toBe(3);
 
         const inputFields = filterFieldDOMNode.actual.getElementsByClassName('rw-input');
-        expect(inputFields.length).toBe(2);
+        expect(inputFields.length).toBe(3);
 
         const attributeSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[0];
         expect(attributeSelect.childNodes[0].nodeValue).toBe("TimeDate");
@@ -430,12 +424,9 @@ describe('FilterField', () => {
         const operatorSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[1];
         expect(operatorSelect.childNodes[0].nodeValue).toBe("isNull");
 
-        const valueSelectContainer = filterFieldDOMNode.actual.getElementsByClassName('filter-field-value')[0];
-
+        const valueSelectContainer = inputFields[2];
         expect(valueSelectContainer).toExist();
-
-
-        expect(valueSelectContainer.innerHTML).toBe('');
+        expect(valueSelectContainer.disabled).toBe(true);
 
     });
     it('creates the FilterField component with number type and isNull operator', () => {
@@ -492,7 +483,7 @@ describe('FilterField', () => {
         expect(childNodes.length).toBe(3);
 
         const inputFields = filterFieldDOMNode.actual.getElementsByClassName('rw-input');
-        expect(inputFields.length).toBe(2);
+        expect(inputFields.length).toBe(3);
 
         const attributeSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[0];
         expect(attributeSelect.childNodes[0].nodeValue).toBe("Number");
@@ -500,12 +491,9 @@ describe('FilterField', () => {
         const operatorSelect = filterFieldDOMNode.actual.getElementsByClassName('rw-input')[1];
         expect(operatorSelect.childNodes[0].nodeValue).toBe("isNull");
 
-        const valueSelectContainer = filterFieldDOMNode.actual.getElementsByClassName('filter-field-value')[0];
-
+        const valueSelectContainer = inputFields[2];
         expect(valueSelectContainer).toExist();
-
-
-        expect(valueSelectContainer.innerHTML).toBe('');
+        expect(valueSelectContainer.disabled).toBe(true);
 
     });
     it('tests the FilterField actions', () => {

--- a/web/client/components/data/query/__tests__/GroupField-test.jsx
+++ b/web/client/components/data/query/__tests__/GroupField-test.jsx
@@ -122,7 +122,7 @@ describe('GroupField', () => {
         const boolean = groupfield.getOperator({type: "boolean"});
         expect(boolean).toEqual(["="]);
         const noType = groupfield.getOperator();
-        expect(noType).toEqual(["=", ">", "<", ">=", "<=", "<>", "><"]);
+        expect(noType).toEqual(["=", ">", "<", ">=", "<=", "<>", "><", "isNull"]);
 
         const noSelected = groupfield.getComboValues();
         expect(noSelected).toBe(null);


### PR DESCRIPTION
## Description
It is an enhancement feature added to filter layer from attribute table. Add 'isNull' operator to date field to filter attribute table based on it. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [s] Feature
 
## Issue
#9325 
**What is the current behavior?**
There was no operator for 'isNull' for date field
#9325 

**What is the new behavior?**
'isNull' operator is added to the filter layer for date field.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

## Other useful information
