### PR TITLE
Fix #9653 force load of font when fontAwesome css is loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "eventlistener": "0.0.1",
     "file-saver": "1.3.3",
     "filtrex": "2.1.0",
+    "font-awesome": "4.7.0",
     "fs-extra": "3.0.1",
     "git-revision-webpack-plugin": "5.0.0",
     "history": "4.6.1",

--- a/web/client/utils/styleparser/StyleParserUtils.js
+++ b/web/client/utils/styleparser/StyleParserUtils.js
@@ -853,6 +853,7 @@ export const parseSymbolizerExpressions = (symbolizer, feature) => {
 };
 
 
+let loaded = false;
 const loadFontAwesome = () => {
     return new Promise((resolve) => {
         const fontAwesomeHref = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css';
@@ -862,13 +863,25 @@ const loadFontAwesome = () => {
             fontAwesome.setAttribute('href', fontAwesomeHref);
             document.head.appendChild(fontAwesome);
             fontAwesome.onload = () => {
-                resolve();
+                const font = document.createElement('link');
+                font.setAttribute('rel', 'preload');
+                font.setAttribute('as', 'font');
+                font.setAttribute('crossorigin', true);
+                font.setAttribute('href', "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/fonts/fontawesome-webfont.woff?v=4.7.0");
+                document.head.appendChild(font);
+                font.onload = () => {
+                    loaded = true;
+                    resolve();
+                };
             };
             fontAwesome.onerror = () => {
                 resolve();
             };
         } else {
-            resolve();
+            if (loaded) {
+                // delaying the resolve to make sure the fontAwesome.onload is triggered before
+                resolve();
+            }
         }
     });
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

the issue was that the font (**.woff** etc) was not loaded until needed this caused this issue [here](https://github.com/geosolutions-it/MapStore2/pull/9660#issuecomment-1827696337)

i've tested also loading directly **.woff** but in my case it was not fixing the issue, but with **.woff2** it was.

we might add a second script for loading also **.woff**

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #9653

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
