### PR TITLE
Fix #9551 Ability to move GLTF 3D models by given x/y

### DIFF
--- a/docs/developer-guide/vector-style.md
+++ b/docs/developer-guide/vector-style.md
@@ -210,6 +210,8 @@ The `symbolizer` could be of following `kinds`:
 | `opacity` | color opacity |  | x |
 | `msHeightReference` | reference to compute the distance of the point geometry, one of **none**, **ground** or **clamp** |  | x |
 | `msHeight` | height of the point, the original geometry is applied if undefined  |  | x |
+| `msTranslateX` | move the model on the x axis with a value in meters (west negative value, east positive value) |  | x |
+| `msTranslateY` | move the model on the y axis with a value in meters (south negative value, north positive value) |  | x |
 | `msLeaderLineColor` | color of the leading line connecting the point to the terrain  |  | x |
 | `msLeaderLineOpacity` | opacity of the leading line connecting the point to the terrain |  | x |
 | `msLeaderLineWidth` | width of the leading line connecting the point to the terrain |  | x |

--- a/web/client/components/styleeditor/__tests__/VisualStyleEditor-test.js
+++ b/web/client/components/styleeditor/__tests__/VisualStyleEditor-test.js
@@ -526,6 +526,8 @@ describe('VisualStyleEditor', () => {
                     'styleeditor.color',
                     'styleeditor.heightReferenceFromGround',
                     'styleeditor.height',
+                    'styleeditor.msTranslateX',
+                    'styleeditor.msTranslateY',
                     'styleeditor.leaderLineColor',
                     'styleeditor.leaderLineWidth'
                 ]);

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -136,7 +136,7 @@ const lineGeometryTransformation = () => ({
     })
 });
 
-const heightPoint3dOptions = ({ isDisabled }) =>  ({
+const heightPoint3dOptions = ({ isDisabled, enableTranslation }) =>  ({
     msHeightReference: property.msHeightReference({
         label: "styleeditor.heightReferenceFromGround",
         isDisabled
@@ -147,6 +147,22 @@ const heightPoint3dOptions = ({ isDisabled }) =>  ({
         uom: 'm',
         placeholderId: 'styleeditor.pointHeight',
         isDisabled: (value, properties) => isDisabled() || properties?.msHeightReference === 'clamp'
+    }),
+    ...(enableTranslation && {
+        msTranslateX: property.number({
+            key: 'msTranslateX',
+            label: 'styleeditor.msTranslateX',
+            uom: 'm',
+            fallbackValue: 0,
+            isDisabled
+        }),
+        msTranslateY: property.number({
+            key: 'msTranslateY',
+            label: 'styleeditor.msTranslateY',
+            uom: 'm',
+            fallbackValue: 0,
+            isDisabled
+        })
     }),
     msLeaderLineColor: property.color({
         key: 'msLeaderLineColor',
@@ -556,7 +572,8 @@ const getBlocks = ({
                     isDisabled: () => !enable3dStyleOptions
                 }),
                 ...heightPoint3dOptions({
-                    isDisabled: () => !enable3dStyleOptions
+                    isDisabled: () => !enable3dStyleOptions,
+                    enableTranslation: true
                 }),
                 ...(!shouldHideVectorStyleOptions && pointGeometryTransformation({}))
             },

--- a/web/client/components/styleeditor/config/property.js
+++ b/web/client/components/styleeditor/config/property.js
@@ -363,8 +363,7 @@ const property = {
         },
         getValue: (value) => {
             return {
-                [key]: value,
-                ...(value === 'clamp' && { msHeight: undefined })
+                [key]: value
             };
         },
         isDisabled

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2630,7 +2630,9 @@
             "offset": "Offset",
             "propertyValue": "Eigenschaftswert",
             "colorPropertyInfoMessage": "Der Farbeigenschaftswert muss eine hexadezimale Zeichenfolge sein. Beispiel: \"#ffffff\"",
-            "pointCloudSizeInfo": "Der Punktwolkenradius wird nur angewendet, wenn die Dämpfungsoptionen deaktiviert sind. Die Dämpfungsoption hat Vorrang vor dieser Eigenschaft."
+            "pointCloudSizeInfo": "Der Punktwolkenradius wird nur angewendet, wenn die Dämpfungsoptionen deaktiviert sind. Die Dämpfungsoption hat Vorrang vor dieser Eigenschaft.",
+            "msTranslateX": "Versatz x",
+            "msTranslateY": "Versatz y"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2602,7 +2602,9 @@
             "offset": "Offset",
             "propertyValue": "Property value",
             "colorPropertyInfoMessage": "The color property value must be an hexadecimal string. Example: \"#ffffff\"",
-            "pointCloudSizeInfo": "The point cloud radius is applied only when the attenuation options is disabled. The attenuation option takes precedence over this property."
+            "pointCloudSizeInfo": "The point cloud radius is applied only when the attenuation options is disabled. The attenuation option takes precedence over this property.",
+            "msTranslateX": "Translate x",
+            "msTranslateY": "Translate y"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2592,7 +2592,9 @@
             "offset": "Desplazamiento",
             "propertyValue": "Valor de la propiedad",
             "colorPropertyInfoMessage": "El valor de la propiedad de color debe ser una cadena hexadecimal. Ejemplo: \"#ffffff\"",
-            "pointCloudSizeInfo": "El radio de la nube de puntos se aplica sólo cuando las opciones de atenuación están deshabilitadas. La opción de atenuación tiene prioridad sobre esta propiedad."
+            "pointCloudSizeInfo": "El radio de la nube de puntos se aplica sólo cuando las opciones de atenuación están deshabilitadas. La opción de atenuación tiene prioridad sobre esta propiedad.",
+            "msTranslateX": "Desplazamiento x",
+            "msTranslateY": "Desplazamiento y"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2592,7 +2592,9 @@
             "offset": "Décalage",
             "propertyValue": "Valeur de la propriété",
             "colorPropertyInfoMessage": "La valeur de la propriété de couleur doit être une chaîne hexadécimale. Exemple : \"#ffffff\"",
-            "pointCloudSizeInfo": "Le rayon du nuage de points est appliqué uniquement lorsque les options d'atténuation sont désactivées. L'option d'atténuation est prioritaire sur cette propriété."
+            "pointCloudSizeInfo": "Le rayon du nuage de points est appliqué uniquement lorsque les options d'atténuation sont désactivées. L'option d'atténuation est prioritaire sur cette propriété.",
+            "msTranslateX": "Décalage x",
+            "msTranslateY": "Décalage y"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2593,7 +2593,9 @@
             "offset": "Offset",
             "propertyValue": "Valore della proprietà",
             "colorPropertyInfoMessage": "Il valore della proprietà colore deve essere una stringa esadecimale. Esempio: \"#ffffff\"",
-            "pointCloudSizeInfo": "Il raggio della nuvola di punti viene applicato solo quando le opzioni di attenuazione sono disabilitate. L'opzione di attenuazione ha la precedenza su questa proprietà."
+            "pointCloudSizeInfo": "Il raggio della nuvola di punti viene applicato solo quando le opzioni di attenuazione sono disabilitate. L'opzione di attenuazione ha la precedenza su questa proprietà.",
+            "msTranslateX": "Offset x",
+            "msTranslateY": "Offset y"
         },
         "playback": {
             "settings": {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces two new properties called `msTranslateX` and `msTranslateY` for model symbolizer available in 3d mode. This two options allows to translate a model with a distance in meter from the original coordinates on the x (West to East) and y (South to North)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9551

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
