### PR TITLE
#8997: fix map sync issue in feature grid

### DIFF
--- a/web/client/actions/__tests__/featuregrid-test.js
+++ b/web/client/actions/__tests__/featuregrid-test.js
@@ -279,6 +279,12 @@ describe('Test correctness of featurgrid actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(CLOSE_FEATURE_GRID);
     });
+    it('Test closeFeatureGrid with closer', () => {
+        const retval = closeFeatureGrid('closer1');
+        expect(retval).toExist();
+        expect(retval.type).toBe(CLOSE_FEATURE_GRID);
+        expect(retval.closer).toBe('closer1');
+    });
     it('Test closeFeatureGridConfirm', () => {
         const retval = closeFeatureGridConfirm();
         expect(retval).toExist();

--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -314,9 +314,10 @@ export function closeFeatureGridConfirm() {
         type: CLOSE_FEATURE_GRID_CONFIRM
     };
 }
-export function closeFeatureGrid() {
+export function closeFeatureGrid(closer) {
     return {
-        type: CLOSE_FEATURE_GRID
+        type: CLOSE_FEATURE_GRID,
+        closer      // the closer of feature grid like: 'queryPanel'
     };
 }
 export function openFeatureGrid() {

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -1038,7 +1038,7 @@ export const onOpenAdvancedSearch = (action$, store) =>
             // hide selected features from map
             selectFeatures([]),
             loadFilter(get(store.getState(), `featuregrid.advancedFilters["${selectedLayerIdSelector(store.getState())}"]`)),
-            closeFeatureGrid(),
+            closeFeatureGrid('queryPanel'),
             setControlProperty('queryPanel', "enabled", true)
         )
             .merge(
@@ -1049,7 +1049,8 @@ export const onOpenAdvancedSearch = (action$, store) =>
                             createQuery(action.searchUrl, action.filterObj),
                             storeAdvancedSearchFilter(assign({}, queryFormUiStateSelector(store.getState()), action.filterObj)),
                             setControlProperty('queryPanel', "enabled", false),
-                            openFeatureGrid()
+                            openFeatureGrid(),
+                            isSyncWmsActive(store.getState()) ? startSyncWMS() : Rx.Observable.empty()          // to keep sync icon active if it is previously active before opening advanced search
                         );
                     }),
                     action$.ofType(TOGGLE_CONTROL)
@@ -1103,9 +1104,18 @@ export const stopSyncWmsFilter = (action$, store) =>
      */
 export const deactivateSyncWmsFilterOnFeatureGridClose = (action$, store) =>
     action$.ofType(CLOSE_FEATURE_GRID)
