### PR TITLE
#9368: adding support 3D tiles resources in catalog for CSW

### DIFF
--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -218,8 +218,6 @@ class RecordItem extends React.Component {
                 caption={
                     <div>
                         {!this.props.hideIdentifier && <div className="identifier">{record && record.identifier}</div>}
-                        {record?.serviceType === '3dtiles' && record?.catalogType === 'csw' && <small className="text-info">
-                            <Message msgId="catalog.3dTileLayerIndicator"/></small>}
                         <div>{!record.isValid && <small className="text-danger"><Message msgId="catalog.missingReference"/></small>}</div>
                         {!this.props.hideExpand &&
                                 <div

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1630,8 +1630,7 @@
           "allowUnsecureLayers": {
               "label": "Nicht sichere Ebenen zulassen",
               "tooltip": "Das Hinzufügen einer Ebene zur Karte mit aktivierter Option zwingt die Anwendung, Proxy anzuwenden"
-          },
-          "3dTileLayerIndicator":"3D -Fliesenschicht"
+          }
         },
         "uploader": {
             "filename": "Dateiname",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1592,8 +1592,7 @@
             "helpTooltip": "This option is used to split content across multiple subdomains",
             "addAliasTooltip": "Add alias",
             "removeAliasTooltip": "Remove alias"
-          },
-          "3dTileLayerIndicator":"3D Tile Layer"
+          }
         },
         "uploader": {
             "filename": "File Name",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1593,8 +1593,7 @@
             "allowUnsecureLayers": {
               "label": "Permitir capas no seguras",
               "tooltip": "Agregar una capa al mapa con esta opción habilitada obliga a la aplicación a aplicar proxy"
-            },
-            "3dTileLayerIndicator":"Capa de mosaico 3D"
+            }
         },
         "uploader": {
             "filename": "Nombre del fichero",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1593,8 +1593,7 @@
             "allowUnsecureLayers": {
               "label": "Autoriser les couches non sécurisées",
               "tooltip": "L'ajout d'une couche à la carte avec cette option activée force l'application à appliquer un proxy"
-            },
-            "3dTileLayerIndicator":"Couche de carreaux 3D"
+            }
         },
         "uploader": {
             "filename": "Nom du fichier",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1592,8 +1592,7 @@
             "allowUnsecureLayers": {
               "label": "Consenti livelli non sicuri",
               "tooltip": "L'aggiunta di un livello da mappare con questa opzione abilitata, costringe l'applicazione ad applicare il proxy"
-            },
-            "3dTileLayerIndicator":"Livello 3D tile"
+            }
         },
         "uploader": {
             "filename": "File Name",


### PR DESCRIPTION
## Description
Adding a support for 3D Tiles resources in CSW metadata.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature
 
## Issue
#9368 

**What is the current behavior?**
adding CSW metadata in catalog doesn't support 3D Tiles if exists within it
#9368 

**What is the new behavior?**
A support for 3D Tiles resources in CSW metadata is added and now user can add 3D tiles via CSW to the map.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No


## Other useful information
