### PR TITLE
#9725: Fix expand layer legend arrows not aligned in TOC

### DIFF
--- a/web/client/themes/default/less/toc.less
+++ b/web/client/themes/default/less/toc.less
@@ -787,7 +787,17 @@
 
         }
     }
+    /* fix not align legend item content in one line in layer group */
+    .toc-group-children {
+        .toc-default-group{
+            .toc-group-children{
+                div.toc-title{
+                    width: calc(140px - 16px);
+                }
+            }
+        }
 
+    }
 
 }
 


### PR DESCRIPTION
## Description
This PR is for fixing css issue happened while expanding layer legend if layer is existing in expanded group ---> arrows were not aligned in TOC.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#9725 

**What is the current behavior?**
#9725 

**What is the new behavior?**
Arrow is properly aligned in TOC if layer is existing in expanded group 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
