### PR TITLE
Fix #9609 missing disabled prop to be passed to the ProperyField comp

### DIFF
--- a/web/client/components/styleeditor/PropertySelector.jsx
+++ b/web/client/components/styleeditor/PropertySelector.jsx
@@ -21,6 +21,7 @@ const PropertySelector = ({
     attributes,
     value,
     onChange,
+    disabled,
     fieldKey,
     config,
     disableAlpha: disableAlphaProp,
@@ -36,6 +37,7 @@ const PropertySelector = ({
     return (
         <div className="ms-symbolizer-property-selector" style={{ width: '100%' }}>
             <PropertyField
+                disabled={disabled}
                 label={labelProp}
                 invalid={value?.args?.[0] === undefined}
                 infoMessageId={config?.propertySelectorInfoMessageId}>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

basically when executing this part 
https://github.com/geosolutions-it/MapStore2/blob/7c71fbfd3093f3e1d89aa2458436802a7ddb1028/web/client/components/styleeditor/PropertyField.jsx#L20

the **disabled** prop was undefined in case of propertySelector

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #9609

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
issue fixed

![image](https://github.com/geosolutions-it/MapStore2/assets/11991428/54bc083b-6a34-456d-aece-ce85a6e51549)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
