### PR TITLE
Fix #9814 Further issue with visibility limits in master

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -336,15 +336,7 @@ class CesiumMap extends React.Component {
     };
 
     getZoomFromHeight = (height) => {
-        let distance = height;
-        // when camera is tilted we could compute the height as the distance between the camera point of view and the viewed point on the map
-        // the viewed point or target is computed as the intersection of an imaginary vector based on the camera direction (ray) and the globe surface
-        // if the camera is orthogonal to the globe distance should match the height so this computation is still valid
-        const target = this.map.scene.globe.pick(new Cesium.Ray(this.map.camera.position, this.map.camera.direction), this.map.scene);
-        if (target) {
-            distance = Cesium.Cartesian3.distance(target, this.map.camera.position);
-        }
-        return Math.log2(this.props.zoomToHeight / distance) + 1;
+        return Math.log2(this.props.zoomToHeight / height) + 1;
     };
 
     getHeightFromZoom = (zoom) => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR reverts the formula introduced in #9777 to compute the zoom level because it is not reliable. The formula needs the globe ready and in some cases it's not at the initialization of a map viewer causing a computation of the zoom with the old formula as fallback. The difference between the new and old formula results increases when the camera is tilted as in the described scenario in the issue.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9814

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Revert computation of zoom level in cesium implementation

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
