### PR TITLE
[Backport 2023.02.xx] #9366 Problems with Bearing measurement (#9400)

### DIFF
--- a/web/client/components/map/openlayers/MeasurementSupport.jsx
+++ b/web/client/components/map/openlayers/MeasurementSupport.jsx
@@ -26,6 +26,7 @@ import {getMessageById} from '../../../utils/LocaleUtils';
 import {createOLGeometry} from '../../../utils/openlayers/DrawUtils';
 
 import {Polygon, LineString} from 'ol/geom';
+import { never } from 'ol/events/condition';
 import Overlay from 'ol/Overlay';
 import VectorSource from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
@@ -599,6 +600,7 @@ export default class MeasurementSupport extends React.Component {
         // create an interaction to draw with
         draw = new Draw({
             source: new VectorSource(),
+            freehandCondition: never,
             type: /** @type {ol.geom.GeometryType} */ geometryType,
             style: new Style({
                 fill: new Fill({
@@ -621,9 +623,9 @@ export default class MeasurementSupport extends React.Component {
             })
         });
 
-        this.clickListener = this.props.map.on('click', this.updateMeasurementResults.bind(this, this.props));
+        this.clickListener = this.props.map.on('click', this.updateMeasurementResults.bind(this));
         if (this.props.updateOnMouseMove) {
-            this.props.map.on('pointermove', this.updateMeasurementResults.bind(this, this.props));
+            this.props.map.on('pointermove', this.updateMeasurementResults.bind(this));
         }
 
         this.props.map.on('pointermove', (evt) => this.pointerMoveHandler(evt));
@@ -896,10 +898,10 @@ export default class MeasurementSupport extends React.Component {
             this.props.map.removeInteraction(this.drawInteraction);
             this.drawInteraction = null;
             this.sketchFeature = null;
-            this.props.map.un('click', this.updateMeasurementResults.bind(this, this.props), this);
+            this.props.map.un('click', this.updateMeasurementResults.bind(this), this);
             unByKey(this.clickListener);
             if (this.props.updateOnMouseMove) {
-                this.props.map.un('pointermove', this.updateMeasurementResults.bind(this, this.props), this);
+                this.props.map.un('pointermove', this.updateMeasurementResults.bind(this), this);
             }
         }
     };
@@ -929,13 +931,13 @@ export default class MeasurementSupport extends React.Component {
         this.helpTooltipElement.classList.remove('hidden');
     };
 
-    updateMeasurementResults = (props) => {
+    updateMeasurementResults = () => {
         if (!this.sketchFeature) {
             return;
         }
         let sketchCoords = this.sketchFeature.getGeometry().getCoordinates();
 
-        if (props.measurement.geomType === 'Bearing' && sketchCoords.length > 1) {
+        if (this.props.measurement.geomType === 'Bearing' && sketchCoords.length > 1) {
             // calculate the azimuth as base for bearing information
             if (sketchCoords.length > 2) {
                 this.drawInteraction.sketchCoords_ = [sketchCoords[0], sketchCoords[1], sketchCoords[0]];


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes some event callbacks that were not properly recieving props and removed the possibility to use freehand option of drawsupport

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9366

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The bearing measurement correct behaviour has been restored. 

This PR fixes some event callbacks that were not properly recieving props

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
