### PR TITLE
#9783: implement zoom to record for parent table in dashboards

### DIFF
--- a/web/client/components/widgets/enhancers/__tests__/tableWidget-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/tableWidget-test.jsx
@@ -62,7 +62,7 @@ describe('widgets tableWidget enhancer', () => {
             expect(id).toBe("123456");
             expect(value).toEqual({
                 bbox: [-10, 0, 0, -10]
-            }, {}, "", { crs: "EPSG:4326", maxZoom: null });
+            }, { crs: "EPSG:4326", maxZoom: null });
         }}/></Provider>, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toExist();
@@ -74,13 +74,7 @@ describe('widgets tableWidget enhancer', () => {
             expect(props.gridTools.length).toEqual(0);
             done();
         }));
-        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} id="123456" mapSync={false} widgetType={"table"} isDashboardOpened={"true"} updateProperty={(id, path, value) => {
-            expect(path).toBe("dependencies.extentObj");
-            expect(id).toBe("123456");
-            expect(value).toEqual({
-                bbox: [-10, 0, 0, -10]
-            }, {}, "", { crs: "EPSG:4326", maxZoom: null });
-        }}/></Provider>, document.getElementById("container"));
+        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} id="123456" mapSync={false} widgetType={"table"} isDashboardOpened={"true"} updateProperty={() => {}} /></Provider>, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toExist();
 
@@ -91,13 +85,70 @@ describe('widgets tableWidget enhancer', () => {
             expect(props.gridTools.length).toEqual(0);
             done();
         }));
-        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={false} id="123456" mapSync={"true"} widgetType={"table"} isDashboardOpened={"true"} updateProperty={(id, path, value) => {
+        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={false} id="123456" mapSync={"true"} widgetType={"table"} isDashboardOpened={"true"} updateProperty={() => {}}/></Provider>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        expect(container).toExist();
+
+    });
+
+    it('tableWidget with gridTools including zoom icon for dashboard viewer in case multiple maps connected to a parent table', (done) => {
+        let widgets = [
+            {
+                widgetType: "table", id: "123456", mapSync: true
+            }, {
+                widgetType: 'map', id: "connectedMapID1", dependenciesMap: {
+                    mapSync: "123456"
+                }
+            },
+            {
+                widgetType: 'map', id: "connectedMapID2", dependenciesMap: {
+                    mapSync: "123456"
+                }
+            }, {
+                widgetType: 'map', id: "notConnectedMapID"
+            }
+        ];
+        const Sink = tableWidget(createSink( props => {
+            expect(props).toExist();
+            expect(props.gridTools.length).toEqual(1);
+            props.gridTools[0].events.onClick(
+                {
+                    bbox: [-10, 0, 0, -10]
+                }, {}, "", { crs: "", maxZoom: null }
+            );
+            expect(props.widgets.length).toEqual(4);
+            let mapWidgetsConnectedWithTbl = props.widgets.filter(i=>i.widgetType === 'map' && i?.dependenciesMap && i?.dependenciesMap?.mapSync?.includes(props.id)) || [];
+            expect(mapWidgetsConnectedWithTbl.length).toEqual(2);
+            done();
+        }));
+        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} widgets={widgets} id="123456" mapSync={"true"} widgetType={"table"} isDashboardOpened={"true"} updateProperty={(id, path, value) => {
             expect(path).toBe("dependencies.extentObj");
             expect(id).toBe("123456");
             expect(value).toEqual({
                 bbox: [-10, 0, 0, -10]
-            }, {}, "", { crs: "EPSG:4326", maxZoom: null });
+            }, { crs: "EPSG:4326", maxZoom: null });
         }}/></Provider>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        expect(container).toExist();
+
+    });
+    it('tableWidget with gridTools including zoom icon for dashboard viewer in case no connected map', (done) => {
+        let widgets = [
+            {
+                widgetType: "table", id: "123456", mapSync: false
+            }, {
+                widgetType: 'map', id: "notConnectedMapID"
+            }
+        ];
+        const Sink = tableWidget(createSink( props => {
+            expect(props).toExist();
+            expect(props.gridTools.length).toEqual(0);
+            expect(props.widgets.length).toEqual(2);
+            let mapWidgetsConnectedWithTbl = props.widgets.filter(i=>i.widgetType === 'map' && i?.dependenciesMap && i?.dependenciesMap?.mapSync?.includes(props.id)) || [];
+            expect(mapWidgetsConnectedWithTbl.length).toEqual(0);
+            done();
+        }));
+        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} widgets={widgets} id="123456" mapSync={false} widgetType={"table"} isDashboardOpened={"true"} updateProperty={() => {}}/></Provider>, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toExist();
 
@@ -113,7 +164,13 @@ describe('widgets tableWidget enhancer', () => {
             );
             done();
         }));
