### PR TITLE
#9589: Notify data projection not compatible / available for COG

### DIFF
--- a/web/client/api/catalog/COG.js
+++ b/web/client/api/catalog/COG.js
@@ -86,6 +86,9 @@ export const getRecords = (_url, startPosition, maxRecords, text, info = {}) => 
                         const isProjectionDefined = isProjectionAvailable(crs);
                         layer = {
                             ...layer,
+                            sourceMetadata: {
+                                crs
+                            },
                             // skip adding bbox when geokeys or extent is empty
                             ...(!isEmpty(extent) && !isEmpty(crs) && isProjectionDefined && {
                                 bbox: {

--- a/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
+++ b/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
@@ -466,4 +466,43 @@ describe('test DefaultLayer module component', () => {
             expect(button.length).toBe(1);
         }
     });
+    it('test with layer source crs', () => {
+        // Invalid CRS
+        let node = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: false,
+            storeIndex: 9,
+            opacity: 0.5,
+            bbox: {
+                crs: "EPSG:3946"
+            }
+        };
+
+        let comp = ReactDOM.render(<Layer node={node}/>, document.getElementById("container"));
+        expect(ReactDOM.findDOMNode(comp)).toBeTruthy();
+        let layerNode = document.querySelector('.toc-default-layer.layer-error');
+        let errorTooltip = document.querySelector('.toc-layer-tool.toc-error');
+        expect(layerNode).toBeTruthy();
+        expect(errorTooltip).toBeTruthy();
+
+        // Valid CRS
+        node = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: false,
+            storeIndex: 9,
+            opacity: 0.5,
+            bbox: {
+                crs: "EPSG:4326"
+            }
+        };
+
+        comp = ReactDOM.render(<Layer node={node}/>, document.getElementById("container"));
+        expect(ReactDOM.findDOMNode(comp)).toBeTruthy();
+        layerNode = document.querySelector('.toc-default-layer.layer-error');
+        errorTooltip = document.querySelector('.toc-layer-tool.toc-error');
+        expect(layerNode).toBeFalsy();
+        expect(errorTooltip).toBeFalsy();
+    });
 });

--- a/web/client/components/TOC/fragments/LayersTool.jsx
+++ b/web/client/components/TOC/fragments/LayersTool.jsx
@@ -21,6 +21,7 @@ class LayersTool extends React.Component {
         style: PropTypes.object,
         glyph: PropTypes.string,
         tooltip: PropTypes.string,
+        msgParams: PropTypes.object,
         className: PropTypes.string
     };
 
@@ -34,7 +35,7 @@ class LayersTool extends React.Component {
             glyph={this.props.glyph}
             onClick={() => this.props.onClick(this.props.node)}/>);
         return this.props.tooltip ?
-            <OverlayTrigger placement="bottom" overlay={(<Tooltip id={"Tooltip-" + this.props.tooltip}><strong><Message msgId={this.props.tooltip}/></strong></Tooltip>)}>
+            <OverlayTrigger placement="bottom" overlay={(<Tooltip id={"Tooltip-" + this.props.tooltip}><strong><Message msgId={this.props.tooltip} msgParams={this.props.msgParams}/></strong></Tooltip>)}>
                 {tool}
             </OverlayTrigger> : tool;
 

--- a/web/client/components/catalog/__tests__/RecordItem-test.jsx
+++ b/web/client/components/catalog/__tests__/RecordItem-test.jsx
@@ -605,7 +605,7 @@ describe('This test for RecordItem', () => {
             }
         };
         let actionsSpy = expect.spyOn(actions, "onError");
