### PR TITLE
[Backport 2023.02.xx] #9362 3D Styling issue (#9403)

### DIFF
--- a/web/client/utils/styleparser/CesiumStyleParser.js
+++ b/web/client/utils/styleparser/CesiumStyleParser.js
@@ -671,7 +671,10 @@ function getStyleFuncFromRules({
             entity._msGlobalOpacity = undefined;
             return resolve(entity);
         }))
-    );
+    // map.scene.requestRender(); does not work without a setTimeout
+    // it seems there is need of a small delay to correctly request the next map rendering
+    // requestRender is used by layer to update the style
+    ).then((response) => new Promise((resolve) => setTimeout(() => resolve(response))));
 }
 
 class CesiumStyleParser {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

> 2 - When you change something interested features disappear. They appear again as soon as you move a bit the map

This PR adds a timeout to the promise used to update the Cesium style. It seems that without this small delay the `map.scene.requestRender();` method used to update the Cesium map does not work as expected.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9362

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The style is rendered correctly again after a style update

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
