### PR TITLE
#9765: fix issue of not saving edits of attribute rules in rules manager

### DIFF
--- a/web/client/components/manager/rulesmanager/ruleseditor/AttributesEditor.jsx
+++ b/web/client/components/manager/rulesmanager/ruleseditor/AttributesEditor.jsx
@@ -23,7 +23,7 @@ const getAttributeValue = (name, constraints) => {
 export default ({attributes = [], constraints = {}, setOption = () => {}, active = false, setEditedAttributes = () => {}, editedAttributes = []}) => {
     const onChange = (at) => {
         const {attributes: attrs} = constraints;
-        const attribute = (attrs && attrs.attribute?.length ? attrs.attribute : [attrs.attribute] || []).filter(e => e.name !== at.name).concat(at);
+        const attribute = ((attrs && attrs?.attribute?.length) ? attrs.attribute : (attrs?.attribute) ? [attrs.attribute] : [] || []).filter(e => e.name !== at.name).concat(at);
         setOption({key: "attributes", value: {attribute}});
         // add it to edited attribute
         if (!editedAttributes.includes(at.name)) setEditedAttributes(at.name);


### PR DESCRIPTION
## Description
Fix issue of not saving edits of Geofence attribute rules in rules manager

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#9765 

**What is the current behavior?**
#9765 
**What is the new behavior?**
Saving edits in attribute rules works well. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
