### PR TITLE
[Backport 2023.02.xx] OpenStreetMap : use HTTPS and endpoint fixes (#9676)

### DIFF
--- a/web/client/utils/ConfigProvider.js
+++ b/web/client/utils/ConfigProvider.js
@@ -1,15 +1,15 @@
 export default {
     OpenStreetMap: {
-        url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
         options: {
             maxZoom: 19,
             maxNativeZoom: 19,
             credits: {
                 text: '© OpenStreetMap, Open Street Map and contributors, CC-BY-SA',
-                link: 'http://www.openstreetmap.org/copyright'
+                link: 'https://www.openstreetmap.org/copyright'
             },
             attribution:
-                    '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
         },
         variants: {
             Mapnik: {},
@@ -21,22 +21,22 @@ export default {
                 }
             },
             DE: {
-                url: 'http://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png',
+                url: 'https://tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png',
                 options: {
                     maxZoom: 18,
                     maxNativeZoom: 18
                 }
             },
             France: {
-                url: 'http://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png',
+                url: 'https://tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png',
                 options: {
                     attribution: '&copy; Openstreetmap France | {attribution.OpenStreetMap}'
                 }
             },
             HOT: {
-                url: 'http://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
+                url: 'https://tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
                 options: {
-                    attribution: '{attribution.OpenStreetMap}, Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>'
+                    attribution: '{attribution.OpenStreetMap}, Tiles courtesy of <a href="https://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>'
                 }
             }
         }


### PR DESCRIPTION
[Backport 2023.02.xx] OpenStreetMap : use HTTPS and endpoint fixes (#9676)

See https://github.com/openstreetmap/operations/issues/737 for informations about OSM URLs

Thanks to @RomainBourgATOL 
