### PR TITLE
#9783: resolve test review of not hiding zoom icon in tbl widget in case of removing connection from map widget to tbl widget

### DIFF
--- a/web/client/components/widgets/enhancers/__tests__/tableWidget-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/tableWidget-test.jsx
@@ -96,12 +96,12 @@ describe('widgets tableWidget enhancer', () => {
             {
                 widgetType: "table", id: "123456", mapSync: true
             }, {
-                widgetType: 'map', id: "connectedMapID1", dependenciesMap: {
+                widgetType: 'map', id: "connectedMapID1", mapSync: true, dependenciesMap: {
                     mapSync: "123456"
                 }
             },
             {
-                widgetType: 'map', id: "connectedMapID2", dependenciesMap: {
+                widgetType: 'map', id: "connectedMapID2", mapSync: true, dependenciesMap: {
                     mapSync: "123456"
                 }
             }, {
@@ -117,7 +117,7 @@ describe('widgets tableWidget enhancer', () => {
                 }, {}, "", { crs: "", maxZoom: null }
             );
             expect(props.widgets.length).toEqual(4);
-            let mapWidgetsConnectedWithTbl = props.widgets.filter(i=>i.widgetType === 'map' && i?.dependenciesMap && i?.dependenciesMap?.mapSync?.includes(props.id)) || [];
+            let mapWidgetsConnectedWithTbl = props.widgets.filter(i=>i.widgetType === 'map' && i?.dependenciesMap && i?.dependenciesMap?.mapSync?.includes(props.id) && i.mapSync) || [];
             expect(mapWidgetsConnectedWithTbl.length).toEqual(2);
             done();
         }));
@@ -144,7 +144,7 @@ describe('widgets tableWidget enhancer', () => {
             expect(props).toExist();
             expect(props.gridTools.length).toEqual(0);
             expect(props.widgets.length).toEqual(2);
-            let mapWidgetsConnectedWithTbl = props.widgets.filter(i=>i.widgetType === 'map' && i?.dependenciesMap && i?.dependenciesMap?.mapSync?.includes(props.id)) || [];
+            let mapWidgetsConnectedWithTbl = props.widgets.filter(i=>i.widgetType === 'map' && i?.dependenciesMap && i?.dependenciesMap?.mapSync?.includes(props.id) && i.mapSync) || [];
             expect(mapWidgetsConnectedWithTbl.length).toEqual(0);
             done();
         }));

--- a/web/client/components/widgets/enhancers/tableWidget.js
+++ b/web/client/components/widgets/enhancers/tableWidget.js
@@ -31,7 +31,7 @@ const withSorting = () => withPropsOnChange(["gridEvents"], ({ gridEvents = {}, 
 export default compose(
     compose(connect(null, (dispatch, ownProps)=>{
         let isTblDashboard = ownProps?.enableZoomInTblWidget && ownProps?.widgetType === 'table' && ownProps?.isDashboardOpened;
-        let mapWidgetsConnectedWithTbl = ownProps?.widgets?.filter(i=>i.widgetType === 'map' && i?.dependenciesMap && i?.dependenciesMap?.mapSync?.includes(ownProps.id)) || [];
+        let mapWidgetsConnectedWithTbl = ownProps?.widgets?.filter(i=>i.widgetType === 'map' && i?.dependenciesMap && i?.dependenciesMap?.mapSync?.includes(ownProps.id) && i.mapSync) || [];
         let isTblSyncWithMap = ownProps?.mapSync || mapWidgetsConnectedWithTbl.length;
         let isTblWidgetInMapViewer = ownProps?.widgetType === 'table' && !isTblDashboard && ownProps?.enableZoomInTblWidget;
         return {


### PR DESCRIPTION
## Description
- In dashboard, fix issue of not hiding zoom icon in tbl widget in case of removing connection from map widget to tbl widget

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#9783 

**What is the current behavior?**
In dashboard, there was an issue of not hiding zoom icon in tbl widget in case of removing connection from map widget to tbl widget
To produce it:
- add map
- add table and create a connection with map
- create a connection from map to the table
- remove the connection from table widget that connects with map
- remove the connection from map widget to the table


**What is the new behavior?**
Zoom icon in table widget in dashboard viewer will hide if user remove the connection from map widget to the table but with the same scenario above. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
