### PR TITLE
[Backport 2023.02.xx] Fix #9575 Avoid full rerender in filterRenderer (#9577)

### DIFF
--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -671,6 +671,20 @@ describe('Test featuregrid selectors', () => {
             }
         };
         expect(selectedLayerFieldsSelector(state)).toEqual([FIELD]);
+        // check that fields are memoized when applying defaults
+        const stateEmptyFields = {
+            featuregrid: {
+                selectedLayer: 'TEST_LAYER'
+            },
+            layers: {
+                flat: [{
+                    id: "TEST_LAYER",
+                    title: "Test Layer",
+                    name: 'editing:polygons.test'
+                }]
+            }
+        };
+        expect(selectedLayerFieldsSelector(stateEmptyFields)).toBe(selectedLayerFieldsSelector(stateEmptyFields));
     });
     it('editingAllowedGroupsSelector', () => {
         const editingAllowedGroups = ['test'];

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -112,7 +112,7 @@ export const getTitleSelector = state => {
     const title = getTitle(getLayerById(state, selectedLayerIdSelector(state)));
     return isObject(title) ? title[currentLocaleSelector(state)] || title.default || '' : title;
 };
-
+const STANDARD_FIELDS = [];
 /**
  * Returns the current selected layer (featuregrid) fields, if any.
  * @param {*} state
@@ -120,7 +120,7 @@ export const getTitleSelector = state => {
  */
 export const selectedLayerFieldsSelector = state => {
     const layer = getLayerById(state, selectedLayerIdSelector(state));
-    const fields = get(layer, "fields", []);
+    const fields = get(layer, "fields", STANDARD_FIELDS);
     return fields;
 };
 export const getCustomizedAttributes = state => {


### PR DESCRIPTION
[Backport 2023.02.xx] Fix #9575 Avoid full rerender in filterRenderer (#9577)