### PR TITLE
Backport to 2022.02.xx ref to PR 9686

### DIFF
--- a/web/client/actions/geostory.js
+++ b/web/client/actions/geostory.js
@@ -167,11 +167,12 @@ export const toggleSettingsPanel = (withSave = false) => ({ type: TOGGLE_SETTING
  * @param {object} element the object to update
  * @param {string|object} [mode="replace"] "merge" or "replace", if "merge", the object passed as element will be merged with the original one (if present and if it is an object)
  */
-export const update = (path, element, mode = "replace") => ({
+export const update = (path, element, mode = "replace", options) => ({
     type: UPDATE,
     path,
     element,
-    mode
+    mode,
+    options
 });
 /**
  * updates the current page with current value of sectionId (future can be extended adding other info about current content).

--- a/web/client/plugins/GeoStory.jsx
+++ b/web/client/plugins/GeoStory.jsx
@@ -71,7 +71,8 @@ const GeoStory = ({
     }, []);
 
     useEffect(() => {
-        onUpdate("settings.theme.fontFamilies", fontFamilies, "merge");
+        // Appended options in actions for key handling to avoid fonts duplication
+        onUpdate("settings.theme.fontFamilies", fontFamilies, "merge", {uniqueByKey: "family"});
         // we need to store settings for media editor
         // so we could use them later when we open the media editor plugin
         if (mediaEditorSettings) {

--- a/web/client/reducers/__tests__/geostory-test.js
+++ b/web/client/reducers/__tests__/geostory-test.js
@@ -121,6 +121,22 @@ describe('geostory reducer', () => {
     });
     describe('update contents', () => {
         const STATE_STORY = geostory(undefined, setCurrentStory(TEST_STORY));
+        it('should handle UPDATE action with fontFamilies and mode merge', () => {
+            const initialState = {
+                currentStory: {
+                    fontFamilies: ['Arial', 'Helvetica']
+                }
+            };
+            const action = {
+                type: 'UPDATE',
+                path: 'fontFamilies',
+                mode: 'merge',
+                element: ['Times New Roman', 'Arial', 'Verdana'],
+                options: { uniqueByKey: 'id' }
+            };
+            const newState = geostory(initialState, action);
+            expect(newState).toBe(initialState);
+        });
         it('update with index path', () => {
             const TEST_CONTENT = "<h1>UNIT TEST CONTENT</h1>";
             const pathToContentHtml = `sections[0].contents[0].html`;

--- a/web/client/reducers/geostory.js
+++ b/web/client/reducers/geostory.js
@@ -306,7 +306,7 @@ export default (state = INITIAL_STATE, action) => {
         )(state);
     }
     case UPDATE: {
-        const { path: rawPath, mode } = action;
+        const { path: rawPath, mode, options } = action;
         let { element: newElement } = action;
         const path = getEffectivePath(`currentStory.${rawPath}`, state);
         const oldElement = get(state, path);
@@ -317,7 +317,8 @@ export default (state = INITIAL_STATE, action) => {
         }
 
         if (isArray(oldElement) && isArray(newElement) && mode === "merge") {
-            newElement = [ ...oldElement, ...newElement ];
+            // check for options to filter unique options
+            newElement = (options?.uniqueByKey) ? uniqBy([ ...oldElement, ...newElement ], options.uniqueByKey) : [...oldElement, ...newElement ];
         }
         return set(path, newElement, state);
     }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#9686 


**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
When passing custom fonts, an object with unique identifier is passed to check & restrict duplicate entries inside GeoStory plugin in edit mode

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Provides backport support for version 2022.02.xx

Issue was only reproducible on Geonode MapStore Client due to async loading of GeoStory component

Custom fonts should be added to localconfig under GeoStory -> cfg:
{
"name": "GeoStory",
"cfg": {
"fontFamilies": [
{
"family": "Arial"
},
{
"family": "Georgia"
},
{
"family": "Impact"
},
{
"family": "Tahoma"
},
{
"family": "Times New Roman"
},
{
"family": "Titillium Web",
"src": "https://fonts.googleapis.com/css2?family=Titillium+Web"
},
{
"family": "Verdana"
}
]
}
}