### PR TITLE
[Backport 2023.02.xx] #9163 fixing a bug of change 3D Tiles height offset with Google 3D tiles #9421

### DIFF
--- a/web/client/components/map/cesium/plugins/ThreeDTilesLayer.js
+++ b/web/client/components/map/cesium/plugins/ThreeDTilesLayer.js
@@ -44,9 +44,9 @@ function getStyle({ style }) {
 function updateModelMatrix(tileSet, { heightOffset }) {
     if (!isNaN(heightOffset) && isNumber(heightOffset)) {
         const boundingSphere = tileSet.boundingSphere;
-        const cartographic = Cesium.Cartographic.fromCartesian(boundingSphere.center);
-        const surface = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, 0.0);
-        const offset = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, heightOffset);
+        const cartographic = Cesium.Cartographic.fromCartesian(boundingSphere.center);          // undefined if the cartesian is at the center of the ellipsoid
+        const surface = Cesium.Cartesian3.fromRadians(cartographic?.longitude || 0, cartographic?.latitude || 0, 0.0);
+        const offset = Cesium.Cartesian3.fromRadians(cartographic?.longitude || 0, cartographic?.latitude || 0, heightOffset);
         const translation = Cesium.Cartesian3.subtract(offset, surface, new Cesium.Cartesian3());
         tileSet.modelMatrix =  Cesium.Matrix4.fromTranslation(translation);
     }


### PR DESCRIPTION
## Description
Fixing the issue of throwing an unhandled error in case change the 3D tiles height offset with Google 3D tiles. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue
#9163 
**What is the current behavior?**
#9163 

**What is the new behavior?**
If a user opens google 3D tiles and set a height offset it will reflect on map and no error is thrown.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
