### PR TITLE
#9422 Zoom level issue on OpenLayers

### DIFF
--- a/web/client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx
+++ b/web/client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx
@@ -95,7 +95,7 @@ function SelectInput({
 function VisibilityLimitsForm({
     title,
     layer,
-    zoom,
+    zoom: zoomProp,
     projection,
     resolutions = getResolutions(),
     defaultLimitsType,
@@ -103,6 +103,8 @@ function VisibilityLimitsForm({
     dpi,
     onChange
 }) {
+
+    const zoom = Math.round(zoomProp || 0);
 
     const [limitsType, setLimitsType] = useState(defaultLimitsType || limitsTypesOptions[0].value);
 

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -505,7 +505,12 @@ class OpenlayersMap extends React.Component {
             projection: normalizeSRS(projection),
             center: [center.x, center.y],
             zoom: zoom,
-            minZoom: limits.minZoom
+            minZoom: limits.minZoom,
+            // allow to zoom to level 0 and see world wrapping
+            multiWorld: true,
+            // does not allow intermediary zoom levels
+            // we need this at true to set correctly the scale box
+            constrainResolution: true
         }, newOptions || {});
         return new View(viewOptions);
     };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds `constrainResolution` and `multiWorld` to OpenLayers component to restore to allow to reach zoom level 0 and to avoid intermediate zoom levels. The PR improves also the zoom level used inside visibility limits component

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9422

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

OpenLayers map can be visualized at lower zoom level avoiding intermediates zoom levels

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
