### PR TITLE
#9792: fix z index order of catalog in app context wizard

### DIFF
--- a/web/client/themes/default/less/dashboard.less
+++ b/web/client/themes/default/less/dashboard.less
@@ -28,6 +28,7 @@
 
     #mapstore-navbar-container {
         margin-bottom: 0;
+        z-index: 1032;
     }
 
     .ms2-border-layout-content {

--- a/web/client/themes/default/less/navbar.less
+++ b/web/client/themes/default/less/navbar.less
@@ -59,7 +59,6 @@ ol {
 
 #mapstore-navbar-container {
     height: @square-btn-size;
-    z-index: 1032;
     .nav {
         &.pull-left {
             display: flex;


### PR DESCRIPTION
## Description
Fix z-index order of catalog in app context wizard when user opens it. 
- z-index was added before in navbar.less for details panel within dashboard which affected later on showing catalog in context properly. 
- So moving it to dashboard.less fixed this issue

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

#9792 

**What is the current behavior?**
#9792 

**What is the new behavior?**
If user open app context and at the 2nd step "map viewer" opens catalog within burger menu, it opens normally as usual.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->
