### PR TITLE
#9585: fix zoom to 3d layer to the correct extent in csw catalog

### DIFF
--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -1,4 +1,4 @@
- /**
+/**
  * Copyright 2016, GeoSolutions Sas.
  * All rights reserved.
  *

--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -410,7 +410,7 @@ const Api = {
                                         obj.dc = dc;
                                     }
                                     // if it is 3D layer ---> get layer extent from tilesetJson
-                                    if (obj.dc.format === THREE_D_TILES) {
+                                    if (obj?.dc?.format === THREE_D_TILES) {
                                         let tilesetJsonURL = obj.dc?.URI?.value;
                                         if (tilesetJsonURL) {
                                             let data = await getCapabilities(tilesetJsonURL);

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -10,8 +10,10 @@ import expect from 'expect';
 import axios from '../../libs/ajax';
 import MockAdapter from 'axios-mock-adapter';
 import GRDCResponse from 'raw-loader!../../test-resources/csw/getRecordsResponseDC.xml';
+import GRDCResponseWith3DLayers from 'raw-loader!../../test-resources/csw/getRecordsResponseDCWith3DLayers.xml';
+import API, {constructXMLBody, getLayerReferenceFromDc } from '../CSW';
 
-import API, {constructXMLBody, getLayerReferenceFromDc} from '../CSW';
+import tileSetResponse from '../../test-resources/3dtiles/tileSetSample2.json';
 
 describe('Test correctness of the CSW APIs', () => {
     it('getRecords ISO Metadata Profile', (done) => {
@@ -280,5 +282,112 @@ describe("getLayerReferenceFromDc", () => {
         expect(layerRef.params.name).toBe('some_layer');
         expect(layerRef.type).toBe('arcgis');
         expect(layerRef.url).toBe('http://esri_url');
+    });
+
+});
+
+describe("getLayerReferenceFromDc", () => {
+    const threeDLayerRecord = {
+        "boundingBox": {
+            "extent": [
+                11.244154369601063,
+                43.75907090685874,
+                11.265929832205956,
+                43.78084636946362
+            ],
+            "crs": "EPSG:4326"
+        },
+        "dc": {
+            "references": [],
+            "identifier": "test:20230829_test_3dtile_01",
+            "date": "2023-09-22",
+            "title": "Metadato di test per 3D-tile",
+            "abstract": "Breve descrizione della risorsa",
+            "description": "Breve descrizione della risorsa",
+            "type": "dataset",
+            "subject": [
+                "Zone a rischio naturale",
+                "health"
+            ],
+            "format": "3D Tiles",
+            "contributor": "Nome dell'ufficio responsabile del dato",
+            "rights": [
+                "otherRestrictions",
+                "otherRestrictions"
+            ],
+            "language": "ita",
+            "source": "Descrizione della provenienza e del processo di produzione del dato (storia, ciclo di vita, rilevazione, acquisizione, forma attuale, qualità richiesta per garantirne l'interoperabilità)",
+            "temporal": "start=2009-01-01; end=2013-12-31",
+            "URI": {
+                "TYPE_NAME": "DC_1_1.URI",
+                "protocol": "https://registry.geodati.gov.it/metadata-codelist/ProtocolValue/www-download",
+                "description": "access point",
+                "value": "https://3d-layers.s3.eu-central-1.amazonaws.com/3dtiles/centro_storico_di_firenze_-_brass_city_model/tileset.json"
+            }
+        }
+    };
+    let mockAxios;
+    beforeEach((done) => {
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        mockAxios.restore();
+        setTimeout(done);
+    });
+    it('test getBboxFor3DLayersToRecords function that handles getting bbox for 3D tile layers from ', (done) => {
+        mockAxios.onPost().replyOnce(()=>{
+            return [200, GRDCResponseWith3DLayers];
+        });
+        mockAxios.onGet().reply(()=>{
+            return [200, tileSetResponse];
+        });
+        mockAxios.onGet().reply(()=>{
+            return [200, tileSetResponse];
+        });
+        API.getRecords('base/web/client/test-resources/csw/getRecordsResponseDCWith3DLayers.xml', 1, 2).then((result) => {
+            try {
+                expect(result).toExist();
+                expect(result.records).toExist();
+                expect(result.records.length).toBe(5);
+                const [rec0, rec1, rec2, rec3, rec4] = result.records;
+
+                expect(rec0.dc).toExist();
+                expect(rec0.boundingBox).toExist();
+                expect(rec0.boundingBox.crs).toBe('EPSG:4326');
+                expect(rec0.boundingBox.extent).toEqual([45.542, 11.874, 46.026, 12.718]);
+                expect(rec1.dc.format).toEqual("3D Tiles");
+                expect(rec1.boundingBox).toExist();
+                expect(rec1.boundingBox.crs).toBe('EPSG:4326');
+                expect(rec1.boundingBox.extent[0]).toEqual(threeDLayerRecord.boundingBox.extent[0]);
+                expect(rec1.boundingBox.extent[1]).toEqual(threeDLayerRecord.boundingBox.extent[1]);
+                expect(rec1.boundingBox.extent[2]).toEqual(threeDLayerRecord.boundingBox.extent[2]);
+                expect(rec1.boundingBox.extent[3]).toEqual(threeDLayerRecord.boundingBox.extent[3]);
+                expect(rec2.dc.URI).toExist();
+                expect(rec2.dc.URI[0]).toExist();
+                const uri = rec2.dc.URI[0];
+                expect(uri.name).toExist();
+                expect(uri.value).toExist();
+                expect(uri.description).toExist();
+                expect(rec2.boundingBox).toExist();
+                expect(rec2.boundingBox.crs).toBe('EPSG:4326');
+                expect(rec2.boundingBox.extent).toEqual([ 12.002717999999996, 45.760718, 12.429282000000002, 46.187282]);
+                expect(rec3.boundingBox).toExist();
+                expect(rec3.boundingBox.crs).toBe('EPSG:4326');
+                expect(rec3.boundingBox.extent).toEqual([ -4.14168, 47.93257, -4.1149, 47.959353362144 ]);
+                expect(rec4.dc.format).toEqual("3D Tiles");
+                expect(rec4.boundingBox).toExist();
+                expect(rec4.boundingBox.crs).toBe('EPSG:4326');
+                expect(rec4.boundingBox.extent[0]).toEqual(threeDLayerRecord.boundingBox.extent[0]);
+                expect(rec4.boundingBox.extent[1]).toEqual(threeDLayerRecord.boundingBox.extent[1]);
+                expect(rec4.boundingBox.extent[2]).toEqual(threeDLayerRecord.boundingBox.extent[2]);
+                expect(rec4.boundingBox.extent[3]).toEqual(threeDLayerRecord.boundingBox.extent[3]);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+        done();
+
     });
 });

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -10,10 +10,14 @@ import expect from 'expect';
 import axios from '../../libs/ajax';
 import MockAdapter from 'axios-mock-adapter';
 import GRDCResponse from 'raw-loader!../../test-resources/csw/getRecordsResponseDC.xml';
-import GRDCResponseWith3DLayers from 'raw-loader!../../test-resources/csw/getRecordsResponseDCWith3DLayers.xml';
+import GRDCResponseWith3DLayersAt1st from 'raw-loader!../../test-resources/csw/getRecordsResponseDCWith3DLayersAt1st.xml';
+import GRDCResponseWith3DLayersAtMiddle from 'raw-loader!../../test-resources/csw/getRecordsResponseDCWith3DLayersAtMiddle.xml';
+import GRDCResponseWith3DLayersAtLast from 'raw-loader!../../test-resources/csw/getRecordsResponseDCWith3DLayersAtLast.xml';
 import API, {constructXMLBody, getLayerReferenceFromDc } from '../CSW';
 
 import tileSetResponse from '../../test-resources/3dtiles/tileSetSample2.json';
+
+let mockAxios;
 
 describe('Test correctness of the CSW APIs', () => {
     it('getRecords ISO Metadata Profile', (done) => {
@@ -165,45 +169,214 @@ describe('Test capabilities data in CSW records', () => {
     });
 });
 
-describe('workspaceSearch', () => {
-    let mockAxios;
-    beforeEach(() => {
+
+describe('tests with mockedActions', () => {
+    beforeEach(done => {
         mockAxios = new MockAdapter(axios);
+        setTimeout(done);
     });
-    afterEach(() => {
+    afterEach(done => {
         mockAxios.restore();
+        setTimeout(done);
     });
-    it('workspaceSearch', (done) => {
-        mockAxios.onPost().reply( (config) => {
-            expect(config.data).toEqual(
-                "<csw:GetRecords xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\" "
-                + "xmlns:ogc=\"http://www.opengis.net/ogc\" "
-                + "xmlns:gml=\"http://www.opengis.net/gml\" "
-                + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" "
-                + "xmlns:dct=\"http://purl.org/dc/terms/\" "
-                + "xmlns:gmd=\"http://www.isotc211.org/2005/gmd\" "
-                + "xmlns:gco=\"http://www.isotc211.org/2005/gco\" "
-                + "xmlns:gmi=\"http://www.isotc211.org/2005/gmi\" "
-                + "xmlns:ows=\"http://www.opengis.net/ows\" service=\"CSW\" "
-                + "version=\"2.0.2\" resultType=\"results\" startPosition=\"1\" "
-                + "maxRecords=\"1\">"
-                +    "<csw:Query typeNames=\"csw:Record\"><csw:ElementSetName>full</csw:ElementSetName>"
-                +       "<csw:Constraint version=\"1.1.0\"><ogc:Filter><ogc:PropertyIsLike wildCard=\"%\" singleChar=\"_\" escapeChar=\"\\\\\">"
-                +       "<ogc:PropertyName>dc:identifier</ogc:PropertyName><ogc:Literal>wp:%test%</ogc:Literal></ogc:PropertyIsLike>"
-                +       "</ogc:Filter></csw:Constraint>"
-                +    "</csw:Query>"
-                + "</csw:GetRecords>"
-            );
-            return [200, GRDCResponse];
+    describe('workspaceSearch', () => {
+        it('workspaceSearch test', (done) => {
+            mockAxios.onPost().reply( (config) => {
+                expect(config.data).toEqual(
+                    "<csw:GetRecords xmlns:csw=\"http://www.opengis.net/cat/csw/2.0.2\" "
+                    + "xmlns:ogc=\"http://www.opengis.net/ogc\" "
+                    + "xmlns:gml=\"http://www.opengis.net/gml\" "
+                    + "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" "
+                    + "xmlns:dct=\"http://purl.org/dc/terms/\" "
+                    + "xmlns:gmd=\"http://www.isotc211.org/2005/gmd\" "
+                    + "xmlns:gco=\"http://www.isotc211.org/2005/gco\" "
+                    + "xmlns:gmi=\"http://www.isotc211.org/2005/gmi\" "
+                    + "xmlns:ows=\"http://www.opengis.net/ows\" service=\"CSW\" "
+                    + "version=\"2.0.2\" resultType=\"results\" startPosition=\"1\" "
+                    + "maxRecords=\"1\">"
+                    +    "<csw:Query typeNames=\"csw:Record\"><csw:ElementSetName>full</csw:ElementSetName>"
+                    +       "<csw:Constraint version=\"1.1.0\"><ogc:Filter><ogc:PropertyIsLike wildCard=\"%\" singleChar=\"_\" escapeChar=\"\\\\\">"
+                    +       "<ogc:PropertyName>dc:identifier</ogc:PropertyName><ogc:Literal>wp:%test%</ogc:Literal></ogc:PropertyIsLike>"
+                    +       "</ogc:Filter></csw:Constraint>"
+                    +    "</csw:Query>"
+                    + "</csw:GetRecords>"
+                );
+                return [200, GRDCResponse];
+            });
+            API.workspaceSearch('/TESTURL', 1, 1, "test", "wp").then((data) => {
+                expect(data).toExist();
+                expect(data.records).toExist();
+                expect(data.records.length).toBe(4);
+                done();
+            });
         });
-        API.workspaceSearch('/TESTURL', 1, 1, "test", "wp").then((data) => {
-            expect(data).toExist();
-            expect(data.records).toExist();
-            expect(data.records.length).toBe(4);
-            done();
+    });
+    describe("getRecords for 3D layers", () => {
+        const threeDLayerRecord = {
+            "boundingBox": {
+                "extent": [
+                    11.244154369601063,
+                    43.75907090685874,
+                    11.265929832205956,
+                    43.78084636946362
+                ],
+                "crs": "EPSG:4326"
+            },
+            "dc": {
+                "references": [],
+                "identifier": "test:20230829_test_3dtile_01",
+                "date": "2023-09-22",
+                "title": "Metadato di test per 3D-tile",
+                "abstract": "Breve descrizione della risorsa",
+                "description": "Breve descrizione della risorsa",
+                "type": "dataset",
+                "subject": [
+                    "Zone a rischio naturale",
+                    "health"
+                ],
+                "format": "3D Tiles",
+                "contributor": "Nome dell'ufficio responsabile del dato",
+                "rights": [
+                    "otherRestrictions",
+                    "otherRestrictions"
+                ],
+                "language": "ita",
+                "source": "Descrizione della provenienza e del processo di produzione del dato (storia, ciclo di vita, rilevazione, acquisizione, forma attuale, qualità richiesta per garantirne l'interoperabilità)",
+                "temporal": "start=2009-01-01; end=2013-12-31",
+                "URI": {
+                    "TYPE_NAME": "DC_1_1.URI",
+                    "protocol": "https://registry.geodati.gov.it/metadata-codelist/ProtocolValue/www-download",
+                    "description": "access point",
+                    "value": "https://3d-layers.s3.eu-central-1.amazonaws.com/3dtiles/centro_storico_di_firenze_-_brass_city_model/tileset.json"
+                }
+            }
+        };
+        it('test getRecords that contain 3D tile layers at 1st index ', (done) => {
+            mockAxios.onPost().replyOnce(()=>{
+                return [200, GRDCResponseWith3DLayersAt1st];
+            });
+            mockAxios.onGet().reply(()=>{
+                return [200, tileSetResponse];
+            });
+            API.getRecords('base/web/client/test-resources/csw/getRecordsResponseDCWith3DLayersAt1st.xml', 1, 2).then((result) => {
+                try {
+                    expect(result).toExist();
+                    expect(result.records).toExist();
+                    expect(result.records.length).toBe(4);
+                    const [rec0, rec1, rec2, rec3] = result.records;
+                    expect(rec0.dc.format).toEqual("3D Tiles");
+                    expect(rec0.boundingBox).toExist();
+                    expect(rec0.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec0.boundingBox.extent[0]).toEqual(threeDLayerRecord.boundingBox.extent[0]);
+                    expect(rec0.boundingBox.extent[1]).toEqual(threeDLayerRecord.boundingBox.extent[1]);
+                    expect(rec0.boundingBox.extent[2]).toEqual(threeDLayerRecord.boundingBox.extent[2]);
+                    expect(rec0.boundingBox.extent[3]).toEqual(threeDLayerRecord.boundingBox.extent[3]);
+                    expect(rec1.dc).toExist();
+                    expect(rec1.boundingBox).toExist();
+                    expect(rec1.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec1.boundingBox.extent).toEqual([45.542, 11.874, 46.026, 12.718]);
+                    expect(rec2.boundingBox).toExist();
+                    expect(rec2.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec2.boundingBox.extent).toEqual([ 12.002717999999996, 45.760718, 12.429282000000002, 46.187282]);
+                    expect(rec3.boundingBox).toExist();
+                    expect(rec3.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec3.boundingBox.extent).toEqual([ -4.14168, 47.93257, -4.1149, 47.959353362144 ]);
+                    done();
+                } catch (ex) {
+                    done(ex);
+                }
+            }).catch(ex=>{
+                done(ex);
+            });
+        });
+        it('test getRecords that contain 3D tile layers at last index', (done) => {
+            mockAxios.onPost().replyOnce(()=>{
+                return [200, GRDCResponseWith3DLayersAtLast];
+            });
+            mockAxios.onGet().reply(()=>{
+                return [200, tileSetResponse];
+            });
+            API.getRecords('base/web/client/test-resources/csw/getRecordsResponseDCWith3DLayersAtLast.xml', 1, 2).then((result) => {
+                try {
+                    expect(result).toExist();
+                    expect(result.records).toExist();
+                    expect(result.records.length).toBe(4);
+                    const [rec0, rec1, rec2, rec3] = result.records;
+                    expect(rec0.dc).toExist();
+                    expect(rec0.boundingBox).toExist();
+                    expect(rec0.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec0.boundingBox.extent).toEqual([45.542, 11.874, 46.026, 12.718]);
+                    expect(rec1.dc.URI).toExist();
+                    expect(rec1.dc.URI[0]).toExist();
+                    const uri = rec1.dc.URI[0];
+                    expect(uri.name).toExist();
+                    expect(uri.value).toExist();
+                    expect(uri.description).toExist();
+                    expect(rec1.boundingBox).toExist();
+                    expect(rec1.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec1.boundingBox.extent).toEqual([ 12.002717999999996, 45.760718, 12.429282000000002, 46.187282]);
+                    expect(rec2.boundingBox).toExist();
+                    expect(rec2.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec2.boundingBox.extent).toEqual([ -4.14168, 47.93257, -4.1149, 47.959353362144 ]);
+                    expect(rec3.dc.format).toEqual("3D Tiles");
+                    expect(rec3.boundingBox).toExist();
+                    expect(rec3.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec3.boundingBox.extent[0]).toEqual(threeDLayerRecord.boundingBox.extent[0]);
+                    expect(rec3.boundingBox.extent[1]).toEqual(threeDLayerRecord.boundingBox.extent[1]);
+                    expect(rec3.boundingBox.extent[2]).toEqual(threeDLayerRecord.boundingBox.extent[2]);
+                    expect(rec3.boundingBox.extent[3]).toEqual(threeDLayerRecord.boundingBox.extent[3]);
+                    done();
+                } catch (ex) {
+                    done(ex);
+                }
+            }).catch(ex=>{
+                done(ex);
+            });
+        });
+        it('test getRecords that contain 3D tile layers at the middle', (done) => {
+            mockAxios.onPost().replyOnce(()=>{
+                return [200, GRDCResponseWith3DLayersAtMiddle];
+            });
+            mockAxios.onGet().reply(()=>{
+                return [200, tileSetResponse];
+            });
+            API.getRecords('base/web/client/test-resources/csw/getRecordsResponseDCWith3DLayersAtMiddle.xml', 1, 2).then((result) => {
+                try {
+                    expect(result).toExist();
+                    expect(result.records).toExist();
+                    expect(result.records.length).toBe(3);
+                    const [rec0, rec1, rec2] = result.records;
+                    expect(rec0.dc).toExist();
+                    expect(rec0.boundingBox).toExist();
+                    expect(rec0.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec0.boundingBox.extent).toEqual([45.542, 11.874, 46.026, 12.718]);
+                    expect(rec1.dc.format).toEqual("3D Tiles");
+                    expect(rec1.boundingBox).toExist();
+                    expect(rec1.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec1.boundingBox.extent[0]).toEqual(threeDLayerRecord.boundingBox.extent[0]);
+                    expect(rec1.boundingBox.extent[1]).toEqual(threeDLayerRecord.boundingBox.extent[1]);
+                    expect(rec1.boundingBox.extent[2]).toEqual(threeDLayerRecord.boundingBox.extent[2]);
+                    expect(rec1.boundingBox.extent[3]).toEqual(threeDLayerRecord.boundingBox.extent[3]);
+                    expect(rec2.dc.URI).toExist();
+                    expect(rec2.dc.URI[0]).toExist();
+                    const uri = rec2.dc.URI[0];
+                    expect(uri.name).toExist();
+                    expect(uri.value).toExist();
+                    expect(uri.description).toExist();
+                    expect(rec2.boundingBox).toExist();
+                    expect(rec2.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec2.boundingBox.extent).toEqual([ 12.002717999999996, 45.760718, 12.429282000000002, 46.187282]);
+                    done();
+                } catch (ex) {
+                    done(ex);
+                }
+            }).catch(ex=>{
+                done(ex);
+            });
         });
     });
 });
+
 
 describe("constructXMLBody", () => {
     it("construct body without PropertyIsLike when there is no search text", () => {
@@ -286,108 +459,4 @@ describe("getLayerReferenceFromDc", () => {
 
 });
 
-describe("getLayerReferenceFromDc", () => {
-    const threeDLayerRecord = {
-        "boundingBox": {
-            "extent": [
-                11.244154369601063,
-                43.75907090685874,
-                11.265929832205956,
-                43.78084636946362
-            ],
-            "crs": "EPSG:4326"
-        },
-        "dc": {
-            "references": [],
-            "identifier": "test:20230829_test_3dtile_01",
-            "date": "2023-09-22",
-            "title": "Metadato di test per 3D-tile",
-            "abstract": "Breve descrizione della risorsa",
-            "description": "Breve descrizione della risorsa",
-            "type": "dataset",
-            "subject": [
-                "Zone a rischio naturale",
-                "health"
-            ],
-            "format": "3D Tiles",
-            "contributor": "Nome dell'ufficio responsabile del dato",
-            "rights": [
-                "otherRestrictions",
-                "otherRestrictions"
-            ],
-            "language": "ita",
-            "source": "Descrizione della provenienza e del processo di produzione del dato (storia, ciclo di vita, rilevazione, acquisizione, forma attuale, qualità richiesta per garantirne l'interoperabilità)",
-            "temporal": "start=2009-01-01; end=2013-12-31",
-            "URI": {
-                "TYPE_NAME": "DC_1_1.URI",
-                "protocol": "https://registry.geodati.gov.it/metadata-codelist/ProtocolValue/www-download",
-                "description": "access point",
-                "value": "https://3d-layers.s3.eu-central-1.amazonaws.com/3dtiles/centro_storico_di_firenze_-_brass_city_model/tileset.json"
-            }
-        }
-    };
-    let mockAxios;
-    beforeEach((done) => {
-        mockAxios = new MockAdapter(axios);
-        setTimeout(done);
-    });
-    afterEach((done) => {
-        mockAxios.restore();
-        setTimeout(done);
-    });
-    it('test getBboxFor3DLayersToRecords function that handles getting bbox for 3D tile layers from ', (done) => {
-        mockAxios.onPost().replyOnce(()=>{
-            return [200, GRDCResponseWith3DLayers];
-        });
-        mockAxios.onGet().reply(()=>{
-            return [200, tileSetResponse];
-        });
-        mockAxios.onGet().reply(()=>{
-            return [200, tileSetResponse];
-        });
-        API.getRecords('base/web/client/test-resources/csw/getRecordsResponseDCWith3DLayers.xml', 1, 2).then((result) => {
-            try {
-                expect(result).toExist();
-                expect(result.records).toExist();
-                expect(result.records.length).toBe(5);
-                const [rec0, rec1, rec2, rec3, rec4] = result.records;
 
-                expect(rec0.dc).toExist();
-                expect(rec0.boundingBox).toExist();
-                expect(rec0.boundingBox.crs).toBe('EPSG:4326');
-                expect(rec0.boundingBox.extent).toEqual([45.542, 11.874, 46.026, 12.718]);
-                expect(rec1.dc.format).toEqual("3D Tiles");
-                expect(rec1.boundingBox).toExist();
-                expect(rec1.boundingBox.crs).toBe('EPSG:4326');
-                expect(rec1.boundingBox.extent[0]).toEqual(threeDLayerRecord.boundingBox.extent[0]);
-                expect(rec1.boundingBox.extent[1]).toEqual(threeDLayerRecord.boundingBox.extent[1]);
-                expect(rec1.boundingBox.extent[2]).toEqual(threeDLayerRecord.boundingBox.extent[2]);
-                expect(rec1.boundingBox.extent[3]).toEqual(threeDLayerRecord.boundingBox.extent[3]);
-                expect(rec2.dc.URI).toExist();
-                expect(rec2.dc.URI[0]).toExist();
-                const uri = rec2.dc.URI[0];
-                expect(uri.name).toExist();
-                expect(uri.value).toExist();
-                expect(uri.description).toExist();
-                expect(rec2.boundingBox).toExist();
-                expect(rec2.boundingBox.crs).toBe('EPSG:4326');
-                expect(rec2.boundingBox.extent).toEqual([ 12.002717999999996, 45.760718, 12.429282000000002, 46.187282]);
-                expect(rec3.boundingBox).toExist();
-                expect(rec3.boundingBox.crs).toBe('EPSG:4326');
-                expect(rec3.boundingBox.extent).toEqual([ -4.14168, 47.93257, -4.1149, 47.959353362144 ]);
-                expect(rec4.dc.format).toEqual("3D Tiles");
-                expect(rec4.boundingBox).toExist();
-                expect(rec4.boundingBox.crs).toBe('EPSG:4326');
-                expect(rec4.boundingBox.extent[0]).toEqual(threeDLayerRecord.boundingBox.extent[0]);
-                expect(rec4.boundingBox.extent[1]).toEqual(threeDLayerRecord.boundingBox.extent[1]);
-                expect(rec4.boundingBox.extent[2]).toEqual(threeDLayerRecord.boundingBox.extent[2]);
-                expect(rec4.boundingBox.extent[3]).toEqual(threeDLayerRecord.boundingBox.extent[3]);
-                done();
-            } catch (ex) {
-                done(ex);
-            }
-        });
-        done();
-
-    });
-});

--- a/web/client/test-resources/3dtiles/tileSetSample2.json
+++ b/web/client/test-resources/3dtiles/tileSetSample2.json
@@ -1,0 +1,1286 @@
+{
+	"asset": {
+	  "version": "1.0",
+	  "extras": {
+		"cesium":{
+		  "credits": [{
+			"html": "'CENTRO STORICO DI FIRENZE - BRASS CITY MODEL' (https://skfb.ly/ozsuX) by Blayne Jackson is licensed under Creative Commons Attribution (http://creativecommons.org/licenses/by/4.0/)."
+		  }]
+		}
+	  }
+	},
+	"geometricError": 100.0,
+	"root": {
+	  "transform": [
+		-0.19518643826956167,
+		0.9807661567956159,
+		0.0,
+		0.0,
+		-0.7081936612571651,
+		-0.14094062829155365,
+		-0.6918073991017686,
+		0.0,
+		-0.6785012840598124,
+		-0.13503142219920336,
+		0.7220820746619087,
+		0.0,
+		4524243.58964167,
+		900388.9316605763,
+		4389975.148663257,
+		1.0
+	  ],
+	  "boundingVolume": {
+		"box": [
+		  -46.12789900000001,
+		  -45.779855500000004,
+		  -376.9231565,
+		  887.7269590000001,
+		  0.0,
+		  0.0,
+		  0.0,
+		  -92.34474750000001,
+		  0.0,
+		  0.0,
+		  0.0,
+		  817.9918825
+		]
+	  },
+	  "geometricError": 100.0,
+	  "refine": "ADD",
+	  "content": null,
+	  "children": [
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  419.85219192144916,
+			  4.095745422540702,
+			  42.213073407500616,
+			  22.116611421449136,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -20.506155663600108,
+			  0.0,
+			  0.0,
+			  0.0,
+			  10.140288657500601
+			]
+		  },
+		  "geometricError": 9.250805133486388,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XR-YR-XR-YR.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  420.6972960044431,
+				  4.178090504776833,
+				  42.213073407500616,
+				  22.961715504443077,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -20.481441743868658,
+				  0.0,
+				  0.0,
+				  0.0,
+				  10.140288657500601
+				]
+			  },
+			  "geometricError": 3.0044851085938626,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XR-YR-XR-YR.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  420.7135110832271,
+					  4.093270917621091,
+					  42.213073407500616,
+					  22.97793058322705,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -20.558839672437735,
+					  0.0,
+					  0.0,
+					  0.0,
+					  10.140288657500601
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XR-YR-XR-YR.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  175.80384075,
+			  1.820949500000001,
+			  143.62393773310916,
+			  221.93173975000002,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -24.0937825,
+			  0.0,
+			  0.0,
+			  0.0,
+			  111.55115298310915
+			]
+		  },
+		  "geometricError": 9.009745481719476,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XR-YR-XL-YR.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  175.80384075,
+				  1.820949500000001,
+				  143.81010388335957,
+				  221.93173975000002,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -24.0937825,
+				  0.0,
+				  0.0,
+				  0.0,
+				  111.73731913335956
+				]
+			  },
+			  "geometricError": 3.0000450033348196,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XR-YR-XL-YR.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  175.80384075,
+					  1.820949500000001,
+					  143.80507533137478,
+					  221.93173975000002,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -24.0937825,
+					  0.0,
+					  0.0,
+					  0.0,
+					  111.73229058137476
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XR-YR-XL-YR.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  619.66732025,
+			  13.9466365,
+			  -172.425185875,
+			  221.93173975,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -32.618255500000004,
+			  0.0,
+			  0.0,
+			  0.0,
+			  204.497970625
+			]
+		  },
+		  "geometricError": 9.000419677857408,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XR-YR-XR-YL.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  619.66732025,
+				  13.9466365,
+				  -172.425185875,
+				  221.93173975,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -32.618255500000004,
+				  0.0,
+				  0.0,
+				  0.0,
+				  204.497970625
+				]
+			  },
+			  "geometricError": 3.0000699454941726,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XR-YR-XR-YL.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  619.66732025,
+					  13.944355,
+					  -172.425185875,
+					  221.93173975,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -32.620537,
+					  0.0,
+					  0.0,
+					  0.0,
+					  204.497970625
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XR-YR-XR-YL.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  175.80384075,
+			  -57.392518115365164,
+			  -172.425185875,
+			  221.93173975000002,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -80.64890411536516,
+			  0.0,
+			  0.0,
+			  0.0,
+			  204.497970625
+			]
+		  },
+		  "geometricError": 9.00309444695593,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XR-YR-XL-YL.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  175.80384075,
+				  -57.43410850000001,
+				  -172.425185875,
+				  221.93173975000002,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -80.6904945,
+				  0.0,
+				  0.0,
+				  0.0,
+				  204.497970625
+				]
+			  },
+			  "geometricError": 3.0,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XR-YR-XL-YL.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  175.80384075,
+					  -57.43410850000001,
+					  -172.425185875,
+					  221.93173975000002,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -80.6904945,
+					  0.0,
+					  0.0,
+					  0.0,
+					  204.497970625
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XR-YR-XL-YL.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  -268.05963875,
+			  -27.100245277938605,
+			  236.57075537500003,
+			  221.93173975,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -50.57774872206139,
+			  0.0,
+			  0.0,
+			  0.0,
+			  204.497970625
+			]
+		  },
+		  "geometricError": 9.007984542748456,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XL-YR-XR-YR.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  -268.05963875,
+				  -27.100245277938605,
+				  236.57075537500003,
+				  221.93173975,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -50.57774872206139,
+				  0.0,
+				  0.0,
+				  0.0,
+				  204.497970625
+				]
+			  },
+			  "geometricError": 3.0013304621031747,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XL-YR-XR-YR.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  -268.05963875,
+					  -27.032953499999998,
+					  236.57075537500003,
+					  221.93173975,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -50.6450405,
+					  0.0,
+					  0.0,
+					  0.0,
+					  204.497970625
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XL-YR-XR-YR.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  -571.4786864988677,
+			  -28.829253992945397,
+			  206.02029611656252,
+			  81.48730799886766,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -59.572296007054604,
+			  0.0,
+			  0.0,
+			  0.0,
+			  173.94751136656248
+			]
+		  },
+		  "geometricError": 9.024395503911954,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XL-YR-XL-YR.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  -571.4786864988677,
+				  -28.829253992945397,
+				  206.30275865898983,
+				  81.48730799886766,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -59.572296007054604,
+				  0.0,
+				  0.0,
+				  0.0,
+				  174.2299739089898
+				]
+			  },
+			  "geometricError": 3.002857224933117,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XL-YR-XL-YR.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  -571.4786864988677,
+					  -28.987028000000002,
+					  206.26638310502358,
+					  81.48730799886766,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -59.414522,
+					  0.0,
+					  0.0,
+					  0.0,
+					  174.1935983550236
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XL-YR-XL-YR.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  -268.05963875,
+			  -12.949604532282189,
+			  -172.425185875,
+			  221.93173975,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -31.37277253228219,
+			  0.0,
+			  0.0,
+			  0.0,
+			  204.497970625
+			]
+		  },
+		  "geometricError": 9.06715492705682,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XL-YR-XR-YL.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  -268.05963875,
+				  -13.158411494229224,
+				  -172.425185875,
+				  221.93173975,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -31.723042135653397,
+				  0.0,
+				  0.0,
+				  0.0,
+				  204.497970625
+				]
+			  },
+			  "geometricError": 3.000006846244177,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XL-YR-XR-YL.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  -268.05963875,
+					  -13.257099319345885,
+					  -172.425185875,
+					  221.93173975,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -31.723259319345885,
+					  0.0,
+					  0.0,
+					  0.0,
+					  204.497970625
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XL-YR-XR-YL.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  -661.22945751898,
+			  6.100170523205582,
+			  -172.425185875,
+			  171.23807901898,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -32.022994476794416,
+			  0.0,
+			  0.0,
+			  0.0,
+			  204.497970625
+			]
+		  },
+		  "geometricError": 9.091012569601437,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XL-YR-XL-YL.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  -661.4706318493029,
+				  5.747224965764039,
+				  -172.425185875,
+				  171.47925334930284,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -32.37594003423596,
+				  0.0,
+				  0.0,
+				  0.0,
+				  204.497970625
+				]
+			  },
+			  "geometricError": 3.002785511456154,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XL-YR-XL-YL.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  -661.46077725,
+					  5.658901999999999,
+					  -172.425185875,
+					  171.46939874999998,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -32.464263,
+					  0.0,
+					  0.0,
+					  0.0,
+					  204.497970625
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XL-YR-XL-YL.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  568.4202192500001,
+			  -20.583627999999997,
+			  -581.421127125,
+			  170.68463875,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -58.508108,
+			  0.0,
+			  0.0,
+			  0.0,
+			  204.497970625
+			]
+		  },
+		  "geometricError": 9.045561832193199,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XR-YL-XR-YR.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  568.64925375,
+				  -20.583627999999997,
+				  -581.421127125,
+				  170.91367324999996,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -58.508108,
+				  0.0,
+				  0.0,
+				  0.0,
+				  204.497970625
+				]
+			  },
+			  "geometricError": 3.0062421946715485,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XR-YL-XR-YR.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  568.64925375,
+					  -20.948847,
+					  -581.421127125,
+					  170.91367324999996,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -58.873327,
+					  0.0,
+					  0.0,
+					  0.0,
+					  204.497970625
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XR-YL-XR-YR.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  175.80384075,
+			  -40.4709845,
+			  -581.421127125,
+			  221.93173975000002,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -70.7598965,
+			  0.0,
+			  0.0,
+			  0.0,
+			  204.497970625
+			]
+		  },
+		  "geometricError": 9.0,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XR-YL-XL-YR.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  175.80384075,
+				  -40.4709845,
+				  -581.421127125,
+				  221.93173975000002,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -70.7598965,
+				  0.0,
+				  0.0,
+				  0.0,
+				  204.497970625
+				]
+			  },
+			  "geometricError": 3.0,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XR-YL-XL-YR.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  175.80384075,
+					  -40.4709845,
+					  -581.421127125,
+					  221.93173975000002,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -70.7598965,
+					  0.0,
+					  0.0,
+					  0.0,
+					  204.497970625
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XR-YL-XL-YR.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  474.01867281378895,
+			  13.884999124593019,
+			  -952.6590779651754,
+			  76.28309231378896,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -21.413729875406982,
+			  0.0,
+			  0.0,
+			  0.0,
+			  166.73998021517536
+			]
+		  },
+		  "geometricError": 9.035181333117173,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XR-YL-XR-YL.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  474.01867281378895,
+				  13.784376000000002,
+				  -952.6590779651754,
+				  76.28309231378896,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -21.514353,
+				  0.0,
+				  0.0,
+				  0.0,
+				  166.73998021517536
+				]
+			  },
+			  "geometricError": 3.001158836108843,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XR-YL-XR-YL.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  474.01867281378895,
+					  13.784376000000002,
+					  -952.8523022750364,
+					  76.28309231378896,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -21.514353,
+					  0.0,
+					  0.0,
+					  0.0,
+					  166.93320452503644
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XR-YL-XR-YL.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  175.80384075,
+			  12.857098,
+			  -990.417068375,
+			  221.93173975000002,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -21.532020000000003,
+			  0.0,
+			  0.0,
+			  0.0,
+			  204.497970625
+			]
+		  },
+		  "geometricError": 9.0,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XR-YL-XL-YL.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  175.80384075,
+				  12.857098,
+				  -990.417068375,
+				  221.93173975000002,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -21.532020000000003,
+				  0.0,
+				  0.0,
+				  0.0,
+				  204.497970625
+				]
+			  },
+			  "geometricError": 3.0,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XR-YL-XL-YL.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  175.80384075,
+					  12.857098,
+					  -990.417068375,
+					  221.93173975000002,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -21.532020000000003,
+					  0.0,
+					  0.0,
+					  0.0,
+					  204.497970625
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XR-YL-XL-YL.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  -268.05963875,
+			  -0.24298320162245446,
+			  -581.421127125,
+			  221.93173975,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -29.475140798377545,
+			  0.0,
+			  0.0,
+			  0.0,
+			  204.497970625
+			]
+		  },
+		  "geometricError": 9.050170085022257,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XL-YL-XR-YR.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  -268.05963875,
+				  -0.04077669028951547,
+				  -581.421127125,
+				  221.93173975,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -29.677347309710484,
+				  0.0,
+				  0.0,
+				  0.0,
+				  204.497970625
+				]
+			  },
+			  "geometricError": 3.0014796703300752,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XL-YL-XR-YR.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  -268.05963875,
+					  0.0020330000000008397,
+					  -581.421127125,
+					  221.93173975,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -29.72126,
+					  0.0,
+					  0.0,
+					  0.0,
+					  204.497970625
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XL-YL-XR-YR.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  -711.92311825,
+			  14.111128606047746,
+			  -581.421127125,
+			  221.93173975000002,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -26.256765267608944,
+			  0.0,
+			  0.0,
+			  0.0,
+			  204.497970625
+			]
+		  },
+		  "geometricError": 9.062620376021641,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XL-YL-XL-YR.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  -711.92311825,
+				  14.160693436828346,
+				  -581.421127125,
+				  221.93173975000002,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -26.207200436828344,
+				  0.0,
+				  0.0,
+				  0.0,
+				  204.497970625
+				]
+			  },
+			  "geometricError": 3.01232961009897,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XL-YL-XL-YR.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  -711.92311825,
+					  14.243437,
+					  -581.421127125,
+					  221.93173975000002,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -26.530324999999998,
+					  0.0,
+					  0.0,
+					  0.0,
+					  204.497970625
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XL-YL-XL-YR.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  -268.05963875,
+			  14.376728000000002,
+			  -900.2939233462467,
+			  221.93173975,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -22.692677000000003,
+			  0.0,
+			  0.0,
+			  0.0,
+			  114.37482559624675
+			]
+		  },
+		  "geometricError": 9.023518079997174,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XL-YL-XR-YL.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  -268.05963875,
+				  14.465618000000001,
+				  -900.2939233462467,
+				  221.93173975,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -22.781567000000003,
+				  0.0,
+				  0.0,
+				  0.0,
+				  114.37482559624675
+				]
+			  },
+			  "geometricError": 3.0,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XL-YL-XR-YL.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  -268.05963875,
+					  14.465618000000001,
+					  -900.2939233462467,
+					  221.93173975,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -22.781567000000003,
+					  0.0,
+					  0.0,
+					  0.0,
+					  114.37482559624675
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XL-YL-XR-YL.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		},
+		{
+		  "transform": null,
+		  "boundingVolume": {
+			"box": [
+			  -519.655372386611,
+			  28.868679,
+			  -800.1277477470123,
+			  29.663993886611024,
+			  0.0,
+			  0.0,
+			  0.0,
+			  -7.142448000000002,
+			  0.0,
+			  0.0,
+			  0.0,
+			  14.208649997012344
+			]
+		  },
+		  "geometricError": 9.0,
+		  "refine": "REPLACE",
+		  "content": {
+			"uri": "LOD-2/Mesh-XL-YL-XL-YL.b3dm"
+		  },
+		  "children": [
+			{
+			  "transform": null,
+			  "boundingVolume": {
+				"box": [
+				  -519.655372386611,
+				  28.868679,
+				  -800.1277477470123,
+				  29.663993886611024,
+				  0.0,
+				  0.0,
+				  0.0,
+				  -7.142448000000002,
+				  0.0,
+				  0.0,
+				  0.0,
+				  14.208649997012344
+				]
+			  },
+			  "geometricError": 3.0,
+			  "refine": "REPLACE",
+			  "content": {
+				"uri": "LOD-1/Mesh-XL-YL-XL-YL.b3dm"
+			  },
+			  "children": [
+				{
+				  "transform": null,
+				  "boundingVolume": {
+					"box": [
+					  -519.655372386611,
+					  28.868679,
+					  -800.1277477470123,
+					  29.663993886611024,
+					  0.0,
+					  0.0,
+					  0.0,
+					  -7.142448000000002,
+					  0.0,
+					  0.0,
+					  0.0,
+					  14.208649997012344
+					]
+				  },
+				  "geometricError": 0.0,
+				  "refine": "REPLACE",
+				  "content": {
+					"uri": "LOD-0/Mesh-XL-YL-XL-YL.b3dm"
+				  },
+				  "children": []
+				}
+			  ]
+			}
+		  ]
+		}
+	  ]
+	}
+  }

--- a/web/client/test-resources/csw/getRecordsResponseDCWith3DLayers.xml
+++ b/web/client/test-resources/csw/getRecordsResponseDCWith3DLayers.xml
@@ -1,0 +1,100 @@
+<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
+  <csw:SearchStatus timestamp="2016-05-11T13:00:06" />
+  <csw:SearchResults numberOfRecordsMatched="100" numberOfRecordsReturned="5" elementSet="full" nextRecord="3">
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:title>c1020047_title</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>sub1, sub2, sub3</dc:subject>
+      <dc:subject>sub4</dc:subject>
+      <dc:format />
+      <dct:abstract>Abstract</dct:abstract>
+      <dc:language />
+      <dc:source />
+      <dc:format />
+      <dct:references scheme="OGC:WMS">base/web/client/test-resources/csw/getCapability.xml</dct:references>
+      <dct:alternative>workspace:layer_name1</dct:alternative>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
+        <ows:LowerCorner>12.718 45.542</ows:LowerCorner>
+        <ows:UpperCorner>11.874 46.026</ows:UpperCorner>
+      </ows:BoundingBox>
+    </csw:Record>
+      <csw:Record xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <dc:identifier>test:20230829_test_3dtile_01</dc:identifier>
+      <dc:date>2023-09-22</dc:date>
+      <dc:title>Metadato di test per 3D-tile</dc:title>
+      <dct:abstract>Breve descrizione della risorsa</dct:abstract>
+      <dc:description>Breve descrizione della risorsa</dc:description>
+      <dc:type>dataset</dc:type>
+      <dc:subject>Zone a rischio naturale</dc:subject>
+      <dc:subject>health</dc:subject>
+      <dc:format>3D Tiles</dc:format>
+      <dc:contributor>Nome dell'ufficio responsabile del dato</dc:contributor>
+      <dc:rights>otherRestrictions</dc:rights>
+      <dc:rights>otherRestrictions</dc:rights>
+      <dc:language>ita</dc:language>
+      <dc:source>Descrizione della provenienza e del processo di produzione del dato (storia, ciclo di vita, rilevazione, acquisizione, forma attuale, qualità richiesta per garantirne l'interoperabilità)</dc:source>
+      <ows:BoundingBox crs="urn:ogc:def:crs:::WGS84">
+        <ows:LowerCorner>11.331132423112592 43.72700677229733</ows:LowerCorner>
+        <ows:UpperCorner>11.154076443108027 43.82471910604458</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dct:temporal>start=2009-01-01; end=2013-12-31</dct:temporal>
+      <dc:URI protocol="https://registry.geodati.gov.it/metadata-codelist/ProtocolValue/www-download" profile="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other" description="access point">https://server.org/name/tileset.json</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>d698f693-6e7e-47a9-a138-918068d0b082</dc:identifier>
+      <dc:title>Title2</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>geoscientificInformation</dc:subject>
+      <dc:format />
+      <dct:abstract />
+      <dc:language />
+      <dc:source />
+      <dc:format />
+      <ows:BoundingBox crs="urn:ogc:def:crs:OGC:1.3:CRS84">
+        <ows:LowerCorner>12.002717999999996 46.187282</ows:LowerCorner>
+        <ows:UpperCorner>12.429282000000002 45.760718</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name2" description="desc2">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187049&amp;fname=d698f693-6e7e-47a9-a138-918068d0b082_s.png&amp;access=public</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>urn:isogeo:metadata:uuid:01ca64b3-6d69-43b7-b953-7743e11daafe</dc:identifier>
+      <dc:title>Title3</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>infoMapAccessService</dc:subject>
+      <dc:format />
+      <dct:abstract />
+      <dc:language />
+      <dc:source />
+      <dc:format />
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::RGF93 / Lambert-93 (EPSG:2154)">
+        <ows:LowerCorner>-4.1149 47.93257</ows:LowerCorner>
+        <ows:UpperCorner>-4.14168 47.959353362144</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name3" description="desc2">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="image/png">http://geowww.agrocampus-ouest.fr/img/metadata/KBZ.png</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <dc:identifier>test:20230829_test_3dtile_01</dc:identifier>
+      <dc:date>2023-09-22</dc:date>
+      <dc:title>Metadato di test per 3D-tile</dc:title>
+      <dct:abstract>Breve descrizione della risorsa</dct:abstract>
+      <dc:description>Breve descrizione della risorsa</dc:description>
+      <dc:type>dataset</dc:type>
+      <dc:subject>Zone a rischio naturale</dc:subject>
+      <dc:subject>health</dc:subject>
+      <dc:format>3D Tiles</dc:format>
+      <dc:contributor>Nome dell'ufficio responsabile del dato</dc:contributor>
+      <dc:rights>otherRestrictions</dc:rights>
+      <dc:rights>otherRestrictions</dc:rights>
+      <dc:language>ita</dc:language>
+      <dc:source>Descrizione della provenienza e del processo di produzione del dato (storia, ciclo di vita, rilevazione, acquisizione, forma attuale, qualità richiesta per garantirne l'interoperabilità)</dc:source>
+      <ows:BoundingBox crs="urn:ogc:def:crs:::WGS84">
+        <ows:LowerCorner>11.331132423112592 43.72700677229733</ows:LowerCorner>
+        <ows:UpperCorner>11.154076443108027 43.82471910604458</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dct:temporal>start=2009-01-01; end=2013-12-31</dct:temporal>
+      <dc:URI protocol="https://registry.geodati.gov.it/metadata-codelist/ProtocolValue/www-download" profile="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other" description="access point">https://server.org/name/tileset.json</dc:URI>
+    </csw:Record>
+  </csw:SearchResults>
+</csw:GetRecordsResponse>

--- a/web/client/test-resources/csw/getRecordsResponseDCWith3DLayersAt1st.xml
+++ b/web/client/test-resources/csw/getRecordsResponseDCWith3DLayersAt1st.xml
@@ -1,0 +1,79 @@
+<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
+  <csw:SearchStatus timestamp="2016-05-11T13:00:06" />
+  <csw:SearchResults numberOfRecordsMatched="100" numberOfRecordsReturned="1" elementSet="full" nextRecord="3">
+       <csw:Record xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <dc:identifier>test:20230829_test_3dtile_01</dc:identifier>
+      <dc:date>2023-09-22</dc:date>
+      <dc:title>Metadato di test per 3D-tile</dc:title>
+      <dct:abstract>Breve descrizione della risorsa</dct:abstract>
+      <dc:description>Breve descrizione della risorsa</dc:description>
+      <dc:type>dataset</dc:type>
+      <dc:subject>Zone a rischio naturale</dc:subject>
+      <dc:subject>health</dc:subject>
+      <dc:format>3D Tiles</dc:format>
+      <dc:contributor>Nome dell'ufficio responsabile del dato</dc:contributor>
+      <dc:rights>otherRestrictions</dc:rights>
+      <dc:rights>otherRestrictions</dc:rights>
+      <dc:language>ita</dc:language>
+      <dc:source>Descrizione della provenienza e del processo di produzione del dato (storia, ciclo di vita, rilevazione, acquisizione, forma attuale, qualità richiesta per garantirne l'interoperabilità)</dc:source>
+      <ows:BoundingBox crs="urn:ogc:def:crs:::WGS84">
+        <ows:LowerCorner>11.331132423112592 43.72700677229733</ows:LowerCorner>
+        <ows:UpperCorner>11.154076443108027 43.82471910604458</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dct:temporal>start=2009-01-01; end=2013-12-31</dct:temporal>
+      <dc:URI protocol="https://registry.geodati.gov.it/metadata-codelist/ProtocolValue/www-download" profile="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other" description="access point">https://server.org/name/tileset.json</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:title>c1020047_title</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>sub1, sub2, sub3</dc:subject>
+      <dc:subject>sub4</dc:subject>
+      <dc:format />
+      <dct:abstract>Abstract</dct:abstract>
+      <dc:language />
+      <dc:source />
+      <dc:format />
+      <dct:references scheme="OGC:WMS">base/web/client/test-resources/csw/getCapability.xml</dct:references>
+      <dct:alternative>workspace:layer_name1</dct:alternative>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
+        <ows:LowerCorner>12.718 45.542</ows:LowerCorner>
+        <ows:UpperCorner>11.874 46.026</ows:UpperCorner>
+      </ows:BoundingBox>
+    </csw:Record>
+   
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>d698f693-6e7e-47a9-a138-918068d0b082</dc:identifier>
+      <dc:title>Title2</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>geoscientificInformation</dc:subject>
+      <dc:format />
+      <dct:abstract />
+      <dc:language />
+      <dc:source />
+      <dc:format />
+      <ows:BoundingBox crs="urn:ogc:def:crs:OGC:1.3:CRS84">
+        <ows:LowerCorner>12.002717999999996 46.187282</ows:LowerCorner>
+        <ows:UpperCorner>12.429282000000002 45.760718</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name2" description="desc2">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187049&amp;fname=d698f693-6e7e-47a9-a138-918068d0b082_s.png&amp;access=public</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>urn:isogeo:metadata:uuid:01ca64b3-6d69-43b7-b953-7743e11daafe</dc:identifier>
+      <dc:title>Title3</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>infoMapAccessService</dc:subject>
+      <dc:format />
+      <dct:abstract />
+      <dc:language />
+      <dc:source />
+      <dc:format />
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::RGF93 / Lambert-93 (EPSG:2154)">
+        <ows:LowerCorner>-4.1149 47.93257</ows:LowerCorner>
+        <ows:UpperCorner>-4.14168 47.959353362144</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name3" description="desc2">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="image/png">http://geowww.agrocampus-ouest.fr/img/metadata/KBZ.png</dc:URI>
+    </csw:Record>
+  </csw:SearchResults>
+</csw:GetRecordsResponse>

--- a/web/client/test-resources/csw/getRecordsResponseDCWith3DLayersAtLast.xml
+++ b/web/client/test-resources/csw/getRecordsResponseDCWith3DLayersAtLast.xml
@@ -1,6 +1,6 @@
 <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
   <csw:SearchStatus timestamp="2016-05-11T13:00:06" />
-  <csw:SearchResults numberOfRecordsMatched="100" numberOfRecordsReturned="5" elementSet="full" nextRecord="3">
+  <csw:SearchResults numberOfRecordsMatched="100" numberOfRecordsReturned="1" elementSet="full" nextRecord="3">
     <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
       <dc:title>c1020047_title</dc:title>
       <dc:type>dataset</dc:type>
@@ -18,28 +18,7 @@
         <ows:UpperCorner>11.874 46.026</ows:UpperCorner>
       </ows:BoundingBox>
     </csw:Record>
-      <csw:Record xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <dc:identifier>test:20230829_test_3dtile_01</dc:identifier>
-      <dc:date>2023-09-22</dc:date>
-      <dc:title>Metadato di test per 3D-tile</dc:title>
-      <dct:abstract>Breve descrizione della risorsa</dct:abstract>
-      <dc:description>Breve descrizione della risorsa</dc:description>
-      <dc:type>dataset</dc:type>
-      <dc:subject>Zone a rischio naturale</dc:subject>
-      <dc:subject>health</dc:subject>
-      <dc:format>3D Tiles</dc:format>
-      <dc:contributor>Nome dell'ufficio responsabile del dato</dc:contributor>
-      <dc:rights>otherRestrictions</dc:rights>
-      <dc:rights>otherRestrictions</dc:rights>
-      <dc:language>ita</dc:language>
-      <dc:source>Descrizione della provenienza e del processo di produzione del dato (storia, ciclo di vita, rilevazione, acquisizione, forma attuale, qualità richiesta per garantirne l'interoperabilità)</dc:source>
-      <ows:BoundingBox crs="urn:ogc:def:crs:::WGS84">
-        <ows:LowerCorner>11.331132423112592 43.72700677229733</ows:LowerCorner>
-        <ows:UpperCorner>11.154076443108027 43.82471910604458</ows:UpperCorner>
-      </ows:BoundingBox>
-      <dct:temporal>start=2009-01-01; end=2013-12-31</dct:temporal>
-      <dc:URI protocol="https://registry.geodati.gov.it/metadata-codelist/ProtocolValue/www-download" profile="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other" description="access point">https://server.org/name/tileset.json</dc:URI>
-    </csw:Record>
+   
     <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
       <dc:identifier>d698f693-6e7e-47a9-a138-918068d0b082</dc:identifier>
       <dc:title>Title2</dc:title>
@@ -74,7 +53,7 @@
       <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name3" description="desc2">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
       <dc:URI protocol="image/png">http://geowww.agrocampus-ouest.fr/img/metadata/KBZ.png</dc:URI>
     </csw:Record>
-    <csw:Record xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <csw:Record xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink">
       <dc:identifier>test:20230829_test_3dtile_01</dc:identifier>
       <dc:date>2023-09-22</dc:date>
       <dc:title>Metadato di test per 3D-tile</dc:title>

--- a/web/client/test-resources/csw/getRecordsResponseDCWith3DLayersAtMiddle.xml
+++ b/web/client/test-resources/csw/getRecordsResponseDCWith3DLayersAtMiddle.xml
@@ -1,0 +1,61 @@
+<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
+  <csw:SearchStatus timestamp="2016-05-11T13:00:06" />
+  <csw:SearchResults numberOfRecordsMatched="100" numberOfRecordsReturned="5" elementSet="full" nextRecord="3">
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:title>c1020047_title</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>sub1, sub2, sub3</dc:subject>
+      <dc:subject>sub4</dc:subject>
+      <dc:format />
+      <dct:abstract>Abstract</dct:abstract>
+      <dc:language />
+      <dc:source />
+      <dc:format />
+      <dct:references scheme="OGC:WMS">base/web/client/test-resources/csw/getCapability.xml</dct:references>
+      <dct:alternative>workspace:layer_name1</dct:alternative>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
+        <ows:LowerCorner>12.718 45.542</ows:LowerCorner>
+        <ows:UpperCorner>11.874 46.026</ows:UpperCorner>
+      </ows:BoundingBox>
+    </csw:Record>
+      <csw:Record xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <dc:identifier>test:20230829_test_3dtile_01</dc:identifier>
+      <dc:date>2023-09-22</dc:date>
+      <dc:title>Metadato di test per 3D-tile</dc:title>
+      <dct:abstract>Breve descrizione della risorsa</dct:abstract>
+      <dc:description>Breve descrizione della risorsa</dc:description>
+      <dc:type>dataset</dc:type>
+      <dc:subject>Zone a rischio naturale</dc:subject>
+      <dc:subject>health</dc:subject>
+      <dc:format>3D Tiles</dc:format>
+      <dc:contributor>Nome dell'ufficio responsabile del dato</dc:contributor>
+      <dc:rights>otherRestrictions</dc:rights>
+      <dc:rights>otherRestrictions</dc:rights>
+      <dc:language>ita</dc:language>
+      <dc:source>Descrizione della provenienza e del processo di produzione del dato (storia, ciclo di vita, rilevazione, acquisizione, forma attuale, qualità richiesta per garantirne l'interoperabilità)</dc:source>
+      <ows:BoundingBox crs="urn:ogc:def:crs:::WGS84">
+        <ows:LowerCorner>11.331132423112592 43.72700677229733</ows:LowerCorner>
+        <ows:UpperCorner>11.154076443108027 43.82471910604458</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dct:temporal>start=2009-01-01; end=2013-12-31</dct:temporal>
+      <dc:URI protocol="https://registry.geodati.gov.it/metadata-codelist/ProtocolValue/www-download" profile="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other" description="access point">https://server.org/name/tileset.json</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>d698f693-6e7e-47a9-a138-918068d0b082</dc:identifier>
+      <dc:title>Title2</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>geoscientificInformation</dc:subject>
+      <dc:format />
+      <dct:abstract />
+      <dc:language />
+      <dc:source />
+      <dc:format />
+      <ows:BoundingBox crs="urn:ogc:def:crs:OGC:1.3:CRS84">
+        <ows:LowerCorner>12.002717999999996 46.187282</ows:LowerCorner>
+        <ows:UpperCorner>12.429282000000002 45.760718</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name2" description="desc2">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187049&amp;fname=d698f693-6e7e-47a9-a138-918068d0b082_s.png&amp;access=public</dc:URI>
+    </csw:Record>
+  </csw:SearchResults>
+</csw:GetRecordsResponse>


### PR DESCRIPTION
## Description
Fix zoom to any 3D layer in CSW Catalog to the correct extent.
I tried to handle bbox in metadata and parse the extent to the correct one but there is a missing point - I think it's related to axis order with different CSW versions and it needs a lot of conditions in code- so I go with the 2nd option fixing by getting layer extent from tileset json.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#9585 

**What is the current behavior?**
#9585 
**What is the new behavior?**
- when user adds a 3D layer from CSW catalog, it gets the extent of 3D layer from the tileset json then it zooms to the correct extent of the layer. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
