### PR TITLE
#9552: keep the legend state for the saved maps

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -642,7 +642,8 @@ export const saveLayer = (layer) => {
         tooltipPlacement: layer.tooltipPlacement,
         legendOptions: layer.legendOptions,
         tileSize: layer.tileSize,
-        version: layer.version
+        version: layer.version,
+        expanded: layer.expanded
     },
     layer.sources ? { sources: layer.sources } : {},
     layer.heightOffset ? { heightOffset: layer.heightOffset } : {},


### PR DESCRIPTION
## Description
If user saves a map with expanded/collapsed legend into TOC, the state of this legend will be saved once user saves the map.
So every time user opens the map, user will see the legend state as it is. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue
#9552 

**What is the current behavior?**
#9552 

**What is the new behavior?**
If user saves a map with expanded/collapsed legend into TOC, the state of this legend will be saved once user saves this map.
User will see the legend state kept when he opens the map later. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
