### PR TITLE
[Backport 2023.02.xx] #9592 - COG option hidden in catalog from default (#9684)

### DIFF
--- a/docs/user-guide/catalog.md
+++ b/docs/user-guide/catalog.md
@@ -363,6 +363,23 @@ In **General Settings** of a COG source type, it is possible to specify the serv
 !!! Note
     To properly display COG layers in your MapStore map, it is necessary to add the reference system definition supported by the COG in the MapStore [projectionDefs configuration](../../developer-guide/local-config/#projectiondefs-configuration)
 
+!!! warning
+    The feature is currently in experimental state, and won't be available in the default service types list of the catalog.
+    In order to enable this service, update the MetadataExplorer plugin's configuration in `localConfig.json` as shown below
+
+    ```diff
+    {
+        "name": "MetadataExplorer",
+        "cfg": {
+            ...
+            serviceTypes: [
+                ...
+    +           { name: "cog", label: "COG" }
+            ]
+        }
+    }
+    ```
+
 #### Advanced Settings
 
 In addition to the standard options, only for COG catalog sources, through the **Advanced Settings** the user can configure also the following option:

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -177,7 +177,7 @@ class MetadataExplorerComponent extends React.Component {
 
     static defaultProps = {
         id: "mapstore-metadata-explorer",
-        serviceTypes: [{ name: "csw", label: "CSW" }, { name: "wms", label: "WMS" }, { name: "wmts", label: "WMTS" }, { name: "tms", label: "TMS", allowedProviders: DEFAULT_ALLOWED_PROVIDERS }, { name: "wfs", label: "WFS" }, { name: "3dtiles", label: "3D Tiles" }, { name: "cog", label: "COG" }],
+        serviceTypes: [{ name: "csw", label: "CSW" }, { name: "wms", label: "WMS" }, { name: "wmts", label: "WMTS" }, { name: "tms", label: "TMS", allowedProviders: DEFAULT_ALLOWED_PROVIDERS }, { name: "wfs", label: "WFS" }, { name: "3dtiles", label: "3D Tiles" }],
         active: false,
         wrap: false,
         modal: true,
@@ -285,7 +285,7 @@ const MetadataExplorerPlugin = connect(metadataExplorerSelector, {
  * @name MetadataExplorer
  * @memberof plugins
  * @prop {string} cfg.hideThumbnail shows/hides thumbnail
- * @prop {object[]} cfg.serviceTypes Service types available to add a new catalog. default: `[{ name: "csw", label: "CSW" }, { name: "wms", label: "WMS" }, { name: "wmts", label: "WMTS" }, { name: "tms", label: "TMS", allowedProviders },{ name: "wfs", label: "WFS" }, { name: "cog", label: "COG" }]`.
+ * @prop {object[]} cfg.serviceTypes Service types available to add a new catalog. default: `[{ name: "csw", label: "CSW" }, { name: "wms", label: "WMS" }, { name: "wmts", label: "WMTS" }, { name: "tms", label: "TMS", allowedProviders },{ name: "wfs", label: "WFS" }]`.
  * `allowedProviders` is a whitelist of tileProviders from ConfigProvider.js. you can set a global variable allowedProviders in localConfig.json to set it up globally. You can configure it to "ALL" to get all the list (at your own risk, some services could change or not be available anymore)
  * @prop {object} cfg.hideIdentifier shows/hides identifier
  * @prop {boolean} cfg.hideExpand shows/hides full description button


### PR DESCRIPTION
 #9592 - COG option hidden in catalog from default (#9684)