### PR TITLE
#9589: Save layer sourceMetadata info

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -658,7 +658,8 @@ export const saveLayer = (layer) => {
     isString(layer.rowViewer) ? { rowViewer: layer.rowViewer } : {},
     !isNil(layer.forceProxy) ? { forceProxy: layer.forceProxy } : {},
     !isNil(layer.disableFeaturesEditing) ? { disableFeaturesEditing: layer.disableFeaturesEditing } : {},
-    layer.pointCloudShading ? { pointCloudShading: layer.pointCloudShading } : {});
+    layer.pointCloudShading ? { pointCloudShading: layer.pointCloudShading } : {},
+    !isNil(layer.sourceMetadata) ? { sourceMetadata: layer.sourceMetadata } : {});
 };
 
 /**

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1260,6 +1260,17 @@ describe('LayersUtils', () => {
                 l => {
                     expect(l.pointCloudShading).toBeTruthy();
                 }
+            ],
+            // Save sourceMetadata
+            [
+                {
+                    sourceMetadata: {
+                        crs: "EPSG:3946"
+                    }
+                },
+                l => {
+                    expect(l.sourceMetadata).toBeTruthy();
+                }
             ]
         ];
         layers.map(([layer, test]) => test(LayersUtils.saveLayer(layer)) );


### PR DESCRIPTION
## Description
This PR fixes the layer's `sourceMetadata` not saved when exporting or saving the map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- https://github.com/geosolutions-it/MapStore2/pull/9690#issuecomment-1823053593

**What is the new behavior?**
The layer's `sourceMetadata` is saved properly on export and map save

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

### Note for testers
Kindly **DO NOT** use the old map import. Add a layer from COG with metadata fetched and export it. Then try importing the same to an instance that has projectionDefs configured to test this bug and to an instance where projectionDefs are not configured to check if notification works fine