### PR TITLE
Fix #9685 Add possibility to use vector layers inside GeoProcessing tool

### DIFF
--- a/web/client/actions/__tests__/geoProcessing-test.js
+++ b/web/client/actions/__tests__/geoProcessing-test.js
@@ -15,8 +15,6 @@ import {
     errorLoadingDFT, ERROR_LOADING_DFT,
     getFeatures, GET_FEATURES,
     initPlugin, INIT_PLUGIN,
-    increaseBufferedCounter, INCREASE_BUFFERED_COUNTER,
-    increaseIntersectedCounter, INCREASE_INTERSECT_COUNTER,
     runningProcess, RUNNING_PROCESS,
     runProcess, RUN_PROCESS,
     setBufferDistance, SET_BUFFER_DISTANCE,
@@ -97,18 +95,6 @@ describe('Test Geo Processing Tools related actions', () => {
         expect(action).toEqual({
             type: INIT_PLUGIN,
             cfg
-        });
-    });
-    it('increaseBufferedCounter', () => {
-        const action = increaseBufferedCounter();
-        expect(action).toEqual({
-            type: INCREASE_BUFFERED_COUNTER
-        });
-    });
-    it('increaseIntersectedCounter', () => {
-        const action = increaseIntersectedCounter();
-        expect(action).toEqual({
-            type: INCREASE_INTERSECT_COUNTER
         });
     });
     it('runningProcess', () => {

--- a/web/client/actions/geoProcessing.js
+++ b/web/client/actions/geoProcessing.js
@@ -11,8 +11,8 @@ export const GPT_TOOL_INTERSECTION = "intersection";
 export const GPT_CONTROL_NAME = "GeoProcessing";
 export const GPT_SOURCE_HIGHLIGHT_ID = "gpt-layer";
 export const GPT_INTERSECTION_HIGHLIGHT_ID = "gpt-layer-intersection";
-export const GPT_INTERSECTION_GROUP_ID = "intersection.layer";
-export const GPT_BUFFER_GROUP_ID = "buffered.layer";
+export const GPT_INTERSECTION_GROUP_ID = "intersection_group";
+export const GPT_BUFFER_GROUP_ID = "buffered_group";
 
 export const CHECK_WPS_AVAILABILITY = "GPT:CHECK_WPS_AVAILABILITY";
 export const CHECKING_WPS_AVAILABILITY = "GPT:CHECKING_WPS_AVAILABILITY";
@@ -21,8 +21,6 @@ export const CHECKED_WPS_AVAILABILITY = "GPT:CHECKED_WPS_AVAILABILITY";
 export const GET_FEATURES = "GPT:GET_FEATURES";
 export const ERROR_LOADING_DFT = "GPT:ERROR_LOADING_DFT";
 export const INIT_PLUGIN = "GPT:INIT_PLUGIN";
-export const INCREASE_BUFFERED_COUNTER = "GPT:INCREASE_BUFFERED_COUNTER";
-export const INCREASE_INTERSECT_COUNTER = "GPT:INCREASE_INTERSECT_COUNTER";
 export const RUNNING_PROCESS = "GPT:RUNNING_PROCESS";
 export const RESET = "GPT:RESET";
 export const RUN_PROCESS = "GPT:RUN_PROCESS";
@@ -114,20 +112,6 @@ export const getFeatures = (layerId, source, page = 0) => ({
 export const initPlugin = (cfg) => ({
     type: INIT_PLUGIN,
     cfg
-});
-/**
- * action for triggering the increase of the number of buffered layers
- * @memberof actions.geoProcessing
-  */
-export const increaseBufferedCounter = () => ({
-    type: INCREASE_BUFFERED_COUNTER
-});
-/**
- * action for triggering the increase of the number of intersected layers
- * @memberof actions.geoProcessing
-  */
-export const increaseIntersectedCounter = () => ({
-    type: INCREASE_INTERSECT_COUNTER
 });
 /**
  * action that clears current status

--- a/web/client/epics/__tests__/geoProcessing-test.js
+++ b/web/client/epics/__tests__/geoProcessing-test.js
@@ -435,7 +435,7 @@ describe('geoProcessing epics', () => {
         });
     });
     it('setSourceFeatureId', (done) => {
-        const featureId = "ft-id";
+        const featureId = "INCENDI_INTERFACCIA.2955";
         const NUM_ACTIONS = 3;
         mockAxios.onGet("mockUrl?service=WFS&version=1.1.0&request=GetFeature").reply(200, GET_FEATURES);
 
@@ -506,7 +506,7 @@ describe('geoProcessing epics', () => {
             }
         });
     });
-    it('setIntersectionFeatureId', (done) => {
+    it('setIntersectionFeatureId as vector', (done) => {
         const featureId = "ft-id2";
         const secondFt = {
             type: "Feature",
@@ -572,7 +572,7 @@ describe('geoProcessing epics', () => {
         });
     });
     it('setIntersectionFeatureId', (done) => {
-        const featureId = "ft-id";
+        const featureId = "INCENDI_INTERFACCIA.2955";
         const NUM_ACTIONS = 3;
         mockAxios.onGet("mockUrl?service=WFS&version=1.1.0&request=GetFeature").reply(200, GET_FEATURES);
 

--- a/web/client/epics/__tests__/geoProcessing-test.js
+++ b/web/client/epics/__tests__/geoProcessing-test.js
@@ -24,12 +24,10 @@ import {
     toggleHighlightLayersGPTEpic,
     disableIdentifyGPTEpic,
     clickToSelectFeatureGPTEpic,
-    LPlongitudinalMapLayoutGPTEpic,
-    createFC,
-    getCounter
+    LPlongitudinalMapLayoutGPTEpic
 } from '../geoProcessing';
+
 import {
-    GPT_BUFFER_GROUP_ID,
     GPT_TOOL_INTERSECTION,
     GPT_TOOL_BUFFER,
     GPT_CONTROL_NAME,
@@ -101,38 +99,7 @@ describe('geoProcessing epics', () => {
     afterEach(() => {
         mockAxios.restore();
     });
-    it('test createFC', () => {
-        const features = [{
-            type: "Feature",
-            id: "ft-id",
-            geometry: {
-                type: "Point",
-                coordinates: [1, 2]
-            }
-        }];
-        const ftColl = createFC(features);
-        expect(ftColl).toEqual({ type: 'FeatureCollection', features: [ { type: 'Feature', id: 'ft-id', geometry: { type: 'Point', coordinates: [ 1, 2 ] } } ] });
-    });
-    it('test getCounter', () => {
-        const layers = [{
-            group: GPT_BUFFER_GROUP_ID,
-            name: "Buffer Layer 0"
-        }];
-        const counter = getCounter(layers, GPT_BUFFER_GROUP_ID);
-        expect(counter).toEqual(1);
-        const counter2 = getCounter([
-            ...layers,
-            {
-                group: GPT_BUFFER_GROUP_ID,
-                name: "Buffer Layer 3"
-            },
-            {
-                group: GPT_BUFFER_GROUP_ID,
-                name: "Buffer Layer 4"
-            }
-        ], GPT_BUFFER_GROUP_ID);
-        expect(counter2).toEqual(5);
-    });
+
     it('checkWPSAvailabilityGPTEpic for a vector layer', (done) => {
         const layerId = "id";
         const source = "source";

--- a/web/client/epics/__tests__/geoProcessing-test.js
+++ b/web/client/epics/__tests__/geoProcessing-test.js
@@ -24,9 +24,12 @@ import {
     toggleHighlightLayersGPTEpic,
     disableIdentifyGPTEpic,
     clickToSelectFeatureGPTEpic,
-    LPlongitudinalMapLayoutGPTEpic
+    LPlongitudinalMapLayoutGPTEpic,
+    createFC,
+    getCounter
 } from '../geoProcessing';
 import {
+    GPT_BUFFER_GROUP_ID,
     GPT_TOOL_INTERSECTION,
     GPT_TOOL_BUFFER,
     GPT_CONTROL_NAME,
@@ -36,8 +39,7 @@ import {
     checkingIntersectionWPSAvailability,
     errorLoadingDFT,
     getFeatures,
-    increaseBufferedCounter,
-    increaseIntersectedCounter,
+    setFeatures,
     setFeatureSourceLoading,
     setFeatureIntersectionLoading,
     setSourceFeatureId,
@@ -98,6 +100,78 @@ describe('geoProcessing epics', () => {
     });
     afterEach(() => {
         mockAxios.restore();
+    });
+    it('test createFC', () => {
+        const features = [{
+            type: "Feature",
+            id: "ft-id",
+            geometry: {
+                type: "Point",
+                coordinates: [1, 2]
+            }
+        }];
+        const ftColl = createFC(features);
+        expect(ftColl).toEqual({ type: 'FeatureCollection', features: [ { type: 'Feature', id: 'ft-id', geometry: { type: 'Point', coordinates: [ 1, 2 ] } } ] });
+    });
+    it('test getCounter', () => {
+        const layers = [{
+            group: GPT_BUFFER_GROUP_ID,
+            name: "Buffer Layer 0"
+        }];
+        const counter = getCounter(layers, GPT_BUFFER_GROUP_ID);
+        expect(counter).toEqual(1);
+        const counter2 = getCounter([
+            ...layers,
+            {
+                group: GPT_BUFFER_GROUP_ID,
+                name: "Buffer Layer 3"
+            },
+            {
+                group: GPT_BUFFER_GROUP_ID,
+                name: "Buffer Layer 4"
+            }
+        ], GPT_BUFFER_GROUP_ID);
+        expect(counter2).toEqual(5);
+    });
+    it('checkWPSAvailabilityGPTEpic for a vector layer', (done) => {
+        const layerId = "id";
+        const source = "source";
+        const NUM_ACTIONS = 2;
+        const startActions = [checkWPSAvailability(layerId, source)];
+        const layer = {
+            id: "id",
+            url: "mockUrl",
+            describeFeatureType: {
+            },
+            type: "vector",
+            features: [{
+                type: "Feature",
+                id: "ft-id",
+                geometry: {
+                    type: "Point",
+                    coordinates: [1, 2]
+                }
+            }]
+        };
+        try {
+            testEpic(addTimeoutEpic(checkWPSAvailabilityGPTEpic), NUM_ACTIONS, startActions, actions => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                const [
+                    action1, // setwps
+                    action2 // setFeatures
+                ] = actions;
+                expect(action1).toEqual(setWPSAvailability(layerId, true, source));
+                expect(action2).toEqual(setFeatures(layerId, source, layer, 0, layer?.features?.[0]?.geometry?.type || ""));
+                done();
+            }, {
+                layers: {
+                    flat: [layer]
+                }
+            }, done);
+
+        } catch (error) {
+            done(error);
+        }
     });
     it('checkWPSAvailabilityGPTEpic describe layer available', (done) => {
         mockAxios.onGet("mockUrl?service=WPS&version=1.0.0&REQUEST=DescribeProcess&IDENTIFIER=geo%3Abuffer%2Cgs%3AIntersectionFeatureCollection%2Cgs%3ACollectGeometries").reply(200, DESCRIBE_PROCESS);
@@ -218,6 +292,39 @@ describe('geoProcessing epics', () => {
         });
     });
 
+    it('getFeaturesGPTEpic source as vector layer', (done) => {
+        const layerId = "id";
+        const source = "source";
+        const NUM_ACTIONS = 1;
+        mockAxios.onPost("mockUrl?service=WFS&outputFormat=json").reply(200, GET_FEATURES);
+
+        const startActions = [getFeatures(layerId, source)];
+        testEpic(getFeaturesGPTEpic, NUM_ACTIONS, startActions, actions => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            const [
+                action1
+            ] = actions;
+            expect(action1.type).toEqual(SET_FEATURES);
+            done();
+        }, {
+            layers: {
+                flat: [{
+                    id: "id",
+                    url: "mockUrl",
+                    describeFeatureType: DESCRIBE_POIS,
+                    type: "vector",
+                    features: [{
+                        type: "Feature",
+                        id: "ft-id",
+                        geometry: {
+                            type: "Point",
+                            coordinates: [1, 2]
+                        }
+                    }]
+                }]
+            }
+        });
+    });
     it('getFeaturesGPTEpic source', (done) => {
         const layerId = "id";
         const source = "source";
@@ -297,6 +404,69 @@ describe('geoProcessing epics', () => {
             }
         });
     });
+    it('setSourceFeatureId as vector', (done) => {
+        const featureId = "ft-id2";
+        const NUM_ACTIONS = 3;
+        mockAxios.onGet("mockUrl?service=WFS&version=1.1.0&request=GetFeature").reply(200, GET_FEATURES);
+        const secondFt = {
+            type: "Feature",
+            id: "ft-id2",
+            geometry: {
+                type: "Point",
+                coordinates: [11, 22]
+            }
+        };
+        const startActions = [setSourceFeatureId(featureId)];
+        testEpic(getFeatureDataGPTEpic, NUM_ACTIONS, startActions, actions => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            const [
+                action1,
+                action2,
+                action3
+            ] = actions;
+            expect(action1.type).toEqual(setSourceFeature().type);
+            expect(action1.feature).toEqual(secondFt);
+            expect(action2.type).toEqual(updateAdditionalLayer().type);
+            expect(action2.options.features).toEqual([{
+                ...secondFt,
+                style: {
+                    color: "#3388ff",
+                    dashArray: "",
+                    fillColor: "#3388ff",
+                    fillOpacity: 0.2,
+                    radius: 4,
+                    weight: 4
+                }}]);
+            expect(action3.type).toEqual(zoomToExtent().type);
+            done();
+        }, {
+            layers: {
+                flat: [{
+                    id: "id",
+                    url: "mockUrl",
+                    name: "name",
+                    type: "vector",
+                    features: [{
+                        type: "Feature",
+                        id: "ft-id",
+                        geometry: {
+                            type: "Point",
+                            coordinates: [1, 2]
+                        }
+                    },
+                    secondFt]
+                }]
+            },
+            geoProcessing: {
+                source: {
+                    layerId: "id"
+                },
+                flags: {
+                    showHighlightLayers: true
+                }
+            }
+        });
+    });
     it('setSourceFeatureId', (done) => {
         const featureId = "ft-id";
         const NUM_ACTIONS = 3;
@@ -361,6 +531,71 @@ describe('geoProcessing epics', () => {
             },
             geoProcessing: {
                 source: {
+                    layerId: "id"
+                },
+                flags: {
+                    showHighlightLayers: true
+                }
+            }
+        });
+    });
+    it('setIntersectionFeatureId', (done) => {
+        const featureId = "ft-id2";
+        const secondFt = {
+            type: "Feature",
+            id: "ft-id2",
+            geometry: {
+                type: "Point",
+                coordinates: [11, 22]
+            }
+        };
+        const NUM_ACTIONS = 3;
+        mockAxios.onGet("mockUrl?service=WFS&version=1.1.0&request=GetFeature").reply(200, GET_FEATURES);
+
+        const startActions = [setIntersectionFeatureId(featureId)];
+        testEpic(getIntersectionFeatureDataGPTEpic, NUM_ACTIONS, startActions, actions => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            const [
+                action1,
+                action2,
+                action3
+            ] = actions;
+            expect(action1.type).toEqual(setIntersectionFeature().type);
+            expect(action1.feature).toEqual(secondFt);
+            expect(action2.type).toEqual(updateAdditionalLayer().type);
+            expect(action2.options.features).toEqual([{
+                ...secondFt,
+                style: {
+                    color: "#3388ff",
+                    dashArray: "",
+                    fillColor: "#3388ff",
+                    fillOpacity: 0.2,
+                    radius: 4,
+                    weight: 4
+                }}]);
+            expect(action3.type).toEqual(zoomToExtent().type);
+
+            done();
+        }, {
+            layers: {
+                flat: [{
+                    id: "id",
+                    url: "mockUrl",
+                    name: "name",
+                    type: "vector",
+                    features: [{
+                        type: "Feature",
+                        id: "ft-id",
+                        geometry: {
+                            type: "Point",
+                            coordinates: [1, 2]
+                        }
+                    },
+                    secondFt]
+                }]
+            },
+            geoProcessing: {
+                intersection: {
                     layerId: "id"
                 },
                 flags: {
@@ -442,7 +677,7 @@ describe('geoProcessing epics', () => {
         });
     });
     it('runBufferProcess with geom collect', (done) => {
-        const NUM_ACTIONS = 7;
+        const NUM_ACTIONS = 6;
         mockAxios.onGet("mockUrl?service=WFS&version=1.1.0&request=GetFeature").reply(200, GET_FEATURES);
         mockAxios.onPost("mockUrl?service=WPS&version=1.0.0&REQUEST=Execute").reply(200, COLLECT_GEOM, {
             "content-type": "application/json"
@@ -457,16 +692,14 @@ describe('geoProcessing epics', () => {
                 action3,
                 action4,
                 action5,
-                action6,
-                action7
+                action6
             ] = actions;
             expect(action1).toEqual(runningProcess(true));
             expect(action2.type).toEqual(addGroup().type);
-            expect(action3.type).toEqual(increaseBufferedCounter().type);
-            expect(action4.type).toEqual(addLayer().type);
-            expect(action5.type).toEqual(zoomToExtent().type);
-            expect(action6.type).toEqual(showSuccessNotification().type);
-            expect(action7).toEqual(runningProcess(false));
+            expect(action3.type).toEqual(addLayer().type);
+            expect(action4.type).toEqual(zoomToExtent().type);
+            expect(action5.type).toEqual(showSuccessNotification().type);
+            expect(action6).toEqual(runningProcess(false));
             done();
         }, {
             layers: {
@@ -490,7 +723,7 @@ describe('geoProcessing epics', () => {
         });
     });
     it('runBufferProcess without geom collect', (done) => {
-        const NUM_ACTIONS = 7;
+        const NUM_ACTIONS = 6;
         mockAxios.onGet("mockUrl?service=WFS&version=1.1.0&request=GetFeature").reply(200, GET_FEATURES);
         mockAxios.onPost("mockUrl?service=WPS&version=1.0.0&REQUEST=Execute").reply(200, COLLECT_GEOM, {
             "content-type": "application/json"
@@ -504,17 +737,14 @@ describe('geoProcessing epics', () => {
                 action3,
                 action4,
                 action5,
-                action6,
-                action7
+                action6
             ] = actions;
             expect(action1).toEqual(runningProcess(true));
             expect(action2.type).toEqual(addGroup().type);
-            expect(action3.type).toEqual(increaseBufferedCounter().type);
-            expect(action4.type).toEqual(addLayer().type);
-            expect(action5.type).toEqual(zoomToExtent().type);
-            expect(action6.type).toEqual(showSuccessNotification().type);
-
-            expect(action7).toEqual(runningProcess(false));
+            expect(action3.type).toEqual(addLayer().type);
+            expect(action4.type).toEqual(zoomToExtent().type);
+            expect(action5.type).toEqual(showSuccessNotification().type);
+            expect(action6).toEqual(runningProcess(false));
             done();
         }, {
             layers: {
@@ -547,6 +777,54 @@ describe('geoProcessing epics', () => {
                             coordinates: [1, 2]
                         }
                     }
+                },
+                flags: {
+                    showHighlightLayers: true
+                }
+            }
+        });
+    });
+    it('runBufferProcess with geom collect as vector layer', (done) => {
+        const NUM_ACTIONS = 6;
+        mockAxios.onGet("mockUrl?service=WFS&version=1.1.0&request=GetFeature").reply(200, GET_FEATURES);
+        mockAxios.onPost("mockUrl?service=WPS&version=1.0.0&REQUEST=Execute").reply(200, COLLECT_GEOM, {
+            "content-type": "application/json"
+        });
+
+        const startActions = [runProcess(GPT_TOOL_BUFFER)];
+        testEpic(addTimeoutEpic(runBufferProcessGPTEpic, 100), NUM_ACTIONS, startActions, actions => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            const [
+                action1,
+                action2,
+                action3,
+                action4,
+                action5,
+                action6
+            ] = actions;
+            expect(action1).toEqual(runningProcess(true));
+            expect(action2.type).toEqual(addGroup().type);
+            expect(action3.type).toEqual(addLayer().type);
+            expect(action4.type).toEqual(zoomToExtent().type);
+            expect(action5.type).toEqual(showSuccessNotification().type);
+            expect(action6).toEqual(runningProcess(false));
+            done();
+        }, {
+            layers: {
+                flat: [{
+                    id: "id",
+                    type: "vector",
+                    features: [{type: "Feature", geometry: {type: "Point", coordinates: [1, 2]}}],
+                    url: "mockUrl",
+                    name: "name",
+                    search: {
+                        url: "mockUrl"
+                    }
+                }]
+            },
+            geoProcessing: {
+                source: {
+                    layerId: "id"
                 },
                 flags: {
                     showHighlightLayers: true
@@ -604,7 +882,7 @@ describe('geoProcessing epics', () => {
     });
     it.skip('runIntersectProcessGPTEpic with double geom collect', (done) => {
         try {
-            const NUM_ACTIONS = 7;
+            const NUM_ACTIONS = 6;
             mockAxios.onGet("mockUrl?service=WFS&version=1.1.0&request=GetFeature").reply(200, GET_FEATURES);
             mockAxios
                 .onPost("mockUrl?service=WPS&version=1.0.0&REQUEST=Execute")
@@ -629,16 +907,14 @@ describe('geoProcessing epics', () => {
                     action3,
                     action4,
                     action5,
-                    action6,
-                    action7
+                    action6
                 ] = actions;
                 expect(action1).toEqual(runningProcess(true));
                 expect(action2.type).toEqual(addGroup().type);
-                expect(action3.type).toEqual(increaseIntersectedCounter().type);
-                expect(action4.type).toEqual(addLayer().type);
-                expect(action5.type).toEqual(zoomToExtent().type);
-                expect(action6.type).toEqual(showSuccessNotification().type);
-                expect(action7).toEqual(runningProcess(false));
+                expect(action3.type).toEqual(addLayer().type);
+                expect(action4.type).toEqual(zoomToExtent().type);
+                expect(action5.type).toEqual(showSuccessNotification().type);
+                expect(action6).toEqual(runningProcess(false));
                 done();
             }, {
                 layers: {

--- a/web/client/epics/geoProcessing.js
+++ b/web/client/epics/geoProcessing.js
@@ -476,7 +476,19 @@ export const runBufferProcessGPTEpic = (action$, store) => action$
             distance = distance * 1000;
         }
         const counter = getCounter(layers, GPT_BUFFER_GROUP_ID);
-
+        let misconfiguredLayers = [];
+        if (!layerUrl) {
+            misconfiguredLayers.push(layer.name + " - " + layer.title);
+        }
+        if (misconfiguredLayers.length) {
+            return Rx.Observable.of(showErrorNotification({
+                title: "errorTitleDefault",
+                message: "GeoProcessing.notifications.errorMissingUrl",
+                autoDismiss: 6,
+                position: "tc",
+                values: {layerName: misconfiguredLayers.join(", ")}
+            }));
+        }
         const executeBufferProcess$ = (wktGeom, feature4326) => {
             const centroid = centroidTurf(feature4326);
             const reprojectedCentroid = reprojectGeoJson(centroid, "EPSG:4326", "EPSG:3857");
@@ -567,19 +579,6 @@ export const runBufferProcessGPTEpic = (action$, store) => action$
                     })
                     .catch((e) => {
                         logError(e);
-                        let misconfiguredLayers = [];
-                        if (!layerUrl) {
-                            misconfiguredLayers.push(layer.name + " - " + layer.title);
-                        }
-                        if (misconfiguredLayers.length) {
-                            return Rx.Observable.of(showErrorNotification({
-                                title: "errorTitleDefault",
-                                message: "GeoProcessing.notifications.errorMissingUrl",
-                                autoDismiss: 6,
-                                position: "tc",
-                                values: {layerName: misconfiguredLayers.join(", ")}
-                            }));
-                        }
                         return Rx.Observable.of(showErrorNotification({
                             title: "errorTitleDefault",
                             message: "GeoProcessing.notifications.errorBuffer",

--- a/web/client/epics/geoProcessing.js
+++ b/web/client/epics/geoProcessing.js
@@ -12,8 +12,7 @@ import get from 'lodash/get';
 import head from 'lodash/head';
 import isEmpty from 'lodash/isEmpty';
 import isNil from 'lodash/isNil';
-import last from 'lodash/last';
-import sortBy from 'lodash/sortBy';
+
 import Rx from 'rxjs';
 import uuidV1 from 'uuid/v1';
 import {parseString} from 'xml2js';
@@ -129,6 +128,11 @@ import {
     reprojectGeoJson,
     calculateDistance
 } from "../utils/CoordinatesUtils";
+import {
+    getGeom,
+    createFC,
+    getCounter
+} from "../utils/GeoProcessingUtils";
 import {buildIdentifyRequest} from "../utils/MapInfoUtils";
 import {logError} from "../utils/DebugUtils";
 import {getFeatureInfo} from "../api/identify";
@@ -141,41 +145,6 @@ const DEACTIVATE_ACTIONS = [
     changeDrawingStatus("stop"),
     changeDrawingStatus("clean", '', GPT_CONTROL_NAME)
 ];
-
-const getGeom = (geomType) => {
-    switch (geomType) {
-    case "Point": case "MultiPoint": return "point";
-    case "LineString": case "MultiLineString": return "line";
-    case "Polygon": case "MultiPolygon": return "polygon";
-    default:
-        return geomType;
-    }
-};
-
-/**
- * generator utility for creating a FeatureCollection GeoJSON from an array of features typically from a mapstore vector layer
- * @param {object[]} features the list of single GeoJSON Feature
- * @return {object} the GeoJSON representation of a FeatureCollection
- */
-export const createFC = (features) => {
-    return {
-        type: "FeatureCollection",
-        features
-    };
-};
-
-/**
- * function used to get latest id of a list of buffered or intersected layers in order to always have the
- * counter increased by 1 based on the maximum number found
- * @param {object[]} layers list of layers to check
- * @param {string} groupName the related group to compare
- * @return {number} the counter value
- */
-export const getCounter = (layers, groupName) => {
-    const allLayers = sortBy(layers?.filter(({group}) => group === groupName), ["name"]);
-    const counter = allLayers.length ? Number(last(allLayers).name.match(/\d/)[0]) + 1 : 0;
-    return counter;
-};
 
 const styleRules = [
     {

--- a/web/client/epics/geoProcessing.js
+++ b/web/client/epics/geoProcessing.js
@@ -567,6 +567,19 @@ export const runBufferProcessGPTEpic = (action$, store) => action$
                     })
                     .catch((e) => {
                         logError(e);
+                        let misconfiguredLayers = [];
+                        if (!layerUrl) {
+                            misconfiguredLayers.push(layer.name + " - " + layer.title);
+                        }
+                        if (misconfiguredLayers.length) {
+                            return Rx.Observable.of(showErrorNotification({
+                                title: "errorTitleDefault",
+                                message: "GeoProcessing.notifications.errorMissingUrl",
+                                autoDismiss: 6,
+                                position: "tc",
+                                values: {layerName: misconfiguredLayers.join(", ")}
+                            }));
+                        }
                         return Rx.Observable.of(showErrorNotification({
                             title: "errorTitleDefault",
                             message: "GeoProcessing.notifications.errorBuffer",
@@ -730,7 +743,7 @@ export const runIntersectProcessGPTEpic = (action$, store) => action$
                 }
 
                 const executeProcess$ = executeProcess(
-                    layerUrl,
+                    layerUrl || intersectionLayerUrl,
                     intersectXML({
                         firstFC: {
                             type: "FeatureCollection",

--- a/web/client/observables/wps/collectGeometries.js
+++ b/web/client/observables/wps/collectGeometries.js
@@ -8,6 +8,9 @@
 import {
     processReference,
     processParameter,
+    processData,
+    complexData,
+    cdata,
     rawDataOutput,
     responseForm
 } from './common';
@@ -25,22 +28,30 @@ const {
  * the gs:CollectGeometries
  * @param {object} options the options to use
  * @param {string} options.name the layer typeName
+ * @param {object} options.featureCollection the GeoJSON fc, if present it will use it otherwise it will do an internal generic getFeature
  */
 export const collectGeometriesXML = ({
-    name
-}) => executeProcessXML(
-    'gs:CollectGeometries',
-    [
-        processParameter('features', processReference(
-            "test/xml",
-            "http://geoserver/wfs",
-            'POST',
-            getFeature(query(name))
-        ))
-    ],
-    responseForm(
-        rawDataOutput('result', "application/json")
-    )
-);
+    name,
+    featureCollection
+}) => {
+    let features = processReference(
+        "test/xml",
+        "http://geoserver/wfs",
+        'POST',
+        getFeature(query(name))
+    );
+    if (featureCollection) {
+        features = processData(complexData(cdata(JSON.stringify(featureCollection)), "application/json"));
+    }
+    return executeProcessXML(
+        'gs:CollectGeometries',
+        [
+            processParameter('features', features)
+        ],
+        responseForm(
+            rawDataOutput('result', "application/json")
+        )
+    );
+};
 
 export default collectGeometriesXML;

--- a/web/client/plugins/GeoProcessing.jsx
+++ b/web/client/plugins/GeoProcessing.jsx
@@ -29,6 +29,7 @@ import { createPlugin } from '../utils/PluginsUtils';
  * @class
 *
  * @prop {string} cfg.selectedTool the values are "buffer", "intersection", default is "buffer"
+ * @prop {string} cfg.wpsUrl the default value to use where to execute geoserver processes. It must support some mandatory wps processes like geo:buffer,gs:IntersectionFeatureCollection,gs:CollectGeometries
  * @prop {number} cfg.buffer.quadrantSegments Number determining the style and smoothness of buffer corners. Positive numbers create round corners with that number of segments per quarter-circle, 0 creates flat corners, default is unset.
  * @prop {string} cfg.buffer.capStyle Style for the buffer end caps. Values are: Round - rounded ends (default), Flat - flat ends; Square - square ends, default is unset
  * @prop {string} cfg.intersection.firstAttributeToRetain First feature collection attribute to include
@@ -42,6 +43,7 @@ import { createPlugin } from '../utils/PluginsUtils';
  * {
  *   "name": "GeoProcessing",
  *   "cfg": {
+ *     "wpsUrl": "http://localhost:8080/geoserver/wps",
  *     "selectedTool": "buffer",
  *     "buffer": {
  *       "quadrantSegments": 200,

--- a/web/client/plugins/GeoProcessing/IntersectionLayer.jsx
+++ b/web/client/plugins/GeoProcessing/IntersectionLayer.jsx
@@ -69,10 +69,14 @@ const Intersection = ({
     }, [intersectionLayerId]);
 
     const handleOnChangeIntersectionLayer = (sel) => {
-        onSetIntersectionLayerId(sel?.value ?? "");
+        if (sel?.value !== intersectionLayerId) {
+            onSetIntersectionLayerId(sel?.value ?? "");
+        }
     };
     const handleOnChangeIntersectionFeatureId = (sel) => {
-        onSetIntersectionFeatureId(sel?.value ?? "");
+        if (sel?.value !== intersectionFeatureId) {
+            onSetIntersectionFeatureId(sel?.value ?? "");
+        }
     };
     const isDisableClickSelectFeature = !intersectionLayerId || isIntersectionFeaturesLoading || checkingWPSAvailabilityIntersection;
     const handleOnClickToSelectIntersectionFeature = () => {

--- a/web/client/plugins/GeoProcessing/IntersectionLayer.jsx
+++ b/web/client/plugins/GeoProcessing/IntersectionLayer.jsx
@@ -69,10 +69,10 @@ const Intersection = ({
     }, [intersectionLayerId]);
 
     const handleOnChangeIntersectionLayer = (sel) => {
-        onSetIntersectionLayerId(sel?.value || "");
+        onSetIntersectionLayerId(sel?.value ?? "");
     };
     const handleOnChangeIntersectionFeatureId = (sel) => {
-        onSetIntersectionFeatureId(sel?.value || "");
+        onSetIntersectionFeatureId(sel?.value ?? "");
     };
     const isDisableClickSelectFeature = !intersectionLayerId || isIntersectionFeaturesLoading || checkingWPSAvailabilityIntersection;
     const handleOnClickToSelectIntersectionFeature = () => {
@@ -119,7 +119,7 @@ const Intersection = ({
                         value={intersectionFeatureId}
                         noResultsText={<Message msgId="GeoProcessing.noMatchedFeature" />}
                         onChange={handleOnChangeIntersectionFeatureId}
-                        options={intersectionFeatures.map(f => ({value: f.id, label: f.id }))}
+                        options={intersectionFeatures.map((f, i) => ({value: f.id ?? `id: ${f.id} Feature #${i}`, label: `id: ${f.id} Feature #${i}` }))}
                         onOpen={() => {
                             if (selectedLayerType !== "intersection" && intersectionFeatures.length === 0 ) {
                                 onGetFeatures(intersectionLayerId, "intersection", 0);

--- a/web/client/plugins/GeoProcessing/SourceLayer.jsx
+++ b/web/client/plugins/GeoProcessing/SourceLayer.jsx
@@ -70,10 +70,10 @@ const Source = ({
     }, [sourceLayerId]);
 
     const handleOnChangeSource = (sel) => {
-        onSetSourceLayerId(sel?.value || "");
+        onSetSourceLayerId(sel?.value ?? "");
     };
     const handleOnChangeSourceFeatureId = (sel) => {
-        onSetSourceFeatureId(sel?.value || "");
+        onSetSourceFeatureId(sel?.value ?? "");
     };
     const isDisableClickSelectFeature = !sourceLayerId || isSourceFeaturesLoading || checkingWPSAvailability;
     const handleOnClickToSelectSourceFeature = () => {
@@ -117,7 +117,7 @@ const Source = ({
                     clearable
                     noResultsText={<Message msgId="GeoProcessing.noMatchedFeature" />}
                     onChange={handleOnChangeSourceFeatureId}
-                    options={sourceFeatures.map(f => ({value: f.id, label: f.id }))}
+                    options={sourceFeatures.map((f, i) => ({value: f.id ?? `id: ${f.id} Feature #${i}`, label: `id: ${f.id} Feature #${i}` }))}
                     value={sourceFeatureId}
 
                     onOpen={() => {

--- a/web/client/plugins/GeoProcessing/SourceLayer.jsx
+++ b/web/client/plugins/GeoProcessing/SourceLayer.jsx
@@ -70,10 +70,14 @@ const Source = ({
     }, [sourceLayerId]);
 
     const handleOnChangeSource = (sel) => {
-        onSetSourceLayerId(sel?.value ?? "");
+        if (sel?.value !== sourceLayerId) {
+            onSetSourceLayerId(sel?.value ?? "");
+        }
     };
     const handleOnChangeSourceFeatureId = (sel) => {
-        onSetSourceFeatureId(sel?.value ?? "");
+        if (sel?.value !== sourceFeatureId) {
+            onSetSourceFeatureId(sel?.value ?? "");
+        }
     };
     const isDisableClickSelectFeature = !sourceLayerId || isSourceFeaturesLoading || checkingWPSAvailability;
     const handleOnClickToSelectSourceFeature = () => {

--- a/web/client/reducers/geoProcessing.js
+++ b/web/client/reducers/geoProcessing.js
@@ -14,8 +14,6 @@ import {
     CHECKING_WPS_AVAILABILITY_INTERSECTION,
     ERROR_LOADING_DFT,
     INIT_PLUGIN,
-    INCREASE_BUFFERED_COUNTER,
-    INCREASE_INTERSECT_COUNTER,
     RESET,
     RUNNING_PROCESS,
     SET_BUFFER_DISTANCE,
@@ -57,13 +55,10 @@ import { LOCATION_CHANGE } from 'connected-react-router';
 
 const initialState = {
     source: {},
-    buffer: {
-        counter: 0
-    },
+    buffer: {},
     selectedLayerId: "",
     selectedLayerType: "",
     intersection: {
-        counter: 0,
         intersectionMode: "INTERSECTION"
     },
     flags: {
@@ -116,24 +111,6 @@ function geoProcessing( state = {
             intersection: {
                 ...state.intersection,
                 ...(action.cfg.intersection || {})
-            }
-        };
-    }
-    case INCREASE_BUFFERED_COUNTER: {
-        return {
-            ...state,
-            buffer: {
-                ...state.buffer,
-                counter: state.buffer.counter + 1
-            }
-        };
-    }
-    case INCREASE_INTERSECT_COUNTER: {
-        return {
-            ...state,
-            intersection: {
-                ...state.intersection,
-                counter: state.intersection.counter + 1
             }
         };
     }

--- a/web/client/selectors/__tests__/geoProcessing-test.js
+++ b/web/client/selectors/__tests__/geoProcessing-test.js
@@ -13,7 +13,6 @@ import {
     distanceUomSelector,
     quadrantSegmentsSelector,
     capStyleSelector,
-    bufferedLayersCounterSelector,
     sourceLayerIdSelector,
     sourceFeatureIdSelector,
     sourceFeatureSelector,
@@ -27,7 +26,6 @@ import {
     intersectionFeaturesSelector,
     intersectionTotalCountSelector,
     intersectionCurrentPageSelector,
-    intersectedLayersCounterSelector,
     firstAttributeToRetainSelector,
     secondAttributeToRetainSelector,
     intersectionModeSelector,
@@ -48,7 +46,8 @@ import {
     selectedLayerIdSelector,
     selectedLayerTypeSelector,
     wfsBackedLayersSelector,
-    maxFeaturesSelector
+    maxFeaturesSelector,
+    wpsUrlSelector
 } from '../geoProcessing';
 import {
     GPT_CONTROL_NAME
@@ -88,15 +87,6 @@ describe('Test Geo Processing Tools selectors', () => {
             }
         };
         expect(capStyleSelector({geoProcessing})).toEqual("Round");
-    });
-    it('bufferedLayersCounterSelector', () => {
-        const geoProcessing = {
-            buffer: {
-                counter: 1
-            }
-        };
-        expect(bufferedLayersCounterSelector({geoProcessing})).toEqual(1);
-        expect(bufferedLayersCounterSelector({})).toEqual(0);
     });
     it('sourceLayerIdSelector', () => {
         const geoProcessing = {
@@ -221,14 +211,6 @@ describe('Test Geo Processing Tools selectors', () => {
             }
         };
         expect(intersectionCurrentPageSelector({geoProcessing})).toEqual(5);
-    });
-    it('intersectedLayersCounterSelector', () => {
-        const geoProcessing = {
-            intersection: {
-                counter: 2
-            }
-        };
-        expect(intersectedLayersCounterSelector({geoProcessing})).toEqual(2);
     });
     it('firstAttributeToRetainSelector', () => {
         const geoProcessing = {
@@ -398,6 +380,12 @@ describe('Test Geo Processing Tools selectors', () => {
         };
         expect(maxFeaturesSelector({geoProcessing})).toEqual(10);
     });
+    it('wpsUrlSelector', () => {
+        const geoProcessing = {
+            wpsUrl: "url"
+        };
+        expect(wpsUrlSelector({geoProcessing})).toEqual("url");
+    });
     it('test wfsBackedLayersSelector', () => {
         let layers = wfsBackedLayersSelector({});
         expect(layers.length).toBeFalsy();
@@ -410,6 +398,10 @@ describe('Test Geo Processing Tools selectors', () => {
                     search: {
                         type: "wfs"
                     }
+                }, {
+                    name: "ws:layer_11",
+                    group: "buffer",
+                    type: "vector"
                 },
                 {
                     name: "ws:layer_3",
@@ -431,6 +423,11 @@ describe('Test Geo Processing Tools selectors', () => {
             search: {
                 type: "wfs"
             }
+        },
+        {
+            name: "ws:layer_11",
+            group: "buffer",
+            type: "vector"
         },
         {
             name: "ws:layer_3",

--- a/web/client/selectors/geoProcessing.js
+++ b/web/client/selectors/geoProcessing.js
@@ -17,7 +17,7 @@ export const distanceSelector = state => state?.geoProcessing?.buffer?.distance 
 export const distanceUomSelector = state => state?.geoProcessing?.buffer?.distanceUom || "m";
 export const quadrantSegmentsSelector = state => state?.geoProcessing?.buffer?.quadrantSegments;
 export const capStyleSelector = state => state?.geoProcessing?.buffer?.capStyle;
-export const bufferedLayersCounterSelector = state => state?.geoProcessing?.buffer?.counter ?? 0;
+
 // source
 export const sourceLayerIdSelector = state => state?.geoProcessing?.source?.layerId;
 export const sourceFeatureIdSelector = state => state?.geoProcessing?.source?.featureId;
@@ -36,7 +36,6 @@ export const intersectionFeatureSelector = state => state?.geoProcessing?.inters
 export const intersectionFeaturesSelector = state => state?.geoProcessing?.intersection?.features || [];
 export const intersectionTotalCountSelector = state => state?.geoProcessing?.intersection?.totalCount || 0;
 export const intersectionCurrentPageSelector = state => state?.geoProcessing?.intersection?.currentPage || 0;
-export const intersectedLayersCounterSelector = state => state?.geoProcessing?.intersection?.counter ?? 0;
 export const firstAttributeToRetainSelector = state => state?.geoProcessing?.intersection?.firstAttributeToRetain;
 export const secondAttributeToRetainSelector = state => state?.geoProcessing?.intersection?.secondAttributeToRetain;
 export const intersectionModeSelector = state => state?.geoProcessing?.intersection?.intersectionMode;
@@ -69,6 +68,10 @@ export const isListeningClickSelector = (state) => !!(get(mapSelector(state), 'e
 export const selectedLayerIdSelector = (state) => state?.geoProcessing?.selectedLayerId;
 export const selectedLayerTypeSelector = (state) => state?.geoProcessing?.selectedLayerType;
 export const maxFeaturesSelector = (state) => state?.geoProcessing?.maxFeatures || 10;
-export const wfsBackedLayersSelector = (state) => layersSelector(state)
-    .filter(l => l.group !== "background")
-    .filter(hasWFSService);
+export const wpsUrlSelector = (state) => state?.geoProcessing?.wpsUrl;
+export const wfsBackedLayersSelector = (state) => {
+    const layers = layersSelector(state);
+    return layers
+        .filter(l => l.group !== "background")
+        .filter(layer => hasWFSService(layer) || layer.type === "vector");
+};

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -4021,6 +4021,7 @@
           "true": "wahr",
           "false": "falsch",
           "notifications": {
+            "errorMissingUrl": "Um Geometrien für diese Layer {layerName} zu erfassen, muss eine Geoserver-WPS-URL angegeben werden. Sie können die wpsUrl-Eigenschaft im GeoProcessing-Plugin konfigurieren",
             "errorIntersectGFI": "Beim Überschneiden der Features ist ein Fehler aufgetreten. Der Schnittpunkt-Layer konnte nicht erstellt werden.",
             "errorGFI": "Beim Laden der Funktion ist ein Fehler aufgetreten",
             "errorGetFeature": "Beim Laden des Features zum Abrufen seiner Geometrie ist ein Fehler aufgetreten",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -3995,6 +3995,7 @@
           "true": "true",
           "false": "false",
           "notifications": {
+            "errorMissingUrl": "A geoserver wps url must be provided to collect geometries for these layers {layerName}. You can configure wpsUrl property in GeoProcessing plugin",
             "errorIntersectGFI": "There was an error intersecting the features. It was not possible to create the intersection layer.",
             "errorGFI": "There was an error loading the feature",
             "errorGetFeature": "There was an error loading the feature in order to obtain its geometry",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -3984,6 +3984,7 @@
           "true": "Verdadera",
           "false": "falsa",
           "notifications": {
+            "errorMissingUrl": "Se debe proporcionar una URL de geoserver wps para recopilar geometrías para estas capas {layerName}. Puede configurar la propiedad wpsUrl en el complemento GeoProcessing",
             "errorIntersectGFI": "Hubo un error al cruzar las entidades. No fue posible crear la capa de intersección.",
             "errorGFI": "Hubo un error al cargar la característica",
             "errorGetFeature": "Hubo un error al cargar la función para obtener su geometría",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -3984,6 +3984,7 @@
           "true": "vrai",
           "false": "faux",
           "notifications": {
+            "errorMissingUrl": "Une URL wps de géoserveur doit être fournie pour collecter les géométries de ces couches {layerName}. Vous pouvez configurer la propriété wpsUrl dans le plugin GeoProcessing",
             "errorIntersectGFI": "Une erreur s'est produite lors de l'intersection des entités. Il n'a pas été possible de créer la couche d'intersection.",
             "errorGFI": "Une erreur s'est produite lors du chargement de la fonctionnalité",
             "errorGetFeature": "Une erreur s'est produite lors du chargement de l'entité afin d'obtenir sa géométrie",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -3984,6 +3984,7 @@
           "true": "vero",
           "false": "falso",
           "notifications": {
+            "errorMissingUrl": "È necessario fornire un URL wps del geoserver per esegurie il processo per i livelli {layerName}. È possibile configurare la proprietà wpsUrl nel plugin GeoProcessing",
             "errorIntersectGFI": "Si è verificato un errore durante l'intersezione delle geometrie. Non è stato possibile creare il livello di intersezione.",
             "errorGFI": "Si è verificato un errore durante il caricamento della feature",
             "errorGetFeature": "Si è verificato un errore durante il caricamento della feature per ottenerne la geometria",

--- a/web/client/utils/GeoProcessingUtils.js
+++ b/web/client/utils/GeoProcessingUtils.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import last from 'lodash/last';
+import sortBy from 'lodash/sortBy';
+
+export const getGeom = (geomType) => {
+    switch (geomType) {
+    case "Point": case "MultiPoint": return "point";
+    case "LineString": case "MultiLineString": return "line";
+    case "Polygon": case "MultiPolygon": return "polygon";
+    default:
+        return geomType;
+    }
+};
+
+/**
+ * generator utility for creating a FeatureCollection GeoJSON from an array of features typically from a mapstore vector layer
+ * @param {object[]} features the list of single GeoJSON Feature
+ * @return {object} the GeoJSON representation of a FeatureCollection
+ */
+export const createFC = (features) => {
+    return {
+        type: "FeatureCollection",
+        features
+    };
+};
+
+/**
+ * function used to get latest id of a list of buffered or intersected layers in order to always have the
+ * counter increased by 1 based on the maximum number found
+ * @param {object[]} layers list of layers to check
+ * @param {string} groupName the related group to compare
+ * @return {number} the counter value
+ */
+export const getCounter = (layers, groupName) => {
+    const allLayers = sortBy(layers?.filter(({group}) => group === groupName), ["name"]);
+    const counter = allLayers.length ? Number(last(allLayers).name.match(/\d/)[0]) + 1 : 0;
+    return counter;
+};

--- a/web/client/utils/__tests__/GeoProcessingUtils-test.js
+++ b/web/client/utils/__tests__/GeoProcessingUtils-test.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import {
+    createFC,
+    getCounter
+} from '../GeoProcessingUtils';
+import {
+    GPT_BUFFER_GROUP_ID
+} from '../../actions/geoProcessing';
+describe('GeoProcessing utils', () => {
+    it('test createFC', () => {
+        const features = [{
+            type: "Feature",
+            id: "ft-id",
+            geometry: {
+                type: "Point",
+                coordinates: [1, 2]
+            }
+        }];
+        const ftColl = createFC(features);
+        expect(ftColl).toEqual({ type: 'FeatureCollection', features: [ { type: 'Feature', id: 'ft-id', geometry: { type: 'Point', coordinates: [ 1, 2 ] } } ] });
+    });
+    it('test getCounter', () => {
+        const layers = [{
+            group: GPT_BUFFER_GROUP_ID,
+            name: "Buffer Layer 0"
+        }];
+        const counter = getCounter(layers, GPT_BUFFER_GROUP_ID);
+        expect(counter).toEqual(1);
+        const counter2 = getCounter([
+            ...layers,
+            {
+                group: GPT_BUFFER_GROUP_ID,
+                name: "Buffer Layer 3"
+            },
+            {
+                group: GPT_BUFFER_GROUP_ID,
+                name: "Buffer Layer 4"
+            }
+        ], GPT_BUFFER_GROUP_ID);
+        expect(counter2).toEqual(5);
+    });
+});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

* refactored the way the counter for each tool is handled, plus some clean up
* add possibility to configure a wpsUrl to be used as default source in the plugin otherwise the url from the layer will be used
* changed the way the groups for buffered and  intersected layers are generated
* remember to test with and without wpsUrl property

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9685

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
you can use vector layers inside GeoProcessing plugin 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
