### PR TITLE
[Backport 2023.02.xx] #9523 Geocarousel section - Click on marker issue

### DIFF
--- a/web/client/components/geostory/common/enhancers/withPopupSupport.jsx
+++ b/web/client/components/geostory/common/enhancers/withPopupSupport.jsx
@@ -99,14 +99,13 @@ export const getIntersectedFeature = (layer, request, metadata) => {
 export const withCarouselMarkerInteraction = compose(
     connect((state)=>({sections: getAllGeoCarouselSections(state)}), {onClickMarker: update}),
     withHandlers({
-        onClickMarker: ({onClickMarker = () => {}, sections = {}}) => (responses, layerInfo, popups) => {
-            const {response: { features: [{contentRefId} = {}] = []} = {}} = find(responses,
-                ({queryParams: {request} = {}, layerMetadata: {title} = {}} = {})=> !request && title.toLowerCase() === layerInfo) || {};
-            const result = find(sections, ({contents}) => find(contents, {id: contentRefId}));
+        onClickMarker: ({onClickMarker = () => {}}) => (responses, layerInfo, popups) => {
+            const {response: { features: [selectedFeature] = []} = {}} = find(responses,
+                ({queryParams: {request} = {}, layerMetadata: {layerId} = {}} = {})=> !request && layerId.toLowerCase() === layerInfo) || {};
             let _popup = {popups: []};
-            if (result) {
-                const {id: contentId, title = ''} = find(result.contents, {id: contentRefId}) || {};
-                onClickMarker(`sections[{"id":"${result.id}"}].contents[{"id":"${contentId}"}].carouselToggle`, true);
+            if (selectedFeature?.properties) {
+                const { sectionId, contentId, title } = selectedFeature?.properties;
+                onClickMarker(`sections[{"id":"${sectionId}"}].contents[{"id":"${contentId}"}].carouselToggle`, true);
                 if (title) {
                     _popup = {popups: popups.map((popup) => ({...popup, component: ()=> (<div className={"ms-geostory-carousel-viewer"}>{title}</div>)}))};
                 }

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -648,6 +648,12 @@ export function getVectorLayerFromContents({
                 (content?.features || [])
                     .map((feature) => ({
                         ...feature,
+                        properties: {
+                            ...feature.properties,
+                            title: content.title,
+                            sectionId: id,
+                            contentId: content.id
+                        },
                         contentRefId: content.id,
                         ...(featureStyle && {
                             style: featureStyle({ content, feature }, idx)

--- a/web/client/utils/__tests__/GeoStoryUtils-test.js
+++ b/web/client/utils/__tests__/GeoStoryUtils-test.js
@@ -535,6 +535,7 @@ describe("GeoStory Utils", () => {
         const contents = [
             {
                 id: 'content-1',
+                title: 'Title',
                 features: [{
                     properties: {},
                     geometry: { type: 'Point', coordinates: [0, 0] }
@@ -555,7 +556,11 @@ describe("GeoStory Utils", () => {
             type: 'vector',
             features: [
                 {
-                    properties: {},
+                    properties: {
+                        title: 'Title',
+                        sectionId: 'section-id',
+                        contentId: 'content-1'
+                    },
                     geometry: { type: 'Point', coordinates: [ 0, 0 ] },
                     contentRefId: 'content-1'
                 }
@@ -574,6 +579,7 @@ describe("GeoStory Utils", () => {
             contents: [
                 {
                     id: 'content-1',
+                    title: 'Title',
                     features: [{
                         properties: {},
                         geometry: { type: 'Point', coordinates: [0, 0] },
@@ -592,7 +598,11 @@ describe("GeoStory Utils", () => {
             type: 'vector',
             features: [
                 {
-                    properties: {},
+                    properties: {
+                        title: 'Title',
+                        sectionId: 'section-id',
+                        contentId: 'content-1'
+                    },
                     geometry: { type: 'Point', coordinates: [ 0, 0 ] },
                     contentRefId: 'content-1',
                     style: {
@@ -613,6 +623,7 @@ describe("GeoStory Utils", () => {
             contents: [
                 {
                     id: 'content-1',
+                    title: 'Title',
                     features: [{
                         properties: {},
                         geometry: { type: 'Point', coordinates: [0, 0] }
@@ -630,7 +641,11 @@ describe("GeoStory Utils", () => {
             type: 'vector',
             features: [
                 {
-                    properties: {},
+                    properties: {
+                        title: 'Title',
+                        sectionId: 'section-id',
+                        contentId: 'content-1'
+                    },
                     geometry: { type: 'Point', coordinates: [ 0, 0 ] },
                     contentRefId: 'content-1'
                 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes  the click event for carousel section. Note: the changes for the backport are different because the annotation improvements are only on master where styles and identify behaviours have been changed

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9523

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The click on marker of carousel section is not breaking the application

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
