### PR TITLE
#9553: Improving readability of long attribute values in attribute table and table widgets

### DIFF
--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web/client/utils/__tests__', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web/client/utils/__tests__', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/web/client/components/data/featuregrid/formatters/index.js
+++ b/web/client/components/data/featuregrid/formatters/index.js
@@ -15,7 +15,7 @@ import NumberFormat from '../../../I18N/Number';
 import { dateFormats as defaultDateFormats } from "../../../../utils/FeatureGridUtils";
 
 const BooleanFormatter =  ({value} = {}) => !isNil(value) ? <span>{value.toString()}</span> : null;
-const StringFormatter = ({value} = {}) => !isNil(value) ? reactStringReplace(value, /(https?:\/\/\S+)/g, (match, i) => (
+export const StringFormatter = ({value} = {}) => !isNil(value) ? reactStringReplace(value, /(https?:\/\/\S+)/g, (match, i) => (
     <a key={match + i} href={match} target={"_blank"}>{match}</a>
 )) : null;
 const NumberFormatter = ({value} = {}) => !isNil(value) ? <NumberFormat value={value} numberParams={{maximumFractionDigits: 17}}/> : null;

--- a/web/client/components/misc/enhancers/__tests__/handleLongTextEnhancer-test.jsx
+++ b/web/client/components/misc/enhancers/__tests__/handleLongTextEnhancer-test.jsx
@@ -25,10 +25,10 @@ describe("handleLongTextEnhancer enhancer", () => {
         setTimeout(done);
     });
 
-    it('handleLongTextEnhancer with defaults [with no formatter]', () => {
-        const Enhancer = handleLongTextEnhancer();
+    it('handleLongTextEnhancer by passing formatter as wrapper', () => {
+        const EnhancerWithFormatter = ()=> handleLongTextEnhancer(StringFormatter)({ value: "test12334567899999" });
         ReactDOM.render(
-            <Enhancer value={"test12334567899999"} />,
+            <EnhancerWithFormatter />,
             document.getElementById("container")
         );
         expect(document.getElementById("container").innerHTML).toExist();
@@ -36,10 +36,37 @@ describe("handleLongTextEnhancer enhancer", () => {
         expect(document.getElementsByTagName('span')[1].innerHTML).toExist();
     });
 
-    it('handleLongTextEnhancer with formatter', () => {
-        const EnhancerWithFormatter = handleLongTextEnhancer(StringFormatter);
+    it('handleLongTextEnhancer with by passing td as wrapper', () => {
+        const wrapper = () => (<td>15234568965</td>);
+        const EnhancerWithFormatter = ()=> handleLongTextEnhancer(wrapper)({ value: "15234568965" });
         ReactDOM.render(
-            <EnhancerWithFormatter value={"test12334567899999"} />,
+            <EnhancerWithFormatter />,
+            document.getElementById("container")
+        );
+        expect(document.getElementById("container").innerHTML).toExist();
+        expect(document.getElementsByTagName('span').length).toEqual(2);
+        expect(document.getElementsByTagName('span')[1].innerHTML).toExist();
+    });
+
+
+    it('handleLongTextEnhancer with by passing span as wrapper', () => {
+        const wrapper = () => (<span>15234568965</span>);
+        const EnhancerWithFormatter = ()=> handleLongTextEnhancer(wrapper)({ value: "15234568965" });
+        ReactDOM.render(
+            <EnhancerWithFormatter />,
+            document.getElementById("container")
+        );
+        expect(document.getElementById("container").innerHTML).toExist();
+        expect(document.getElementsByTagName('span').length).toEqual(3);
+        expect(document.getElementsByTagName('span')[1].innerHTML).toExist();
+    });
+
+
+    it('handleLongTextEnhancer with by passing td div wrapper', () => {
+        const wrapper = () => (<div>test</div>);
+        const EnhancerWithFormatter = ()=> handleLongTextEnhancer(wrapper)({ value: "test" });
+        ReactDOM.render(
+            <EnhancerWithFormatter />,
             document.getElementById("container")
         );
         expect(document.getElementById("container").innerHTML).toExist();

--- a/web/client/components/misc/enhancers/__tests__/handleLongTextEnhancer-test.jsx
+++ b/web/client/components/misc/enhancers/__tests__/handleLongTextEnhancer-test.jsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { handleLongTextEnhancer } from '../handleLongTextEnhancer';
+import { StringFormatter } from '../../../data/featuregrid/formatters';
+
+describe("handleLongTextEnhancer enhancer", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('handleLongTextEnhancer with defaults [with no formatter]', () => {
+        const Enhancer = handleLongTextEnhancer();
+        ReactDOM.render(
+            <Enhancer value={"test12334567899999"} />,
+            document.getElementById("container")
+        );
+        expect(document.getElementById("container").innerHTML).toExist();
+        expect(document.getElementsByTagName('span').length).toEqual(2);
+        expect(document.getElementsByTagName('span')[1].innerHTML).toExist();
+    });
+
+    it('handleLongTextEnhancer with formatter', () => {
+        const EnhancerWithFormatter = handleLongTextEnhancer(StringFormatter);
+        ReactDOM.render(
+            <EnhancerWithFormatter value={"test12334567899999"} />,
+            document.getElementById("container")
+        );
+        expect(document.getElementById("container").innerHTML).toExist();
+        expect(document.getElementsByTagName('span').length).toEqual(2);
+        expect(document.getElementsByTagName('span')[1].innerHTML).toExist();
+    });
+});

--- a/web/client/components/misc/enhancers/handleLongTextEnhancer.jsx
+++ b/web/client/components/misc/enhancers/handleLongTextEnhancer.jsx
@@ -15,7 +15,7 @@ import { Tooltip } from "react-bootstrap";
  * @name handleLongTextEnhancer
  * @memberof components.misc.enhancers
  * Wraps [wrapped component with content] to add tooltip for long content if shown content less than the main content
- * @param {Component} Wrapped the wrapper to add tooltip for its long content
+ * @param {Component} Wrapped the component wrapped with a tooltip when its content is too long
  * @param {object} props the props that contains value content
  * @return {Component} the rendered component that renders the content with the tooltip if the content is long or renders the content with no tooltip if not long
  * @example

--- a/web/client/components/misc/enhancers/handleLongTextEnhancer.jsx
+++ b/web/client/components/misc/enhancers/handleLongTextEnhancer.jsx
@@ -10,7 +10,7 @@ import React from "react";
 import OverlayTrigger from "../OverlayTrigger";
 import { Tooltip } from "react-bootstrap";
 
-export const handleLongTextEnhancer = (props, RenderFormatter) => {
+export  const handleLongTextEnhancer = (RenderFormatter) => (props) => {
     const { value } = props;
     const cellRef = React.useRef(null);
     const contentRef = React.useRef(null);

--- a/web/client/components/misc/enhancers/handleLongTextEnhancer.jsx
+++ b/web/client/components/misc/enhancers/handleLongTextEnhancer.jsx
@@ -1,3 +1,11 @@
+/*
+* Copyright 2023, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
 import React from "react";
 import OverlayTrigger from "../OverlayTrigger";
 import { Tooltip } from "react-bootstrap";

--- a/web/client/components/misc/enhancers/handleLongTextEnhancer.jsx
+++ b/web/client/components/misc/enhancers/handleLongTextEnhancer.jsx
@@ -9,9 +9,24 @@
 import React from "react";
 import OverlayTrigger from "../OverlayTrigger";
 import { Tooltip } from "react-bootstrap";
-
-export  const handleLongTextEnhancer = (RenderFormatter) => (props) => {
-    const { value } = props;
+/**
+ * handleLongTextEnhancer enhancer. Enhances a long text content by adding a tooltip.
+ * @type {function}
+ * @name handleLongTextEnhancer
+ * @memberof components.misc.enhancers
+ * Wraps [wrapped component with content] to add tooltip for long content if shown content less than the main content
+ * @param {Component} Wrapped the wrapper to add tooltip for its long content
+ * @param {object} props the props that contains value content
+ * @return {Component} the rendered component that renders the content with the tooltip if the content is long or renders the content with no tooltip if not long
+ * @example
+ * const wrapper = () = > <span>testtttttttttt</span>
+ * const Component = ()=> handleLongTextEnhancer(wrapper)(props);
+ * render (){
+ * return <Component />
+ * }
+ *
+ */
+export const handleLongTextEnhancer = (Wrapped) => (props) => {
     const cellRef = React.useRef(null);
     const contentRef = React.useRef(null);
     const [isContentOverflowing, setIsContentOverflowing] = React.useState(false);
@@ -24,11 +39,11 @@ export  const handleLongTextEnhancer = (RenderFormatter) => (props) => {
 
     return (<OverlayTrigger
         placement="top"
-        overlay={isContentOverflowing ? <Tooltip id="tooltip">{RenderFormatter ? <RenderFormatter {...props} /> : value}</Tooltip> : <></>}
+        overlay={isContentOverflowing ? <Tooltip id="tooltip">{<Wrapped {...props} />}</Tooltip> : <></>}
     >
         <div ref={cellRef} onMouseEnter={handleMouseEnter}>
             <span ref={contentRef}>
-                <span>{RenderFormatter ? <RenderFormatter {...props} /> : value}</span>
+                <span>{<Wrapped {...props} />}</span>
             </span>
         </div>
     </OverlayTrigger>);

--- a/web/client/components/misc/enhancers/handleLongTextEnhancer.jsx
+++ b/web/client/components/misc/enhancers/handleLongTextEnhancer.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import OverlayTrigger from "../OverlayTrigger";
+import { Tooltip } from "react-bootstrap";
+
+export const handleLongTextEnhancer = (props, RenderFormatter) => {
+    const { value } = props;
+    const cellRef = React.useRef(null);
+    const contentRef = React.useRef(null);
+    const [isContentOverflowing, setIsContentOverflowing] = React.useState(false);
+
+    const handleMouseEnter = () => {
+        const cellWidth = cellRef.current.offsetWidth;
+        const contentWidth = contentRef.current.offsetWidth;
+        setIsContentOverflowing(contentWidth > cellWidth);
+    };
+
+    return (<OverlayTrigger
+        placement="top"
+        overlay={isContentOverflowing ? <Tooltip id="tooltip">{RenderFormatter ? <RenderFormatter {...props} /> : value}</Tooltip> : <></>}
+    >
+        <div ref={cellRef} onMouseEnter={handleMouseEnter}>
+            <span ref={contentRef}>
+                <span>{RenderFormatter ? <RenderFormatter {...props} /> : value}</span>
+            </span>
+        </div>
+    </OverlayTrigger>);
+};

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -148,7 +148,7 @@ export const featureTypeToGridColumns = (
             editable,
             filterable,
             editor: getEditor(desc, field),
-            formatter: (props)=>handleLongTextEnhancer(props, getFormatter(desc, field)),
+            formatter: handleLongTextEnhancer(getFormatter(desc, field)),
             filterRenderer: getFilterRenderer(desc, field)
         };
     });

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -18,9 +18,7 @@ import {
 } from './ogc/WFS/base';
 
 import { applyDefaultToLocalizedString } from '../components/I18N/LocalizedString';
-import React from 'react';
-import OverlayTrigger from '../components/misc/OverlayTrigger';
-import { Tooltip } from 'react-bootstrap';
+import { handleLongTextEnhancer } from '../components/misc/enhancers/handleLongTextEnhancer';
 
 const getGeometryName = (describe) => get(findGeometryProperty(describe), "name");
 const getPropertyName = (name, describe) => name === "geometry" ? getGeometryName(describe) : name;
@@ -119,34 +117,6 @@ export const getCurrentPaginationOptions = ({ startPage, endPage }, oldPages, si
 };
 
 
-const formatterWrapperForLongContent = (props, RenderFormatter) => {
-    const { value } = props;
-    const cellRef = React.useRef(null);
-    const contentRef = React.useRef(null);
-    const [isContentOverflowing, setIsContentOverflowing] = React.useState(false);
-
-    const handleMouseEnter = () => {
-        const cellWidth = cellRef.current.offsetWidth;
-        const contentWidth = contentRef.current.offsetWidth;
-
-        if (contentWidth > cellWidth) {
-            setIsContentOverflowing(contentWidth > cellWidth);
-        } else setIsContentOverflowing(false);
-    };
-
-    return (<OverlayTrigger
-        placement="top"
-        overlay={isContentOverflowing ? <Tooltip id="tooltip">{RenderFormatter ? <RenderFormatter {...props} /> : value}</Tooltip> : <></>}
-    >
-        <div ref={cellRef} onMouseEnter={handleMouseEnter}>
-            <span ref={contentRef}>
-                <span>{RenderFormatter ? <RenderFormatter {...props} /> : value}</span>
-            </span>
-        </div>
-    </OverlayTrigger>);
-};
-
-
 /**
  * Utility function to get from a describeFeatureType response the columns to use in the react-data-grid
  * @param {object} describe describeFeatureType response
@@ -178,7 +148,7 @@ export const featureTypeToGridColumns = (
             editable,
             filterable,
             editor: getEditor(desc, field),
-            formatter: (props_) => formatterWrapperForLongContent(props_, getFormatter(desc, field)),
+            formatter: (props)=>handleLongTextEnhancer(props, getFormatter(desc, field)),
             filterRenderer: getFilterRenderer(desc, field)
         };
     });

--- a/web/client/utils/__tests__/FeatureGridUtils-test.js
+++ b/web/client/utils/__tests__/FeatureGridUtils-test.js
@@ -349,23 +349,17 @@ describe('FeatureGridUtils', () => {
 
     });
     it('featureTypeToGridColumns formatters', () => {
-        const describe = {featureTypes: [{properties: [{name: 'Test1', type: "xsd:number"}, {name: 'Test2', type: "xsd:number"}, {name: 'Test3', type: "xsd:string"}]}]};
+        const DUMMY = () => {};
+        const formatterWrapper = () => (<div>testtttt</div>);
+        const describe = {featureTypes: [{properties: [{name: 'Test1', type: "xsd:number"}, {name: 'Test2', type: "xsd:number"}]}]};
         const columnSettings = {name: 'Test1', hide: false};
-        const fields = [{name: 'Test1', type: "xsd:number", alias: 'Test1 alias'}];
-        const featureGridColumns = featureTypeToGridColumns(describe, columnSettings, fields);
-        expect(featureGridColumns.length).toBe(3);
-        expect(featureGridColumns[0].title).toBe('Test1 alias');
-        // test alias empty string
-        expect(featureTypeToGridColumns(describe, columnSettings, [{name: "Test1", alias: ""}])[0].title).toEqual('Test1');
-        // test localized alias
-        expect(featureTypeToGridColumns(describe, columnSettings, [{name: "Test1", alias: {"default": "XX"}}])[0].title.default).toEqual('XX');
-        // test localized alias with empty default
-        expect(featureTypeToGridColumns(describe, columnSettings, [{name: "Test1", alias: {"default": ""}}])[0].title.default).toEqual('Test1');
-        const values = [123456, 12.3256, "test"];
-        featureGridColumns.forEach((fgColumns, index)=>{
+        const options = [{name: 'Test1', title: 'Some title', description: 'Some description'}];
+        const featureGridColumns = featureTypeToGridColumns(describe, columnSettings, [], {options}, {getHeaderRenderer: () => DUMMY, getFilterRenderer: () => DUMMY, getFormatter: () => formatterWrapper, getEditor: () => DUMMY});
+        expect(featureGridColumns.length).toBe(2);
+        featureGridColumns.forEach((fgColumns)=>{
             const Formatter = fgColumns.formatter;
             ReactDOM.render(
-                <Formatter value={values[index]} />,
+                <Formatter/>,
                 document.getElementById("container")
             );
             expect(document.getElementById("container").innerHTML).toExist();

--- a/web/client/utils/__tests__/FeatureGridUtils-test.js
+++ b/web/client/utils/__tests__/FeatureGridUtils-test.js
@@ -5,7 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
 */
+import React from "react";
+import ReactDOM from "react-dom";
 import expect from 'expect';
+
 import {
     updatePages,
     gridUpdateToQueryUpdate,
@@ -18,6 +21,18 @@ import {
 
 
 describe('FeatureGridUtils', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(
+            document.getElementById("container")
+        );
+        document.body.innerHTML = "";
+        setTimeout(done);
+    });
     it('Test updatePages when needPages * size is less then features', () => {
         const oldFeatures = Array(350);
         const features = Array(60);
@@ -331,6 +346,32 @@ describe('FeatureGridUtils', () => {
         expect(featureTypeToGridColumns(describe, columnSettings, [{name: "Test1", alias: {"default": "XX"}}])[0].title.default).toEqual('XX');
         // test localized alias with empty default
         expect(featureTypeToGridColumns(describe, columnSettings, [{name: "Test1", alias: {"default": ""}}])[0].title.default).toEqual('Test1');
+
+    });
+    it('featureTypeToGridColumns formatters', () => {
+        const describe = {featureTypes: [{properties: [{name: 'Test1', type: "xsd:number"}, {name: 'Test2', type: "xsd:number"}, {name: 'Test3', type: "xsd:string"}]}]};
+        const columnSettings = {name: 'Test1', hide: false};
+        const fields = [{name: 'Test1', type: "xsd:number", alias: 'Test1 alias'}];
+        const featureGridColumns = featureTypeToGridColumns(describe, columnSettings, fields);
+        expect(featureGridColumns.length).toBe(3);
+        expect(featureGridColumns[0].title).toBe('Test1 alias');
+        // test alias empty string
+        expect(featureTypeToGridColumns(describe, columnSettings, [{name: "Test1", alias: ""}])[0].title).toEqual('Test1');
+        // test localized alias
+        expect(featureTypeToGridColumns(describe, columnSettings, [{name: "Test1", alias: {"default": "XX"}}])[0].title.default).toEqual('XX');
+        // test localized alias with empty default
+        expect(featureTypeToGridColumns(describe, columnSettings, [{name: "Test1", alias: {"default": ""}}])[0].title.default).toEqual('Test1');
+        const values = [123456, 12.3256, "test"];
+        featureGridColumns.forEach((fgColumns, index)=>{
+            const Formatter = fgColumns.formatter;
+            ReactDOM.render(
+                <Formatter value={values[index]} />,
+                document.getElementById("container")
+            );
+            expect(document.getElementById("container").innerHTML).toExist();
+            expect(document.getElementsByTagName('span').length).toEqual(2);
+            expect(document.getElementsByTagName('span')[1].innerHTML).toExist();
+        });
 
     });
     describe("supportsFeatureEditing", () => {


### PR DESCRIPTION
## Description
In this PR, I handled showing a tooltip for long attribute value in attribute table and table widgets only if user hovers on the cells that has shown content less than the attribute value. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Enhancement

## Issue
#9553 

**What is the current behavior?**
#9553 

**What is the new behavior?**
 Showing a tooltip for long attribute value in attribute table and table widgets only if user hovers on the cells that has shown content less than the attribute value. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
I created a generic enhancer with name "handleLongTextEnhancer" to handle the tooltip for long content