### PR TITLE
#9318: Print plugin - Ability to rotate the map

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -314,8 +314,8 @@ class OpenlayersMap extends React.Component {
             }, 0);
         }
 
-        if (this.map && ((this.props.projection !== newProps.projection) || this.haveResolutionsChanged(newProps)) || this.props.limits !== newProps.limits) {
-            if (this.props.projection !== newProps.projection || this.props.limits !== newProps.limits) {
+        if (this.map && ((this.props.projection !== newProps.projection) || this.haveResolutionsChanged(newProps)) || this.haveRotationChanged(newProps) || this.props.limits !== newProps.limits) {
+            if (this.props.projection !== newProps.projection || this.props.limits !== newProps.limits || this.haveRotationChanged(newProps)) {
                 let mapProjection = newProps.projection;
                 const center = reproject([
                     newProps.center.x,
@@ -491,6 +491,12 @@ class OpenlayersMap extends React.Component {
         const resolutions = this.props.mapOptions && this.props.mapOptions.view ? this.props.mapOptions.view.resolutions : undefined;
         const newResolutions = newProps.mapOptions && newProps.mapOptions.view ? newProps.mapOptions.view.resolutions : undefined;
         return !isEqual(resolutions, newResolutions);
+    };
+
+    haveRotationChanged = (newProps) => {
+        const rotation = this.props.mapOptions && this.props.mapOptions.view ? this.props.mapOptions.view.rotation : undefined;
+        const newRotation = newProps.mapOptions && newProps.mapOptions.view ? newProps.mapOptions.view.rotation : undefined;
+        return !isEqual(rotation, newRotation);
     };
 
     createView = (center, zoom, projection, options, limits = {}) => {

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -712,6 +712,83 @@ describe('OpenlayersMap', () => {
         expect( map.haveResolutionsChanged(testProps({mapOptions: {view: {resolutions: [100, 50, 25]}}})) ).toBe(true);
     });
 
+    it('check result of "haveRotationChanged()" when receiving new props', () => {
+        let map = ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 43.9, x: 10.3}}
+                zoom={11.6}
+                measurement={{}}
+            />
+            , document.getElementById("map"));
+
+        let origProps = assign({}, map.props);
+        function testProps(newProps) {
+            // update original props with newProps
+            return assign({}, origProps, newProps);
+        }
+
+        map = ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 43.9, x: 10.3}}
+                zoom={11.6}
+                measurement={{}}
+                mapOptions={undefined}
+            />
+            , document.getElementById("map"));
+
+        expect(map.haveRotationChanged(testProps({mapOptions: undefined}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {}}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {}}}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: undefined}}}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: 0}}}))).toBe(true);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: 20}}}))).toBe(true);
+
+        map = ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 43.9, x: 10.3}}
+                zoom={11.6}
+                measurement={{}}
+                mapOptions={{}}
+            />
+            , document.getElementById("map"));
+        expect(map.haveRotationChanged(testProps({mapOptions: undefined}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {}}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {}}}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: undefined}}}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: 0}}}))).toBe(true);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: 20}}}))).toBe(true);
+
+        map = ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 43.9, x: 10.3}}
+                zoom={11.6}
+                measurement={{}}
+                mapOptions={{view: {}}}
+            />
+            , document.getElementById("map"));
+        expect(map.haveRotationChanged(testProps({mapOptions: undefined}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {}}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {}}}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: undefined}}}))).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: 0}}}))).toBe(true);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: 20}}}))).toBe(true);
+        map = ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 43.9, x: 10.3}}
+                zoom={11.6}
+                measurement={{}}
+                mapOptions={{view: {rotation: 1}}}
+                maxExtent= {[-180, -90, 180, 80]}
+            />
+            , document.getElementById("map"));
+        expect(map.haveRotationChanged(testProps({mapOptions: undefined})) ).toBe(true);
+        expect(map.haveRotationChanged(testProps({mapOptions: {}})) ).toBe(true);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {}}})) ).toBe(true);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: undefined}}})) ).toBe(true);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: 1}}})) ).toBe(false);
+        expect(map.haveRotationChanged(testProps({mapOptions: {view: {rotation: 20}}})) ).toBe(true);
+    });
+
     it('check if the map has "auto" cursor as default', () => {
         const map = ReactDOM.render(
             <OpenlayersMap

--- a/web/client/components/print/MapPreview.jsx
+++ b/web/client/components/print/MapPreview.jsx
@@ -15,6 +15,7 @@ import { getMapZoom, getResolutionMultiplier } from '../../utils/PrintUtils';
 import ScaleBox from '../mapcontrols/scale/ScaleBox';
 import Button from '../misc/Button';
 import isNil from 'lodash/isNil';
+import isEmpty from 'lodash/isEmpty';
 import { MapLibraries } from '../../utils/MapTypeUtils';
 
 let PMap;
@@ -40,6 +41,7 @@ class MapPreview extends React.Component {
         layout: PropTypes.string,
         layoutSize: PropTypes.object,
         useFixedScales: PropTypes.bool,
+        rotation: PropTypes.number,
         env: PropTypes.object,
         onLoadingMapPlugins: PropTypes.func
     };
@@ -133,7 +135,12 @@ class MapPreview extends React.Component {
             height: this.props.height + "px"
         });
         const resolutions = this.getResolutions();
-        const mapOptions = resolutions ? {view: {resolutions}} : {};
+        let mapOptions = !isEmpty(resolutions) || !isNil(this.props.rotation) ? {
+            view: {
+                ...(!isEmpty(resolutions) && {resolutions}),
+                rotation: !isNil(this.props.rotation) ? Number(this.props.rotation) : 0
+            }
+        } : {};
         const projection = this.props.map && this.props.map.projection || 'EPSG:3857';
         return this.props.map && this.props.map.center ?
 

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -10,6 +10,7 @@ import './print/print.css';
 
 import head from 'lodash/head';
 import castArray from "lodash/castArray";
+import isNil from "lodash/isNil";
 import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -28,7 +29,7 @@ import { layersSelector } from '../selectors/layers';
 import { currentLocaleSelector } from '../selectors/locale';
 import { mapSelector, scalesSelector } from '../selectors/map';
 import { mapTypeSelector } from '../selectors/maptype';
-import { normalizeSRS, reprojectBbox } from '../utils/CoordinatesUtils';
+import { normalizeSRS, reprojectBbox, convertDegreesToRadian } from '../utils/CoordinatesUtils';
 import { getMessageById } from '../utils/LocaleUtils';
 import { defaultGetZoomForExtent, getResolutions, mapUpdated, dpi2dpu, DEFAULT_SCREEN_DPI } from '../utils/MapUtils';
 import { isInsideResolutionsLimits } from '../utils/LayersUtils';
@@ -449,6 +450,7 @@ export default {
                             notAllowedLayers: this.isBackgroundIgnored(this.props.layers, map?.projection),
                             actionConfig: this.props.submitConfig,
                             validations: this.props.printingService.validate(),
+                            rotation: !isNil(this.props.printSpec.rotation) ? convertDegreesToRadian(Number(this.props.printSpec.rotation)) : 0,
                             actions: {
                                 print: this.print,
                                 addParameter: this.addParameter

--- a/web/client/plugins/__tests__/Print-test.jsx
+++ b/web/client/plugins/__tests__/Print-test.jsx
@@ -73,6 +73,7 @@ function expectDefaultItems() {
     expect(getByXPath("//*[text()='print.description']")).toExist();
     expect(getByXPath("//*[text()='print.outputFormat']")).toExist();
     expect(getByXPath("//*[text()='print.projection']")).toExist();
+    expect(getByXPath("//*[text()='print.rotation']")).toExist();
     expect(document.getElementById("print_preview")).toExist();
     expect(getByXPath("//*[text()='print.sheetsize']")).toExist();
     expect(getByXPath("//*[text()='print.alternatives.legend']")).toExist();

--- a/web/client/plugins/print/index.js
+++ b/web/client/plugins/print/index.js
@@ -82,6 +82,17 @@ export const Projection = connect((state) => ({
     onChangeParameter: setPrintParameter
 })(ProjectionComp);
 
+export const Rotation = connect((state) => ({
+    spec: state.print?.spec || {},
+    additionalProperty: false,
+    property: "rotation",
+    path: "",
+    type: "number",
+    label: "print.rotation"
+}), {
+    onChangeParameter: setPrintParameter
+})(TextInput);
+
 export const Layout = connect((state) => ({
     spec: state.print?.spec || {},
     layouts: state?.print?.capabilities?.layouts || []
@@ -190,12 +201,16 @@ export const standardItems = {
         },
         position: 4
     }, {
+        id: "rotation",
+        plugin: Rotation,
+        position: 5
+    }, {
         id: "overlayLayers",
         plugin: AdditionalLayers,
         cfg: {
             enabled: false
         },
-        position: 5
+        position: 6
     }],
     "left-panel-accordion": [{
         id: "layout",

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -37,7 +37,8 @@ const initialSpec = {
     resolution: 96,
     name: '',
     description: '',
-    outputFormat: "pdf"
+    outputFormat: "pdf",
+    rotation: 0
 };
 
 const getSheetName = (name = '') => {

--- a/web/client/themes/default/less/print.less
+++ b/web/client/themes/default/less/print.less
@@ -34,4 +34,14 @@
         border-width: 1px;
         border-style: solid;
     }
+    #print_preview {
+        .ol-rotate {
+            background-color: transparent;
+            button{
+                &.ol-rotate-reset{
+                    display: none; //hide rotate button on map-preview
+                }
+            }
+        }
+    }
 }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -740,6 +740,7 @@
                 "iconsSize": "Symbolgröße:",
                 "dpi": "dpi:"
             },
+            "rotation": "Rotation",
             "layoutWarning": "Layout nicht erlaubt",
             "scale": "Maßstab",
             "includeScale": "in Druck einschließen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -701,6 +701,7 @@
                 "iconsSize": "Icons size:",
                 "dpi": "Dpi:"
             },
+            "rotation": "Rotation",
             "layoutWarning": "Not allowed layout",
             "scale": "Scale",
             "includeScale": "Include in print",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -701,6 +701,7 @@
                 "iconsSize": "Tamaño de los iconos:",
                 "dpi": "ppp:"
             },
+            "rotation": "Rotation",
             "layoutWarning": "Lienzo no permitido",
             "scale": "escala",
             "includeScale": "incluir en la impresión",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -701,6 +701,7 @@
                 "iconsSize": "Taille d'icône :",
                 "dpi": "Ppp :"
             },
+            "rotation": "Rotation",
             "layoutWarning": "Mise en page non permise",
             "scale": "échelle",
             "includeScale": "inclure dans l'impression",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -701,6 +701,7 @@
                 "iconsSize": "Dimensione icone:",
                 "dpi": "Dpi:"
             },
+            "rotation": "Rotation",
             "layoutWarning": "Layout non consentito",
             "scale": "Scala",
             "includeScale": "Includi nella stampa",

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -32,6 +32,7 @@ import { printSpecificationSelector } from "../selectors/print";
 import assign from 'object-assign';
 import sortBy from "lodash/sortBy";
 import head from "lodash/head";
+import isNil from "lodash/isNil";
 
 import { getGridGeoJson } from "./grids/MapGridsUtils";
 
@@ -266,7 +267,7 @@ export const getMapfishPrintSpecification = (rawSpec, state) => {
                     projectedCenter.y
                 ],
                 "scale": reprojectedScale,
-                "rotation": 0
+                "rotation": !isNil(spec.rotation) ? -Number(spec.rotation) : 0 // negate the rotation value to match rotation in map preview and printed output
             }
         ],
         "legends": PrintUtils.getMapfishLayersSpecification(spec.layers, projectedSpec, state, 'legend'),


### PR DESCRIPTION
## Description
This PR adds ability to rotate map in print tool and print the rotated map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #9318

**What is the new behavior?**
<img width="828" alt="Screenshot 2023-09-11 at 4 51 42 PM" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/7095ffe0-1ce2-450e-9d7f-c166b883541d">
<img width="831" alt="Screenshot 2023-09-11 at 4 51 58 PM" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/e1006b3a-a6ee-479b-b8be-9933f1864d65">


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
