### PR TITLE
[2023.02.xx] #9522 Measure annotations issue on 3D mode

### DIFF
--- a/build/testConfig.js
+++ b/build/testConfig.js
@@ -1,11 +1,16 @@
 const assign = require('object-assign');
 const nodePath = require('path');
+const os = require('os');
 const webpack = require('webpack');
 const ProvidePlugin = require("webpack/lib/ProvidePlugin");
 
 const {
     VERSION_INFO_DEFINE_PLUGIN
 } = require('./BuildUtils');
+
+const output = {
+    path: nodePath.join(os.tmpdir(), '_karma_webpack_') + Math.floor(Math.random() * 1000000)
+};
 
 module.exports = ({browsers = [ 'ChromeHeadless' ], files, path, testFile, singleRun, basePath = ".", alias = {}}) => ({
     browsers,
@@ -23,7 +28,14 @@ module.exports = ({browsers = [ 'ChromeHeadless' ], files, path, testFile, singl
     files: [
         ...files,
         // add all assets needed for Cesium library
-        { pattern: './node_modules/cesium/Build/CesiumUnminified/**/*', included: false }
+        { pattern: './node_modules/cesium/Build/CesiumUnminified/**/*', included: false },
+        // see https://github.com/ryanclark/karma-webpack/issues/498#issuecomment-790040818
+        // this is needed in combination with the webpack output to load resources with url-loader such as png
+        {
+            pattern: `${output.path}/**/*`,
+            watched: false,
+            included: false
+        }
     ],
 
     plugins: [
@@ -66,7 +78,7 @@ module.exports = ({browsers = [ 'ChromeHeadless' ], files, path, testFile, singl
     webpack: {
         devtool: 'eval',
         mode: 'development',
-
+        output,
         module: {
             rules: [
                 {

--- a/web/client/utils/VectorStyleUtils.js
+++ b/web/client/utils/VectorStyleUtils.js
@@ -368,6 +368,11 @@ export const getStyleParser = (format = 'sld') => {
 };
 
 function msStyleToSymbolizer(style, feature) {
+    const geometryProperty = style.geometry && {
+        msGeometry: {
+            name: style.geometry
+        }
+    };
     if (isTextStyle(style) && feature?.properties?.valueText) {
         const fontParts = (style.font || '').split(' ');
         return Promise.resolve({
@@ -395,7 +400,8 @@ function msStyleToSymbolizer(style, feature) {
             radius: style.radius ?? 10,
             wellKnownName: 'Circle',
             msHeightReference: 'none',
-            msBringToFront: true
+            msBringToFront: true,
+            ...geometryProperty
         });
     }
     if (isAttrPresent(style, ['iconUrl']) && !style.iconGlyph && !style.iconShape) {
@@ -412,7 +418,8 @@ function msStyleToSymbolizer(style, feature) {
                 msLeaderLineColor: '#333333',
                 msLeaderLineOpacity: 1,
                 msLeaderLineWidth: 1
-            })
+            }),
+            ...geometryProperty
         });
     }
     if (isMarkerStyle(style)) {
@@ -423,7 +430,8 @@ function msStyleToSymbolizer(style, feature) {
             opacity: 1,
             rotate: 0,
             msHeightReference: 'none',
-            msBringToFront: true
+            msBringToFront: true,
+            ...geometryProperty
         });
     }
     if (isSymbolStyle(style)) {
@@ -441,7 +449,8 @@ function msStyleToSymbolizer(style, feature) {
                     opacity: 1,
                     rotate: 0,
                     msHeightReference: 'none',
-                    msBringToFront: true
+                    msBringToFront: true,
+                    ...geometryProperty
                 };
             })
             .catch(() => ({}));
@@ -543,7 +552,7 @@ export function layerToGeoStylerStyle(layer) {
         return Promise.all(
             flatten(filteredFeatures.map((feature) => {
                 const styles = castArray(feature.style);
-                return styles.map((style) =>
+                return styles.filter(style => style.filtering !== false).map((style) =>
                     msStyleToSymbolizer(style, feature)
                         .then((symbolizer) => ({ symbolizer, filter: ['==', 'id', feature.properties.id] }))
                 );

--- a/web/client/utils/__tests__/VectorStyleUtils-test.js
+++ b/web/client/utils/__tests__/VectorStyleUtils-test.js
@@ -638,4 +638,75 @@ describe("VectorStyleUtils ", () => {
             });
     });
 
+    it('should parse mapstore annotation style with filtering and marker to geostyler style with layerToGeoStylerStyle', (done) => {
+
+        const layer = {
+            type: 'vector',
+            features: [
+                {
+                    type: 'FeatureCollection',
+                    features: [
+                        {
+                            type: 'Feature',
+                            properties: {
+                                id: 'annotation-id'
+                            },
+                            geometry: {
+                                type: 'Polygon',
+                                coordinates: [[[7, 41], [14, 41], [14, 46], [7, 46], [7, 41]]]
+                            },
+                            style: [
+                                {
+                                    fillColor: '#ff0000',
+                                    fillOpacity: 0.5,
+                                    color: '#00ff00',
+                                    opacity: 0.25,
+                                    weight: 2
+                                },
+                                {
+                                    iconGlyph: 'comment',
+                                    iconShape: 'square',
+                                    iconColor: 'blue',
+                                    iconAnchor: [
+                                        0.5,
+                                        0.5
+                                    ],
+                                    type: 'Point',
+                                    title: 'StartPoint Style',
+                                    geometry: 'startPoint',
+                                    filtering: true
+                                },
+                                {
+                                    iconGlyph: 'comment',
+                                    iconShape: 'square',
+                                    iconColor: 'blue',
+                                    highlight: false,
+                                    iconAnchor: [
+                                        0.5,
+                                        0.5
+                                    ],
+                                    type: 'Point',
+                                    title: 'EndPoint Style',
+                                    geometry: 'endPoint',
+                                    filtering: false
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        layerToGeoStylerStyle(layer)
+            .then((style) => {
+                expect(style).toBeTruthy();
+                expect(style.body.rules.length).toBe(2);
+                expect(style.body.rules[0].symbolizers[0].kind).toBe('Fill');
+                expect(style.body.rules[1].symbolizers[0].kind).toBe('Icon');
+                expect(style.body.rules[1].symbolizers[0].msGeometry.name).toBe('startPoint');
+                done();
+            }).catch(done);
+    });
+
+
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes the conversion of annotations feature style to geostyler style taking into account the geometry transformation and filtering options

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9522 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Annotations style in 3D is applying correctly marker and icon symbolizer

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
