### PR TITLE
React Quill replaced with Draftjs in Dashboard's Txt Widget

### DIFF
--- a/web/client/components/mapviews/settings/CompactRichTextEditor.jsx
+++ b/web/client/components/mapviews/settings/CompactRichTextEditor.jsx
@@ -58,7 +58,8 @@ function CompactRichTextEditor({
                     urlEnabled: true,
                     // disable the upload at the moment
                     // it will increase the size of the map too much
-                    uploadEnabled: false,
+                    // allows to set enable imge upload on/off via props
+                    uploadEnabled: props.uploadEnabled || false,
                     alignmentEnabled: false,
                     uploadCallback: (file) => new Promise((resolve, reject) => {
                         const reader = new FileReader();

--- a/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
@@ -11,7 +11,7 @@ import { Col, Form, FormControl, FormGroup } from "react-bootstrap";
 import localizedProps from "../../../../misc/enhancers/localizedProps";
 import {
     htmlToDraftJSEditorState,
-    draftJSEditorStateToHtml,
+    draftJSEditorStateToHtml
 } from "../../../../../utils/EditorUtils";
 
 import withDebounceOnCallback from "../../../../misc/enhancers/withDebounceOnCallback";
@@ -52,8 +52,7 @@ function TextOptions({ data = {}, onChange = () => {} }) {
                 onEditorStateChange={(newEditorState) => {
                     onChange("text", draftJSEditorStateToHtml(newEditorState));
                 }}
-                //enable image upload
-                uploadEnabled = {true}
+                uploadEnabled
             />
         </div>
     );

--- a/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
@@ -6,34 +6,56 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import { Col, Form, FormControl, FormGroup } from 'react-bootstrap';
-import ReactQuill from '../../../../../libs/quill/react-quill-suspense';
+import React, { useState } from "react";
+import { Col, Form, FormControl, FormGroup } from "react-bootstrap";
+import localizedProps from "../../../../misc/enhancers/localizedProps";
+import {
+    htmlToDraftJSEditorState,
+    draftJSEditorStateToHtml,
+} from "../../../../../utils/EditorUtils";
 
-import localizedProps from '../../../../misc/enhancers/localizedProps';
+import withDebounceOnCallback from "../../../../misc/enhancers/withDebounceOnCallback";
+import CompactRichTextEditor from "../../../../mapviews/settings/CompactRichTextEditor";
 
 const TitleInput = localizedProps("placeholder")(FormControl);
+const DescriptorEditor = withDebounceOnCallback(
+    "onEditorStateChange",
+    "editorState"
+)(CompactRichTextEditor);
 
-const Editor = localizedProps("placeholder")(ReactQuill);
+function TextOptions({ data = {}, onChange = () => {} }) {
+    const [editorState, setEditorState] = useState(
+        htmlToDraftJSEditorState(data.text || "")
+    );
 
-export default ({ data = {}, onChange = () => { }}) => (
-    <div>
-        <Col key="form" xs={12}>
-            <Form>
-                <FormGroup controlId="title">
-                    <Col sm={12}>
-                        <TitleInput style={{ marginBottom: 10 }} placeholder="widgets.builder.wizard.titlePlaceholder" value={data.title} type="text" onChange={e => onChange("title", e.target.value)} />
-                    </Col>
-                </FormGroup>
-            </Form>
-        </Col>
-        <Editor modules={{
-            toolbar: [
-                [{'size': ['small', false, 'large', 'huge'] }, 'bold', 'italic', 'underline', 'blockquote'],
-                [{'list': 'bullet' }, {'align': [] }],
-                [{'color': [] }, {'background': [] }, 'clean'], ['image', 'link']
-            ]
-        }} placeholder="widgets.builder.wizard.textPlaceholder" value={data && data.text || ''} onChange={(val) => onChange("text", val)} />
-    </div>
-);
-
+    return (
+        <div>
+            <Col key="form" xs={12}>
+                <Form>
+                    <FormGroup controlId="title">
+                        <Col sm={12}>
+                            <TitleInput
+                                style={{ marginBottom: 10 }}
+                                placeholder="widgets.builder.wizard.titlePlaceholder"
+                                value={data.title}
+                                type="text"
+                                onChange={(e) =>
+                                    onChange("title", e.target.value)
+                                }
+                            />
+                        </Col>
+                    </FormGroup>
+                </Form>
+            </Col>
+            <DescriptorEditor
+                editorState={editorState}
+                onEditorStateChange={(newEditorState) => {
+                    onChange("text", draftJSEditorStateToHtml(newEditorState));
+                }}
+                //enable image upload
+                uploadEnabled = {true}
+            />
+        </div>
+    );
+}
+export default TextOptions;

--- a/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
@@ -5,8 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-import React, { useState } from "react";
+import React from "react";
 import { Col, Form, FormControl, FormGroup } from "react-bootstrap";
 import localizedProps from "../../../../misc/enhancers/localizedProps";
 import {
@@ -24,9 +23,7 @@ const DescriptorEditor = withDebounceOnCallback(
 )(CompactRichTextEditor);
 
 function TextOptions({ data = {}, onChange = () => {} }) {
-    const [editorState, setEditorState] = useState(
-        htmlToDraftJSEditorState(data.text || "")
-    );
+    const editorState = htmlToDraftJSEditorState(data.text || "");
 
     return (
         <div>


### PR DESCRIPTION
## Description

React Quill editor has been replaced with Draftjs in Dashboard Text Wigets

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**

Fix https://github.com/geosolutions-it/MapStore2/issues/9627

**What is the new behavior?**

Draftjs added, allows embedding of PDFs or any link, plus allow upload of image rather than a link via props option

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
