### PR TITLE
Fix #9605 issue with <> transformed into ogc filter

### DIFF
--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -159,7 +159,7 @@ export const  ogcStringField = (attribute, operator, value, nsplaceholder) => {
                         attribute +
                     propertyTagReference[nsplaceholder].endTag
                 );
-        } else if (operator === "=") {
+        } else if (operator === "=" || operator === "<>") {
             fieldFilter =
                 ogcComparisonOperators[operator](nsplaceholder,
                     propertyTagReference[nsplaceholder].startTag +

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -16,6 +16,7 @@ import {
     processOGCCrossLayerFilter,
     cqlBooleanField,
     cqlStringField,
+    ogcStringField,
     ogcBooleanField,
     getCrossLayerCqlFilter,
     composeAttributeFilters,
@@ -1238,6 +1239,14 @@ describe('FilterUtils', () => {
         expect(cqlStringField("attribute_1", "ilike", "*A*")).toBe("strToLowerCase(\"attribute_1\") LIKE '%a%'");
         // test LIKE wrapped with wildcard
         expect(cqlStringField("attribute_1", "like", "*A*")).toBe("\"attribute_1\" LIKE '%A%'");
+    });
+    it('Check if ogcStringField(attribute, operator, value, ns)', () => {
+        // testing operator =
+        expect(ogcStringField("attribute_1", "=", "Alabama", "ogc")).toBe("<ogc:PropertyIsEqualTo><ogc:PropertyName>attribute_1</ogc:PropertyName><ogc:Literal>Alabama</ogc:Literal></ogc:PropertyIsEqualTo>");
+        expect(ogcStringField("attribute_1", "<>", "Alabama", "ogc")).toBe("<ogc:PropertyIsNotEqualTo><ogc:PropertyName>attribute_1</ogc:PropertyName><ogc:Literal>Alabama</ogc:Literal></ogc:PropertyIsNotEqualTo>");
+        expect(ogcStringField("attribute_1", "like", "Alabama", "ogc")).toBe("<ogc:PropertyIsLike matchCase=\"true\" wildCard=\"*\" singleChar=\".\" escapeChar=\"!\"><ogc:PropertyName>attribute_1</ogc:PropertyName><ogc:Literal>*Alabama*</ogc:Literal></ogc:PropertyIsLike>");
+        expect(ogcStringField("attribute_1", "ilike", "Alabama", "ogc")).toBe("<ogc:PropertyIsLike matchCase=\"false\" wildCard=\"*\" singleChar=\".\" escapeChar=\"!\"><ogc:PropertyName>attribute_1</ogc:PropertyName><ogc:Literal>*Alabama*</ogc:Literal></ogc:PropertyIsLike>");
+        expect(ogcStringField("attribute_1", "isNull", "", "ogc")).toBe("<ogc:PropertyIsNull><ogc:PropertyName>attribute_1</ogc:PropertyName></ogc:PropertyIsNull>");
     });
     it('Check if ogcBooleanField(attribute, operator, value, nsplaceholder)', () => {
         // testing operators


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Fix #9605, the reason is explained here  https://github.com/geosolutions-it/MapStore2/issues/9605#issuecomment-1768928060

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9605

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
