### PR TITLE
#9711: Fix - WFS layer filter triggers infinite requests

### DIFF
--- a/web/client/components/map/openlayers/plugins/WFSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WFSLayer.js
@@ -36,7 +36,7 @@ const createLoader = (source, options) => (extent, resolution, projection) => {
             source.addFeatures(
                 source.getFormat().readFeatures(response.data));
             source.set('@wfsFeatureCollection', response.data);
-            options.onLoadEnd();
+            options.onLoadEnd && options.onLoadEnd();
         } else {
             onError();
         }


### PR DESCRIPTION
## Description
This PR fixes the WFS layer filter triggering infinite requests when `onLoadEnd` prop is missing

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9711 

**What is the new behavior?**
Able to perform layer filtering and infinite calls are not triggered in the process

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
