### PR TITLE
fix #9071 add advanced options to counter widgets

### DIFF
--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -527,7 +527,11 @@ export const toPlotly = (props) => {
  * @prop {number} [xAxisOpts.nTicks] max number of ticks. Can be used to force to display all labels, instead of skipping.
  * @prop {number} [xAxisAngle] the angle, in degrees, of xAxisAngle.
  * @prop {object|boolean} [yAxis=true] if false, hide the yAxis. true by default. (should contain future options for yAxis)
- * @prop {object} [yAxisOpts] options for yAxis: `type`, `tickPrefix`, `tickPostfix`, `format`, `formula`
+ * @prop {object} [counterOpts] options for counter widgets that manipulates the value:  `tickPrefix`, `tickPostfix`, `format`, `formula`)
+ * @prop {string} [counterOpts.format] format. See {@link https://d3-wiki.readthedocs.io/zh_CN/master/Formatting/}
+ * @prop {string} [counterOpts.tickPrefix] the prefix.
+ * @prop {string} [counterOpts.tickSuffix] the suffix.
+ * @prop {object} [yAxisOpts] options for yAxis: `type`, `tickPrefix`, `tickPostfix`, `format`, `formula`)
  * @prop {string} [yAxisOpts.type] determine the type of the y axis of `date`, `-` (automatic), `log`, `linear`, `category`, `date`.
  * @prop {string} [yAxisOpts.format] format for y axis value. See {@link https://d3-wiki.readthedocs.io/zh_CN/master/Formatting/}
  * @prop {string} [yAxisOpts.tickPrefix] the prefix on y value

--- a/web/client/components/widgets/builder/wizard/CounterWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/CounterWizard.jsx
@@ -9,6 +9,7 @@
 import {isNil} from 'lodash';
 import React from 'react';
 import { compose, lifecycle } from 'recompose';
+import PropTypes from 'prop-types';
 
 import loadingEnhancer from '../../../misc/enhancers/loadingState';
 import {wizardHandlers} from '../../../misc/wizard/enhancers';
@@ -70,7 +71,14 @@ const Wizard = wizardHandlers(WizardContainer);
 
 
 const Preview = enhancePreview(Counter);
-const CounterPreview = ({ data = {}, layer, dependencies = {}, valid, setValid = () => { }, hasAggregateProcess }) =>
+const CounterPreview = ({
+    data = {},
+    layer,
+    dependencies = {},
+    valid,
+    setValid = () => {},
+    hasAggregateProcess
+}) =>
     !isCounterOptionsValid(data.options, { hasAggregateProcess })
         ? <Counter
             {...sampleProps}
@@ -85,6 +93,8 @@ const CounterPreview = ({ data = {}, layer, dependencies = {}, valid, setValid =
             dependencies={dependencies}
             setValid={setValid}
             type={data.type}
+            counterOpts={data.counterOpts}
+            formula={data.formula}
             legend={data.legend}
             layer={data.layer || layer}
             filter={data.filter}
@@ -138,3 +148,13 @@ export default enhanceWizard(({ onChange = () => { }, onFinish = () => { }, setP
                 setValid={v => setValid(v && isCounterOptionsValid(data.options, { hasAggregateProcess }))} />}
         />
     </Wizard>));
+
+CounterPreview.propTypes = {
+    data: PropTypes.object,
+    dependencies: PropTypes.object,
+    hasAggregateProcess: PropTypes.bool,
+    layer: PropTypes.object,
+    setValid: PropTypes.func,
+    valid: PropTypes.bool,
+    value: PropTypes.string
+};

--- a/web/client/components/widgets/builder/wizard/common/ChartAdvancedOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/ChartAdvancedOptions.jsx
@@ -9,15 +9,14 @@ import React, { useState } from 'react';
 import { isNil } from 'lodash';
 import Select from 'react-select';
 import { Col, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+import PropTypes from 'prop-types';
 
 import Message from '../../../../I18N/Message';
-import HTML from '../../../../I18N/HTML';
 
 import Slider from '../../../../misc/Slider';
 import InfoPopover from '../../../widget/InfoPopover';
-import DisposablePopover from '../../../../misc/popover/DisposablePopover';
-import FormulaInput from './FormulaInput';
-
+import Format from './Format';
+import Formula from './Formula';
 
 import SwitchPanel from '../../../../misc/switch/SwitchPanel';
 import SwitchButton from '../../../../misc/switch/SwitchButton';
@@ -60,7 +59,7 @@ function Header({}) {
     </span>);
 }
 
-export default function ChartAdvancedOptions({
+function ChartAdvancedOptions({
     classificationAttribute,
     data,
     onChange = () => {}
@@ -132,29 +131,8 @@ export default function ChartAdvancedOptions({
                     onChange={(val) => { onChange("yAxis", !val); }}
                 />
             </Col>
-            <Col componentClass={ControlLabel} sm={12}>
-                <Message msgId="widgets.advanced.format" />
-            </Col>
-            <Col sm={4}>
-                <ControlLabel>
-                    <Message msgId="widgets.advanced.prefix" />
-                    <FormControl placeholder="e.g.: ~" disabled={data.yAxis === false} value={data?.yAxisOpts?.tickPrefix} type="text" onChange={e => onChange("yAxisOpts.tickPrefix", e.target.value)} />
-                </ControlLabel>
-            </Col>
-            <Col sm={4}>
-                <ControlLabel>
-                    <Message msgId="widgets.advanced.format" />
-                </ControlLabel>
-                <DisposablePopover placement="top" title={<Message msgId="widgets.advanced.examples"/>} text={<HTML msgId="widgets.advanced.formatExamples" />} />
-                <FormControl placeholder="e.g.: .2s" disabled={data.yAxis === false} value={data?.yAxisOpts?.format} type="text" onChange={e => onChange("yAxisOpts.format", e.target.value)} />
-            </Col>
-            <Col sm={4}>
-                <ControlLabel><Message msgId="widgets.advanced.suffix" /></ControlLabel>
-                <FormControl placeholder="e.g.: W" disabled={data.yAxis === false} value={data?.yAxisOpts?.tickSuffix} type="text" onChange={e => onChange("yAxisOpts.tickSuffix", e.target.value)} />
-            </Col>
-            <Col sm={12}>
-                <FormulaInput disabled={data.yAxis === false} value={data.formula} type="text" onChange={e => onChange("formula", e.target.value)} />
-            </Col>
+            <Format data={data} onChange={onChange}/>
+            <Formula data={data} onChange={onChange}/>
             {/* X AXIS */}
             <Col componentClass={"label"} sm={12}>
                 <Message msgId="widgets.advanced.xAxis" />
@@ -240,3 +218,11 @@ export default function ChartAdvancedOptions({
         </FormGroup>
     </SwitchPanel>);
 }
+
+ChartAdvancedOptions.propTypes = {
+    classificationAttribute: PropTypes.string, // [ ] verify is a string
+    data: PropTypes.object,
+    onChange: PropTypes.func
+};
+
+export default ChartAdvancedOptions;

--- a/web/client/components/widgets/builder/wizard/common/CounterAdvancedOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/CounterAdvancedOptions.jsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import { FormGroup } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+import Message from '../../../../I18N/Message';
+import Format from './Format';
+import Formula from './Formula';
+import SwitchPanel from '../../../../misc/switch/SwitchPanel';
+
+function Header({}) {
+    return (<span>
+        <span style={{ cursor: "pointer" }}><Message msgId="widgets.advanced.title"/></span>
+    </span>);
+}
+
+function CounterAdvancedOptions({
+    data,
+    onChange = () => {}
+}) {
+    return (<SwitchPanel id="displayCartesian"
+        header={<Header data={data}/>}
+        collapsible
+        expanded={data.panel}
+        onSwitch={(val) => { onChange("panel", val); }}
+    >
+        <FormGroup controlId="AdvancedOptions">
+            <Format prefix="counterOpts" data={data} onChange={onChange}/>
+            <Formula data={data} onChange={onChange}/>
+        </FormGroup>
+    </SwitchPanel>);
+}
+
+CounterAdvancedOptions.propTypes = {
+    data: PropTypes.object,
+    onChange: PropTypes.func
+};
+
+export default CounterAdvancedOptions;

--- a/web/client/components/widgets/builder/wizard/common/Format.jsx
+++ b/web/client/components/widgets/builder/wizard/common/Format.jsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import { Col, FormControl, ControlLabel } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+import Message from '../../../../I18N/Message';
+import HTML from '../../../../I18N/HTML';
+import DisposablePopover from '../../../../misc/popover/DisposablePopover';
+
+const Format = ({
+    data,
+    onChange = () => {},
+    prefix = "yAxisOpts"
+}) => {
+
+    return (
+        <>
+            <Col componentClass={ControlLabel} sm={12}>
+                <Message msgId="widgets.advanced.format" />
+            </Col>
+            <Col sm={4}>
+                <ControlLabel>
+                    <Message msgId="widgets.advanced.prefix" />
+                    <FormControl placeholder="e.g.: ~" disabled={data.yAxis === false} value={data?.[prefix]?.tickPrefix} type="text" onChange={e => onChange(prefix + ".tickPrefix", e.target.value)} />
+                </ControlLabel>
+            </Col>
+            <Col sm={4}>
+                <ControlLabel>
+                    <Message msgId="widgets.advanced.format" />
+                </ControlLabel>
+                <DisposablePopover placement="top" title={<Message msgId="widgets.advanced.examples"/>} text={<HTML msgId="widgets.advanced.formatExamples" />} />
+                <FormControl placeholder="e.g.: .2s" disabled={data.yAxis === false} value={data?.[prefix]?.format} type="text" onChange={e => onChange(prefix + ".format", e.target.value)} />
+            </Col>
+            <Col sm={4}>
+                <ControlLabel><Message msgId="widgets.advanced.suffix" /></ControlLabel>
+                <FormControl placeholder="e.g.: W" disabled={data.yAxis === false} value={data?.[prefix]?.tickSuffix} type="text" onChange={e => onChange(prefix + ".tickSuffix", e.target.value)} />
+            </Col>
+
+        </>);
+};
+Format.propTypes = {
+    data: PropTypes.object,
+    onChange: PropTypes.func,
+    prefix: PropTypes.string
+};
+
+export default Format;

--- a/web/client/components/widgets/builder/wizard/common/Format.jsx
+++ b/web/client/components/widgets/builder/wizard/common/Format.jsx
@@ -39,7 +39,7 @@ const Format = ({
             </Col>
             <Col sm={4}>
                 <ControlLabel><Message msgId="widgets.advanced.suffix" /></ControlLabel>
-                <FormControl placeholder="e.g.: W" disabled={data.yAxis === false} value={data?.[prefix]?.tickSuffix} type="text" onChange={e => onChange(prefix + ".tickSuffix", e.target.value)} />
+                <FormControl placeholder="e.g.: W" disabled={data.yAxis === false} value={data?.[prefix]?.tickSuffix || data?.options?.seriesOptions?.[0].uom} type="text" onChange={e => onChange(prefix + ".tickSuffix", e.target.value)} />
             </Col>
 
         </>);

--- a/web/client/components/widgets/builder/wizard/common/Formula.jsx
+++ b/web/client/components/widgets/builder/wizard/common/Formula.jsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Col } from 'react-bootstrap';
+
+import FormulaInput from './FormulaInput';
+
+
+const Formula = ({
+    data,
+    onChange = () => {}
+}) => {
+    return (
+        <Col sm={12}>
+            <FormulaInput disabled={data.yAxis === false} value={data.formula} type="text" onChange={e => onChange("formula", e.target.value)} />
+        </Col>
+    );
+};
+
+Formula.propTypes = {
+    data: PropTypes.object,
+    onChange: PropTypes.func
+};
+
+export default Formula;

--- a/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
@@ -8,8 +8,12 @@
 import React, {useEffect, useState} from 'react';
 import { head, get} from 'lodash';
 import { Row, Col, Form, FormGroup, FormControl, ControlLabel, Glyphicon, OverlayTrigger, Tooltip } from 'react-bootstrap';
-import Message from '../../../../I18N/Message';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
+import classNames from 'classnames';
+import uuid from 'uuid';
+
+import Message from '../../../../I18N/Message';
 import ColorRamp from '../../../../styleeditor/ColorRamp';
 import { generateRandomHexColor } from '../../../../../utils/ColorUtils';
 import Button from '../../../../misc/Button';
@@ -17,10 +21,9 @@ import ConfirmModal from '../../../../../components/resources/modals/ConfirmModa
 import StepHeader from '../../../../misc/wizard/StepHeader';
 import SwitchButton from '../../../../misc/switch/SwitchButton';
 import ChartAdvancedOptions from './ChartAdvancedOptions';
+import CounterAdvancedOptions from './CounterAdvancedOptions';
 import ColorClassModal from '../chart/ColorClassModal';
 import { defaultColorGenerator } from '../../../../charts/WidgetChart';
-import classNames from 'classnames';
-import uuid from 'uuid';
 
 const DEFAULT_CUSTOM_COLOR_OPTIONS = {
     base: 190,
@@ -101,7 +104,7 @@ const formatAutoColorOptions = (classification, attributeType) => (
     ))
 );
 
-export default ({
+const WPSWidgetOptions = ({
     hasAggregateProcess,
     data = { options: {}, autoColorOptions: {} },
     onChange = () => { },
@@ -116,7 +119,8 @@ export default ({
     },
     aggregationOptions = [],
     sampleChart,
-    layer }) => {
+    layer
+}) => {
 
     const [showModal, setShowModal] = useState(false);
     const [showConfirmModal, setShowConfirmModal] = useState(false);
@@ -346,12 +350,34 @@ export default ({
                             </Col>
                         </FormGroup> : null}
                     {formOptions.advancedOptions && data.widgetType === "chart" && (data.type === "bar" || data.type === "line")
-                        ? <ChartAdvancedOptions data={data} classificationAttribute={classificationAttribute} onChange={onChange} />
+                        ? <ChartAdvancedOptions
+                            data={data}
+                            classificationAttribute={classificationAttribute}
+                            onChange={onChange}
+                        />
                         : null}
-
+                    {formOptions.advancedOptions && data.widgetType === "counter"
+                        ? <CounterAdvancedOptions
+                            data={data}
+                            onChange={onChange}
+                        />
+                        : null}
                 </Form>
 
             </Col>
         </Row>
     );
 };
+
+WPSWidgetOptions.propTypes = {
+    aggregationOptions: PropTypes.array,
+    data: PropTypes.object,
+    formOptions: PropTypes.object,
+    hasAggregateProcess: PropTypes.bool,
+    layer: PropTypes.object,
+    onChange: PropTypes.func,
+    options: PropTypes.array,
+    sampleChart: PropTypes.node,
+    showTitle: PropTypes.bool
+};
+export default WPSWidgetOptions;

--- a/web/client/components/widgets/widget/CounterView.jsx
+++ b/web/client/components/widgets/widget/CounterView.jsx
@@ -6,46 +6,107 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
-import loadingStateFactory from '../../misc/enhancers/loadingState';
-
-const loadingState = loadingStateFactory();
-import errorChartState from '../enhancers/errorChartState';
-import emptyChartState from '../enhancers/emptyChartState';
-import FormatNumber from '../../I18N/Number';
 import { compose } from 'recompose';
 import { get } from 'lodash';
 import { Textfit } from 'react-textfit';
-const Counter = ({ value = "", uom = "", ...props } = {}) => (<Textfit
-    mode="single"
-    forceSingleModeWidth={false}
-    max={500}
-    throttle={20}
-    {...props}>
-    <FormatNumber value={value} /><span style={{fontSize: "75%"}}>{uom}</span>
-</Textfit>);
+import PropTypes from 'prop-types';
+import {format} from 'd3-format';
+import React from 'react';
+
+import loadingStateFactory from '../../misc/enhancers/loadingState';
+import errorChartState from '../enhancers/errorChartState';
+import emptyChartState from '../enhancers/emptyChartState';
+
+import { parseExpression } from '../../../utils/ExpressionUtils';
+
+const loadingState = loadingStateFactory();
+const processFormula = (v, formula = "") => {
+    const value = v;
+    try {
+        return parseExpression(formula, {value});
+    } catch {
+        // if error (e.g. null values), return the value itself
+        return v;
+    }
+};
+const Counter = ({
+    value = "",
+    uom = "",
+    formula = "",
+    counterOpts = {
+        tickPrefix: "",
+        tickSuffix: ""
+    },
+    ...props
+} = {}) =>{
+    let val = value;
+    if (formula) {
+        val = processFormula(value, formula);
+    }
+    if (counterOpts?.format) {
+        try {
+            const formatter = format(counterOpts.format);
+            val = formatter(val);
+        } catch (e) {
+            console.error(e);
+        }
+    }
+    return (<Textfit
+        mode="single"
+        forceSingleModeWidth={false}
+        max={500}
+        throttle={20}
+        {...props}
+    >
+        <span style={{fontSize: "75%"}}>
+            {counterOpts?.tickPrefix ? counterOpts.tickPrefix : null}
+        </span>
+        <span className="value">
+            {val}
+        </span>
+        <span style={{fontSize: "75%"}}>
+            {uom ? uom : counterOpts?.tickSuffix}
+        </span>
+    </Textfit>);
+};
 const enhanceCounter = compose(
     loadingState,
     errorChartState,
     emptyChartState
 );
-import React from 'react';
 
-export default enhanceCounter(({ series = [], data = [], options = {}, style = {
-    width: "100%",
-    height: "100%",
-    transform: "translate(-50%, -50%)",
-    position: "absolute",
-    display: "inline",
-    padding: "1%",
-    top: "50%",
-    left: "50%"
-}} ) => {
+const CounterView = enhanceCounter(({
+    series = [],
+    data = [],
+    options = {},
+    style = {
+        width: "100%",
+        height: "100%",
+        transform: "translate(-50%, -50%)",
+        position: "absolute",
+        display: "inline",
+        padding: "1%",
+        top: "50%",
+        left: "50%"
+    },
+    counterOpts,
+    formula
+}) => {
     const renderCounter = ({ dataKey } = {}, i) => (<Counter
         key={dataKey}
         uom={get(options, `seriesOptions[${i}].uom`)}
         value={data[0][dataKey]}
+        counterOpts={counterOpts}
+        formula={formula}
         style={{ textAlign: "center", ...style }}
     />);
     return (<div className="counter-widget-view">{series.map(renderCounter)}</div>);
 });
+
+Counter.propTypes = {
+    uom: PropTypes.string,
+    value: PropTypes.string,
+    formula: PropTypes.string,
+    counterOpts: PropTypes.object
+};
+export default CounterView;

--- a/web/client/components/widgets/widget/CounterView.jsx
+++ b/web/client/components/widgets/widget/CounterView.jsx
@@ -65,7 +65,7 @@ const Counter = ({
             {val}
         </span>
         <span style={{fontSize: "75%"}}>
-            {uom ? uom : counterOpts?.tickSuffix}
+            {counterOpts?.tickSuffix || uom}
         </span>
     </Textfit>);
 };

--- a/web/client/plugins/widgetbuilder/CounterBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/CounterBuilder.jsx
@@ -89,8 +89,9 @@ export default chooseLayerEnhancer(({ enabled, onClose = () => { }, exitButton, 
     >
         {enabled ? <Builder formOptions={{
             showColorRamp: false,
-            showUom: true,
+            showUom: false,
             showGroupBy: false,
-            showLegend: false
+            showLegend: false,
+            advancedOptions: true
         }} dependencies={dependencies} {...props} /> : null}
     </BorderLayout>));


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

adding advanced options to counter
![image](https://github.com/geosolutions-it/MapStore2/assets/11991428/2384285c-3f89-4510-8a93-980e4122f664)


**NOTE** I'm including d3-format because formatting the number value with Formatted number of react-intl is not the same

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
fix #9071

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
for counter widgets now it's possible to define:
- prefix
- suffix
- format
- formula

note the old field uom is removed in favor of suffix, and this requires user guide update

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

tester can import this dashboard that had uom configured as states, after renaming it as .json
[dashboard.txt](https://github.com/geosolutions-it/MapStore2/files/12790321/dashboard.txt)
