### PR TITLE
Added fix for #9606

### DIFF
--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -149,7 +149,7 @@ class CoordinatesEditor extends React.Component {
                             if (this.isValid(this.props.components, radius )) {
                                 this.props.onChangeRadius(parseFloat(radius), this.props.components.map(coordToArray), uom);
                             } else if (radius !== "") {
-                                this.props.onChangeRadius(parseFloat(radius), [], uom);
+                                this.props.onChangeRadius(parseFloat(radius), [[0, 0]], uom);
                             } else {
                                 this.props.onChangeRadius(null, this.props.components.map(coordToArray), uom);
                                 this.props.onSetInvalidSelected("radius", this.props.components.map(coordToArray));

--- a/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
@@ -551,7 +551,7 @@ describe("test the CoordinatesEditor Panel", () => {
         inputRadius.value = 10000;
         TestUtils.Simulate.change(inputRadius);
         expect(spyOnChangeRadius).toHaveBeenCalled();
-        expect(spyOnChangeRadius).toHaveBeenCalledWith(10000, [], mapProjection);
+        expect(spyOnChangeRadius).toHaveBeenCalledWith(10000, [[0, 0]], mapProjection);
         expect(spyOnSetInvalidSelected).toNotHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Description
This code aims to solve the exception thrown at #9606

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
#9606

**What is the new behavior?**
The exception is solved and is posible to select a radius value with the arrow of the numeric input

## Breaking change
 - [ ] Yes, and I documented them in migration notes
 - [x] No