### PR TITLE
#9702: Fix - Background selector in contexts won't retain thumbnail in view mode

### DIFF
--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -247,7 +247,7 @@ export const storeDetailsInfoDashboardEpic = (action$, store) =>
         });
 
 /**
- * Incerpt MAP_CONFIG_LOADED and update background layers thumbnail
+ * Intercept MAP_CONFIG_LOADED and update background layers thumbnail
  * Epic is placed here to better intercept and update background layers thumbnail info,
  * when loading context with map and to avoid race condition
  * when loading plugins and map configuration


### PR DESCRIPTION
## Description
This PR fixes the background thumbnail not updated in the layer object on map config is loaded (context)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9702 

**What is the new behavior?**
The background layer's thumbnail is properly loaded in context, context saved with map config and in context edit mode. Same applies to when loading map resources

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
### Test data
https://dev-mapstore.geosolutionsgroup.com/mapstore/#/context/COFI_ortoforo_context
https://dev-mapstore.geosolutionsgroup.com/mapstore/#/viewer/8931
