### PR TITLE
#9625: fix not showing layer name in identify dropdown for imported vector layers

### DIFF
--- a/web/client/components/data/identify/LayerSelector.jsx
+++ b/web/client/components/data/identify/LayerSelector.jsx
@@ -21,7 +21,7 @@ const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, e
     useEffect(()=>{
         if (!isEmpty(responses)) {
             setOptions(responses.map((opt, idx)=> {
-                const value = opt?.layerMetadata?.title;
+                const value = opt?.layerMetadata?.title || opt?.layer?.name;
                 // Display only valid responses in the drop down if showAllResponses is false,
                 // otherwise all response are visible and the first layer in toc is present in here
                 const valid = !!validator(format)?.getValidResponses([opt]).length;
@@ -37,7 +37,7 @@ const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, e
     }, [responses]);
 
     useEffect(()=>{
-        loaded && setTitle(responses[index]?.layerMetadata?.title || "");
+        loaded && setTitle(responses[index]?.layerMetadata?.title || responses[index]?.layer?.name || "");
     }, [responses, index, loaded]);
 
     const onChange = (event) => {


### PR DESCRIPTION
## Description
Fix issue of not showing layer name of imported vector layers in identify dropdown layer list.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue
#9625 

**What is the current behavior?**
#9625 

**What is the new behavior?**
Now if user makes an import for a vector layer on the map then clicks on any of its feature on the map ---> identify part will open and the dropdown list of layer names will containing the name of this layer like:

![image](https://github.com/geosolutions-it/MapStore2/assets/58145645/c7f80f94-31b3-448d-b0a0-f70adb91859d)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

