### PR TITLE
[Backport 2023.02.xx] #9363 Wrong scale value reported using the scroll wheel (#9401)

### DIFF
--- a/web/client/components/mapcontrols/scale/ScaleBox.jsx
+++ b/web/client/components/mapcontrols/scale/ScaleBox.jsx
@@ -45,7 +45,7 @@ class ScaleBox extends React.Component {
     }
 
     onComboChange = (event) => {
-        var selectedZoomLvl = parseInt(event.nativeEvent.target.value, 10);
+        let selectedZoomLvl = parseInt(event.nativeEvent.target.value, 10);
         this.props.onChange(selectedZoomLvl, this.props.scales[selectedZoomLvl]);
     };
 
@@ -58,14 +58,15 @@ class ScaleBox extends React.Component {
     };
 
     render() {
-        var control = null;
+        let control = null;
+        const currentZoomLvl = Math.round(this.props.currentZoomLvl);
         if (this.props.readOnly) {
             control =
-                <label>{this.props.template(this.props.scales[this.props.currentZoomLvl], this.props.currentZoomLvl)}</label>
+                <label>{this.props.template(this.props.scales[currentZoomLvl], currentZoomLvl)}</label>
             ;
         } else if (this.props.useRawInput) {
             control =
-                (<select label={this.props.label} onChange={this.onComboChange} bsSize="small" value={this.props.currentZoomLvl || ""}>
+                (<select label={this.props.label} onChange={this.onComboChange} bsSize="small" value={currentZoomLvl || ""}>
                     {this.getOptions()}
                 </select>)
             ;
@@ -73,7 +74,7 @@ class ScaleBox extends React.Component {
             control =
                 (<Form inline><FormGroup bsSize="small">
                     <ControlLabel>{this.props.label}</ControlLabel>
-                    <FormControl componentClass="select" onChange={this.onComboChange} value={this.props.currentZoomLvl || ""}>
+                    <FormControl componentClass="select" onChange={this.onComboChange} value={currentZoomLvl || ""}>
                         {this.getOptions()}
                     </FormControl>
                 </FormGroup></Form>)

--- a/web/client/components/mapcontrols/scale/__tests__/ScaleBox-test.jsx
+++ b/web/client/components/mapcontrols/scale/__tests__/ScaleBox-test.jsx
@@ -96,4 +96,10 @@ describe('ScaleBox', () => {
         expect(domLabel).toExist();
         expect(domLabel.innerHTML).toContain("Scale:");
     });
+
+    it('should support not rounded zoom levels', () => {
+        TestUtils.act(() => { ReactDOM.render(<ScaleBox currentZoomLvl={5.1}/>, document.getElementById('container')); });
+        const select = document.querySelector('select');
+        expect(select.value).toBe('5');
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR improves the scale box component to support not rounded scales

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9363

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The scale selector shows the correct value again

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
