### PR TITLE
Fix #9729 fixed formats in catalog used in dashboard

### DIFF
--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -16,7 +16,6 @@ const {
     autoSearchEpic,
     openCatalogEpic,
     recordSearchEpic,
-    getSupportedFormatsEpic,
     updateGroupSelectedMetadataExplorerEpic,
     newCatalogServiceAdded
 } = catalog(API);
@@ -34,12 +33,8 @@ import {
     RECORD_LIST_LOADED,
     RECORD_LIST_LOAD_ERROR,
     SET_LOADING,
-    formatOptionsFetch,
-    FORMAT_OPTIONS_LOADING,
-    SET_FORMAT_OPTIONS,
     ADD_LAYER_AND_DESCRIBE,
     addLayerAndDescribe,
-    SHOW_FORMAT_ERROR,
     DESCRIBE_ERROR,
     SAVING_SERVICE,
     NEW_SERVICE_STATUS,
@@ -747,38 +742,6 @@ describe('catalog Epics', () => {
                     pageSize: 2
                 }
             });
-    });
-    it('getSupportedFormatsEpic wms', (done) => {
-        const NUM_ACTIONS = 4;
-        const url = "base/web/client/test-resources/wms/GetCapabilities-1.1.1.xml";
-        testEpic(addTimeoutEpic(getSupportedFormatsEpic, 0), NUM_ACTIONS, formatOptionsFetch(url), (actions) => {
-            expect(actions.length).toBe(NUM_ACTIONS);
-            try {
-                actions.map((action) => {
-                    switch (action.type) {
-                    case SET_FORMAT_OPTIONS:
-                        expect(action.formats).toBeTruthy();
-                        expect(action.formats.imageFormats).toEqual(['image/png', 'image/gif', 'image/jpeg', 'image/png8', 'image/png; mode=8bit', 'image/vnd.jpeg-png']);
-                        expect(action.formats.infoFormats).toEqual(['text/plain', 'text/html', 'application/json']);
-                        break;
-                    case SHOW_FORMAT_ERROR:
-                        expect(action.status).toBeFalsy();
-                        break;
-                    case FORMAT_OPTIONS_LOADING:
-                        break;
-                    case TEST_TIMEOUT:
-                        break;
-                    default:
-                        expect(true).toBe(false);
-                    }
-                });
-            } catch (e) {
-                done(e);
-            }
-            done();
-        }, {
-            catalog: {}
-        });
     });
 
     it('updateGroupSelectedMetadataExplorerEpic allows clicking on group to set destination to current group', done => {

--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -8,7 +8,9 @@
 
 import expect from 'expect';
 import {head} from 'lodash';
-import {loadMapConfigAndConfigureMap, loadMapInfoEpic, storeDetailsInfoDashboardEpic, storeDetailsInfoEpic, backgroundsListInitEpic} from '../config';
+import {
+    loadMapConfigAndConfigureMap, loadMapInfoEpic, storeDetailsInfoDashboardEpic, storeDetailsInfoEpic, backgroundsListInitEpic,    getSupportedFormatsEpic
+} from '../config';
 import {LOAD_USER_SESSION} from '../../actions/usersession';
 import {
     loadMapConfig,
@@ -32,13 +34,50 @@ import ConfigUtils from "../../utils/ConfigUtils";
 import { DETAILS_LOADED } from '../../actions/details';
 import { EMPTY_RESOURCE_VALUE } from '../../utils/MapInfoUtils';
 import { dashboardLoaded } from '../../actions/dashboard';
-
+import {
+    formatOptionsFetch,
+    FORMAT_OPTIONS_LOADING,
+    SET_FORMAT_OPTIONS,
+    SHOW_FORMAT_ERROR
+} from '../../actions/catalog';
 const api = {
     getResource: () => Promise.resolve({mapId: 1234})
 };
 let mockAxios;
 
 describe('config epics', () => {
+    it('getSupportedFormatsEpic wms', (done) => {
+        const NUM_ACTIONS = 4;
+        const url = "base/web/client/test-resources/wms/GetCapabilities-1.1.1.xml";
+        testEpic(addTimeoutEpic(getSupportedFormatsEpic, 0), NUM_ACTIONS, formatOptionsFetch(url), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            try {
+                actions.map((action) => {
+                    switch (action.type) {
+                    case SET_FORMAT_OPTIONS:
+                        expect(action.formats).toBeTruthy();
+                        expect(action.formats.imageFormats).toEqual(['image/png', 'image/gif', 'image/jpeg', 'image/png8', 'image/png; mode=8bit', 'image/vnd.jpeg-png']);
+                        expect(action.formats.infoFormats).toEqual(['text/plain', 'text/html', 'application/json']);
+                        break;
+                    case SHOW_FORMAT_ERROR:
+                        expect(action.status).toBeFalsy();
+                        break;
+                    case FORMAT_OPTIONS_LOADING:
+                        break;
+                    case TEST_TIMEOUT:
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+            } catch (e) {
+                done(e);
+            }
+            done();
+        }, {
+            catalog: {}
+        });
+    });
     describe('loadMapConfigAndConfigureMap', () => {
         beforeEach(done => {
             ConfigUtils.setConfigProp("userSessions", {

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -36,6 +36,18 @@ import {getRequestParameterValue} from "../utils/QueryParamsUtils";
 import { EMPTY_RESOURCE_VALUE } from '../utils/MapInfoUtils';
 import { changeLayerProperties } from '../actions/layers';
 import { createBackgroundsList, setCurrentBackgroundLayer } from '../actions/backgroundselector';
+import {
+    FORMAT_OPTIONS_FETCH,
+    formatsLoading,
+    showFormatError,
+    setSupportedFormats
+} from '../actions/catalog';
+import {
+    getFormatUrlUsedSelector
+} from '../selectors/catalog';
+import { getSupportedFormat } from '../api/WMS';
+import { wrapStartStop } from '../observables/epics';
+import { error } from '../actions/notifications';
 
 const prepareMapConfiguration = (data, override, state) => {
     const queryParamsMap = getRequestParameterValue('map', state);
@@ -279,4 +291,42 @@ export const backgroundsListInitEpic = (action$) =>
                 ...layerUpdateActions.concat(createBackgroundsList(backgrounds)),
                 ...(currentBackground ? [setCurrentBackgroundLayer(currentBackground.id)] : [])
             );
+        });
+
+
+/**
+     * this epic is moved here because it needs to work also in dashboards
+     * Fetch all supported formats of a WMS service configured (infoFormats and imageFormats)
+     * Dispatches an action that sets the supported formats of the service.
+     * @param {Observable} action$ the actions triggered
+     * @param {object} getState store object
+     * @memberof epics.catalog
+     * @return {external:Observable}
+     */
+export const getSupportedFormatsEpic = (action$, {getState = ()=> {}} = {}) =>
+    action$.ofType(FORMAT_OPTIONS_FETCH)
+        .filter((action)=> action.force || getFormatUrlUsedSelector(getState()) !== action?.url)
+        .switchMap(({url = ''} = {})=> {
+            return Observable.defer(() => getSupportedFormat(url, true))
+                .switchMap((supportedFormats) => {
+                    return Observable.of(
+                        setSupportedFormats(supportedFormats, url),
+                        showFormatError(supportedFormats.imageFormats.length === 0 && supportedFormats.infoFormats.length === 0)
+                    );
+                })
+                .let(
+                    wrapStartStop(
+                        formatsLoading(true),
+                        formatsLoading(false),
+                        () => {
+                            return Observable.of(
+                                error({
+                                    title: "layerProperties.format.error.title",
+                                    message: 'layerProperties.format.error.message'
+                                }),
+                                formatsLoading(false)
+                            );
+                        }
+                    )
+                );
         });

--- a/web/client/plugins/widgetbuilder/enhancers/catalogEditorEnhancer.js
+++ b/web/client/plugins/widgetbuilder/enhancers/catalogEditorEnhancer.js
@@ -12,6 +12,16 @@ import { dashboardSetSelectedService, setDashboardCatalogMode, dashboardDeleteSe
 import { dashboardServicesSelector,
     selectedDashboardServiceSelector, dashboardCatalogModeSelector, dashboardIsNewServiceSelector } from '../../../selectors/dashboard';
 import { error } from '../../../actions/notifications';
+import {
+    getSupportedFormatsInNewServiceSelector,
+    getSupportedGFIFormatsSelector,
+    formatsLoadingSelector,
+    showFormatErrorSelector
+} from '../../../selectors/catalog';
+import {
+    formatOptionsFetch
+} from '../../../actions/catalog';
+
 import CatalogServiceEditor from '../CatalogServiceEditor';
 
 export const catalogEditorEnhancer = compose(
@@ -20,12 +30,17 @@ export const catalogEditorEnhancer = compose(
         marginRight: "5px"}}),
     connect((state) => ({
         mode: dashboardCatalogModeSelector(state),
+        showFormatError: showFormatErrorSelector(state),
         dashboardServices: dashboardServicesSelector(state),
+        formatsLoading: formatsLoadingSelector(state),
+        infoFormatOptions: getSupportedGFIFormatsSelector(state),
+        formatOptions: getSupportedFormatsInNewServiceSelector(state),
         dashboardSelectedService: selectedDashboardServiceSelector(state),
         isNew: dashboardIsNewServiceSelector(state)
     }), {
         onChangeSelectedService: dashboardSetSelectedService,
         onChangeCatalogMode: setDashboardCatalogMode,
+        onFormatOptionsFetch: formatOptionsFetch,
         onDeleteService: dashboardDeleteService,
         onAddService: updateDashboardService,
         error: error

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -56,9 +56,11 @@ export const catalogSearchInfoSelector = createStructuredSelector({
     projection: projectionSelector
 });
 export const formatsLoadingSelector = (state) => get(state, "catalog.formatsLoading", false);
+export const getSupportedFormatsInNewServiceSelector = (state) => get(state, "catalog.newService.supportedFormats.imageFormats", []);
 export const getSupportedFormatsSelector = (state) => modeSelector(state) === 'edit'
-    ? get(state, "catalog.newService.supportedFormats.imageFormats", [])
+    ? getSupportedFormatsInNewServiceSelector(state)
     : selectedCatalogSelector(state)?.supportedFormats?.imageFormats || [];
+
 export const getSupportedGFIFormatsSelector = (state) => get(state, "catalog.newService.supportedFormats.infoFormats", getDefaultSupportedGetFeatureInfoFormats());
 export const getFormatUrlUsedSelector = (state) => get(state, "catalog.newService.formatUrlUsed", '');
 export const getNewServiceStatusSelector = (state) => get(state, "catalog.isNewServiceAdded", false);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

* when used inside dasbhaord the fill of supported formats always ends up in
* the newService part of the catalog reducer, so i have used a dedicated selector
* for picking this info in the catalogEditorEnhancer


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #9729 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
