### PR TITLE
#9683: add Details Panel for MS dashboard [Editing the detail panel tooltip and title] 

### DIFF
--- a/web/client/components/resources/modals/enhancers/handleSave.js
+++ b/web/client/components/resources/modals/enhancers/handleSave.js
@@ -18,7 +18,7 @@ export default mapPropsStream(props$ => {
             .withLatestFrom(props$)
             .switchMap(([resource, props]) =>
                 updateResource(resource)
-                    .flatMap(rid => (['MAP', 'DASHBOARD'].includes(resource.categoryName)) ?
+                    .flatMap(rid => (['MAP', 'DASHBOARD'].includes(resource.category)) ?
                         updateResourceAttribute({
                             id: rid,
                             name: 'detailsSettings',

--- a/web/client/plugins/MapConnectionDashboard.jsx
+++ b/web/client/plugins/MapConnectionDashboard.jsx
@@ -36,7 +36,7 @@ class MapConnectionDashboard extends React.Component {
         return  (<ToolbarButton
             glyph={showConnections ? 'bulb-on' : 'bulb-off'}
             tooltipId={showConnections ? 'dashboard.editor.hideConnections' : 'dashboard.editor.showConnections'}
-            bsStyle={showConnections ? 'success' : 'primary'}
+            bsStyle={showConnections ? 'success' : 'tray'}
             onClick={()=>onShowConnections(!showConnections)}
             tooltipPosition={'left'}
             id={'ms-map-connection-card-dashboard'}

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -58,8 +58,8 @@
             "404": "Übersetzungsdatei nicht gefunden"
         },
         "details": {
-            "title": "Infos zu dieser Karte",
-            "tooltip": "Infos zu dieser Karte"
+            "title": "Infos zu dieser Inhalt",
+            "tooltip": "Infos zu dieser Inhalt"
         },
         "showEmptyMessageGFI": "Nachricht mit leeren Ergebnissen anzeigen",
         "remove": "Löschen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -58,8 +58,8 @@
             "404": "Translation file not found"
         },
         "details": {
-            "title": "About this map",
-            "tooltip": "About this map"
+            "title": "About this content",
+            "tooltip": "About this content"
         },
         "showEmptyMessageGFI": "Show empty results message in GetFeatureInfo panel",
         "remove": "Delete",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -58,8 +58,8 @@
             "404": "Archivo de traducción no encontrado"
         },
         "details": {
-            "title": "Información en este mapa",
-            "tooltip": "Información en este mapa"
+            "title": "Información en este contenido",
+            "tooltip": "Información en este contenido"
         },
         "showEmptyMessageGFI": "Mostrar mensaje de resultados vacío en el panel de GFI",
         "remove": "Borrar",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -58,8 +58,8 @@
             "404": "Fichier de traduction introuvable"
         },
         "details": {
-            "title": "À propos de cette carte",
-            "tooltip": "À propos de cette carte"
+            "title": "À propos de cette contenu",
+            "tooltip": "À propos de cette contenu"
         },
         "showEmptyMessageGFI": "Afficher un message de résultat vide dans le panneau GetFeatureInfo",
         "remove": "Supprimer",

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -57,8 +57,8 @@
       "404": "Translation file not found"
     },
     "details": {
-      "title": "About this map",
-      "tooltip": "About this map"
+      "title": "About this content",
+      "tooltip": "About this content"
     },
     "showEmptyMessageGFI": "Show empty results message in GetFeatureInfo panel",
     "remove": "Delete",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -58,8 +58,8 @@
             "404": "File di traduzione non trovato"
         },
         "details": {
-            "title": "Info su questa mappa",
-            "tooltip": "Info su questa mappa"
+            "title": "Info su questa contenuto",
+            "tooltip": "Info su questa contenuto"
         },
         "showEmptyMessageGFI": "Mostra il messaggio: Nessuna feature per gli altri layer",
         "remove": "Rimuovi",


### PR DESCRIPTION
## Description
- edit the detail panel tooltip and shown title and make it generic one
- Add translations for the new tooltip
- edit typo in handleSave file 
- the connections button, when disabled, is white. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#9683 

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/issues/9683#issuecomment-1824021254 
https://github.com/geosolutions-it/MapStore2/issues/9683#issuecomment-1824288344

**What is the new behavior?**
Make tooltip/title of detail panel generic and edit translations based on. Plus The connections button, when disabled, is white. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
