### PR TITLE
#9268: Fix domain values on empty areas

### DIFF
--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -61,7 +61,7 @@ import {
     layersWithTimeDataSelector
 } from '../selectors/dimension';
 
-import { getNearestDate, roundRangeResolution, isTimeDomainInterval } from '../utils/TimeUtils';
+import { getNearestDate, roundRangeResolution, isTimeDomainInterval, getStartEndDomainValues } from '../utils/TimeUtils';
 import { getHistogram, describeDomains } from '../api/MultiDim';
 import { getTimeDomainsObservable } from '../observables/multidim';
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -122,12 +122,13 @@ const RATIO = 5; // ratio of the size of the offset to set relative to the curre
  * @returns a stream of data with histogram and/or domain values
  */
 const loadRangeData = (id, timeData, getState) => {
-    /**
-     * when there is no timeline state rangeSelector(getState()) returns undefined, so instead we use the timeData[id] range
-     */
-    const dataRange = timeData.domain.split('--');
-
-    const initialRange = rangeSelector(getState()) || {start: new Date(dataRange[0]), end: new Date(dataRange[1])};
+    let initialRange = rangeSelector(getState());
+    // when there is no timeline state rangeSelector(getState()) returns undefined, so instead we use the timeData[id] range
+    if (!initialRange) {
+        const dataRange = getStartEndDomainValues(timeData.domain);
+        // dateRange is only 1 value for single values (extreme case, to avoid errors)
+        initialRange = {start: new Date(dataRange[0]), end: new Date(dataRange[1] || dataRange[0])};
+    }
 
     const {range, resolution} = roundRangeResolution( initialRange, MAX_HISTOGRAM);
     const layerName = getLayerFromId(getState(), id).name;
@@ -212,7 +213,7 @@ const updateRangeOnInit = (state, value, currentTime) => {
     // The startTime and endTime is full range of the layer
     let values;
 
-    // convert to array
+    // convert to array (evaluate to use getStartEndDomainValues instead)
     if (isString(value)) {
         if (value.indexOf('--') > 0) {
             values = value.split('--');

--- a/web/client/selectors/__tests__/timeline-test.js
+++ b/web/client/selectors/__tests__/timeline-test.js
@@ -204,6 +204,31 @@ describe('timeline selector', () => {
         timeItems = getTimeItems(data, range, rangeData);
         expect(timeItems.length).toBe(1);
     });
+    it('getTimeItems should give priority to rangeData even when both domain and histogram are empty (so no data in the current viewport, with filter active)', () => {
+        const data = {
+            source: {
+                type: 'multidim-extension',
+                version: '1.2',
+                url: '/geoserver/gwc/service/wmts'
+            },
+            name: 'time',
+            domain: '2022-06-01T00:00:00.000Z/2023-06-01T00:00:00.000Z,2023-01-01T00:00:00.000Z/2023-06-01T00:00:00.000Z,2023-01-01T00:00:00.000Z/2023-12-31T00:00:00.000Z'
+        };
+        const range = {
+            start: '2022-06-01T00:00:00.000Z',
+            end: '2024-01-09T11:07:53.218Z'
+        };
+        let timeItems = getTimeItems(data, range);
+        expect(timeItems.length).toBe(3);
+        const rangeData = {
+            range: {
+                start: '2022-06-01T00:00:00.000Z',
+                end: '2024-01-09T11:07:53.218Z'
+            }
+        };
+        timeItems = getTimeItems(data, range, rangeData);
+        expect(timeItems.length).toBe(0);
+    });
     it('itemsSelector', () => {
         const histogramItems = itemsSelector(SAMPLE_STATE_HISTOGRAM);
         expect(histogramItems.length).toBe(31);

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -133,7 +133,7 @@ export const getTimeItems = (data = {}, range, rangeData) => {
     // rangeData populates when some changes ara applied with map sync
     // we should use this when available
     // because represent the latest updated value
-    if (rangeData?.domain || rangeData?.histogram) {
+    if (rangeData) {
         return rangeDataToItems(rangeData, range);
     }
     if (data && data.values || data && data.domain && !isTimeDomainInterval(data.domain)) {


### PR DESCRIPTION
## Description

The issue #9268 was caused by `rangeData` (data on the current timeline viewport downloaded) to not have complete priority over domain data, that happened only when the domain values are less than 20. 

In fact in this case, the back-end lists all of them, not only the generic interval (startDate--endDate) and the code didn't take into account this use case.

During the investigation we have also found another issue concerning the filter on viewport when the timeline was closed

[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2023.10.06-15_15_48.webm](https://github.com/geosolutions-it/MapStore2/assets/1279510/409bd50c-2628-4270-8159-302e3bc59fad)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9268

**What is the new behavior?**
Fix #9268

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