-        const item = ReactDOM.render(<RecordItem
+        let item = ReactDOM.render(<RecordItem
             record={sampleRecord2}
             onError={actions.onError}
             crs="EPSG:3857"/>, document.getElementById("container"));
@@ -617,6 +617,22 @@ describe('This test for RecordItem', () => {
         expect(button).toBeTruthy();
         button.click();
         expect(actionsSpy.calls.length).toBe(1);
+
+        // With source metadata
+        const record = {...sampleRecord2, serviceType: "cog", sourceMetadata: {crs: "EPSG:3946"}};
+        item = ReactDOM.render(<RecordItem
+            record={record}
+            onError={actions.onError}
+            crs="EPSG:3857"/>, document.getElementById("container"));
+        expect(item).toBeTruthy();
+
+        button = TestUtils.findRenderedDOMComponentWithTag(
+            item, 'button'
+        );
+        expect(button).toBeTruthy();
+        button.click();
+        expect(actionsSpy.calls.length).toBe(2);
+
     });
     it('check add layer with bounding box', (done) => {
         let actions = {

--- a/web/client/components/map/openlayers/plugins/COGLayer.js
+++ b/web/client/components/map/openlayers/plugins/COGLayer.js
@@ -10,6 +10,7 @@ import Layers from '../../../../utils/openlayers/Layers';
 
 import GeoTIFF from 'ol/source/GeoTIFF.js';
 import TileLayer from 'ol/layer/WebGLTile.js';
+import { isProjectionAvailable } from '../../../../utils/ProjectionUtils';
 
 function create(options) {
     return new TileLayer({
@@ -41,5 +42,8 @@ Layers.registerType('cog', {
             layer.setMaxResolution(newOptions.maxResolution === undefined ? Infinity : newOptions.maxResolution);
         }
         return null;
+    },
+    isCompatible: (layer) => {
+        return isProjectionAvailable(layer?.sourceMetadata?.crs);
     }
 });

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -626,6 +626,7 @@
             "browseData": "Attributtabelle der ausgewählten Ebene öffnen",
             "removeLayer": "Ebene entfernen",
             "loadingerror": "Diese Ebene wurde nicht korrekt geladen oder ist nicht verfügbar",
+            "sourceCRSNotCompatible": "Die Quelldatenprojektionsdefinition {sourceCRS} des Layers ist in der Anwendung nicht für die Neuprojektion der Daten in der aktuellen Karte verfügbar",
             "measure": "Messen",
             "backgroundSwitcher": "Hintergrund",
             "layers": "Ebenen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -588,6 +588,7 @@
             "browseData": "Open Attribute Table",
             "removeLayer": "Remove layer",
             "loadingerror": "The layer has not been loaded correctly or not available.",
+            "sourceCRSNotCompatible": "The layer's source data projection definition {sourceCRS} is not available in the application for reprojecting the data in the current map",
             "measure": "Measure",
             "layers": "Layers",
             "drawerButton": "Layers",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -588,6 +588,7 @@
             "browseData": "Abrir la tabla de atributos",
             "removeLayer": "Borrar la capa",
             "loadingerror": "La capa no se ha cargado correctamente o no está disponible",
+            "sourceCRSNotCompatible": "La definición de proyección de datos de origen de la capa {sourceCRS} no está disponible en la aplicación para reproyectar los datos en el mapa actual",
             "measure": "Medir",
             "layers": "Capas",
             "drawerButton": "Capas",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -588,6 +588,7 @@
             "browseData": "Ouvrir la table d'attribut",
             "removeLayer": "Supprimer la couche",
             "loadingerror": "La couche n'a pas été chargée correctement ou n'est pas disponible.",
+            "sourceCRSNotCompatible": "La définition de projection des données sources de la couche {sourceCRS} n'est pas disponible dans l'application de reprojection des données dans la carte actuelle",
             "measure": "Mesurer",
             "layers": "Couches",
             "drawerButton": "Couches",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -588,6 +588,7 @@
             "browseData": "Apri tabella degli attributi",
             "removeLayer": "Rimuovi livello",
             "loadingerror": "Il livello non è stato caricato correttamente o non disponible.",
+            "sourceCRSNotCompatible": "La definizione di proiezione dei dati di origine del layer {sourceCRS} non è disponibile nell'applicazione per riproiettare i dati nella mappa corrente",
             "measure": "Misure",
             "layers": "Livelli",
             "drawerButton": "Livelli",


### PR DESCRIPTION
## Description
This PR check for projection compatibility and notifies the user with meaningful feedback

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Enhancement


## Issue

**What is the current behavior?**
- #9589 

**What is the new behavior?**

**CATALOG**
<img width="552" alt="Screenshot 2023-11-10 at 6 02 16 PM" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/4ee558ee-1afa-49bf-815d-0201ee81b2d6">

**TOC**
<img width="1227" alt="Screenshot 2023-11-10 at 5 44 33 PM" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/57e7c452-1b6b-4c0b-ad13-9705c000f5de">

**NOTIFICATION**
<img width="152" alt="Screenshot 2023-11-10 at 5 44 44 PM" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/da1dbc0d-5bb1-4341-ac9a-b15ece0ad496">

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
