### PR TITLE
Fix #9654 updates of feature styles

### DIFF
--- a/web/client/components/map/openlayers/plugins/VectorLayer.js
+++ b/web/client/components/map/openlayers/plugins/VectorLayer.js
@@ -64,7 +64,19 @@ Layers.registerType('vector', {
             });
         }
 
-        if (!isEqual(oldOptions.style, newOptions.style) || oldOptions.styleName !== newOptions.styleName) {
+        /**
+         * we need to also check when features changes because there could be styles depending of features
+         * so when the latter changes we have to redraw to redo the checks and apply correct style based on new feature props
+        */
+        const areFeaturesChanged = !isEqual(oldOptions.features, newOptions.features);
+
+        const isStyleChanged = !isEqual(oldOptions.style, newOptions.style);
+        const isStyleNameChanged = oldOptions.styleName !== newOptions.styleName;
+        if (
+            isStyleChanged ||
+            isStyleNameChanged ||
+            areFeaturesChanged
+        ) {
             getStyle(applyDefaultStyleToVectorLayer({ ...newOptions, asPromise: true }))
                 .then((style) => {
                     if (style) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

the issues was that it was creating a scale of 46 [here](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/utils/styleparser/OLStyleParser.js#L600) because the features initially were empty and the [drawIcons function](https://github.com/geosolutions-it/MapStore2/blob/99c69da663d537337124f27a5ca1b9a07e610ec8/web/client/utils/styleparser/StyleParserUtils.js#L873) was not able to fetch images 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9654

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

switching to style will make the marker properly sized
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
