### PR TITLE
#9761: fix style bug - capitalize the login plugin content in sidebar

### DIFF
--- a/web/client/themes/default/less/dropdown-menu.less
+++ b/web/client/themes/default/less/dropdown-menu.less
@@ -32,7 +32,8 @@
 }
 
 .navbar-dx .dropdown-menu,
-.navbar-home .dropdown-menu {
+.navbar-home .dropdown-menu,
+#mapstore-sidebar-menu .dropdown-menu {
     text-transform: uppercase;
 }
 


### PR DESCRIPTION
## Description
Fix style issue: capitalize the login plugin content in sidebar

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

**What is the current behavior?**
#9761 
**What is the new behavior?**
Capitalize the login plugin content in sidebar like the login style in navBar


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