-        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} id="123456" widgetType={"table"} /></Provider>, document.getElementById("container"));
+        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} id="123456" widgetType={"table"} updateProperty={(id, path, value) => {
+            expect(path).toBe("dependencies.extentObj");
+            expect(id).toBe("123456");
+            expect(value).toEqual({
+                bbox: [-10, 0, 0, -10]
+            }, { crs: "EPSG:4326", maxZoom: null });
+        }} /></Provider>, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toExist();
 

--- a/web/client/components/widgets/enhancers/dependenciesToExtent.js
+++ b/web/client/components/widgets/enhancers/dependenciesToExtent.js
@@ -36,10 +36,18 @@ export default compose(
             const tblWidgetWithExtentObj = widgets?.find(i=>i?.dependencies?.extentObj);
             const extentObj = tblWidgetWithExtentObj?.dependencies?.extentObj;
             const mapWidgetID = id;
-            const mapWidget = widgets?.find(i=>tblWidgetWithExtentObj?.dependenciesMap?.mapSync.includes(i.id) && i.id === mapWidgetID);
-            const connectedMap = mapWidget?.maps.find(i=>i.mapStateSource === mapWidget.id);
+            let connectedMaps;
+            if (!tblWidgetWithExtentObj) return {};
+            if (tblWidgetWithExtentObj?.mapSync) {
+                const mapWidget = widgets?.find(i=>tblWidgetWithExtentObj?.dependenciesMap?.mapSync.includes(i.id) && i.id === mapWidgetID);
+                connectedMaps = mapWidget?.maps?.find(i=>i.mapStateSource === mapWidget.id);
+            }
+            if (!connectedMaps || !tblWidgetWithExtentObj?.mapSync) {
+                const mapWidgets = widgets.filter(i=>i.widgetType === 'map' && i?.dependenciesMap && i?.dependenciesMap?.mapSync?.includes(tblWidgetWithExtentObj?.id) && i.id === mapWidgetID);
+                connectedMaps = mapWidgets?.length ? [...mapWidgets] : undefined;
+            }
             const hook = hookRegister?.getHook("ZOOM_TO_EXTENT_HOOK");
-            if (hook && hookRegister?.id === id && connectedMap) {          // a condition to detect which connected map with its id to zoom within
+            if (hook && hookRegister?.id === id && connectedMaps) {          // a condition to detect which connected map with its id to zoom within
                 // trigger "internal" zoom to extent
                 hook(extentObj.extent, {
                     crs: extentObj.crs, maxZoom: extentObj.maxZoom

--- a/web/client/components/widgets/enhancers/tableWidget.js
+++ b/web/client/components/widgets/enhancers/tableWidget.js
@@ -31,8 +31,9 @@ const withSorting = () => withPropsOnChange(["gridEvents"], ({ gridEvents = {}, 
 export default compose(
     compose(connect(null, (dispatch, ownProps)=>{
         let isTblDashboard = ownProps?.enableZoomInTblWidget && ownProps?.widgetType === 'table' && ownProps?.isDashboardOpened;
+        let mapWidgetsConnectedWithTbl = ownProps?.widgets?.filter(i=>i.widgetType === 'map' && i?.dependenciesMap && i?.dependenciesMap?.mapSync?.includes(ownProps.id)) || [];
+        let isTblSyncWithMap = ownProps?.mapSync || mapWidgetsConnectedWithTbl.length;
         let isTblWidgetInMapViewer = ownProps?.widgetType === 'table' && !isTblDashboard && ownProps?.enableZoomInTblWidget;
-        let isTblSyncWithMap = ownProps?.mapSync;
         return {
             gridTools: (isTblSyncWithMap && isTblDashboard) || (isTblWidgetInMapViewer) ? gridTools.map((t) => ({
                 ...t,


### PR DESCRIPTION
## Description
In this PR, an enhancement is added for zooming to record in dashboard viewer. Implement zooming to record for Parent Table in dashboards if there are multiple maps linked with a parent table and all have the same layer dataset.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#9783 

**What is the current behavior?**
#9783 

**What is the new behavior?**
If multiple maps are linked to the same parent table and all contain a layer that references the same table dataset, zooming is performed for all map widgets as per usual logic.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
