### PR TITLE
[Backport 2023.02.xx] #9533 Problem placing widgets in map viewer

### DIFF
--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -33,6 +33,7 @@ export default pure(({
     widgets = [],
     layouts,
     dependencies,
+    verticalCompact = false,
     compactMode,
     useDefaultWidthProvider = true,
     measureBeforeMount,
@@ -71,6 +72,10 @@ export default pure(({
         className={`widget-container ${className} ${canEdit ? '' : 'no-drag'}`}
         rowHeight={rowHeight}
         autoSize
+        // TODO: this prop triggers a deprecation warning
+        // we should remove it keeping the current behavior
+        // a user should be able to move cards everywhere without force cards on first row
+        verticalCompact={verticalCompact}
         compactMode={compactMode}
         breakpoints={breakpoints}
         cols={cols}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR restores the verticalCompact prop of the ResponsiveReactGridLayout in the WidgetsView component. When verticalCompact is false a user can move the cards in all location without forcing the placement on the first row. This property was removed because of deprecation warning in UI while developing, we should find the correct replacement of properties before removing the verticalCompact prop

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9533

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

A user can move cards of widgets also in lower rows

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
