### PR TITLE
#9332: Convert WPS download ROI geometries to WKT

### DIFF
--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -341,7 +341,7 @@ export const startFeatureExportDownload = (action$, store) =>
                     type: 'TEXT',
                     data: {
                         mimeType: 'application/wkt',
-                        data: JSON.stringify(toWKT(bboxToFeatureGeometry(mapBbox.bounds)))
+                        data: toWKT(bboxToFeatureGeometry(mapBbox.bounds))
                     }
                 } : undefined,
                 roiCRS: cropToROI ? (mapBbox.crs || 'EPSG:4326') : undefined,

--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -74,6 +74,7 @@ import { getLayerTitle } from '../utils/LayersUtils';
 import { bboxToFeatureGeometry } from '../utils/CoordinatesUtils';
 import { interceptOGCError } from '../utils/ObservableUtils';
 import requestBuilder from '../utils/ogc/WFS/RequestBuilder';
+import { toWKT } from '../utils/ogc/WKT';
 import {extractGeometryAttributeName} from "../utils/WFSLayerUtils";
 
 const DOWNLOAD_FORMATS_LOOKUP = {
@@ -339,8 +340,8 @@ export const startFeatureExportDownload = (action$, store) =>
                 ROI: cropToROI ? {
                     type: 'TEXT',
                     data: {
-                        mimeType: 'application/json',
-                        data: JSON.stringify(bboxToFeatureGeometry(mapBbox.bounds))
+                        mimeType: 'application/wkt',
+                        data: JSON.stringify(toWKT(bboxToFeatureGeometry(mapBbox.bounds)))
                     }
                 } : undefined,
                 roiCRS: cropToROI ? (mapBbox.crs || 'EPSG:4326') : undefined,


### PR DESCRIPTION
## Description
This PR fixes JSON geometries parsing error in Geoserver by converting ROI geometries to WKT

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #9332 

**What is the new behavior?**
WPS download with ROI works as expected

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
