### PR TITLE
#9548: fix issue of 3D point measurement

### DIFF
--- a/web/client/utils/cesium/ClickUtils.js
+++ b/web/client/utils/cesium/ClickUtils.js
@@ -81,8 +81,9 @@ export function computePositionInfo(map, movement, {
 
     const feature = scene.pick(position);
     const depthCartesian = scene.pickPosition(position);
-
-    if (!!(feature && depthCartesian)) {
+    if (!(feature?.primitive instanceof Cesium.GroundPrimitive)
+    && !(feature?.primitive instanceof Cesium.GroundPolylinePrimitive)
+    && !!(feature && depthCartesian)) {
         return {
             cartesian: depthCartesian,
             cartographic: Cesium.Cartographic.fromCartesian(depthCartesian),

--- a/web/client/utils/cesium/DrawGeometryInteraction.js
+++ b/web/client/utils/cesium/DrawGeometryInteraction.js
@@ -215,7 +215,11 @@ class CesiumDrawGeometryInteraction {
         this._coordinatesLength = options?.coordinatesLength;
         this._geodesic = options?.geodesic;
         this._sampleTerrain = options?.sampleTerrain;
-        this._getObjectsToExcludeOnPick = options?.getObjectsToExcludeOnPick;
+        this._getObjectsToExcludeOnPick = () => [
+            ...(options?.getObjectsToExcludeOnPick ? options.getObjectsToExcludeOnPick() : []),
+            this._dynamicPrimitivesCollection,
+            this._dynamicBillboardCollection
+        ];
         this._depthTestAgainstTerrain = options?.depthTestAgainstTerrain;
         this._getPositionInfo =  options?.getPositionInfo || defaultGetPositionInfo;
 


### PR DESCRIPTION
## Description
At this PR, I fixed the issue of not performing 3D point measurement properly by not providing the correct measurement value of attitude. In the code, improving the pickPosition detection is implemented and it fixes the issue by showing attitude value = 0 for the places with no feature detection.
This improving fixes the issue #9549  as well during the tests. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#9548 

**What is the current behavior?**
#9548 

**What is the new behavior?**
Now, height from terrain measure in 3D mode shows the correct values (coordinates and height), showing attitude value = 0 for the places with no feature detection.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
#9549 is resolved by this PR as well