### PR TITLE
Fix #9650 forcing geometries tab to be selected when adding a new one

### DIFF
--- a/web/client/plugins/Annotations/components/FeaturesEditor.jsx
+++ b/web/client/plugins/Annotations/components/FeaturesEditor.jsx
@@ -167,6 +167,7 @@ export function FeaturesEditor({
     }
 
     function handleAddFeature(type, properties) {
+        onSelectTab('coordinates', selected);
         const id = uuid();
         handleOnChange((prevCollection) => {
             const newFeature = {

--- a/web/client/plugins/Annotations/containers/AnnotationsPanel.jsx
+++ b/web/client/plugins/Annotations/containers/AnnotationsPanel.jsx
@@ -241,7 +241,7 @@ function AnnotationsPanel({
                     <Glyphicon glyph={validateFeatures() ? 'ok-sign text-success' : 'exclamation-mark text-danger'}/>
                 </NavItem>
                 <NavItem
-                    key="geometries"
+                    key="settings"
                     eventKey="settings"
                     onClick={() => setTab('settings')}>
                     <Message msgId="settings"/>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Forcing geometries tab to be selected when adding a new one

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #9650

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
It auto selected the geometries if style was previously selected

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
