### PR TITLE
#9466: handling GetFeatureInfo exceptions parameter format configuration

### DIFF
--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -26,7 +26,6 @@ import {
     LOAD_FEATURE_INFO,
     NO_QUERYABLE_LAYERS,
     ERROR_FEATURE_INFO,
-    EXCEPTIONS_FEATURE_INFO,
     SHOW_MAPINFO_MARKER,
     HIDE_MAPINFO_MARKER,
     SET_CURRENT_EDIT_FEATURE_QUERY,
@@ -392,45 +391,6 @@ describe('identify Epics', () => {
                 expect(a2).toExist();
                 expect(a2.type).toBe(ERROR_FEATURE_INFO);
                 expect(a2.error).toExist();
-                expect(a2.reqId).toExist();
-                expect(a2.requestParams).toExist();
-                expect(a2.layerMetadata.title).toBe(state.layers.flat[0].title);
-                done();
-            } catch (ex) {
-                done(ex);
-            }
-        }, state);
-    });
-    it('getFeatureInfoOnFeatureInfoClick handle server exception', (done) => {
-        // remove previous hook
-        registerHook('RESOLUTION_HOOK', undefined);
-        const state = {
-            map: TEST_MAP_STATE,
-            mapInfo: {
-                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } }
-            },
-            layers: {
-                flat: [{
-                    id: "TEST",
-                    "title": "TITLE",
-                    type: "wms",
-                    visibility: true,
-                    url: 'base/web/client/test-resources/featureInfo-exception.json'
-                }]
-            }
-        };
-        const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } })];
-        testEpic(getFeatureInfoOnFeatureInfoClick, 3, sentActions, ([a0, a1, a2]) => {
-            try {
-                expect(a0).toExist();
-                expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
-                expect(a1).toExist();
-                expect(a1.type).toBe(NEW_MAPINFO_REQUEST);
-                expect(a1.reqId).toExist();
-                expect(a1.request).toExist();
-                expect(a2).toExist();
-                expect(a2.type).toBe(EXCEPTIONS_FEATURE_INFO);
-                expect(a2.exceptions).toExist();
                 expect(a2.reqId).toExist();
                 expect(a2.requestParams).toExist();
                 expect(a2.layerMetadata.title).toBe(state.layers.flat[0].title);

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -16,7 +16,7 @@ import {
     PURGE_MAPINFO_RESULTS, EDIT_LAYER_FEATURES,
     UPDATE_FEATURE_INFO_CLICK_POINT,
     featureInfoClick, updateCenterToMarker, purgeMapInfoResults,
-    exceptionsFeatureInfo, loadFeatureInfo, errorFeatureInfo,
+    loadFeatureInfo, errorFeatureInfo,
     noQueryableLayers, newMapInfoRequest,
     showMapinfoMarker, hideMapinfoMarker, setCurrentEditFeatureQuery,
     SET_MAP_TRIGGER, CLEAR_WARNING
@@ -129,12 +129,8 @@ export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { }
                             // this delay allows the panel to open and show the spinner for the first one
                             // this delay mitigates the freezing of the app when there are a great amount of queried layers at the same time
                             .delay(0)
-                            .map((response) =>
-                                response.data.exceptions
-                                    ? exceptionsFeatureInfo(reqId, response.data.exceptions, requestParams, lMetaData)
-                                    : loadFeatureInfo(reqId, response.data, requestParams, { ...lMetaData, features: response.features, featuresCrs: response.featuresCrs }, layer)
-                            )
-                            .catch((e) => Rx.Observable.of(errorFeatureInfo(reqId, e.data || e.statusText || e.status, requestParams, lMetaData)))
+                            .map((response) =>loadFeatureInfo(reqId, response.data, requestParams, { ...lMetaData, features: response.features, featuresCrs: response.featuresCrs }, layer))
+                            .catch((e) => Rx.Observable.of(errorFeatureInfo(reqId, e, requestParams, lMetaData)))
                             .concat(Rx.Observable.defer(() => {
                                 // update the layout only after the initial response
                                 // we don't need to trigger this for each query layer

--- a/web/client/utils/mapinfo/__tests__/wms-test.js
+++ b/web/client/utils/mapinfo/__tests__/wms-test.js
@@ -126,8 +126,6 @@ describe('mapinfo wms utils', () => {
             .subscribe((response) => {
                 expect(response?.data?.features).toEqual([]);
                 done();
-            }, error => {
-                done();
             });
     });
     it('test intercept ogc error in wms if exception', (done)=>{
@@ -146,8 +144,6 @@ describe('mapinfo wms utils', () => {
             .getIdentifyFlow(undefined, "/", { features: [] })
             .subscribe((response) => {
                 expect(response?.data?.exceptions).toExist();
-                done();
-            }, error => {
                 done();
             });
     });

--- a/web/client/utils/mapinfo/__tests__/wms-test.js
+++ b/web/client/utils/mapinfo/__tests__/wms-test.js
@@ -130,20 +130,21 @@ describe('mapinfo wms utils', () => {
     });
     it('test intercept ogc error in wms if exception', (done)=>{
         mockAxios.onGet().reply(() => {
-            return [200, {
-                "version": "1.1.1",
-                "exceptions": [
-                    {
-                        "code": "LayerNotDefined",
-                        "locator": "layers",
-                        "text": "Could not find layer misc:Bonnebladen1900_index2121 Details:org.geoserver.platform.ServiceException: Could not find layer misc:Bonnebladen1900_index2121"
-                    }]
-            }];
+            return [200, `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <!DOCTYPE ServiceExceptionReport SYSTEM "https://geobretagne.fr/geoserver/schemas/wms/1.1.1/WMS_exception_1_1_1.dtd">
+            <ServiceExceptionReport version="1.1.1" >
+                <ServiceException>
+                  java.lang.NumberFormatException: For input string: &quot;asd&quot;
+            For input string: &quot;asd&quot;
+            </ServiceException>
+            </ServiceExceptionReport>`];
         });
         wms
             .getIdentifyFlow(undefined, "/", { features: [] })
             .subscribe((response) => {
                 expect(response?.data?.exceptions).toExist();
+            }, error=>{
+                expect(error.name).toEqual('OGCError');
                 done();
             });
     });

--- a/web/client/utils/mapinfo/__tests__/wms-test.js
+++ b/web/client/utils/mapinfo/__tests__/wms-test.js
@@ -112,7 +112,7 @@ describe('mapinfo wms utils', () => {
     });
     it('test intercept ogc error in wms if success', (done)=>{
         mockAxios.onGet().reply(() => {
-            return [200, {
+            return [200,  {
                 "type": "FeatureCollection",
                 "features": [],
                 "totalFeatures": "unknown",
@@ -127,7 +127,28 @@ describe('mapinfo wms utils', () => {
                 expect(response?.data?.features).toEqual([]);
                 done();
             }, error => {
-                done(error);
+                done();
+            });
+    });
+    it('test intercept ogc error in wms if exception', (done)=>{
+        mockAxios.onGet().reply(() => {
+            return [200, {
+                "version": "1.1.1",
+                "exceptions": [
+                    {
+                        "code": "LayerNotDefined",
+                        "locator": "layers",
+                        "text": "Could not find layer misc:Bonnebladen1900_index2121 Details:org.geoserver.platform.ServiceException: Could not find layer misc:Bonnebladen1900_index2121"
+                    }]
+            }];
+        });
+        wms
+            .getIdentifyFlow(undefined, "/", { features: [] })
+            .subscribe((response) => {
+                expect(response?.data?.exceptions).toExist();
+                done();
+            }, error => {
+                done();
             });
     });
     it('test intercept ogc error in wms if failed', (done)=>{
@@ -138,7 +159,6 @@ describe('mapinfo wms utils', () => {
             .getIdentifyFlow(undefined, "/", { features: [] })
             .subscribe((response) => {
                 expect(response?.data?.features).toEqual([]);
-                done();
             }, error => {
                 expect(error.status).toEqual(404);
                 done();


### PR DESCRIPTION
## Description
- Handling GFI exceptions parameter format by removing "application/json" and putting the geoserver default format for exceptions 'application/vnd.ogc.se_xml' that will work with all WMS servcies including arcgis services.
- Add getIdentifyWorkflow to catch the GFI errors and exceptions. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


## Issue
#9466 

**What is the current behavior?**
Some services has no "application/json" into their exception format list. So an exception of "Parameter 'exceptions' contains unacceptable value" shown for the GFI and prevent showing the identify results.

#<issue>
#9466 

**What is the new behavior?**
There is no exception related to wrong exception format in GFI and identify works well with all WMS servcies including arcgis services and the identify results shown to user normally.


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

## Other useful information
