### PR TITLE
support loading COG layers from query params

### DIFF
--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -384,7 +384,8 @@ The COG service endpoint does not contain a default property for the name of the
 
 GET: `#/viewer/config?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["My huge remote satellite COG"],"sources":[{"type":"cog","url":"https://example.com/satellite_imagery.tif"}]}]`
 
-Depending on the internal structure optimization done on the remote COG file, the map load time might be long.
+!!! note
+    Depending on the internal structure optimization done on the remote COG source, the map load time might be long. Furthermore, it is not feasible to cancel metadata fetching for the COG layer(s) when loading layers via query parameters.
 
 The 3D tiles service endpoint does not contain a default property for the name of the layer and it returns only a single record for this reason the name used in the layers array will be used to apply the title to the added 3D Tiles layer:
 

--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -343,7 +343,7 @@ Requirements:
 - The number of layers should match the number of sources
 - The source name can be a string that must match a catalog service name present in the map or an object that defines an external catalog (see example)
 
-Supported layer types are WMS, WMTS, WFS, 3D Tiles and GeoJSON.
+Supported layer types are WMS, WMTS, WFS, COG, 3D Tiles and GeoJSON.
 
 Example:
 
@@ -371,6 +371,20 @@ Data of resulting layer can be additionally filtered by passing "CQL_FILTER" int
 GET `#/viewer/config?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["layer1","layer2","workspace:externallayername"],"sources":["catalog1","catalog2",{"type":"WMS","url":"https://example.com/wms"}],"options": [{"params":{"CQL_FILTER":"NAME='value'"}}, {}, {"params":{"CQL_FILTER":"NAME='value2'"}}]}]`
 
 Number of objects passed to the options can be different to the number of layers, in this case options will be applied to the first X layers, where X is the length of options array.
+
+The COG service endpoint does not contain a default property for the name of the layer and it returns only a single record for this reason the name used in the layers array will be used to apply the title to the added COG layer:
+
+```json
+{
+    "type": "CATALOG:ADD_LAYERS_FROM_CATALOGS",
+    "layers": ["My huge remote satellite COG"],
+    "sources": [{ "type":"cog", "url":"https://example.com/satellite_imagery.tif" }]
+}
+```
+
+GET: `#/viewer/config?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["My huge remote satellite COG"],"sources":[{"type":"cog","url":"https://example.com/satellite_imagery.tif"}]}]`
+
+Depending on the internal structure optimization done on the remote COG file, the map load time might be long.
 
 The 3D tiles service endpoint does not contain a default property for the name of the layer and it returns only a single record for this reason the name used in the layers array will be used to apply the title to the added 3D Tiles layer:
 

--- a/web/client/api/catalog/COG.js
+++ b/web/client/api/catalog/COG.js
@@ -34,6 +34,7 @@ const searchAndPaginate = (layers, startPosition, maxRecords, text) => {
 let capabilitiesCache = {};
 export const getRecords = (_url, startPosition, maxRecords, text, info = {}) => {
     const service = get(info, 'options.service');
+    const controller = get(info, 'options.controller');
     let layers = [];
     if (service.records) {
         // each record/url corresponds to a layer
@@ -46,7 +47,6 @@ export const getRecords = (_url, startPosition, maxRecords, text, info = {}) => 
                 sources: record.sources ?? [{url}],
                 options: record.options ?? (service.options || {})
             };
-            const controller = get(info, 'options.controller');
             const isSave = get(info, 'options.save', false);
             const cached = capabilitiesCache[url];
             if (cached && new Date().getTime() < cached.timestamp + (ConfigUtils.getConfigProp('cacheExpire') || 60) * 1000) {
@@ -68,6 +68,25 @@ export const getRecords = (_url, startPosition, maxRecords, text, info = {}) => 
         });
     }
     return Promise.all([...layers]).then((_layers) => {
+        if (!_layers.length) {
+            let layer = {
+                ...service,
+                title: text,
+                identifier: _url,
+                type: COG_LAYER_TYPE,
+                sources: [{url: _url}],
+                options: service.options || {}
+            };
+            return LayerUtils.getLayerConfig({_url, layer, controller})
+                .then(lyr => {
+                    const records = [lyr];
+                    return {
+                        numberOfRecordsMatched: 1,
+                        numberOfRecordsReturned: 1,
+                        records
+                    };
+                });
+        }
         return searchAndPaginate(_layers, startPosition, maxRecords, text);
     });
 };

--- a/web/client/api/catalog/COG.js
+++ b/web/client/api/catalog/COG.js
@@ -85,7 +85,7 @@ export const getRecords = (_url, startPosition, maxRecords, text, info = {}) => 
                         numberOfRecordsReturned: 1,
                         records
                     };
-                });
+                }).catch(() => ({...layer}));
         }
         return searchAndPaginate(_layers, startPosition, maxRecords, text);
     });

--- a/web/client/api/catalog/COG.js
+++ b/web/client/api/catalog/COG.js
@@ -77,7 +77,7 @@ export const getRecords = (_url, startPosition, maxRecords, text, info = {}) => 
                 sources: [{url: _url}],
                 options: service.options || {}
             };
-            return LayerUtils.getLayerConfig({_url, layer, controller})
+            return LayerUtils.getLayerConfig({url: _url, layer, controller})
                 .then(lyr => {
                     const records = [lyr];
                     return {

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -176,7 +176,7 @@ export default (API) => ({
                         const layerOptionsParam = get(options, i, searchOptionsSelector(state));
                         // use the selected layer text as title for 3d tiles
                         // because currently we get only a single record for this service type
-                        const layerOptions = format === '3dtiles' || format === 'geojson'
+                        const layerOptions = format === '3dtiles' || format === 'geojson' || format === 'cog'
                             ? {
                                 ...layerOptionsParam,
                                 title: isObject(layerOptionsParam?.title)


### PR DESCRIPTION
## Description
implements #9527

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
fixes #9527

**What is the new behavior?**
http://localhost:8081/#/viewer/new?actions=%5B%7B%22type%22:%22CATALOG:ADD_LAYERS_FROM_CATALOGS%22,%22layers%22:%5B%22testtitle%22%5D,%22sources%22:%5B%7B%22type%22:%22cog%22,%22url%22:%22https%3A%2F%2Fcogeo.craig.fr%2Fopendata%2Fortho%2Forthocraig3_vichy_2021.cog.tif%22%7D%5D%7D%5D should work and zoom to the provided COG

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
