### PR TITLE
[Backport 2023.02.xx] #9216: Handle fixing not visibility of spatial filter for widgets created by attribute table (#9674)

### DIFF
--- a/web/client/actions/__tests__/wfsquery-test.js
+++ b/web/client/actions/__tests__/wfsquery-test.js
@@ -11,6 +11,7 @@ import expect from 'expect';
 import {
     LAYER_SELECTED_FOR_SEARCH,
     FEATURE_TYPE_SELECTED,
+    FEATURE_TYPE_LOADED,
     FEATURE_TYPE_ERROR,
     FEATURE_LOADING,
     FEATURE_LOADED,
@@ -25,6 +26,7 @@ import {
     initQueryPanel,
     layerSelectedForSearch,
     featureTypeSelected,
+    featureTypeLoaded,
     featureTypeError,
     featureLoading,
     featureLoaded,
@@ -47,12 +49,35 @@ describe('wfsquery actions', () => {
         let {type} = initQueryPanel();
         expect(type).toBe(INIT_QUERY_PANEL);
     });
-    it('featureTypeSelected', () => {
+    it('featureTypeSelected without owner', () => {
         let {type, url, typeName, fields} = featureTypeSelected("/geoserver/", "topp:states", [{name: "name", alias: "alias"}]);
         expect(type).toBe(FEATURE_TYPE_SELECTED);
         expect(url).toBe("/geoserver/");
         expect(typeName).toBe("topp:states");
         expect(fields).toEqual([{name: "name", alias: "alias"}]);
+    });
+
+    it('featureTypeSelected with owner as parameter', () => {
+        let {type, url, typeName, fields, owner} = featureTypeSelected("/geoserver/", "topp:states", [{name: "name", alias: "alias"}], "owner");
+        expect(type).toBe(FEATURE_TYPE_SELECTED);
+        expect(url).toBe("/geoserver/");
+        expect(typeName).toBe("topp:states");
+        expect(fields).toEqual([{name: "name", alias: "alias"}]);
+        expect(owner).toBe("owner");
+    });
+    it('featureTypeLoaded without owner', () => {
+        let {type, typeName, featureType} = featureTypeLoaded("topp:states", "featureType");
+        expect(type).toBe(FEATURE_TYPE_LOADED);
+        expect(typeName).toBe("topp:states");
+        expect(featureType).toBe("featureType");
+    });
+
+    it('featureTypeLoaded with owner as parameter', () => {
+        let {type, typeName, featureType, owner} = featureTypeLoaded("topp:states", "featureType", "owner");
+        expect(type).toBe(FEATURE_TYPE_LOADED);
+        expect(typeName).toBe("topp:states");
+        expect(featureType).toBe("featureType");
+        expect(owner).toBe("owner");
     });
     it('featureTypeError', () => {
         let {type, error, typeName} = featureTypeError("topp:states", "ERROR");
@@ -66,6 +91,12 @@ describe('wfsquery actions', () => {
         expect(isLoading).toBe(true);
     });
     it('featureLoaded', () => {
+        let {type, typeName, feature} = featureLoaded("topp:states", "feature");
+        expect(type).toBe(FEATURE_LOADED);
+        expect(typeName).toBe("topp:states");
+        expect(feature).toBe(feature);
+    });
+    it('featureLoaded with owner as parameter', () => {
         let {type, typeName, feature} = featureLoaded("topp:states", "feature");
         expect(type).toBe(FEATURE_LOADED);
         expect(typeName).toBe("topp:states");
@@ -94,6 +125,13 @@ describe('wfsquery actions', () => {
         expect(type).toBe(QUERY_CREATE);
         expect(searchUrl).toBe("searchUrl");
         expect(filterObj).toBe("filterObj");
+    });
+    it('createQuery with owner param', () => {
+        let {type, searchUrl, filterObj, owner} = createQuery("searchUrl", "filterObj", "owner");
+        expect(type).toBe(QUERY_CREATE);
+        expect(searchUrl).toBe("searchUrl");
+        expect(filterObj).toBe("filterObj");
+        expect(owner).toBe("owner");
     });
     it('query', () => {
         let {type, searchUrl, filterObj} = query("searchUrl", "filterObj");

--- a/web/client/actions/wfsquery.js
+++ b/web/client/actions/wfsquery.js
@@ -46,19 +46,21 @@ export function initQueryPanel() {
         type: INIT_QUERY_PANEL
     };
 }
-export function featureTypeSelected(url, typeName, fields = []) {
+export function featureTypeSelected(url, typeName, fields = [], owner) {
     return {
         type: FEATURE_TYPE_SELECTED,
         url,
         typeName,
-        fields
+        fields,
+        owner
     };
 }
-export function featureTypeLoaded(typeName, featureType) {
+export function featureTypeLoaded(typeName, featureType, owner) {
     return {
         type: FEATURE_TYPE_LOADED,
         typeName,
-        featureType
+        featureType,
+        owner
     };
 }
 
@@ -142,11 +144,12 @@ export function loadFeature(baseUrl, typeName) {
         });
     };
 }
-export function createQuery(searchUrl, filterObj) {
+export function createQuery(searchUrl, filterObj, owner) {
     return {
         type: QUERY_CREATE,
         searchUrl,
-        filterObj
+        filterObj,
+        owner
     };
 }
 

--- a/web/client/epics/__tests__/widgetsbuilder-test.js
+++ b/web/client/epics/__tests__/widgetsbuilder-test.js
@@ -215,8 +215,8 @@ describe('widgetsbuilder epic', () => {
     });
     it('handleWidgetsFilterPanel', (done) => {
         const startActions = [openFilterEditor()];
-        testEpic(handleWidgetsFilterPanel, 4, startActions, actions => {
-            expect(actions.length).toBe(4);
+        testEpic(handleWidgetsFilterPanel, 3, startActions, actions => {
+            expect(actions.length).toBe(3);
             actions.map((action) => {
                 switch (action.type) {
                 case SET_CONTROL_PROPERTY:
@@ -236,6 +236,7 @@ describe('widgetsbuilder epic', () => {
                         type: "string",
                         alias: "X alias"
                     }]);
+                    expect(action.owner).toEqual("widgets");
                     break;
                 case LOAD_FILTER:
                     break;
@@ -274,8 +275,8 @@ describe('widgetsbuilder epic', () => {
         const startActions = [openFilterEditor(), search("TEST", {
 
         })];
-        testEpic(handleWidgetsFilterPanel, 8, startActions, actions => {
-            expect(actions.length).toBe(8);
+        testEpic(handleWidgetsFilterPanel, 7, startActions, actions => {
+            expect(actions.length).toBe(7);
             actions.map((action) => {
                 switch (action.type) {
                 case SET_CONTROL_PROPERTY:

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -273,11 +273,11 @@ const createLoadPageFlow = (store) => ({page, size, reason} = {}) => {
 
 const createInitialQueryFlow = (action$, store, {url, name, id, fields} = {}) => {
     const filterObj = get(store.getState(), `featuregrid.advancedFilters["${id}"]`);
-    const createInitialQuery = () => createQuery(url, filterObj || {
+    const createInitialQuery = (action) => createQuery(url, filterObj || {
         featureTypeName: name,
         filterType: 'OGC',
         ogcVersion: '1.1.0'
-    });
+    }, action.owner);
 
     return Rx.Observable.of(featureTypeSelected(url, name, fields)).merge(
         action$.ofType(FEATURE_TYPE_LOADED).filter(({typeName} = {}) => typeName === name)
@@ -356,8 +356,8 @@ export const featureGridLayerSelectionInitialization = (action$) =>
  */
 export const featureGridStartupQuery = (action$, store) =>
     action$.ofType(QUERY_CREATE)
-        .switchMap(() => Rx.Observable.of(changePage(0))
-            .concat(modeSelector(store.getState()) === MODES.VIEW ? Rx.Observable.of(toggleViewMode()) : Rx.Observable.empty()));
+        .switchMap(({ owner }) => Rx.Observable.of(changePage(0))
+            .concat(modeSelector(store.getState()) === MODES.VIEW && owner !== "widgets" ? Rx.Observable.of(toggleViewMode()) : Rx.Observable.empty()));
 /**
  * Create sorted queries on sort action
  * With virtualScroll active reset to page 0 but the grid will reload

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -102,7 +102,7 @@ export const featureTypeSelectedEpic = (action$, store) =>
                 const info = extractInfo(layerDescribeSelector(state, action.typeName), action.fields);
                 const geometry = info.geometry[0] && info.geometry[0].attribute ? info.geometry[0].attribute : 'the_geom';
 
-                return Rx.Observable.of(featureTypeLoaded(action.typeName, info), changeSpatialAttribute(geometry), Rx.Scheduler.async); // async scheduler is needed to allow invokers of `FEATURE_TYPE_SELECTED` to intercept `FEATURE_TYPE_LOADED` action as response.
+                return Rx.Observable.of(featureTypeLoaded(action.typeName, info, action.owner), changeSpatialAttribute(geometry), Rx.Scheduler.async); // async scheduler is needed to allow invokers of `FEATURE_TYPE_SELECTED` to intercept `FEATURE_TYPE_LOADED` action as response.
             }
 
             const selectedLayer = selectedLayerSelector(state);

--- a/web/client/epics/widgetsbuilder.js
+++ b/web/client/epics/widgetsbuilder.js
@@ -91,7 +91,7 @@ export const handleWidgetsFilterPanel = (action$, {getState = () => {}} = {}) =>
         .switchMap(() =>
             // open and setup query form
             Rx.Observable.of(
-                featureTypeSelected(...getFTSelectedArgs(getState())),
+                featureTypeSelected(...getFTSelectedArgs(getState()).concat(["widgets"])),
                 loadFilter(getEditingWidgetFilter(getState())),
                 setControlProperty("widgetBuilder", "enabled", false),
                 setControlProperty('queryPanel', "enabled", true)


### PR DESCRIPTION
Backport 2023.02.xx - #9216 : Handle fixing not visibility of spatial filter for widgets created by attribute table (#9674 )