### PR TITLE
#9464: fix issue of not showing background layer in case of switching from 2D mode to 3D mode

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -22,6 +22,14 @@ This is a list of things to check if you want to update from a previous version 
 
 ## Migration from 2023.02.xx to 2024.01.00
 
+### Fixing background config
+
+From this version in order to fix default 3d background config a change is needed here
+- `localConfig.json` by adding **visibility: false**  to the Empty Background entry in intialState.defaultState.catalog.default.staticServices.default_map_backgrounds.backgrounds
+- `new.json` by adding **visibility: false**  to the Empty Background entry
+
+see this PR [9614](https://github.com/geosolutions-it/MapStore2/pull/9614/files) for more details
+
 ### Adding spatial filter to dashboard widgets
 
 In order to enable the possibility to add in and the spatial filter to the widgets ( see [#9098](https://github.com/geosolutions-it/MapStore2/issues/9098) ) you have to edit the `QueryPanel` config in the `plugins.dashboard` array of the `localConfig.json` file by adding:

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -25,10 +25,8 @@ This is a list of things to check if you want to update from a previous version 
 ### Fixing background config
 
 From this version in order to fix default 3d background config a change is needed here
-- `localConfig.json` by adding **visibility: false**  to the Empty Background entry in intialState.defaultState.catalog.default.staticServices.default_map_backgrounds.backgrounds
-- `new.json` by adding **visibility: false**  to the Empty Background entry
-
-see this PR [9614](https://github.com/geosolutions-it/MapStore2/pull/9614/files) for more details
+- update `localConfig.json` by adding **visibility: false**  to the Empty Background entry in intialState.defaultState.catalog.default.staticServices.default_map_backgrounds.backgrounds
+- update `new.json` by adding **visibility: false**  to the Empty Background entry
 
 ### Adding spatial filter to dashboard widgets
 

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -26,8 +26,8 @@ This is a list of things to check if you want to update from a previous version 
 
 From this version in order to fix default 3d background config a change is needed here:
 
-- update `localConfig.json` by adding **visibility: false**  to the Empty Background entry in intialState.defaultState.catalog.default.staticServices.default_map_backgrounds.backgrounds
-- update `new.json` by adding **visibility: false**  to the Empty Background entry
+- update `localConfig.json` by adding **visibility: false**  to the Empty Background entry in intialState.defaultState.catalog.default.staticServices.default_map_backgrounds.backgrounds.
+- update `new.json` by adding **visibility: false**  to the Empty Background entry.
 
 ### Adding spatial filter to dashboard widgets
 

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -24,7 +24,8 @@ This is a list of things to check if you want to update from a previous version 
 
 ### Fixing background config
 
-From this version in order to fix default 3d background config a change is needed here
+From this version in order to fix default 3d background config a change is needed here:
+
 - update `localConfig.json` by adding **visibility: false**  to the Empty Background entry in intialState.defaultState.catalog.default.staticServices.default_map_backgrounds.backgrounds
 - update `new.json` by adding **visibility: false**  to the Empty Background entry
 

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -26,7 +26,7 @@ This is a list of things to check if you want to update from a previous version 
 
 From this version in order to fix default 3d background config a change is needed here:
 
-- update `localConfig.json` by adding **visibility: false**  to the Empty Background entry in intialState.defaultState.catalog.default.staticServices.default_map_backgrounds.backgrounds.
+- update `localConfig.json` by adding **visibility: false**  to the Empty Background entry in `intialState.defaultState.catalog.default.staticServices.default_map_backgrounds.backgrounds`
 - update `new.json` by adding **visibility: false**  to the Empty Background entry.
 
 ### Adding spatial filter to dashboard widgets

--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -26,8 +26,7 @@ class CesiumLayer extends React.Component {
 
     componentDidMount() {
         this.createLayer(this.props.type, this.props.options, this.props.position, this.props.map, this.props.securityToken);
-        let mapHasDefaultBackgroundLayer = this.props.map.scene.imageryLayers.length;          // TO CHECK IF THERE IS AN EXISTING ACTIVE BACKGROUND LAYER IF NOT ADD THIS LAYER BE THE DEFAULT
-        if (this.props.options && this.layer && this.getVisibilityOption(this.props) && !mapHasDefaultBackgroundLayer) {
+        if (this.props.options && this.layer && this.getVisibilityOption(this.props)) {
             this.addLayer(this.props);
             this.updateZIndex();
         }
@@ -168,7 +167,7 @@ class CesiumLayer extends React.Component {
                 return false;
             }
         }
-        return visibility !== false;
+        return visibility;
     };
 
     setLayerOpacity = (opacity) => {

--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -26,7 +26,8 @@ class CesiumLayer extends React.Component {
 
     componentDidMount() {
         this.createLayer(this.props.type, this.props.options, this.props.position, this.props.map, this.props.securityToken);
-        if (this.props.options && this.layer && this.getVisibilityOption(this.props)) {
+        let mapHasDefaultBackgroundLayer = this.props.map.scene.imageryLayers.length;          // TO CHECK IF THERE IS AN EXISTING ACTIVE BACKGROUND LAYER IF NOT ADD THIS LAYER BE THE DEFAULT
+        if (this.props.options && this.layer && this.getVisibilityOption(this.props) && !mapHasDefaultBackgroundLayer) {
             this.addLayer(this.props);
             this.updateZIndex();
         }

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -98,7 +98,9 @@ describe('Cesium layer', () => {
     });
 
     it('creates a osm layer for cesium map', () => {
-        var options = {};
+        var options = {
+            visibility: true
+        };
         // create layers
         var layer = ReactDOM.render(
             <CesiumLayer type="osm"
@@ -113,7 +115,8 @@ describe('Cesium layer', () => {
             "source": "osm",
             "title": "Open Street Map",
             "name": "mapnik",
-            "group": "background"
+            "group": "background",
+            "visibility": true
         };
         // create layer
         var layer = ReactDOM.render(
@@ -455,7 +458,8 @@ describe('Cesium layer', () => {
             "title": "Bing Aerial",
             "name": "Aerial",
             "group": "background",
-            "apiKey": "required"
+            "apiKey": "required",
+            "visibility": true
         };
         // create layers
         var layer = ReactDOM.render(
@@ -472,7 +476,7 @@ describe('Cesium layer', () => {
                 options={{}} position={0} map={map}/>, document.getElementById("container"));
 
         expect(layer).toExist();
-        expect(map.imageryLayers.length).toBe(1);
+        expect(map.imageryLayers.length).toBe(0);
         // not visibile layers are removed from the leaflet maps
         layer = ReactDOM.render(
             <CesiumLayer type="osm"

--- a/web/client/components/map/cesium/__tests__/Map-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test.jsx
@@ -440,9 +440,9 @@ describe('CesiumMap', () => {
         act(() => {
             ReactDOM.render(
                 <CesiumMap ref={value => { ref = value; } } id="mymap" center={{ y: 43.9, x: 10.3 }} zoom={11}>
-                    <CesiumLayer type="wms" position={1} options={{ url: '/wms', name: 'layer01' }} />
-                    <CesiumLayer type="wms" position={3} options={{ url: '/wms', name: 'layer02' }} />
-                    <CesiumLayer type="wms" position={6} options={{ url: '/wms', name: 'layer03' }} />
+                    <CesiumLayer type="wms" position={1} options={{ url: '/wms', name: 'layer01', "visibility": true }} />
+                    <CesiumLayer type="wms" position={3} options={{ url: '/wms', name: 'layer02', "visibility": true }} />
+                    <CesiumLayer type="wms" position={6} options={{ url: '/wms', name: 'layer03', "visibility": true }} />
                 </CesiumMap>,
                 document.getElementById('container')
             );
@@ -455,9 +455,9 @@ describe('CesiumMap', () => {
         act(() => {
             ReactDOM.render(
                 <CesiumMap ref={value => { ref = value; } } id="mymap" center={{ y: 43.9, x: 10.3 }} zoom={11}>
-                    <CesiumLayer type="wms" position={1} options={{ url: '/wms', name: 'layer01' }} />
-                    <CesiumLayer type="wms" position={3} options={{ url: '/wms', name: 'layer02' }} />
-                    <CesiumLayer type="wms" position={4} options={{ url: '/wms', name: 'layer03' }} />
+                    <CesiumLayer type="wms" position={1} options={{ url: '/wms', name: 'layer01', "visibility": true }} />
+                    <CesiumLayer type="wms" position={3} options={{ url: '/wms', name: 'layer02', "visibility": true }} />
+                    <CesiumLayer type="wms" position={4} options={{ url: '/wms', name: 'layer03', "visibility": true }} />
                 </CesiumMap>,
                 document.getElementById('container')
             );
@@ -468,9 +468,9 @@ describe('CesiumMap', () => {
         act(() => {
             ReactDOM.render(
                 <CesiumMap ref={value => { ref = value; } } id="mymap" center={{ y: 43.9, x: 10.3 }} zoom={11}>
-                    <CesiumLayer type="wms" position={1} options={{ url: '/wms', name: 'layer01' }} />
-                    <CesiumLayer type="wms" position={3} options={{ url: '/wms', name: 'layer02' }} />
-                    <CesiumLayer type="wms" position={2} options={{ url: '/wms', name: 'layer03' }} />
+                    <CesiumLayer type="wms" position={1} options={{ url: '/wms', name: 'layer01', "visibility": true }} />
+                    <CesiumLayer type="wms" position={3} options={{ url: '/wms', name: 'layer02', "visibility": true }} />
+                    <CesiumLayer type="wms" position={2} options={{ url: '/wms', name: 'layer03', "visibility": true }} />
                 </CesiumMap>,
                 document.getElementById('container')
             );

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -215,7 +215,8 @@
 						"group": "background",
 						"title": "Empty Background",
 						"fixed": true,
-						"type": "empty"
+						"type": "empty",
+						"visibility": false
 					}
 				]
 			  }

--- a/web/client/configs/new.json
+++ b/web/client/configs/new.json
@@ -123,7 +123,8 @@
                 "group": "background",
                 "title": "Empty Background",
                 "fixed": true,
-                "type": "empty"
+                "type": "empty",
+                "visibility": false
             }
         ]
 	}


### PR DESCRIPTION
## Description
Fixing not showing the default background layer on the map when user switches from 2D mode to 3D mode.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#9464 
**What is the current behavior?**
#9464 

**What is the new behavior?**
When a user switches from 2d mode map to 3D mode, the default background layer will be shown. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

