### PR TITLE
#9510: Improving GeoFence rule filtering capabilities 

### DIFF
--- a/web/client/actions/rulesmanager.js
+++ b/web/client/actions/rulesmanager.js
@@ -30,11 +30,12 @@ export function delRules(ids) {
     };
 }
 
-export function setFilter(key, value) {
+export function setFilter(key, value, isResetField) {
     return {
         type: SET_FILTER,
         key,
-        value
+        value,
+        isResetField
     };
 }
 

--- a/web/client/api/geofence/RuleService.js
+++ b/web/client/api/geofence/RuleService.js
@@ -83,7 +83,7 @@ const Api = ({addBaseUrl, addBaseUrlGS, getGeoServerInstance}) => ({
             .then( (response) => {
                 return toJSONPromise(response.data);
             }
-            ).then(({RuleList = {}}) => ({rules: RuleList.rule || []}));
+            ).then(({RuleList = {}}) => ({rules: [].concat(RuleList.rule || [])}));
     },
 
     getRulesCount: (rulesFiltersValues) => {

--- a/web/client/components/manager/rulesmanager/rulesgrid/enhancers/rulesgrid.js
+++ b/web/client/components/manager/rulesmanager/rulesgrid/enhancers/rulesgrid.js
@@ -77,14 +77,15 @@ export default compose(
             error: undefined,
             isEditing: editing
         }),
-        setFilters: (state, {filters = {}, setFilters}) => ({column, filterTerm}) => {
+        setFilters: (state, {filters = {}, setFilters}) => ({column, filterTerm, isResetField}) => {
             // Can add  some logic here to clean related filters
             if (column.key === "workspace" && filters.layer) {
                 setFilters("layer");
             } else if (column.key === "service" && filters.request) {
                 setFilters("request");
             }
-            setFilters(column.key, filterTerm);
+
+            setFilters(column.key, filterTerm, isResetField);
             return {rowsCount: 0, pages: {}};
         },
         incrementVersion: ({ version }) => () => ({

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/LayersFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/LayersFilter.jsx
@@ -35,8 +35,8 @@ export default compose(
         parentsFilter: {},
         filter: false,
         placeholder: "rulesmanager.placeholders.filterAny",
-        checkedTooltip: "Show all eligible rules",
-        unCheckedTooltip: "Filter list using selected value",
+        unCheckedAnyField: "rulesmanager.tooltip.filterRuleList",
+        checkedAnyField: "rulesmanager.tooltip.showAllRules",
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingLayers"
@@ -48,6 +48,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder", "loadingErroMsg", "checkedTooltip", "unCheckedTooltip"]),
+    localizedProps(["placeholder", "loadingErroMsg", "checkedAnyField", "unCheckedAnyField"]),
     autoComplete
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/LayersFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/LayersFilter.jsx
@@ -21,7 +21,8 @@ const parentFiltersSel = createSelector(workspaceSelector, (workspace) => ({
 }));
 const selector = createSelector([filterSelector, parentFiltersSel], (filter, parentsFilter) => ({
     selected: filter.layer,
-    parentsFilter
+    parentsFilter,
+    anyFieldVal: filter.layerAny
 }));
 
 export default compose(
@@ -37,7 +38,8 @@ export default compose(
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingLayers"
-        }
+        },
+        anyFilterRuleMode: 'layerAny'
     }),
     withHandlers({
         onValueSelected: ({column = {}, onFilterChange = () => {}}) => filterTerm => {

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/LayersFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/LayersFilter.jsx
@@ -34,7 +34,9 @@ export default compose(
         loadData: loadLayers,
         parentsFilter: {},
         filter: false,
-        placeholder: "rulesmanager.placeholders.filter",
+        placeholder: "rulesmanager.placeholders.filterAny",
+        checkedTooltip: "Show all eligible rules",
+        unCheckedTooltip: "Filter list using selected value",
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingLayers"
@@ -46,6 +48,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder"]),
+    localizedProps(["placeholder", "loadingErroMsg", "checkedTooltip", "unCheckedTooltip"]),
     autoComplete
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RequestsFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RequestsFilter.jsx
@@ -22,7 +22,8 @@ const selector = createSelector([filterSelector, parentFiltersSel, servicesConfi
     disabled: !filter.service,
     service: filter.service,
     parentsFilter,
-    services
+    services,
+    anyFieldVal: filter.requestAny
 }));
 
 
@@ -52,7 +53,8 @@ export default compose(
                 "GetMap",
                 "GetStyles"
             ]
-        }
+        },
+        anyFilterRuleMode: 'requestAny'
     }),
     withPropsOnChange(["service", "services"], ({services = {}, service}) => {
         return {

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RequestsFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RequestsFilter.jsx
@@ -36,8 +36,8 @@ export default compose(
         parentsFilter: {},
         filter: "startsWith",
         placeholder: "rulesmanager.placeholders.filterAny",
-        checkedTooltip: "Show all eligible rules",
-        unCheckedTooltip: "Filter list using selected value",
+        unCheckedAnyField: "rulesmanager.tooltip.filterRuleList",
+        checkedAnyField: "rulesmanager.tooltip.showAllRules",
         services: {
             "WFS": [
                 "DescribeFeatureType",
@@ -68,6 +68,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder", "checkedTooltip", "unCheckedTooltip"]),
+    localizedProps(["placeholder", "checkedAnyField", "unCheckedAnyField"]),
     fixedOptions
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RequestsFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RequestsFilter.jsx
@@ -35,7 +35,9 @@ export default compose(
         valueField: "value",
         parentsFilter: {},
         filter: "startsWith",
-        placeholder: "rulesmanager.placeholders.filter",
+        placeholder: "rulesmanager.placeholders.filterAny",
+        checkedTooltip: "Show all eligible rules",
+        unCheckedTooltip: "Filter list using selected value",
         services: {
             "WFS": [
                 "DescribeFeatureType",
@@ -66,6 +68,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder"]),
+    localizedProps(["placeholder", "checkedTooltip", "unCheckedTooltip"]),
     fixedOptions
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RolesFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RolesFilter.jsx
@@ -16,7 +16,8 @@ import { createSelector } from 'reselect';
 import { error } from '../../../../../actions/notifications';
 import { filterSelector } from '../../../../../selectors/rulesmanager';
 const selector = createSelector(filterSelector, (filter) => ({
-    selected: filter.rolename
+    selected: filter.rolename,
+    anyFieldVal: filter.groupAny
 }));
 
 export default compose(
@@ -32,7 +33,8 @@ export default compose(
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingRoles"
-        }
+        },
+        anyFilterRuleMode: 'groupAny'
     }),
     withHandlers({
         onValueSelected: ({column = {}, onFilterChange = () => {}}) => filterTerm => {

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RolesFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RolesFilter.jsx
@@ -30,8 +30,8 @@ export default compose(
         parentsFilter: {},
         filter: false,
         placeholder: "rulesmanager.placeholders.filterAny",
-        checkedTooltip: "Show all eligible rules",
-        unCheckedTooltip: "Filter list using selected value",
+        unCheckedAnyField: "rulesmanager.tooltip.filterRuleList",
+        checkedAnyField: "rulesmanager.tooltip.showAllRules",
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingRoles"
@@ -43,6 +43,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder", "loadingErroMsg", "checkedTooltip", "unCheckedTooltip"]),
+    localizedProps(["placeholder", "loadingErroMsg", "checkedAnyField", "unCheckedAnyField"]),
     autoComplete
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RolesFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/RolesFilter.jsx
@@ -29,7 +29,9 @@ export default compose(
         loadData: getRoles,
         parentsFilter: {},
         filter: false,
-        placeholder: "rulesmanager.placeholders.filter",
+        placeholder: "rulesmanager.placeholders.filterAny",
+        checkedTooltip: "Show all eligible rules",
+        unCheckedTooltip: "Filter list using selected value",
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingRoles"
@@ -41,6 +43,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder", "loadingErroMsg"]),
+    localizedProps(["placeholder", "loadingErroMsg", "checkedTooltip", "unCheckedTooltip"]),
     autoComplete
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/ServicesFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/ServicesFilter.jsx
@@ -28,7 +28,9 @@ export default compose(
         valueField: "value",
         parentsFilter: {},
         filter: "startsWith",
-        placeholder: "rulesmanager.placeholders.filter",
+        placeholder: "rulesmanager.placeholders.filterAny",
+        checkedTooltip: "Show all eligible rules",
+        unCheckedTooltip: "Filter list using selected value",
         data: [
             {value: "WMS", label: "WMS"},
             {value: "WFS", label: "WFS"},
@@ -42,6 +44,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder"]),
+    localizedProps(["placeholder", "checkedTooltip", "unCheckedTooltip"]),
     fixedOptions
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/ServicesFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/ServicesFilter.jsx
@@ -16,7 +16,8 @@ import { filterSelector, servicesSelector } from '../../../../../selectors/rules
 
 const selector = createSelector(filterSelector, servicesSelector, (filter, services) => ({
     selected: filter.service,
-    services
+    services,
+    anyFieldVal: filter.serviceAny
 }));
 
 export default compose(
@@ -32,7 +33,8 @@ export default compose(
             {value: "WMS", label: "WMS"},
             {value: "WFS", label: "WFS"},
             {value: "WCS", label: "WCS"}
-        ]
+        ],
+        anyFilterRuleMode: 'serviceAny'
     }),
     withPropsOnChange(["services"], ({services, data}) => ({data: services || data})),
     withHandlers({

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/ServicesFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/ServicesFilter.jsx
@@ -29,8 +29,8 @@ export default compose(
         parentsFilter: {},
         filter: "startsWith",
         placeholder: "rulesmanager.placeholders.filterAny",
-        checkedTooltip: "Show all eligible rules",
-        unCheckedTooltip: "Filter list using selected value",
+        unCheckedAnyField: "rulesmanager.tooltip.filterRuleList",
+        checkedAnyField: "rulesmanager.tooltip.showAllRules",
         data: [
             {value: "WMS", label: "WMS"},
             {value: "WFS", label: "WFS"},
@@ -44,6 +44,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder", "checkedTooltip", "unCheckedTooltip"]),
+    localizedProps(["placeholder", "checkedAnyField", "unCheckedAnyField"]),
     fixedOptions
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/UsersFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/UsersFilter.jsx
@@ -16,7 +16,8 @@ import { createSelector } from 'reselect';
 import { filterSelector } from '../../../../../selectors/rulesmanager';
 import { error } from '../../../../../actions/notifications';
 const selector = createSelector(filterSelector, (filter) => ({
-    selected: filter.username
+    selected: filter.username,
+    anyFieldVal: filter.anyUser
 }));
 
 export default compose(
@@ -32,7 +33,8 @@ export default compose(
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingUsers"
-        }
+        },
+        anyFilterRuleMode: 'userAny'
     }),
     withHandlers({
         onValueSelected: ({column = {}, onFilterChange = () => {}}) => filterTerm => {

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/UsersFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/UsersFilter.jsx
@@ -17,7 +17,7 @@ import { filterSelector } from '../../../../../selectors/rulesmanager';
 import { error } from '../../../../../actions/notifications';
 const selector = createSelector(filterSelector, (filter) => ({
     selected: filter.username,
-    anyFieldVal: filter.anyUser
+    anyFieldVal: filter.userAny
 }));
 
 export default compose(
@@ -30,8 +30,8 @@ export default compose(
         parentsFilter: {},
         filter: false,
         placeholder: "rulesmanager.placeholders.filterAny",
-        checkedTooltip: "Show all eligible rules",
-        unCheckedTooltip: "Filter list using selected value",
+        unCheckedAnyField: "rulesmanager.tooltip.filterRuleList",
+        checkedAnyField: "rulesmanager.tooltip.showAllRules",
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingUsers"
@@ -43,6 +43,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder", "loadingErroMsg", "checkedTooltip", "unCheckedTooltip"]),
+    localizedProps(["placeholder", "loadingErroMsg", "checkedAnyField", "unCheckedAnyField"]),
     autoComplete
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/UsersFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/UsersFilter.jsx
@@ -29,7 +29,9 @@ export default compose(
         loadData: getUsers,
         parentsFilter: {},
         filter: false,
-        placeholder: "rulesmanager.placeholders.filter",
+        placeholder: "rulesmanager.placeholders.filterAny",
+        checkedTooltip: "Show all eligible rules",
+        unCheckedTooltip: "Filter list using selected value",
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingUsers"
@@ -41,6 +43,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder"]),
+    localizedProps(["placeholder", "loadingErroMsg", "checkedTooltip", "unCheckedTooltip"]),
     autoComplete
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/WorkspacesFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/WorkspacesFilter.jsx
@@ -33,8 +33,8 @@ export default compose(
         parentsFilter: {},
         filter: "startsWith",
         placeholder: "rulesmanager.placeholders.filterAny",
-        checkedTooltip: "Show all eligible rules",
-        unCheckedTooltip: "Filter list using selected value",
+        unCheckedAnyField: "rulesmanager.tooltip.filterRuleList",
+        checkedAnyField: "rulesmanager.tooltip.showAllRules",
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingWorkspaces"
@@ -46,6 +46,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder", "loadingErroMsg", "checkedTooltip", "unCheckedTooltip"]),
+    localizedProps(["placeholder", "loadingErroMsg", "checkedAnyField", "unCheckedAnyField"]),
     autoComplete
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/WorkspacesFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/WorkspacesFilter.jsx
@@ -32,7 +32,9 @@ export default compose(
         loadData: getWorkspaces,
         parentsFilter: {},
         filter: "startsWith",
-        placeholder: "rulesmanager.placeholders.filter",
+        placeholder: "rulesmanager.placeholders.filterAny",
+        checkedTooltip: "Show all eligible rules",
+        unCheckedTooltip: "Filter list using selected value",
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingWorkspaces"
@@ -44,6 +46,6 @@ export default compose(
             onFilterChange({column, filterTerm});
         }
     }),
-    localizedProps(["placeholder"]),
+    localizedProps(["placeholder", "loadingErroMsg", "checkedTooltip", "unCheckedTooltip"]),
     autoComplete
 )(PagedCombo);

--- a/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/WorkspacesFilter.jsx
+++ b/web/client/components/manager/rulesmanager/rulesgrid/filterRenderers/WorkspacesFilter.jsx
@@ -17,7 +17,8 @@ import { createSelector } from 'reselect';
 import { filterSelector } from '../../../../../selectors/rulesmanager';
 
 const selector = createSelector(filterSelector, (filter) => ({
-    selected: filter.workspace
+    selected: filter.workspace,
+    anyFieldVal: filter.workspaceAny
 }));
 
 
@@ -35,7 +36,8 @@ export default compose(
         loadingErrorMsg: {
             title: "rulesmanager.errorTitle",
             message: "rulesmanager.errorLoadingWorkspaces"
-        }
+        },
+        anyFilterRuleMode: 'workspaceAny'
     }),
     withHandlers({
         onValueSelected: ({column = {}, onFilterChange = () => {}}) => filterTerm => {

--- a/web/client/components/misc/__tests__/PagedCombobox-test.jsx
+++ b/web/client/components/misc/__tests__/PagedCombobox-test.jsx
@@ -171,10 +171,11 @@ describe("This test for PagedCombobox component", () => {
         expect(comp).toExist();
         const domNode = ReactDOM.findDOMNode(comp);
         expect(domNode).toExist();
-        const checkbox = domNode.getElementsByTagName("input");
-        expect(checkbox.length).toEqual(2);
-        expect(checkbox[0].checked).toEqual(true);
-        expect(checkbox[0].name).toEqual('userAny');
+        const inputs = domNode.getElementsByTagName("input");
+        const checkbox = inputs[1];
+        expect(inputs.length).toEqual(2);
+        expect(checkbox.checked).toEqual(true);
+        expect(checkbox.name).toEqual('userAny');
 
         const tool = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithClass(comp, "rw-i rw-i-caret-down")[0]);
         tool.click();

--- a/web/client/components/misc/__tests__/PagedCombobox-test.jsx
+++ b/web/client/components/misc/__tests__/PagedCombobox-test.jsx
@@ -159,4 +159,34 @@ describe("This test for PagedCombobox component", () => {
             done();
         }, 50);
     });
+    it('tests PagedCombobox anyFilter Mode', (done) => {
+        const actions = {
+            onSelect: () => {}
+        };
+        const spy = expect.spyOn(actions, "onSelect");
+        const data = [{
+            label: "label", value: "value"
+        }];
+        const comp = ReactDOM.render(<PagedCombobox onSelect={actions.onSelect} anyFieldVal={false} anyFilterRuleMode={"userAny"} data={data}/>, document.getElementById("container"));
+        expect(comp).toExist();
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        const checkbox = domNode.getElementsByTagName("input");
+        expect(checkbox.length).toEqual(2);
+        expect(checkbox[0].checked).toEqual(true);
+        expect(checkbox[0].name).toEqual('userAny');
+
+        const tool = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithClass(comp, "rw-i rw-i-caret-down")[0]);
+        tool.click();
+        // this tests if the option list is opened
+        const firstOption = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithClass(comp, "rw-list-option")[0]);
+        expect(firstOption).toExist();
+        const valueOption = firstOption.getElementsByTagName("span")[0];
+        expect(valueOption).toExist();
+        TestUtils.Simulate.click(firstOption);
+        setTimeout(() => {
+            expect(spy.calls.length).toEqual(1);
+            done();
+        }, 50);
+    });
 });

--- a/web/client/components/misc/combobox/PagedCombobox.jsx
+++ b/web/client/components/misc/combobox/PagedCombobox.jsx
@@ -55,7 +55,10 @@ class PagedCombobox extends React.Component {
         stopPropagation: PropTypes.bool,
         clearable: PropTypes.bool,
         onReset: PropTypes.func,
-        attribute: PropTypes.string
+        attribute: PropTypes.string,
+        anyFilterRuleMode: PropTypes.bool,
+        onFilterChange: PropTypes.func,
+        anyFieldVal: PropTypes.bool
     };
 
     static contextTypes = {
@@ -94,7 +97,9 @@ class PagedCombobox extends React.Component {
             placement: "top"
         },
         valueField: "value",
-        clearable: false
+        clearable: false,
+        anyFilterRuleMode: false,
+        onFilterChange: ()=>{}
     };
 
     componentDidUpdate(prevProps) {
@@ -182,16 +187,21 @@ class PagedCombobox extends React.Component {
         return this.props.tooltip && this.props.tooltip.enabled ? this.renderWithTooltip(field) : field;
     }
     render() {
-        const {selectedValue: v, disabled, onReset, label: l, clearable} = this.props;
+        const {selectedValue: v, disabled, onReset, label: l, clearable, onFilterChange, anyFieldVal } = this.props;
         let label = l ? (<label>{l}</label>) : (<span/>); // TODO change "the else case" value with null ?
         return (
-            <div className="autocompleteField">
-                {label}
+            <div className={`autocompleteField ${this.props.anyFilterRuleMode ? 'd-flex' : ''}`}>
+                <div className="d-flex"> {label} { this.props.anyFilterRuleMode &&
+                <input onChange={(evt)=>{
+                    onFilterChange({column: {key: evt.target.name}, filterTerm: !evt.target.checked});
+                }} type="checkbox" disabled={v ? false : true} checked={typeof anyFieldVal === 'boolean' && !anyFieldVal ? true : false} title={'filter-mode'} name={this.props.anyFilterRuleMode} />}
+                </div>
                 {clearable ? (
                     <div className={`rw-combo-clearable ${disabled && 'disabled' || ''}`}>
                         {this.renderField()}
                         <span className={`rw-combo-clear ${!v && 'hidden' || ''}`} onClick={onReset}>x</span>
-                    </div>) : this.renderField()
+                    </div>) :
+                    this.renderField()
                 }
             </div>);
     }

--- a/web/client/components/misc/combobox/PagedCombobox.jsx
+++ b/web/client/components/misc/combobox/PagedCombobox.jsx
@@ -60,8 +60,8 @@ class PagedCombobox extends React.Component {
         onFilterChange: PropTypes.func,
         anyFieldVal: PropTypes.bool,
         column: PropTypes.object,
-        checkedTooltip: PropTypes.string,
-        unCheckedTooltip: PropTypes.string
+        checkedAnyField: PropTypes.string,
+        unCheckedAnyField: PropTypes.string
     };
 
     static contextTypes = {
@@ -104,8 +104,8 @@ class PagedCombobox extends React.Component {
         anyFilterRuleMode: '',
         onFilterChange: ()=>{},
         column: {},
-        checkedTooltip: "",
-        unCheckedTooltip: ""
+        checkedAnyField: "",
+        unCheckedAnyField: ""
     };
 
     componentDidUpdate(prevProps) {
@@ -129,6 +129,21 @@ class PagedCombobox extends React.Component {
         </OverlayTrigger>);
     };
 
+    renderTooltipCheckbox = () => {
+        const { onFilterChange, anyFieldVal } = this.props;
+
+        let checkboxInput = (
+            <input onChange={(evt)=>{
+                onFilterChange({column: {key: evt.target.name}, filterTerm: !evt.target.checked});
+            }} type="checkbox" checked={!!(typeof anyFieldVal === 'boolean' && !anyFieldVal)}
+            name={this.props.anyFilterRuleMode} />
+        );
+        const tooltip = (<Tooltip id={this.props.tooltip.id + anyFieldVal ? "checked" : "unchecked"}>
+            { !!(typeof anyFieldVal === 'boolean' && !anyFieldVal) ? this.props.checkedAnyField : this.props.unCheckedAnyField }</Tooltip>);
+        return (<OverlayTrigger key={this.props.tooltip.overlayTriggerKey} placement={this.props.tooltip.placement} overlay={tooltip}>
+            { checkboxInput }
+        </OverlayTrigger>);
+    }
 
     renderPagination = () => {
         const firstPage = this.props.pagination.firstPage;
@@ -193,7 +208,7 @@ class PagedCombobox extends React.Component {
         return this.props.tooltip && this.props.tooltip.enabled ? this.renderWithTooltip(field) : field;
     }
     render() {
-        const {selectedValue: v, disabled, onReset, label: l, clearable, onFilterChange, anyFieldVal } = this.props;
+        const {selectedValue: v, disabled, onReset, label: l, clearable, onFilterChange } = this.props;
         let label = l ? (<label>{l}</label>) : (<span/>); // TODO change "the else case" value with null ?
         return (
             <div className={`autocompleteField ${this.props.anyFilterRuleMode ? 'd-flex' : ''}`}>
@@ -215,10 +230,7 @@ class PagedCombobox extends React.Component {
                 <div>
                     {label}
                     { this.props.anyFilterRuleMode ?
-                        <input onChange={(evt)=>{
-                            onFilterChange({column: {key: evt.target.name}, filterTerm: !evt.target.checked});
-                        }} type="checkbox" checked={!!(typeof anyFieldVal === 'boolean' && !anyFieldVal)} title={anyFieldVal ? this.props.unCheckedTooltip : this.props.checkedTooltip}
-                        name={this.props.anyFilterRuleMode} /> : null}
+                        this.renderTooltipCheckbox() : null}
                 </div>
             </div>);
     }

--- a/web/client/components/misc/combobox/PagedCombobox.jsx
+++ b/web/client/components/misc/combobox/PagedCombobox.jsx
@@ -56,9 +56,12 @@ class PagedCombobox extends React.Component {
         clearable: PropTypes.bool,
         onReset: PropTypes.func,
         attribute: PropTypes.string,
-        anyFilterRuleMode: PropTypes.bool,
+        anyFilterRuleMode: PropTypes.string,
         onFilterChange: PropTypes.func,
-        anyFieldVal: PropTypes.bool
+        anyFieldVal: PropTypes.bool,
+        column: PropTypes.object,
+        checkedTooltip: PropTypes.string,
+        unCheckedTooltip: PropTypes.string
     };
 
     static contextTypes = {
@@ -98,8 +101,11 @@ class PagedCombobox extends React.Component {
         },
         valueField: "value",
         clearable: false,
-        anyFilterRuleMode: false,
-        onFilterChange: ()=>{}
+        anyFilterRuleMode: '',
+        onFilterChange: ()=>{},
+        column: {},
+        checkedTooltip: "",
+        unCheckedTooltip: ""
     };
 
     componentDidUpdate(prevProps) {
@@ -191,18 +197,29 @@ class PagedCombobox extends React.Component {
         let label = l ? (<label>{l}</label>) : (<span/>); // TODO change "the else case" value with null ?
         return (
             <div className={`autocompleteField ${this.props.anyFilterRuleMode ? 'd-flex' : ''}`}>
-                <div className="d-flex"> {label} { this.props.anyFilterRuleMode &&
-                <input onChange={(evt)=>{
-                    onFilterChange({column: {key: evt.target.name}, filterTerm: !evt.target.checked});
-                }} type="checkbox" disabled={v ? false : true} checked={typeof anyFieldVal === 'boolean' && !anyFieldVal ? true : false} title={'filter-mode'} name={this.props.anyFilterRuleMode} />}
-                </div>
                 {clearable ? (
                     <div className={`rw-combo-clearable ${disabled && 'disabled' || ''}`}>
                         {this.renderField()}
-                        <span className={`rw-combo-clear ${!v && 'hidden' || ''}`} onClick={onReset}>x</span>
+                        <span className={`rw-combo-clear ${!v && 'hidden' || ''}`} onClick={()=>{
+                            if (this.props.anyFilterRuleMode) {
+                                // reset the checkbox as well
+                                onFilterChange({column: {key: this.props.column?.key}, filterTerm: undefined, isResetField: true});
+                            } else {
+                                onReset();
+                            }
+                        }}>x</span>
                     </div>) :
                     this.renderField()
                 }
+                 &nbsp;
+                <div>
+                    {label}
+                    { this.props.anyFilterRuleMode ?
+                        <input onChange={(evt)=>{
+                            onFilterChange({column: {key: evt.target.name}, filterTerm: !evt.target.checked});
+                        }} type="checkbox" checked={!!(typeof anyFieldVal === 'boolean' && !anyFieldVal)} title={anyFieldVal ? this.props.unCheckedTooltip : this.props.checkedTooltip}
+                        name={this.props.anyFilterRuleMode} /> : null}
+                </div>
             </div>);
     }
 }

--- a/web/client/reducers/__tests__/rulesmanager-test.js
+++ b/web/client/reducers/__tests__/rulesmanager-test.js
@@ -127,6 +127,43 @@ describe('test rules manager reducer', () => {
             filter3: "value3"
         });
     });
+    it('update set filter values', () => {
+        const oldState = {
+            filters: {
+                layer: "layer1"
+            }
+        };
+        var state = rulesmanager(oldState, {
+            type: 'RULES_MANAGER:SET_FILTER',
+            key: "workspace",
+            value: "workspace1"
+        });
+        expect(state.filters).toEqual({
+            layer: "layer1",
+            workspace: "workspace1"
+        });
+    });
+
+    it('update set reset filter values', () => {
+        const oldState = {
+            filters: {
+                workspace: "workspace1",
+                workspaceAny: false,
+                layer: "layer1"
+            }
+        };
+        var state = rulesmanager(oldState, {
+            type: 'RULES_MANAGER:SET_FILTER',
+            key: "workspace",
+            value: undefined,
+            isResetField: true
+        });
+        expect(state.filters).toEqual({
+            workspace: undefined,
+            workspaceAny: true,
+            layer: "layer1"
+        });
+    });
 
     it('options loaded', () => {
         const oldState = {

--- a/web/client/reducers/__tests__/rulesmanager-test.js
+++ b/web/client/reducers/__tests__/rulesmanager-test.js
@@ -160,7 +160,7 @@ describe('test rules manager reducer', () => {
         });
         expect(state.filters).toEqual({
             workspace: undefined,
-            workspaceAny: true,
+            workspaceAny: undefined,
             layer: "layer1"
         });
     });

--- a/web/client/reducers/rulesmanager.js
+++ b/web/client/reducers/rulesmanager.js
@@ -106,7 +106,7 @@ function rulesmanager(state = defaultState, action) {
         return assign({}, state, {loading: action.loading});
     case SET_FILTER: {
         const {key, value} = action;
-        if (value) {
+        if (value || key?.includes('Any')) {
             return assign({}, state, {filters: {...state.filters, [key]: value}});
         }
         const {[key]: omit, ...newFilters} = state.filters;

--- a/web/client/reducers/rulesmanager.js
+++ b/web/client/reducers/rulesmanager.js
@@ -105,7 +105,15 @@ function rulesmanager(state = defaultState, action) {
     case LOADING:
         return assign({}, state, {loading: action.loading});
     case SET_FILTER: {
-        const {key, value} = action;
+        const {key, value, isResetField} = action;
+        if (isResetField) {
+            if (key === "rolename") {
+                return assign({}, state, {filters: {...state.filters, [key]: value, ['groupAny']: true}});
+            } else if (key === "username") {
+                return assign({}, state, {filters: {...state.filters, [key]: value, ['userAny']: true}});
+            }
+            return assign({}, state, {filters: {...state.filters, [key]: value, [key + 'Any']: true}});
+        }
         if (value || key?.includes('Any')) {
             return assign({}, state, {filters: {...state.filters, [key]: value}});
         }

--- a/web/client/reducers/rulesmanager.js
+++ b/web/client/reducers/rulesmanager.js
@@ -108,11 +108,11 @@ function rulesmanager(state = defaultState, action) {
         const {key, value, isResetField} = action;
         if (isResetField) {
             if (key === "rolename") {
-                return assign({}, state, {filters: {...state.filters, [key]: value, ['groupAny']: true}});
+                return assign({}, state, {filters: {...state.filters, [key]: value, ['groupAny']: undefined}});
             } else if (key === "username") {
-                return assign({}, state, {filters: {...state.filters, [key]: value, ['userAny']: true}});
+                return assign({}, state, {filters: {...state.filters, [key]: value, ['userAny']: undefined}});
             }
-            return assign({}, state, {filters: {...state.filters, [key]: value, [key + 'Any']: true}});
+            return assign({}, state, {filters: {...state.filters, [key]: value, [key + 'Any']: undefined}});
         }
         if (value || key?.includes('Any')) {
             return assign({}, state, {filters: {...state.filters, [key]: value}});

--- a/web/client/selectors/__tests__/rulesmanager-test.js
+++ b/web/client/selectors/__tests__/rulesmanager-test.js
@@ -28,15 +28,21 @@ describe('test rules manager selectors', () => {
         const rules = rulesSelector(state);
         expect(rules.length).toBe(1);
         expect(rules[0]).toEqual({
-            id: "rules1",
+            id: 'rules1',
             priority: 1,
-            roleName: "role1",
-            userName: "*",
-            service: "*",
-            request: "*",
-            workspace: "*",
-            layer: "*",
-            access: "ALLOW"
+            roleName: 'role1',
+            groupAny: '*',
+            userName: '*',
+            userAny: '*',
+            service: '*',
+            serviceAny: '*',
+            request: '*',
+            requestAny: '*',
+            workspace: '*',
+            workspaceAny: '*',
+            layer: '*',
+            layerAny: '*',
+            access: 'ALLOW'
         });
     });
 

--- a/web/client/selectors/rulesmanager.js
+++ b/web/client/selectors/rulesmanager.js
@@ -21,11 +21,17 @@ export const rulesSelector = (state) => {
         assign(formattedRule, {'id': rule.id});
         assign(formattedRule, {'priority': rule.priority});
         assign(formattedRule, {'roleName': rule.roleName ? rule.roleName : '*'});
+        assign(formattedRule, {'groupAny': rule.groupAny ? rule.groupAny : '*'});
         assign(formattedRule, {'userName': rule.userName ? rule.userName : '*'});
+        assign(formattedRule, {'userAny': rule.userAny ? rule.userAny : '*'});
         assign(formattedRule, {'service': rule.service ? rule.service : '*'});
+        assign(formattedRule, {'serviceAny': rule.serviceAny ? rule.serviceAny : '*'});
         assign(formattedRule, {'request': rule.request ? rule.request : '*'});
+        assign(formattedRule, {'requestAny': rule.requestAny ? rule.requestAny : '*'});
         assign(formattedRule, {'workspace': rule.workspace ? rule.workspace : '*'});
+        assign(formattedRule, {'workspaceAny': rule.workspaceAny ? rule.workspaceAny : '*'});
         assign(formattedRule, {'layer': rule.layer ? rule.layer : '*'});
+        assign(formattedRule, {'layerAny': rule.layerAny ? rule.layerAny : '*'});
         assign(formattedRule, {'access': rule.access});
         return formattedRule;
     });

--- a/web/client/themes/default/less/autocomplete.less
+++ b/web/client/themes/default/less/autocomplete.less
@@ -38,3 +38,6 @@
 .rw-combobox .rw-btn {
     overflow: hidden;
 }
+.d-flex{
+    display: flex;
+}

--- a/web/client/themes/default/less/react-data-grid.less
+++ b/web/client/themes/default/less/react-data-grid.less
@@ -301,3 +301,12 @@
          }
      }
 }
+#page-rulesmanager{
+    .ms2-border-layout-body{
+        .rules-data-gird {
+            .react-grid-HeaderCell{
+                display: flex !important;
+            }
+        }
+    }
+}

--- a/web/client/themes/default/less/react-data-grid.less
+++ b/web/client/themes/default/less/react-data-grid.less
@@ -305,7 +305,10 @@
     .ms2-border-layout-body{
         .rules-data-gird {
             .react-grid-HeaderCell{
-                display: flex !important;
+               .autocompleteField input {
+                position: relative;
+                top: 15%;
+               } 
             }
         }
     }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2667,7 +2667,8 @@
                 "layer": "Ebenen suchen",
                 "access": "Zugriff suchen",
                 "ip": "###.###.###.###/##",
-                "priority": "Priorität festlegen"
+                "priority": "Priorität festlegen",
+                "filterAny": "beliebig"
             },
             "menutitle": "GeoFence-Regeln Verwalten",
             "tooltip": {
@@ -2678,7 +2679,9 @@
                 "deleteT": "Entferne ausgewählte Regeln",
                 "cacheT": "Cache leeren",
                 "save": "Aktuelle Regel speichern",
-                "close": "Beenden Sie die Regelerstellung"
+                "close": "Beenden Sie die Regelerstellung",
+                "filterRuleList": "Toon alle in aanmerking komende regels",
+                "showAllRules": "Filterlijst met geselecteerde waarde"
             },
             "navItems": {
                 "main": "Allgemeine Regel",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2680,8 +2680,8 @@
                 "cacheT": "Cache leeren",
                 "save": "Aktuelle Regel speichern",
                 "close": "Beenden Sie die Regelerstellung",
-                "filterRuleList": "Toon alle in aanmerking komende regels",
-                "showAllRules": "Filterlijst met geselecteerde waarde"
+                "showAllRules": "Toon alle in aanmerking komende regels",
+                "filterRuleList": "Filterlijst met geselecteerde waarde"
             },
             "navItems": {
                 "main": "Allgemeine Regel",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2640,7 +2640,8 @@
                 "access": "Type to search Access",
                 "ip": "###.###.###.###/##",
                 "priority": "Select Priority",
-                "filter": "Filter styles..."
+                "filter": "Filter styles...",
+                "filterAny": "ANY"
             },
             "menutitle": "Manage Access Rules",
             "tooltip": {
@@ -2651,7 +2652,9 @@
                 "deleteT": "Remove selected rules",
                 "cacheT": "Clear cache",
                 "save": "Save current rule",
-                "close": "Exit from create rule"
+                "close": "Exit from create rule",
+                "filterRuleList": "Show all eligible rules",
+                "showAllRules": "Filter list using selected value"
             },
             "navItems": {
                 "main": "General Rule",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2653,8 +2653,8 @@
                 "cacheT": "Clear cache",
                 "save": "Save current rule",
                 "close": "Exit from create rule",
-                "filterRuleList": "Show all eligible rules",
-                "showAllRules": "Filter list using selected value"
+                "showAllRules": "Show all eligible rules",
+                "filterRuleList": "Filter list using selected value"
             },
             "navItems": {
                 "main": "General Rule",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2643,8 +2643,8 @@
                 "cacheT": "Limpiar cache",
                 "save": "Guardar la regla actual",
                 "close": "Salir de crear regla",
-                "filterRuleList": "Mostrar todas las reglas elegibles",
-                "showAllRules": "Lista de filtros usando un valor seleccionado"
+                "showAllRules": "Mostrar todas las reglas elegibles",
+                "filterRuleList": "Lista de filtros usando un valor seleccionado"
             },
             "navItems": {
                 "main": "Regla general",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2630,7 +2630,8 @@
                 "layer": "Escriba para buscar Capas",
                 "access": "Escriba para buscar Acceso",
                 "ip": "###.###.###.###/##",
-                "priority": "Seleccionar prioridad"
+                "priority": "Seleccionar prioridad",
+                "filterAny": "Cualquier"
             },
             "menutitle": "Administrar reglas de GeoFence",
             "tooltip": {
@@ -2641,7 +2642,9 @@
                 "deleteT": "Eliminar las reglas seleccionadas",
                 "cacheT": "Limpiar cache",
                 "save": "Guardar la regla actual",
-                "close": "Salir de crear regla"
+                "close": "Salir de crear regla",
+                "filterRuleList": "Mostrar todas las reglas elegibles",
+                "showAllRules": "Lista de filtros usando un valor seleccionado"
             },
             "navItems": {
                 "main": "Regla general",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2643,8 +2643,8 @@
                 "cacheT": "Vider le cache",
                 "save": "Enregistrer la règle actuelle",
                 "close": "Fermer la règle",
-                "filterRuleList": "Montrer toutes les règles éligibles",
-                "showAllRules": "Liste de filtre à l'aide d'une valeur sélectionnée"
+                "showAllRules": "Montrer toutes les règles éligibles",
+                "filterRuleList": "Liste de filtre à l'aide d'une valeur sélectionnée"
             },
             "navItems": {
                 "main": "Règle générale",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2630,7 +2630,8 @@
                 "layer": "Rechercher des couches",
                 "access": "Rechercher des accès",
                 "ip": "###.###.###.###/##",
-                "priority": "Sélectionner la priorité"
+                "priority": "Sélectionner la priorité",
+                "filterAny": "n'importe quel"
             },
             "menutitle": "Gérer les règles d'accès",
             "tooltip": {
@@ -2641,7 +2642,9 @@
                 "deleteT": "Supprimer les règles sélectionnées",
                 "cacheT": "Vider le cache",
                 "save": "Enregistrer la règle actuelle",
-                "close": "Fermer la règle"
+                "close": "Fermer la règle",
+                "filterRuleList": "Montrer toutes les règles éligibles",
+                "showAllRules": "Liste de filtre à l'aide d'une valeur sélectionnée"
             },
             "navItems": {
                 "main": "Règle générale",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2644,8 +2644,8 @@
                 "cacheT": "Pulisci la cache",
                 "save": "Salva regola corrente",
                 "close": "Esci da modifica regola",
-                "filterRuleList": "Mostra tutte le regole idonei",
-                "showAllRules": "Filter list using selected value"
+                "showAllRules": "Mostra tutte le regole applicabili",
+                "filterRuleList": "Filtra la lista usando il valore selezionato"
             },
             "navItems": {
                 "main": "Regola Generica",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2631,7 +2631,8 @@
                 "layer": "Cerca Layers",
                 "access": "Cerca Permesso",
                 "ip": "###.###.###.###/##",
-                "priority": "Seleziona Priorità"
+                "priority": "Seleziona Priorità",
+                "filterAny": "Qualsiasi"
             },
             "menutitle": "Configura Regole di Accesso",
             "tooltip": {
@@ -2642,7 +2643,9 @@
                 "deleteT": "Rimuovi regole selezionate",
                 "cacheT": "Pulisci la cache",
                 "save": "Salva regola corrente",
-                "close": "Esci da modifica regola"
+                "close": "Esci da modifica regola",
+                "filterRuleList": "Mostra tutte le regole idonei",
+                "showAllRules": "Filter list using selected value"
             },
             "navItems": {
                 "main": "Regola Generica",


### PR DESCRIPTION
## Description
Improving GeoFence rule filtering capabilities by adding checkbox in UI to filter based on its mode

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#9510 

**What is the current behavior?**
#9510 
**What is the new behavior?**
Improving GeoFence rule filtering capabilities by adding checkbox with each header in rule manager grid to filter based on its mode like: 'userAny', 'layerAny', 'groupAny' ...etc
So now user can filter apply some kind of filtermode for each column filter, first user should select from the list  then checkbox will be able to be clicked. 
![image](https://github.com/geosolutions-it/MapStore2/assets/58145645/26f3b153-4654-42a4-b36a-8d8c8ec62059)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
