### PR TITLE
[Backport 2023.02.xx] Fix #9775 Visibility limits not working in 3D for detached layers (#9777)

### DIFF
--- a/web/client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx
+++ b/web/client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx
@@ -254,13 +254,6 @@ function VisibilityLimitsForm({
         clearMessages();
     }, [ dpu,  resolutionString ]);
 
-    useEffect(() => {
-        if (isMounted.current && (!isNil(maxResolution) || !isNil(minResolution))) {
-            setCapabilitiesMessage(maxResolution, minResolution);
-            setRangeError(maxResolution, minResolution);
-        }
-    }, [isMounted]);
-
     return (
         <div className="ms-visibility-limits-form">
             <div className="ms-visibility-limits-form-title" style={{ display: 'flex', alignItems: 'center' }}>

--- a/web/client/components/TOC/fragments/settings/__tests__/VisibilityLimitsForm-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/VisibilityLimitsForm-test.jsx
@@ -47,8 +47,6 @@ describe('VisibilityLimitsForm', () => {
             '1 : 37795',
             'layerProperties.visibilityLimits.scale'
         ]);
-        const message = document.querySelector('.alert-success');
-        expect(message.textContent).toBe('layerProperties.visibilityLimits.serverValuesUpdate');
     });
     it('should render maxResolution and minResolution labels as resolution', () => {
         const layer = {

--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -197,7 +197,7 @@ class CesiumLayer extends React.Component {
                 return false;
             }
         }
-        return !!visibility;
+        return visibility !== false;
     };
 
     setLayerOpacity = (opacity) => {

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -334,7 +334,15 @@ class CesiumMap extends React.Component {
     };
 
     getZoomFromHeight = (height) => {
-        return Math.log2(this.props.zoomToHeight / height) + 1;
+        let distance = height;
+        // when camera is tilted we could compute the height as the distance between the camera point of view and the viewed point on the map
+        // the viewed point or target is computed as the intersection of an imaginary vector based on the camera direction (ray) and the globe surface
+        // if the camera is orthogonal to the globe distance should match the height so this computation is still valid
+        const target = this.map.scene.globe.pick(new Cesium.Ray(this.map.camera.position, this.map.camera.direction), this.map.scene);
+        if (target) {
+            distance = Cesium.Cartesian3.distance(target, this.map.camera.position);
+        }
+        return Math.log2(this.props.zoomToHeight / distance) + 1;
     };
 
     getHeightFromZoom = (zoom) => {

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -584,7 +584,8 @@ describe('Cesium layer', () => {
 
         let options = {
             id: 'overlay-1',
-            position: { x: 13, y: 43 }
+            position: { x: 13, y: 43 },
+            visibility: true
         };
         // create layers
         let layer = ReactDOM.render(
@@ -612,7 +613,8 @@ describe('Cesium layer', () => {
             position: { x: 13, y: 43 },
             onClose: () => {
                 closed = true;
-            }
+            },
+            visibility: true
         };
         // create layers
         let layer = ReactDOM.render(
@@ -639,7 +641,8 @@ describe('Cesium layer', () => {
         document.body.appendChild(element);
         let options = {
             id: 'overlay-1',
-            position: { x: 13, y: 43 }
+            position: { x: 13, y: 43 },
+            visibility: true
         };
         // create layers
         let layer = ReactDOM.render(
@@ -655,7 +658,8 @@ describe('Cesium layer', () => {
 
     it('creates a marker layer for cesium map', () => {
         let options = {
-            point: { lng: 13, lat: 43 }
+            point: { lng: 13, lat: 43 },
+            visibility: true
         };
         // create layers
         let layer = ReactDOM.render(

--- a/web/client/components/map/cesium/__tests__/Map-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test.jsx
@@ -168,7 +168,7 @@ describe('CesiumMap', () => {
                         try {
                             expect(Math.round(Math.round(center.y * precision) / precision)).toBe(30);
                             expect(Math.round(Math.round(center.x * precision) / precision)).toBe(20);
-                            expect(zoom).toBe(5);
+                            expect(Math.round(zoom)).toBe(5);
                             expect(bbox.bounds).toBeTruthy();
                             expect(bbox.crs).toBeTruthy();
                             expect(size.height).toBeTruthy();

--- a/web/client/components/map/cesium/plugins/MarkerLayer.js
+++ b/web/client/components/map/cesium/plugins/MarkerLayer.js
@@ -16,6 +16,13 @@ import { isEqual } from 'lodash';
  */
 Layers.registerType('marker', {
     create: (options, map) => {
+        if (!options.visibility) {
+            return {
+                detached: true,
+                point: undefined,
+                remove: () => {}
+            };
+        }
         const style = {
             point: {
                 pixelSize: 5,
@@ -26,7 +33,7 @@ Layers.registerType('marker', {
             ...options.style
         };
         const point = map.entities.add({
-            position: Cesium.Cartesian3.fromDegrees(options.point.lng, options.point.lat),
+            position: Cesium.Cartesian3.fromDegrees(options?.point?.lng || 0, options?.point?.lat || 0),
             ...style
         });
         return {
@@ -38,12 +45,8 @@ Layers.registerType('marker', {
         };
     },
     update: function(layer, newOptions, oldOptions, map) {
-        if (!isEqual(newOptions.point, oldOptions.point)
-        || newOptions.visibility !== oldOptions.visibility) {
-            layer.remove();
-            return newOptions.visibility
-                ? this.create(newOptions, map)
-                : null;
+        if (!isEqual(newOptions.point, oldOptions.point)) {
+            return this.create(newOptions, map);
         }
         return null;
     }

--- a/web/client/components/map/cesium/plugins/OverlayLayer.js
+++ b/web/client/components/map/cesium/plugins/OverlayLayer.js
@@ -166,11 +166,19 @@ const cloneOriginalOverlay = (original, options) => {
 Layers.registerType('overlay', {
     create: (options, map) => {
 
+        if (!options.visibility) {
+            return {
+                detached: true,
+                info: undefined,
+                remove: () => {}
+            };
+        }
         const original = document.getElementById(options.id);
-        const cloned = cloneOriginalOverlay(original, options);
+        // use a div fallback to avoid error if the original element does not exist
+        const cloned = original ? cloneOriginalOverlay(original, options) : document.createElement('div');
 
         let infoWindow = new InfoWindow(map);
-        infoWindow.showAt(options.position.y, options.position.x, cloned);
+        infoWindow.showAt(options?.position?.y || 0, options?.position?.x || 0, cloned);
         infoWindow.setVisible(true);
         let info = map.scene.primitives.add(infoWindow);
 
@@ -183,12 +191,8 @@ Layers.registerType('overlay', {
         };
     },
     update: function(layer, newOptions, oldOptions, map) {
-        if (!isEqual(newOptions.position, oldOptions.position)
-        || newOptions.visibility !== oldOptions.visibility) {
-            layer.remove();
-            return newOptions.visibility
-                ? this.create(newOptions, map)
-                : null;
+        if (!isEqual(newOptions.position, oldOptions.position)) {
+            return this.create(newOptions, map);
         }
         return null;
     }

--- a/web/client/components/map/cesium/plugins/TerrainLayer.js
+++ b/web/client/components/map/cesium/plugins/TerrainLayer.js
@@ -48,8 +48,7 @@ const createLayer = (config, map) => {
         terrainProvider,
         remove: () => {
             map.terrainProvider = new Cesium.EllipsoidTerrainProvider();
-        },
-        setVisible: () => {}
+        }
     };
 };
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces following changes:

- ensure correct visibility when a layer is created
- review visibility workflow of 3D detached layers. The changes are centralizing the add/remove based on visibility inside the Layer.jsx component instead to have specific implementation per layer type
- compute of the zoom level based on the distance between camera and target point
- remove a side effect in the visibility limits form that was showing alerts every time the settings panel was opened

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9775

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
