### PR TITLE
[Backport 2023.02.xx] #9344: Adding clause in documentation for google photorealistic 3D tiles (#9458)

### DIFF
--- a/docs/user-guide/catalog.md
+++ b/docs/user-guide/catalog.md
@@ -340,3 +340,9 @@ MapStore allows to publish 3D Tiles contents in its 3D mode on top of the [Cesiu
 In **general settings of** 3D Tiles service, the user can specify the title to assign to this service and the URL of the service.
 
 <img src="../img/catalog/3dtiles_service.jpg" class="ms-docimage"  style="max-width:600px;"/>
+
+!!! warning
+    MapStore allows you to load also [Google Photorealistic 3D Tiles](https://cloud.google.com/blog/products/maps-platform/create-immersive-3d-map-experiences-photorealistic-3d-tiles) and some constraints need to be respected in this case.
+    Since the Google Photorealistic 3D Tiles are not ‘survey-grade’ at this time, the use of certain MapStore tools could be considered derivative and, for this reason, prohibited. Please, make sure you have read the [Google conditions of use](https://developers.google.com/maps/documentation/tile/policies)
+    (some [FAQs](https://cloud.google.com/blog/products/maps-platform/commonly-asked-questions-about-our-recently-launched-photorealistic-3d-tiles) are also available online for this purpose) before providing Google Photorealistic 3D Tile in your MapStore maps in order to enable only allowed tools (e.g. *Measurement* and *Identify* tools should be probably disabled).
+    For this purpose it is possible to appropriately set the [configuration of MapStore plugins](../../developer-guide/maps-configuration/#map-options)  to exclude tools that could conflict with Google policies. Alternatively, it is possible to use a dedicated [application context](application-context.md#configure-plugins) to show Photorealistic 3D Tiles by including only the permitted tools within it.


### PR DESCRIPTION
https://github.com/geosolutions-it/MapStore2/issues/9344: Adding clause in documentation for google photorealistic 3D tiles(https://github.com/geosolutions-it/MapStore2/pull/9458)

