### PR TITLE
backport 2023.02.xx - Fix version used for log4j-slf4j-impl that was causing build issue (#9515)

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -385,7 +385,7 @@ with
  <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-slf4j-impl</artifactId>
-    <version>1.7.2</version>
+    <version>2.19.0</version>
  </dependency>
 
 ```


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->


backport 2023.02.xx - Fix version used for log4j-slf4j-impl that was causing build issue (#9515)