+        .switchMap(() => {
+            let state = store.getState();
+            let isQueryPanelCloserGrid = state.featuregrid?.closer === 'queryPanel';
+            if (isQueryPanelCloserGrid && isSyncWmsActive(state)) return Rx.Observable.of(removeFilterFromWMSLayer(store.getState()));      // in case close grid by queryPanel, remove filter to dislay all feats on map
+            else if (isSyncWmsActive(state) && !isQueryPanelCloserGrid) return Rx.Observable.of(toggleSyncWms());       // if close feature grid by others---> reset wms sync
+            return Rx.Observable.empty();
+        });
+export const activateSyncWmsFilterOnFeatureGridOpen = (action$, store) =>
+    action$.ofType(OPEN_FEATURE_GRID)
         .filter(() => isSyncWmsActive(store.getState()))
         .switchMap(() => {
-            return Rx.Observable.of(toggleSyncWms());
+            return Rx.Observable.of(startSyncWMS());
         });
 /**
  * Sync map with filter.

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -1106,9 +1106,12 @@ export const deactivateSyncWmsFilterOnFeatureGridClose = (action$, store) =>
     action$.ofType(CLOSE_FEATURE_GRID)
         .switchMap(() => {
             let state = store.getState();
-            let isQueryPanelCloserGrid = state.featuregrid?.closer === 'queryPanel';
-            if (isQueryPanelCloserGrid && isSyncWmsActive(state)) return Rx.Observable.of(removeFilterFromWMSLayer(store.getState()));      // in case close grid by queryPanel, remove filter to dislay all feats on map
-            else if (isSyncWmsActive(state) && !isQueryPanelCloserGrid) return Rx.Observable.of(toggleSyncWms());       // if close feature grid by others---> reset wms sync
+            let isQueryPanelClosingFeatureGrid  = state.featuregrid?.closer === 'queryPanel';
+            if (isQueryPanelClosingFeatureGrid  && isSyncWmsActive(state)) {        // in case close grid by queryPanel, remove filter to dislay all feats on map
+                return Rx.Observable.of(removeFilterFromWMSLayer(store.getState()));
+            } else if (isSyncWmsActive(state) && !isQueryPanelClosingFeatureGrid ) {            // if close feature grid by others---> reset wms sync
+                return Rx.Observable.of(toggleSyncWms());
+            }
             return Rx.Observable.empty();
         });
 export const activateSyncWmsFilterOnFeatureGridOpen = (action$, store) =>

--- a/web/client/plugins/featuregrid/FeatureEditor.jsx
+++ b/web/client/plugins/featuregrid/FeatureEditor.jsx
@@ -283,28 +283,23 @@ const EditorPlugin = compose(
     lifecycle({
         componentDidMount() {
             // only the passed properties will be picked
-            this.props.onMount(pick(this.props, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions', 'isSyncWmsActive']));
-            if (this.props.isSyncWmsActive) return;
-            if (this.props.enableMapFilterSync) {
-                this.props.setSyncTool(true);
-            } else {
-                this.props.setSyncTool(false);
+            this.props.onMount(pick(this.props, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions']));
+            if (!this.props.isSyncWmsActive) {
+                if (this.props.enableMapFilterSync) {
+                    this.props.setSyncTool(true);
+                } else {
+                    this.props.setSyncTool(false);
+                }
             }
         },
         // TODO: fix this in contexts
         // due to multiple renders of plugins in contexts (one with default props, then with context props)
         // the options have to be updated when change.
         componentDidUpdate(oldProps) {
-            const newOptions = pick(this.props, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions', 'isSyncWmsActive']);
-            const oldOptions = pick(oldProps, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions', 'isSyncWmsActive']);
+            const newOptions = pick(this.props, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions']);
+            const oldOptions = pick(oldProps, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions']);
             if (!isEqual(newOptions, oldOptions) ) {
                 this.props.onMount(newOptions);
-            }
-            if (newOptions.isSyncWmsActive) return;
-            if (this.props.enableMapFilterSync) {
-                this.props.setSyncTool(true);
-            } else {
-                this.props.setSyncTool(false);
             }
         }
     }),

--- a/web/client/reducers/__tests__/featuregrid-test.js
+++ b/web/client/reducers/__tests__/featuregrid-test.js
@@ -149,6 +149,13 @@ describe('Test the featuregrid reducer', () => {
         expect(state.open).toBe(false);
         expect(state.mode).toBe(MODES.VIEW);
     });
+    it('closeFeatureGrid with closer', () => {
+        let state = featuregrid(undefined, closeFeatureGrid('closer1'));
+        expect(state).toExist();
+        expect(state.open).toBe(false);
+        expect(state.mode).toBe(MODES.VIEW);
+        expect(state.closer).toBe('closer1');
+    });
 
     it('selectFeature', () => {
         // TODO FIX this test or the reducer

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -330,7 +330,8 @@ function featuregrid(state = emptyResultsState, action) {
     }
     case OPEN_FEATURE_GRID: {
         return assign({}, state, {
-            open: true
+            open: true,
+            closer: null
         });
     }
     case CLOSE_FEATURE_GRID: {
@@ -346,7 +347,8 @@ function featuregrid(state = emptyResultsState, action) {
             deleteConfirm: false,
             drawing: false,
             newFeatures: [],
-            changes: []
+            changes: [],
+            closer: action.closer
         });
     }
     case DISABLE_TOOLBAR: {


### PR DESCRIPTION
## Description
This PR fixes the issue of map sync activation in feature grid. Now user can activate map sync tool then applies an advanced search via query panel then will see the map sync features on map without the need to clicks twice to map sync icon. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue
#8997

**What is the current behavior?**
#8997 

**What is the new behavior?**
 User can activate map sync tool on feature grid table then applies an advanced search query via query panel then user will see the map sync features on map without the need to clicks twice to map sync icon. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
