### PR TITLE
Fix #9666 Include pointCloudShading option to saved layer config

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -657,7 +657,8 @@ export const saveLayer = (layer) => {
     layer.tileGridCacheSupport ? { tileGridCacheSupport: layer.tileGridCacheSupport } : {},
     isString(layer.rowViewer) ? { rowViewer: layer.rowViewer } : {},
     !isNil(layer.forceProxy) ? { forceProxy: layer.forceProxy } : {},
-    !isNil(layer.disableFeaturesEditing) ? { disableFeaturesEditing: layer.disableFeaturesEditing } : {});
+    !isNil(layer.disableFeaturesEditing) ? { disableFeaturesEditing: layer.disableFeaturesEditing } : {},
+    layer.pointCloudShading ? { pointCloudShading: layer.pointCloudShading } : {});
 };
 
 /**

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1246,6 +1246,20 @@ describe('LayersUtils', () => {
                 l => {
                     expect(l.disableFeaturesEditing).toBeTruthy();
                 }
+            ],
+            [
+                {
+                    pointCloudShading: {
+                        attenuation: true,
+                        maximumAttenuation: 4,
+                        eyeDomeLighting: true,
+                        eyeDomeLightingStrength: 1,
+                        eyeDomeLightingRadius: 1
+                    }
+                },
+                l => {
+                    expect(l.pointCloudShading).toBeTruthy();
+                }
             ]
         ];
         layers.map(([layer, test]) => test(LayersUtils.saveLayer(layer)) );


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR includes the pointCloudShading option to saved layer configuration

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9666 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

This PR includes the pointCloudShading option to saved layer configuration

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
