### PR TITLE
Fix #9603 enhancing feedback to the user when source is using a Point layer

### DIFF
--- a/web/client/epics/geoProcessing.js
+++ b/web/client/epics/geoProcessing.js
@@ -665,7 +665,16 @@ export const runIntersectProcessGPTEpic = (action$, store) => action$
                                     })
                                 ));
                     })
-                    .catch(() => {
+                    .catch((e) => {
+                        console.error(e);
+                        if (e.message.includes("First feature collection must be polygonal or linear")) {
+                            return Rx.Observable.of(showErrorNotification({
+                                title: "errorTitleDefault",
+                                message: "GeoProcessing.notifications.errorIntersectGFIPointSource",
+                                autoDismiss: 6,
+                                position: "tc"
+                            }));
+                        }
                         return Rx.Observable.of(showErrorNotification({
                             title: "errorTitleDefault",
                             message: "GeoProcessing.notifications.errorIntersectGFI",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -3969,6 +3969,7 @@
           "false": "falsch",
           "notifications": {
             "errorIntersectGFI": "Beim Überschneiden der Features ist ein Fehler aufgetreten. Der Schnittpunkt-Layer konnte nicht erstellt werden.",
+            "errorIntersectGFIPointSource": "Die erste Schicht muss polygonal oder linear sein.",
             "errorGFI": "Beim Laden der Funktion ist ein Fehler aufgetreten",
             "errorGetFeature": "Beim Laden des Features zum Abrufen seiner Geometrie ist ein Fehler aufgetreten",
             "layerNotSupported": "Ausgewählte Ebene wird nicht unterstützt. Bitte wählen Sie WMS, WFS oder Vektorebene aus.",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -3943,6 +3943,7 @@
           "false": "false",
           "notifications": {
             "errorIntersectGFI": "There was an error intersecting the features. It was not possible to create the intersection layer.",
+            "errorIntersectGFIPointSource": "First feature collection must be polygonal or linear.",
             "errorGFI": "There was an error loading the feature",
             "errorGetFeature": "There was an error loading the feature in order to obtain its geometry",
             "layerNotSupported": "Selected layer is not supported. Please select WMS, WFS or vector layer.",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -3932,6 +3932,7 @@
           "false": "falsa",
           "notifications": {
             "errorIntersectGFI": "Hubo un error al cruzar las entidades. No fue posible crear la capa de intersección.",
+            "errorIntersectGFIPointSource": "La primera capa debe ser poligonal o lineal.",
             "errorGFI": "Hubo un error al cargar la característica",
             "errorGetFeature": "Hubo un error al cargar la función para obtener su geometría",
             "layerNotSupported": "La capa seleccionada no es compatible. Seleccione WMS, WFS o capa vectorial.",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -3932,6 +3932,7 @@
           "false": "faux",
           "notifications": {
             "errorIntersectGFI": "Une erreur s'est produite lors de l'intersection des entités. Il n'a pas été possible de créer la couche d'intersection.",
+            "errorIntersectGFIPointSource": "La première couche doit être polygonale ou linéaire.",
             "errorGFI": "Une erreur s'est produite lors du chargement de la fonctionnalité",
             "errorGetFeature": "Une erreur s'est produite lors du chargement de l'entité afin d'obtenir sa géométrie",
             "layerNotSupported": "La couche sélectionnée n'est pas prise en charge. Veuillez sélectionner une couche WMS, WFS ou vectorielle.",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -3932,6 +3932,7 @@
           "false": "falso",
           "notifications": {
             "errorIntersectGFI": "Si è verificato un errore durante l'intersezione delle geometrie. Non è stato possibile creare il livello di intersezione.",
+            "errorIntersectGFIPointSource": "Il primo livello deve essere poligonale o lineare.",
             "errorGFI": "Si è verificato un errore durante il caricamento della feature",
             "errorGetFeature": "Si è verificato un errore durante il caricamento della feature per ottenerne la geometria",
             "layerNotSupported": "Il layer selezionato non è supportato. Seleziona WMS, WFS o layer vettoriale.",


### PR DESCRIPTION
Fix #9603 enhancing feedback to the user when source is using a Point layer

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #9603

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
