### PR TITLE
Fix #8579 Review showElevation property of MousePosition plugin

### DIFF
--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -319,7 +319,9 @@ Some other feature will break, for example the layer properties will stop workin
 },
 ```
 
-##### special case - The Elevation layer
+##### [Deprecated] special case - The Elevation layer
+
+This configuration is deprecated. It should be used a terrain layer and elevation layer instead.
 
 !!! note
     This type of layer configuration is still needed to show the elevation data inside the MousePosition plugin. The `terrain` layer section shows a more versatile way of handling elevation but it will work only as visualization in the 3D map viewer.
@@ -1147,6 +1149,52 @@ In order to use these layers they need to be added to the `additionalLayers` in 
             "visibility": true,
             "crs": "CRS:84"
         }]
+    }
+}
+```
+
+#### Elevation layer
+
+This layer provides information related to elevation based on a provided DTM layer and it does not display the terrain profile (see terrain type instead). This type of layer is introduced in substitution of the `useForElevation` property of the wms layer type and the main reason is to separate the visualization from the information displayed with the mouse position plugin aligning the behaviour of the 2D/3D viewers. The current implementation supports only a WMS layer in format `application/bil16`.
+
+Note that in the Cesium 3D viewer all the heights are relative to the WGS84 ellipsoid while usually locally DTM/DEM file could have an elevation value relative to the mean sea level (MSL). So with this new layer it's possible to have a terrain layer with the correct WGS84 ellipsoidal height while querying the mouse position with a MSL height.
+
+This requires:
+
+- a GeoServer WMS service with the [DDS/BIL plugin](https://docs.geoserver.org/stable/en/user/community/dds/index.html)
+- A WMS layer configured with **BIL 16 bit** output in **big endian mode** and **-9999 nodata value**
+- a static layer in the Map plugin configuration (use the additionalLayers configuration option):
+
+in `localConfig.json`
+
+```javascript
+{
+    "name": "Map",
+    "cfg": {
+        "additionalLayers": [{
+            "type": "elevation",
+            "provider": "wms",
+            "url": "/geoserver/wms",
+            "name": "elevation",
+            "visibility": true,
+            // optional
+            "littleEndian": false, 
+            "nodata": -9999
+        }]
+    }
+}
+```
+
+The layer will be used for showing elevation in the MousePosition plugin (requires showElevation: true in the plugin configuration)
+
+in `localConfig.json`
+
+```javascript
+{
+    "name": "MousePosition",
+    "cfg": {
+        "showElevation": true,
+        ...
     }
 }
 ```

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -24,7 +24,7 @@ This is a list of things to check if you want to update from a previous version 
 
 ### Using `elevation` layer type instead of wms layer with useForElevation property
 
-The wms layer with useForElevation property is deprecated and a `elevation` layer introduced in substitution.
+The wms layer with `useForElevation` property is deprecated and a `elevation` layer introduced in substitution.
 The `elevation` layer is used only to display height information inside the mouse position plugin.
 
 A configuration update example:

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -25,8 +25,7 @@ This is a list of things to check if you want to update from a previous version 
 ### Using `elevation` layer type instead of wms layer with useForElevation property
 
 The wms layer with `useForElevation` property is deprecated and a `elevation` layer introduced in substitution.
-The `elevation` layer is used only to display height information inside the mouse position plugin.
-
+The new `elevation` layer is used only to display height information inside the mouse position plugin and it will not provide a support for terrain model of the 3D visualziation mode. In order to provide this support, you need to add a `terrain` layer too. See documentation about [Elevation layer](maps-configuration.md#elevation) and [Terrain layer](maps-configuration.md#terrain) for more details.
 A configuration update example:
 
 ```diff
@@ -37,14 +36,12 @@ A configuration update example:
             {
 -               "type": "wms",
 +               "type": "elevation",
-+               "type": "provider",
                 "url": "/geoserver/wms",
                 "name": "workspace:layername",
 -               "format": "application/bil16",
                 "visibility": true,
--               "littleendian": false,
-+               "littleEndian": false,
--               "useForElevation": true
+-               "useForElevation": true,
+                "littleEndian": false
             },
             // only needed for 3D terrain
 +           {
@@ -90,7 +87,7 @@ In order to enable the possibility to add in and the spatial filter to the widge
 ...
 "dashboard": [
 ...
-{ 
+{
     "name": "QueryPanel",
     "cfg": {
         "toolsOptions": {

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -22,6 +22,45 @@ This is a list of things to check if you want to update from a previous version 
 
 ## Migration from 2023.02.xx to 2024.01.00
 
+### Using `elevation` layer type instead of wms layer with useForElevation property
+
+The wms layer with useForElevation property is deprecated and a `elevation` layer introduced in substitution.
+The `elevation` layer is used only to display height information inside the mouse position plugin.
+
+A configuration update example:
+
+```diff
+{
+    "name": "Map",
+    "cfg": {
+        "additionalLayers": [
+            {
+-               "type": "wms",
++               "type": "elevation",
++               "type": "provider",
+                "url": "/geoserver/wms",
+                "name": "workspace:layername",
+-               "format": "application/bil16",
+                "visibility": true,
+-               "littleendian": false,
++               "littleEndian": false,
+-               "useForElevation": true
+            },
+            // only needed for 3D terrain
++           {
++               "type": "terrain",
++               "provider": "wms",
++               "url": "/geoserver/wms",
++               "name": "workspace:layername",
++               "littleEndian": false,
++               "visibility": true,
++               "crs": "CRS:84"
+            }
+        ]
+    }
+}
+```
+
 ### Removing possibility to add custom fonts to the Map
 
 From this version we limited the load of the font to FontAwesome.

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -411,10 +411,10 @@ class CesiumMap extends React.Component {
     getElevation(longitude, latitude) {
         const elevationLayers = this.map.msElevationLayers || [];
         return elevationLayers?.[0]?.getElevation
-            ? elevationLayers[0].getElevation(
+            ? elevationLayers[0].getElevation({
                 longitude,
                 latitude
-            )
+            })
             : undefined;
     }
 

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -246,6 +246,17 @@ class CesiumMap extends React.Component {
                 const latitude = cartographic.latitude * 180.0 / Math.PI;
                 const longitude = cartographic.longitude * 180.0 / Math.PI;
 
+                let elevation = Math.round(cartographic.height);
+                // cartographic height of terrain in cesium is ellipsoidal
+                // if we want the elevation above the sea level from a DTM
+                // we should use an elevation layer instead
+                if (this.map?.msElevationLayers?.[0]) {
+                    elevation = this.getElevation(
+                        cartographic.longitude,
+                        cartographic.latitude
+                    );
+                }
+
                 const y = (90.0 - latitude) / 180.0 * this.props.standardHeight * (this.props.zoom + 1);
                 const x = (180.0 + longitude) / 360.0 * this.props.standardWidth * (this.props.zoom + 1);
                 this.props.onClick({
@@ -259,7 +270,8 @@ class CesiumMap extends React.Component {
                     cartographic,
                     latlng: {
                         lat: latitude,
-                        lng: longitude
+                        lng: longitude,
+                        z: elevation
                     },
                     crs: "EPSG:4326",
                     intersectedFeatures,
@@ -275,7 +287,16 @@ class CesiumMap extends React.Component {
             let cartographic = ClickUtils.getMouseXYZ(this.map, movement) || cartesian && Cesium.Cartographic.fromCartesian(cartesian);
             if (cartographic) {
                 const intersectedFeatures = this.getIntersectedFeatures(this.map, movement.endPosition);
-                const elevation = Math.round(cartographic.height);
+                let elevation = Math.round(cartographic.height);
+                // cartographic height of terrain in cesium is ellipsoidal
+                // if we want the elevation above the sea level from a DTM
+                // we should use an elevation layer instead
+                if (this.map?.msElevationLayers?.[0]) {
+                    elevation = this.getElevation(
+                        cartographic.longitude,
+                        cartographic.latitude
+                    );
+                }
                 this.props.onMouseMove({
                     y: cartographic.latitude * 180.0 / Math.PI,
                     x: cartographic.longitude * 180.0 / Math.PI,
@@ -385,6 +406,16 @@ class CesiumMap extends React.Component {
             return Object.keys(groupIntersectedFeatures).map(id => ({ id, features: groupIntersectedFeatures[id] }));
         }
         return [];
+    }
+
+    getElevation(longitude, latitude) {
+        const elevationLayers = this.map.msElevationLayers || [];
+        return elevationLayers?.[0]?.getElevation
+            ? elevationLayers[0].getElevation(
+                longitude,
+                latitude
+            )
+            : undefined;
     }
 
     render() {

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -26,6 +26,7 @@ import '../plugins/ThreeDTilesLayer';
 import '../plugins/VectorLayer';
 import '../plugins/WFSLayer';
 import '../plugins/TerrainLayer';
+import '../plugins/ElevationLayer';
 
 import {setStore} from '../../../../utils/SecurityUtils';
 import ConfigUtils from '../../../../utils/ConfigUtils';
@@ -1604,5 +1605,23 @@ describe('Cesium layer', () => {
         expect(cmp).toBeTruthy();
         expect(cmp.layer).toBeTruthy();
         expect(cmp.layer.terrainProvider).toBeTruthy();
+    });
+    it('should create am elevation layer from wms layer', () => {
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url: 'https://host-sample/geoserver/wms',
+            name: 'workspace:layername',
+            visibility: true
+        };
+        const cmp = ReactDOM.render(
+            <CesiumLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        expect(cmp).toBeTruthy();
+        expect(cmp.layer).toBeTruthy();
+        expect(cmp.layer.getElevation).toBeTruthy();
     });
 });

--- a/web/client/components/map/cesium/__tests__/Map-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test.jsx
@@ -102,7 +102,7 @@ describe('CesiumMap', () => {
         expect(ref.map.imageryLayers.length).toBe(1);
     });
 
-    it('check layers for elevation', () => {
+    it('check layers for elevation (deprecated)', () => {
         const options = {
             "url": "http://fake",
             "name": "mylayer",
@@ -118,6 +118,24 @@ describe('CesiumMap', () => {
         expect(ref).toBeTruthy();
         expect(ref.map.terrainProvider).toBeTruthy();
         expect(ref.map.terrainProvider.layerName).toBe('mylayer');
+    });
+    it('check layers for elevation', () => {
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url: 'https://host-sample/geoserver/wms',
+            name: 'workspace:layername',
+            visibility: true
+        };
+        let ref;
+        act(() => {
+            ReactDOM.render(<CesiumMap ref={value => { ref = value; } } center={{ y: 43.9, x: 10.3 }} zoom={11}>
+                <CesiumLayer type={options.type} options={options} />
+            </CesiumMap>, document.getElementById("container"));
+        });
+        expect(ref).toBeTruthy();
+        expect(ref.map.msElevationLayers).toBeTruthy();
+        expect(ref.map.msElevationLayers.length).toBe(1);
     });
     it('check wmts layer for custom attribution', () => {
         const options = {

--- a/web/client/components/map/cesium/plugins/ElevationLayer.js
+++ b/web/client/components/map/cesium/plugins/ElevationLayer.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Layers from '../../../../utils/cesium/Layers';
+import * as Cesium from 'cesium';
+
+import { wmsToCesiumOptions } from '../../../../utils/cesium/WMSUtils';
+import { addElevationTile, getElevation, getElevationKey, getTileRelativePixel } from '../../../../utils/ElevationUtils';
+
+let canvas;
+
+const createEmptyCanvas = () => {
+    if (!canvas) {
+        canvas = document.createElement('canvas');
+        canvas.width = 1;
+        canvas.height = 1;
+    }
+    return canvas;
+};
+
+const templateRegex = /{[^}]+}/g;
+
+function buildTileResource(imageryProvider, x, y, level, request) {
+    const resource = imageryProvider._resource;
+    const url = resource.getUrlComponent(true);
+    const allTags = imageryProvider._tags;
+    const templateValues = {};
+    const match = url.match(templateRegex);
+    if (Cesium.defined(match)) {
+        match.forEach(function(tag) {
+            const key = tag.substring(1, tag.length - 1); // strip {}
+            if (!['westProjected', 'southProjected', 'eastProjected', 'northProjected'].includes(key) && Cesium.defined(allTags[key])) {
+                templateValues[key] = allTags[key](imageryProvider, x, y, level);
+            }
+        });
+    }
+    const nativeRectangle = imageryProvider.tilingScheme.tileXYToNativeRectangle(x, y, level);
+    return resource.getDerivedResource({
+        request: request,
+        templateValues: {
+            ...templateValues,
+            // the bbox value must be computed here
+            // because the internal Cesium tags are using the same object to store the cartesian value with a private boolean
+            // causing wrong output related on previous tile bounding boxes
+            westProjected: nativeRectangle.west,
+            southProjected: nativeRectangle.south,
+            eastProjected: nativeRectangle.east,
+            northProjected: nativeRectangle.north
+        }
+    });
+}
+
+class ElevationWMS extends Cesium.WebMapServiceImageryProvider {
+    constructor({
+        nodata,
+        littleendian,
+        map,
+        ...options
+    }) {
+        super(options);
+        this._msId = options.id;
+        this._nodata = nodata ?? -9999;
+        this._littleEndian = littleendian ?? false;
+        this._map = map;
+        if (!this._map.msElevationLayers) {
+            this._map.msElevationLayers = [];
+        }
+        this._map.msElevationLayers.push(this);
+    }
+    requestImage(x, y, z, request) {
+        const tileRequest = buildTileResource(this._tileProvider, x, y, z, request.clone());
+        const resource = Cesium.Resource.createIfNeeded(tileRequest);
+        const promise = resource.fetchArrayBuffer();
+        if (promise) {
+            return promise.then((data) => {
+                if (!this._zoomLevelRequested) {
+                    this._zoomLevelRequested = [];
+                }
+                if (!this._zoomLevelRequested.includes(z)) {
+                    this._zoomLevelRequested.push(z);
+                    this._zoomLevelRequested.sort((a, b) => b - a);
+                }
+                addElevationTile(data, { x, y, z }, getElevationKey(x, y, z, this._msId), tileRequest.url);
+                return createEmptyCanvas();
+            });
+        }
+        return promise;
+    }
+    getElevation(
+        longitude,
+        latitude
+    ) {
+        let elevation;
+        const zoomLevelRequested = this._zoomLevelRequested || [];
+        for (let i = 0; i < zoomLevelRequested.length; i++) {
+            const z = zoomLevelRequested[i];
+            const tile = this._tileProvider.tilingScheme.positionToTileXY(new Cesium.Cartographic(longitude, latitude), z);
+            if (tile) {
+                const x = tile.x;
+                const y = tile.y;
+                const rectangle = this._tileProvider.tilingScheme.tileXYToRectangle(x, y, z);
+                const currentElevation = getElevation(
+                    getElevationKey(x, y, z, this._msId),
+                    getTileRelativePixel(
+                        [longitude, latitude],
+                        [rectangle.west, rectangle.south, rectangle.east, rectangle.north],
+                        [this._tileProvider.tileWidth, this._tileProvider.tileHeight]
+                    ),
+                    this._tileProvider.tileWidth,
+                    this._nodata,
+                    this._littleEndian
+                );
+                if (currentElevation.available) {
+                    elevation = currentElevation;
+                    break;
+                }
+            }
+        }
+        return elevation?.available ? elevation.value : '';
+    }
+    destroy() {
+        this._map.msElevationLayers = this._map.msElevationLayers.filter(elevationLayer => elevationLayer._msId !== this._msId);
+    }
+}
+
+const createLayer = (options, map) => {
+    if (options.provider === 'wms') {
+        const layer = new ElevationWMS({
+            ...wmsToCesiumOptions(options),
+            id: options.id,
+            map
+        });
+        return layer;
+    }
+    return null;
+};
+
+Layers.registerType('elevation', {
+    create: createLayer
+});

--- a/web/client/components/map/cesium/plugins/ElevationLayer.js
+++ b/web/client/components/map/cesium/plugins/ElevationLayer.js
@@ -91,10 +91,10 @@ class ElevationWMS extends Cesium.WebMapServiceImageryProvider {
         }
         return promise;
     }
-    getElevation(
+    getElevation({
         longitude,
         latitude
-    ) {
+    }) {
         let elevation;
         const zoomLevelRequested = this._zoomLevelRequested || [];
         for (let i = 0; i < zoomLevelRequested.length; i++) {

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -9,88 +9,8 @@
 import Layers from '../../../../utils/cesium/Layers';
 import * as Cesium from 'cesium';
 import GeoServerBILTerrainProvider from '../../../../utils/cesium/GeoServerBILTerrainProvider';
-import assign from 'object-assign';
-import {isArray, isEqual} from 'lodash';
+import { isEqual } from 'lodash';
 import WMSUtils from '../../../../utils/cesium/WMSUtils';
-import { getAuthenticationParam, getURLs, getWMSVendorParams } from '../../../../utils/LayersUtils';
-import { optionsToVendorParams } from '../../../../utils/VendorParamsUtils';
-import { addAuthenticationToSLD, getAuthenticationHeaders } from '../../../../utils/SecurityUtils';
-
-import { isVectorFormat } from '../../../../utils/VectorTileUtils';
-
-function getQueryString(parameters) {
-    return Object.keys(parameters).map((key) => key + '=' + encodeURIComponent(parameters[key])).join('&');
-}
-
-function wmsToCesiumOptionsSingleTile(options) {
-    const opacity = options.opacity !== undefined ? options.opacity : 1;
-    const params = optionsToVendorParams(options);
-    const parameters = assign({
-        styles: options.style || "",
-        format: isVectorFormat(options.format) && 'image/png' || options.format || 'image/png',
-        transparent: options.transparent !== undefined ? options.transparent : true,
-        opacity: opacity,
-        ...getWMSVendorParams(options),
-        layers: options.name,
-        width: options.size || 2000,
-        height: options.size || 2000,
-        bbox: "-180.0,-90,180.0,90",
-        srs: "EPSG:4326"
-    }, params || {}, getAuthenticationParam(options));
-
-    const url = (isArray(options.url) ? options.url[Math.round(Math.random() * (options.url.length - 1))] : options.url) + '?service=WMS&version=1.1.0&request=GetMap&'
-        + getQueryString(addAuthenticationToSLD(parameters, options));
-    const headers = getAuthenticationHeaders(url, options.securityToken);
-    return {
-        url: new Cesium.Resource({
-            url,
-            headers,
-            proxy: WMSUtils.getProxy(options)
-        })
-    };
-}
-
-function wmsToCesiumOptions(options) {
-    var opacity = options.opacity !== undefined ? options.opacity : 1;
-    const params = optionsToVendorParams(options);
-    const cr = options.credits;
-    const credit = cr ? new Cesium.Credit(cr.text || cr.title, cr.imageUrl, cr.link) : options.attribution;
-    // NOTE: can we use opacity to manage visibility?
-    const urls = getURLs(isArray(options.url) ? options.url : [options.url]);
-    const headers = getAuthenticationHeaders(urls[0], options.securityToken);
-
-    return assign({
-        url: new Cesium.Resource({
-            url: "{s}",
-            headers,
-            proxy: WMSUtils.getProxy(options)
-        }),
-        // #7516 this helps Cesium to use CORS requests in a proper way, even when headers are not
-        // present in the Resource
-        tileDiscardPolicy: options.tileDiscardPolicy === "none" ?
-            undefined :
-            (options.tileDiscardPolicy ?? new Cesium.NeverTileDiscardPolicy()),
-        credit,
-        subdomains: urls,
-        layers: options.name,
-        enablePickFeatures: false,
-        parameters: assign({
-            styles: options.style || "",
-            format: isVectorFormat(options.format) && 'image/png' || options.format || 'image/png',
-            transparent: options.transparent !== undefined ? options.transparent : true,
-            opacity: opacity,
-            tiled: options.tiled !== undefined ? options.tiled : true,
-            width: options.tileSize || 256,
-            height: options.tileSize || 256
-
-        }, assign(
-            {},
-            (options._v_ ? {_v_: options._v_} : {}),
-            (params || {}),
-            getAuthenticationParam(options)
-        ))
-    });
-}
 
 const createLayer = (options) => {
     let layer;
@@ -98,15 +18,19 @@ const createLayer = (options) => {
         return new GeoServerBILTerrainProvider(WMSUtils.wmsToCesiumOptionsBIL(options));
     }
     if (options.singleTile) {
-        layer = new Cesium.SingleTileImageryProvider(wmsToCesiumOptionsSingleTile(options));
+        layer = new Cesium.SingleTileImageryProvider(WMSUtils.wmsToCesiumOptionsSingleTile(options));
     } else {
-        layer = new Cesium.WebMapServiceImageryProvider(wmsToCesiumOptions(options));
+        layer = new Cesium.WebMapServiceImageryProvider(WMSUtils.wmsToCesiumOptions(options));
     }
 
     layer.updateParams = (params) => {
-        const newOptions = assign({}, options, {
-            params: assign({}, options.params || {}, params)
-        });
+        const newOptions = {
+            ...options,
+            params: {
+                ...(options.params || {}),
+                ...params
+            }
+        };
         return createLayer(newOptions);
     };
     return layer;

--- a/web/client/components/map/cesium/plugins/index.js
+++ b/web/client/components/map/cesium/plugins/index.js
@@ -19,5 +19,6 @@ import './ThreeDTilesLayer';
 import './VectorLayer';
 import './WFSLayer';
 import './TerrainLayer';
+import './ElevationLayer';
 
 export default {};

--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -161,7 +161,7 @@ class LeafletMap extends React.Component {
                     latlng: {
                         lat: event.latlng.lat,
                         lng: event.latlng.lng,
-                        z: this.elevationLayer && this.elevationLayer.getElevation(event.latlng, event.containerPoint) || undefined
+                        z: this.getElevation(event.latlng, event.containerPoint)
                     },
                     rawPos: [event.latlng.lat, event.latlng.lng],
                     modifiers: {
@@ -201,9 +201,6 @@ class LeafletMap extends React.Component {
                 return;
             }
             event.layer._ms2Added = true;
-            if (event.layer.getElevation) {
-                this.elevationLayer = event.layer;
-            }
 
             // avoid binding if not possible, e.g. for measurement vector layers
             if (!event.layer.layerId) {
@@ -359,6 +356,13 @@ class LeafletMap extends React.Component {
         return Object.keys(groupIntersectedFeatures).map(id => ({ id, features: groupIntersectedFeatures[id] }));
     }
 
+    getElevation(pos, containerPoint) {
+        const elevationLayers = this.map.msElevationLayers || [];
+        return elevationLayers?.[0]?.getElevation
+            ? elevationLayers[0].getElevation(pos, containerPoint)
+            : undefined;
+    }
+
     render() {
         const map = this.map;
         const mapProj = this.props.projection;
@@ -480,7 +484,7 @@ class LeafletMap extends React.Component {
         this.props.onMouseMove({
             x: pos.lng || 0.0,
             y: pos.lat || 0.0,
-            z: this.elevationLayer && this.elevationLayer.getElevation(pos, event.containerPoint) || undefined,
+            z: this.getElevation(pos, event.containerPoint),
             crs: "EPSG:4326",
             pixel: {
                 x: event.containerPoint.x,
@@ -489,7 +493,7 @@ class LeafletMap extends React.Component {
             latlng: {
                 lat: event.latlng.lat,
                 lng: event.latlng.lng,
-                z: this.elevationLayer && this.elevationLayer.getElevation(event.latlng, event.containerPoint) || undefined
+                z: this.getElevation(event.latlng, event.containerPoint)
             },
             rawPos: [event.latlng.lat, event.latlng.lng],
             intersectedFeatures

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -1760,4 +1760,22 @@ describe('Leaflet layer', () => {
         expect(map.hasLayer(layer.layer)).toBe(true);
 
     });
+    it('should create am elevation layer from wms layer', () => {
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url: 'https://host-sample/geoserver/wms',
+            name: 'workspace:layername',
+            visibility: true
+        };
+        const cmp = ReactDOM.render(
+            <LeafLetLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        expect(cmp).toBeTruthy();
+        expect(cmp.layer).toBeTruthy();
+        expect(cmp.layer.getElevation).toBeTruthy();
+    });
 });

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -28,6 +28,7 @@ import '../plugins/BingLayer';
 import '../plugins/MapQuest';
 import '../plugins/WFSLayer';
 import '../plugins/VectorLayer';
+import '../plugins/ElevationLayer';
 
 let mockAxios;
 
@@ -268,7 +269,8 @@ describe('Leaflet layer', () => {
     });
 
     it('creates a wms elevation layer for leaflet map', () => {
-        var options = {
+        const options = {
+            "id": 'elevation',
             "type": "wms",
             "visibility": true,
             "name": "nurc:Arc_Sample",
@@ -278,18 +280,18 @@ describe('Leaflet layer', () => {
             "url": "http://sample.server/geoserver/wms"
         };
         // create layers
-        var layer = ReactDOM.render(
+        const layer = ReactDOM.render(
             <LeafLetLayer type="wms"
                 options={options} map={map} />, document.getElementById("container"));
-        var lcount = 0;
+        let lcount = 0;
 
-        expect(layer).toExist();
+        expect(layer).toBeTruthy();
         // count layers
         map.eachLayer(function() { lcount++; });
         expect(lcount).toBe(1);
         let elevationFunc;
         map.eachLayer((l) => {elevationFunc = l.getElevation;});
-        expect(elevationFunc).toExist();
+        expect(elevationFunc).toBeTruthy();
     });
     it('creates a wms layer with credits', () => {
         const CREDITS1 = {

--- a/web/client/components/map/leaflet/__tests__/Map-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Map-test.jsx
@@ -168,8 +168,9 @@ describe('LeafletMap', () => {
         const map = ReactDOM.render(<LeafletMap center={{ y: 43.9, x: 10.3 }} zoom={11} mapOptions={{ zoomAnimation: false }}>
             <LeafLetLayer type="wms" options={options} />
         </LeafletMap>, document.getElementById("container"));
-        expect(map).toExist();
-        expect(map.elevationLayer).toExist();
+        expect(map).toBeTruthy();
+        expect(map.map.msElevationLayers).toBeTruthy();
+        expect(map.map.msElevationLayers.length).toBe(1);
         expect(document.getElementsByClassName('leaflet-layer').length).toBe(1);
     });
 
@@ -293,10 +294,10 @@ describe('LeafletMap', () => {
         });
         expect(spy.calls.length).toBe(1);
         expect(spy.calls[0].arguments.length).toBe(1);
-        expect(spy.calls[0].arguments[0].pixel).toExist();
-        expect(spy.calls[0].arguments[0].latlng).toExist();
-        expect(spy.calls[0].arguments[0].latlng.z).toExist();
-        expect(spy.calls[0].arguments[0].modifiers).toExist();
+        expect(spy.calls[0].arguments[0].pixel).toBeTruthy();
+        expect(spy.calls[0].arguments[0].latlng).toBeTruthy();
+        expect(spy.calls[0].arguments[0].latlng.z).toBe('');
+        expect(spy.calls[0].arguments[0].modifiers).toBeTruthy();
         expect(spy.calls[0].arguments[0].modifiers.alt).toBe(false);
         expect(spy.calls[0].arguments[0].modifiers.ctrl).toBe(false);
         expect(spy.calls[0].arguments[0].modifiers.shift).toBe(false);
@@ -401,9 +402,9 @@ describe('LeafletMap', () => {
         const testHandlers = {
             handler: () => { }
         };
-        var spy = expect.spyOn(testHandlers, 'handler');
+        const spy = expect.spyOn(testHandlers, 'handler');
 
-        var options = {
+        const options = {
             "url": "http://fake",
             "name": "mylayer",
             "visibility": true,
@@ -438,10 +439,10 @@ describe('LeafletMap', () => {
         });
         expect(spy.calls.length).toBe(1);
         expect(spy.calls[0].arguments.length).toBe(1);
-        expect(spy.calls[0].arguments[0].pixel).toExist();
-        expect(spy.calls[0].arguments[0].x).toExist();
-        expect(spy.calls[0].arguments[0].y).toExist();
-        expect(spy.calls[0].arguments[0].z).toExist();
+        expect(spy.calls[0].arguments[0].pixel).toBeTruthy();
+        expect(spy.calls[0].arguments[0].x).toBeTruthy();
+        expect(spy.calls[0].arguments[0].y).toBeTruthy();
+        expect(spy.calls[0].arguments[0].z).toBe('');
     });
 
     it('check if the map changes when receive new props', () => {

--- a/web/client/components/map/leaflet/__tests__/Map-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Map-test.jsx
@@ -398,7 +398,7 @@ describe('LeafletMap', () => {
         expect(spy.calls[0].arguments[0].z).toNotExist();
     });
 
-    it('check if the handler for "mousemove" event is called with elevation', () => {
+    it('check if the handler for "mousemove" event is called with elevation (deprecated)', () => {
         const testHandlers = {
             handler: () => { }
         };
@@ -417,6 +417,52 @@ describe('LeafletMap', () => {
                 onMouseMove={testHandlers.handler}
                 mapOptions={{ zoomAnimation: false }}
             ><LeafLetLayer type="wms" options={options} /></LeafletMap>
+            , document.getElementById("container"));
+
+        const leafletMap = map.map;
+        leafletMap.fire('mousemove', {
+            containerPoint: {
+                x: 100,
+                y: 100
+            },
+            latlng: {
+                wrap: () => ({
+                    lat: 43,
+                    lng: 10
+                })
+            },
+            originalEvent: {
+                altKey: false,
+                ctrlKey: false,
+                shiftKey: false
+            }
+        });
+        expect(spy.calls.length).toBe(1);
+        expect(spy.calls[0].arguments.length).toBe(1);
+        expect(spy.calls[0].arguments[0].pixel).toBeTruthy();
+        expect(spy.calls[0].arguments[0].x).toBeTruthy();
+        expect(spy.calls[0].arguments[0].y).toBeTruthy();
+        expect(spy.calls[0].arguments[0].z).toBe('');
+    });
+    it('check layers for elevation', () => {
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url: 'https://host-sample/geoserver/wms',
+            name: 'workspace:layername',
+            visibility: true
+        };
+        const testHandlers = {
+            handler: () => { }
+        };
+        const spy = expect.spyOn(testHandlers, 'handler');
+        const map = ReactDOM.render(
+            <LeafletMap
+                center={{ y: 43.9, x: 10.3 }}
+                zoom={11}
+                onMouseMove={testHandlers.handler}
+                mapOptions={{ zoomAnimation: false }}
+            ><LeafLetLayer type={options.type} options={options} /></LeafletMap>
             , document.getElementById("container"));
 
         const leafletMap = map.map;

--- a/web/client/components/map/leaflet/plugins/ElevationLayer.js
+++ b/web/client/components/map/leaflet/plugins/ElevationLayer.js
@@ -15,11 +15,11 @@ import { loadTile, getElevation, getElevationKey } from '../../../../utils/Eleva
 import { getWMSURLs, wmsToLeafletOptions, removeNulls } from '../../../../utils/leaflet/WMSUtils';
 
 L.TileLayer.ElevationWMS = L.TileLayer.MultipleUrlWMS.extend({
-    initialize: function(urls, options, nodata, littleendian, id) {
+    initialize: function(urls, options, nodata, littleEndian, id) {
         this._msId = id;
         this._tiles = {};
         this._nodata = nodata;
-        this._littleendian = littleendian;
+        this._littleEndian = littleEndian;
         L.TileLayer.MultipleUrlWMS.prototype.initialize.apply(this, arguments);
     },
     _addTile: function(coords) {
@@ -34,7 +34,7 @@ L.TileLayer.ElevationWMS = L.TileLayer.MultipleUrlWMS.extend({
                 getElevationKey(tilePoint.x, tilePoint.y, tilePoint.z, this._msId),
                 this._getTileRelativePixel(tilePoint, containerPoint),
                 this.getTileSize().x,
-                this._nodata, this._littleendian
+                this._nodata, this._littleEndian
             );
             if (elevation.available) {
                 return elevation.value;
@@ -68,15 +68,24 @@ L.TileLayer.ElevationWMS = L.TileLayer.MultipleUrlWMS.extend({
     }
 });
 
-L.tileLayer.elevationWMS = function(urls, options, nodata, littleendian, id) {
-    return new L.TileLayer.ElevationWMS(urls, options, nodata, littleendian, id);
+L.tileLayer.elevationWMS = function(urls, options, nodata, littleEndian, id) {
+    return new L.TileLayer.ElevationWMS(urls, options, nodata, littleEndian, id);
 };
 
 const createWMSElevationLayer = (options) => {
     const urls = getWMSURLs(isArray(options.url) ? options.url : [options.url]);
     const queryParameters = removeNulls(wmsToLeafletOptions(options) || {});
     urls.forEach(url => addAuthenticationParameter(url, queryParameters, options.securityToken));
-    const layer = L.tileLayer.elevationWMS(urls, queryParameters, options.nodata || -9999, options.littleendian || false, options.id);
+    const layer = L.tileLayer.elevationWMS(
+        urls,
+        {
+            ...queryParameters,
+            format: options?.format || 'application/bil16'
+        },
+        options.nodata || -9999,
+        options?.littleEndian ?? options?.littleendian ?? false,
+        options.id
+    );
     return layer;
 };
 

--- a/web/client/components/map/leaflet/plugins/ElevationLayer.js
+++ b/web/client/components/map/leaflet/plugins/ElevationLayer.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Layers from '../../../../utils/leaflet/Layers';
+import L from 'leaflet';
+import objectAssign from 'object-assign';
+import { isArray } from 'lodash';
+import { addAuthenticationParameter } from '../../../../utils/SecurityUtils';
+import { loadTile, getElevation, getElevationKey } from '../../../../utils/ElevationUtils';
+import { getWMSURLs, wmsToLeafletOptions, removeNulls } from '../../../../utils/leaflet/WMSUtils';
+
+L.TileLayer.ElevationWMS = L.TileLayer.MultipleUrlWMS.extend({
+    initialize: function(urls, options, nodata, littleendian, id) {
+        this._msId = id;
+        this._tiles = {};
+        this._nodata = nodata;
+        this._littleendian = littleendian;
+        L.TileLayer.MultipleUrlWMS.prototype.initialize.apply(this, arguments);
+    },
+    _addTile: function(coords) {
+        const tileUrl = this.getTileUrl(coords);
+        loadTile(tileUrl, coords, getElevationKey(coords.x, coords.y, coords.z, this._msId));
+    },
+
+    getElevation: function(latLng, containerPoint) {
+        try {
+            const tilePoint = this._getTileFromCoords(latLng);
+            const elevation = getElevation(
+                getElevationKey(tilePoint.x, tilePoint.y, tilePoint.z, this._msId),
+                this._getTileRelativePixel(tilePoint, containerPoint),
+                this.getTileSize().x,
+                this._nodata, this._littleendian
+            );
+            if (elevation.available) {
+                return elevation.value;
+            }
+            return '';
+        } catch (e) {
+            return '';
+        }
+    },
+    _getTileFromCoords: function(latLng) {
+        const layerPoint = this._map.project(latLng).divideBy(256).floor();
+        return objectAssign(layerPoint, {z: this._tileZoom});
+    },
+    _getTileRelativePixel: function(tilePoint, containerPoint) {
+        const x = Math.floor(containerPoint.x - this._getTilePos(tilePoint).x - this._map._getMapPanePos().x);
+        const y = Math.min(this.getTileSize().x - 1, Math.floor(containerPoint.y - this._getTilePos(tilePoint).y - this._map._getMapPanePos().y));
+        return new L.Point(x, y);
+    },
+    _removeTile: function() {},
+    _abortLoading: function() {},
+    onAdd(map) {
+        if (!map.msElevationLayers) {
+            map.msElevationLayers = [];
+        }
+        map.msElevationLayers.push(this);
+        return L.TileLayer.MultipleUrlWMS.prototype.onAdd.call(this, map);
+    },
+    onRemove(map) {
+        map.msElevationLayers = map.msElevationLayers.filter(elevationLayer => elevationLayer._msId !== this._msId);
+        return L.TileLayer.MultipleUrlWMS.prototype.onRemove.call(this, map);
+    }
+});
+
+L.tileLayer.elevationWMS = function(urls, options, nodata, littleendian, id) {
+    return new L.TileLayer.ElevationWMS(urls, options, nodata, littleendian, id);
+};
+
+const createWMSElevationLayer = (options) => {
+    const urls = getWMSURLs(isArray(options.url) ? options.url : [options.url]);
+    const queryParameters = removeNulls(wmsToLeafletOptions(options) || {});
+    urls.forEach(url => addAuthenticationParameter(url, queryParameters, options.securityToken));
+    const layer = L.tileLayer.elevationWMS(urls, queryParameters, options.nodata || -9999, options.littleendian || false, options.id);
+    return layer;
+};
+
+Layers.registerType('elevation', {
+    create: (options) => {
+        if (options.provider === 'wms') {
+            return createWMSElevationLayer(options);
+        }
+        return null;
+    }
+});

--- a/web/client/components/map/leaflet/plugins/index.js
+++ b/web/client/components/map/leaflet/plugins/index.js
@@ -18,5 +18,6 @@ module.exports = {
     WFSLayer: require('./WFSLayer').default,
     WMSLayer: require('./WMSLayer'),
     WMTSLayer: require('./WMTSLayer'),
-    VectorLayer: require('./VectorLayer')
+    VectorLayer: require('./VectorLayer'),
+    ElevationLayer: require('./ElevationLayer')
 };

--- a/web/client/components/map/openlayers/Layer.jsx
+++ b/web/client/components/map/openlayers/Layer.jsx
@@ -194,9 +194,6 @@ export default class OpenlayersLayer extends React.Component {
                 this.addLayer(options);
             }
 
-            if (this.layer && this.layer.get && this.layer.get('getElevation')) {
-                this.props.map.set('elevationLayer', this.layer);
-            }
             this.forceUpdate();
         }
     };

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -3153,5 +3153,22 @@ describe('Openlayers layer', () => {
         expect(layer.layer.getMinResolution()).toBe(0);
         expect(layer.layer.getMaxResolution()).toBe(Infinity);
     });
-
+    it('should create am elevation layer from wms layer', () => {
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url: 'https://host-sample/geoserver/wms',
+            name: 'workspace:layername',
+            visibility: true
+        };
+        const cmp = ReactDOM.render(
+            <OpenlayersLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        expect(cmp).toBeTruthy();
+        expect(cmp.layer).toBeTruthy();
+        expect(cmp.layer.get('getElevation')).toBeTruthy();
+    });
 });

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import expect from 'expect';
 import OpenlayersLayer from '../Layer';
-
+import { waitFor } from '@testing-library/react';
 import assign from 'object-assign';
 import Layers from '../../../../utils/openlayers/Layers';
 import '../plugins/OSMLayer';
@@ -24,6 +24,7 @@ import '../plugins/OverlayLayer';
 import '../plugins/TMSLayer';
 import '../plugins/WFSLayer';
 import '../plugins/WFS3Layer';
+import '../plugins/ElevationLayer';
 
 import {
     setStore
@@ -483,20 +484,17 @@ describe('Openlayers layer', () => {
         expect(map.getLayers().getLength()).toBe(1);
         expect(layer.layer.constructor.name).toBe('VectorTileLayer');
         expect(layer.layer.getSource().format_.constructor.name).toBe('GeoJSON');
-        setTimeout(() => {
-            try {
-                const style = layer.layer.getStyle()()[0];
-                expect(style).toBeTruthy();
-                expect(style.getStroke().getColor()).toBe('#FF0000');
-                // currently SLD parser use fillOpacity instead of opacity
-                // and probably this cause wrong parsing of opacity
-                // added a wrapper to the openlayers parser to manage the issue related to opacity
-                expect(style.getFill().getColor()).toBe('rgba(255, 255, 0, 0.5)');
-            } catch (e) {
-                done(e);
-            }
-            done();
-        }, 0);
+        waitFor(() => {
+            const style = layer.layer.getStyle()()[0];
+            expect(style).toBeTruthy();
+            expect(style.getStroke().getColor()).toBe('#FF0000');
+            // currently SLD parser use fillOpacity instead of opacity
+            // and probably this cause wrong parsing of opacity
+            // added a wrapper to the openlayers parser to manage the issue related to opacity
+            return expect(style.getFill().getColor()).toBe('rgba(255, 255, 0, 0.5)');
+        })
+            .then(() => done())
+            .catch(done);
     });
 
     it('wms layer attribution with credits - create and update layer', () => {

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -499,7 +499,7 @@ describe('OpenlayersMap', () => {
         expect(map.map.getLayers().getLength()).toBe(1);
     });
 
-    it('check layers for elevation', () => {
+    it('check layers for elevation (deprecated)', () => {
         const options = {
             "url": "http://fake",
             "name": "mylayer",
@@ -508,6 +508,23 @@ describe('OpenlayersMap', () => {
         };
         const map = ReactDOM.render(<OpenlayersMap center={{y: 43.9, x: 10.3}} zoom={11}>
             <OpenlayersLayer type="wms" srs="EPSG:3857" options={options} />
+        </OpenlayersMap>, document.getElementById("map"));
+        expect(map).toBeTruthy();
+        const msElevationLayers = map.map.get('msElevationLayers');
+        expect(msElevationLayers).toBeTruthy();
+        expect(msElevationLayers.length).toBe(1);
+    });
+
+    it('check layers for elevation', () => {
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url: 'https://host-sample/geoserver/wms',
+            name: 'workspace:layername',
+            visibility: true
+        };
+        const map = ReactDOM.render(<OpenlayersMap center={{y: 43.9, x: 10.3}} zoom={11}>
+            <OpenlayersLayer type={options.type} srs="EPSG:3857" options={options} />
         </OpenlayersMap>, document.getElementById("map"));
         expect(map).toBeTruthy();
         const msElevationLayers = map.map.get('msElevationLayers');

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -170,9 +170,9 @@ describe('OpenlayersMap', () => {
         const testHandlers = {
             handler: () => { }
         };
-        var spy = expect.spyOn(testHandlers, 'handler');
+        const spy = expect.spyOn(testHandlers, 'handler');
 
-        var options = {
+        const options = {
             "url": "http://fake",
             "name": "mylayer",
             "visibility": true,
@@ -199,7 +199,7 @@ describe('OpenlayersMap', () => {
         expect(spy.calls[0].arguments.length).toBe(2);
         expect(spy.calls[0].arguments[0].pixel).toBeTruthy();
         expect(spy.calls[0].arguments[0].latlng).toBeTruthy();
-        expect(spy.calls[0].arguments[0].latlng.z).toBeTruthy();
+        expect(spy.calls[0].arguments[0].latlng.z).toBe('');
         expect(spy.calls[0].arguments[0].modifiers).toBeTruthy();
         expect(spy.calls[0].arguments[0].modifiers.alt).toBe(false);
         expect(spy.calls[0].arguments[0].modifiers.ctrl).toBe(false);
@@ -242,9 +242,9 @@ describe('OpenlayersMap', () => {
         const testHandlers = {
             handler: () => { }
         };
-        var spy = expect.spyOn(testHandlers, 'handler');
+        const spy = expect.spyOn(testHandlers, 'handler');
 
-        var options = {
+        const options = {
             "url": "http://fake",
             "name": "mylayer",
             "visibility": true,
@@ -273,7 +273,7 @@ describe('OpenlayersMap', () => {
         expect(spy.calls[0].arguments[0].pixel).toBeTruthy();
         expect(spy.calls[0].arguments[0].x).toBeTruthy();
         expect(spy.calls[0].arguments[0].y).toBeTruthy();
-        expect(spy.calls[0].arguments[0].z).toBeTruthy();
+        expect(spy.calls[0].arguments[0].z).toBe('');
     });
 
     it('click on feature', (done) => {
@@ -500,7 +500,7 @@ describe('OpenlayersMap', () => {
     });
 
     it('check layers for elevation', () => {
-        var options = {
+        const options = {
             "url": "http://fake",
             "name": "mylayer",
             "visibility": true,
@@ -510,7 +510,9 @@ describe('OpenlayersMap', () => {
             <OpenlayersLayer type="wms" srs="EPSG:3857" options={options} />
         </OpenlayersMap>, document.getElementById("map"));
         expect(map).toBeTruthy();
-        expect(map.map.get('elevationLayer')).toBeTruthy();
+        const msElevationLayers = map.map.get('msElevationLayers');
+        expect(msElevationLayers).toBeTruthy();
+        expect(msElevationLayers.length).toBe(1);
     });
 
     it('check if the handler for "moveend" event is called after setZoom', (done) => {

--- a/web/client/components/map/openlayers/plugins/ElevationLayer.js
+++ b/web/client/components/map/openlayers/plugins/ElevationLayer.js
@@ -70,7 +70,10 @@ const createWMSElevationLayer = (options, map) => {
             attributions: toOLAttributions(options.credits),
             urls: urls,
             crossOrigin: options.crossOrigin,
-            params: queryParameters,
+            params: {
+                ...queryParameters,
+                format: options?.format || 'application/bil16'
+            },
             tileGrid: generateTileGrid(options, map),
             tileLoadFunction: (imageTile, src) => {
                 let newSrc = proxySource(options.forceProxy, src);
@@ -83,7 +86,7 @@ const createWMSElevationLayer = (options, map) => {
     });
     layer.set('map', map);
     layer.set('nodata', options.nodata);
-    layer.set('littleEndian', options.littleendian ?? false);
+    layer.set('littleEndian', options?.littleEndian ?? options?.littleendian ?? false);
     layer.set('getElevation', getElevation.bind(layer));
 
     if (!map.get('msElevationLayers')) {

--- a/web/client/components/map/openlayers/plugins/ElevationLayer.js
+++ b/web/client/components/map/openlayers/plugins/ElevationLayer.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Layers from '../../../../utils/openlayers/Layers';
+import isArray from 'lodash/isArray';
+import { addAuthenticationParameter } from '../../../../utils/SecurityUtils';
+import  {
+    loadTile,
+    getElevation as getElevationFunc,
+    getElevationKey,
+    getTileRelativePixel
+} from '../../../../utils/ElevationUtils';
+import TileLayer from 'ol/layer/Tile';
+import TileWMS from 'ol/source/TileWMS';
+import {
+    proxySource,
+    getWMSURLs,
+    wmsToOpenlayersOptions,
+    toOLAttributions,
+    generateTileGrid
+} from '../../../../utils/openlayers/WMSUtils';
+
+function getTileFromCoords(layer, pos) {
+    const map = layer.get('map');
+    const tileGrid = layer.getSource().getTileGrid();
+    return tileGrid.getTileCoordForCoordAndZ(pos, map.getView().getZoom());
+}
+
+function getElevation(pos) {
+    try {
+        const tilePoint = getTileFromCoords(this, pos);
+        const [z, x, y] = tilePoint;
+        const tileGrid = this.getSource().getTileGrid();
+        const tileSize = tileGrid.getTileSize();
+        const extent = tileGrid.getTileCoordExtent(tilePoint);
+        const tileSizeArray = isArray(tileSize) ? tileSize : [tileSize, tileSize];
+        const elevation = getElevationFunc(
+            getElevationKey(x, y, z, this.get('msId')),
+            getTileRelativePixel(pos, extent, tileSizeArray),
+            tileSizeArray[0],
+            this.get('nodata'),
+            this.get('littleEndian')
+        );
+        if (elevation.available) {
+            return elevation.value;
+        }
+        return '';
+    } catch (e) {
+        return '';
+    }
+}
+
+const createWMSElevationLayer = (options, map) => {
+    const urls = getWMSURLs(isArray(options.url) ? options.url : [options.url]);
+    const queryParameters = wmsToOpenlayersOptions(options) || {};
+    urls.forEach(url => addAuthenticationParameter(url, queryParameters, options.securityToken));
+    const layer = new TileLayer({
+        msId: options.id,
+        opacity: options.opacity !== undefined ? options.opacity : 1,
+        visible: options.visibility !== false,
+        zIndex: options.zIndex,
+        minResolution: options.minResolution,
+        maxResolution: options.maxResolution,
+        source: new TileWMS({
+            attributions: toOLAttributions(options.credits),
+            urls: urls,
+            crossOrigin: options.crossOrigin,
+            params: queryParameters,
+            tileGrid: generateTileGrid(options, map),
+            tileLoadFunction: (imageTile, src) => {
+                let newSrc = proxySource(options.forceProxy, src);
+                const coords = imageTile.getTileCoord();
+                imageTile.getImage().src = "";
+                const [z, x, y] = coords;
+                loadTile(newSrc, coords, getElevationKey(x, y, z, options.id));
+            }
+        })
+    });
+    layer.set('map', map);
+    layer.set('nodata', options.nodata);
+    layer.set('littleEndian', options.littleendian ?? false);
+    layer.set('getElevation', getElevation.bind(layer));
+
+    if (!map.get('msElevationLayers')) {
+        map.set('msElevationLayers', []);
+    }
+    map.get('msElevationLayers').push(layer);
+    const removeElevationLayer = (e) => {
+        if (e.key === 'map') {
+            const newMap = e.target.get(e.key);
+            if (newMap === null) {
+                map.set('msElevationLayers',
+                    map.get('msElevationLayers')
+                        .filter(elevationLayer => elevationLayer.get('msId') !== options.id)
+                );
+                layer.un('propertychange', removeElevationLayer);
+            }
+        }
+    };
+    layer.on('propertychange', removeElevationLayer);
+    return layer;
+};
+
+Layers.registerType('elevation', {
+    create: (options, map) => {
+        if (options.provider === 'wms') {
+            return createWMSElevationLayer(options, map);
+        }
+        return null;
+    }
+});

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -5,8 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
-import Message from '../../../../components/I18N/Message';
+
 import Layers from '../../../../utils/openlayers/Layers';
 import isNil from 'lodash/isNil';
 import isEqual from 'lodash/isEqual';
@@ -16,20 +15,14 @@ import assign from 'object-assign';
 import axios from '../../../../libs/ajax';
 import CoordinatesUtils from '../../../../utils/CoordinatesUtils';
 import { getProjection } from '../../../../utils/ProjectionUtils';
-import {needProxy, getProxyUrl} from '../../../../utils/ProxyUtils';
 import { getConfigProp } from '../../../../utils/ConfigUtils';
 
 import {optionsToVendorParams} from '../../../../utils/VendorParamsUtils';
 import {addAuthenticationToSLD, addAuthenticationParameter, getAuthenticationHeaders} from '../../../../utils/SecurityUtils';
-import { creditsToAttribution, getWMSVendorParams } from '../../../../utils/LayersUtils';
-
-import { getResolutionsForProjection } from '../../../../utils/MapUtils';
-import  {loadTile, getElevation as getElevationFunc} from '../../../../utils/ElevationUtils';
 
 import ImageLayer from 'ol/layer/Image';
 import ImageWMS from 'ol/source/ImageWMS';
 import {get} from 'ol/proj';
-import TileGrid from 'ol/tilegrid/TileGrid';
 import TileLayer from 'ol/layer/Tile';
 import TileWMS from 'ol/source/TileWMS';
 
@@ -38,24 +31,8 @@ import VectorTileLayer from 'ol/layer/VectorTile';
 
 import { isVectorFormat } from '../../../../utils/VectorTileUtils';
 import { OL_VECTOR_FORMATS, applyStyle } from '../../../../utils/openlayers/VectorTileUtils';
-import { generateEnvString } from '../../../../utils/LayerLocalizationUtils';
-import { getTileGridFromLayerOptions } from '../../../../utils/WMSUtils';
 
-/**
- * Check source and apply proxy
- * when `forceProxy` is set on layer options
- * @param {boolean} forceProxy
- * @param {string} src
- * @returns {string}
- */
-const proxySource = (forceProxy, src) => {
-    let newSrc = src;
-    if (forceProxy && needProxy(src)) {
-        let proxyUrl = getProxyUrl();
-        newSrc = proxyUrl + encodeURIComponent(src);
-    }
-    return newSrc;
-};
+import { proxySource, getWMSURLs, wmsToOpenlayersOptions, toOLAttributions, generateTileGrid } from '../../../../utils/openlayers/WMSUtils';
 
 const loadFunction = (options, headers) => function(image, src) {
     // fixes #3916, see https://gis.stackexchange.com/questions/175057/openlayers-3-wms-styling-using-sld-body-and-post-request
@@ -110,138 +87,17 @@ const loadFunction = (options, headers) => function(image, src) {
         }
     }
 };
-/**
-    @param {object} options of the layer
-    @return the Openlayers options from the layers ones and/or default.
-    tiled params must be tru if not defined
-*/
-function wmsToOpenlayersOptions(options) {
-    const params = optionsToVendorParams(options);
-    // NOTE: can we use opacity to manage visibility?
-    const result = assign({}, options.baseParams, {
-        LAYERS: options.name,
-        STYLES: options.style || "",
-        FORMAT: options.format || 'image/png',
-        TRANSPARENT: options.transparent !== undefined ? options.transparent : true,
-        SRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
-        CRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
-        ...getWMSVendorParams(options),
-        VERSION: options.version || "1.3.0"
-    }, assign(
-        {},
-        (options._v_ ? {_v_: options._v_} : {}),
-        (params || {}),
-        (options.localizedLayerStyles &&
-            options.env && options.env.length &&
-            options.group !== 'background' ? {ENV: generateEnvString(options.env) } : {})
-    ));
-    return addAuthenticationToSLD(result, options);
-}
 
-function getWMSURLs( urls ) {
-    return urls.map((url) => url.split("\?")[0]);
-}
-
-function tileCoordsToKey(coords) {
-    return coords.join(':');
-}
-
-function elevationLoadFunction(forceProxy, imageTile, src) {
-    let newSrc = proxySource(forceProxy, src);
-    const coords = imageTile.getTileCoord();
-    imageTile.getImage().src = "";
-    loadTile(newSrc, coords, tileCoordsToKey(coords));
-}
-
-function addTileLoadFunction(sourceOptions, options) {
+const createLayer = (options, map, mapId) => {
+    // the useForElevation in wms types will be deprecated
+    // as support for existing configuration
+    // we can use this fallback
     if (options.useForElevation) {
-        return assign({}, sourceOptions, { tileLoadFunction: elevationLoadFunction.bind(null, [options.forceProxy]) });
+        return Layers.createLayer('elevation', {
+            ...options,
+            provider: 'wms'
+        }, map, mapId);
     }
-    return sourceOptions;
-}
-
-function getTileFromCoords(layer, pos) {
-    const map = layer.get('map');
-    const tileGrid = layer.getSource().getTileGrid();
-    return tileGrid.getTileCoordForCoordAndZ(pos, map.getView().getZoom());
-}
-
-
-function getTileRelativePixel(layer, pos, tilePoint) {
-    const tileGrid = layer.getSource().getTileGrid();
-    const extent = tileGrid.getTileCoordExtent(tilePoint);
-    const ratio = tileGrid.getTileSize() / (extent[2] - extent[0]);
-    const x = Math.floor((pos[0] - extent[0]) * ratio);
-    const y = Math.floor((extent[3] - pos[1]) * ratio);
-    return { x, y };
-}
-
-function getElevation(pos) {
-    try {
-        const tilePoint = getTileFromCoords(this, pos);
-        const tileSize = this.getSource().getTileGrid().getTileSize();
-        const elevation = getElevationFunc(tileCoordsToKey(tilePoint), getTileRelativePixel(this, pos, tilePoint), tileSize, this.get('nodata'), this.get('littleEndian'));
-        if (elevation.available) {
-            return elevation.value;
-        }
-        return <Message msgId={elevation.message} />;
-    } catch (e) {
-        return <Message msgId="elevationLoadingError" />;
-    }
-}
-const toOLAttributions = credits => credits && creditsToAttribution(credits) || undefined;
-
-const generateTileGrid = (options, map) => {
-    const mapSrs = map?.getView()?.getProjection()?.getCode() || 'EPSG:3857';
-    const normalizedSrs = CoordinatesUtils.normalizeSRS(options.srs || mapSrs, options.allowedSRS);
-    const tileSize = options.tileSize ? options.tileSize : 256;
-    const extent = get(normalizedSrs).getExtent() || getProjection(normalizedSrs).extent;
-    const { TILED } = getWMSVendorParams(options);
-    const customTileGrid = TILED && options.tileGridStrategy === 'custom' && options.tileGrids
-        ? getTileGridFromLayerOptions({ tileSize, projection: normalizedSrs, tileGrids: options.tileGrids })
-        : null;
-    if (customTileGrid
-        && (customTileGrid.resolutions || customTileGrid.scales)
-        && (customTileGrid.origins || customTileGrid.origin)
-        && (customTileGrid.tileSizes || customTileGrid.tileSize)) {
-        const {
-            resolutions: customTileGridResolutions,
-            scales,
-            origin,
-            origins,
-            tileSize: customTileGridTileSize,
-            tileSizes
-        } = customTileGrid;
-        const projection = get(normalizedSrs);
-        const metersPerUnit = projection.getMetersPerUnit();
-        const scaleToResolution = s => s * 0.28E-3 / metersPerUnit;
-        const resolutions = customTileGridResolutions
-            ? customTileGridResolutions
-            : scales.map(scale => scaleToResolution(scale));
-        return new TileGrid({
-            extent,
-            resolutions,
-            tileSizes,
-            tileSize: customTileGridTileSize,
-            origin,
-            origins
-        });
-    }
-    const resolutions = options.resolutions || getResolutionsForProjection(normalizedSrs, {
-        tileWidth: tileSize,
-        tileHeight: tileSize,
-        extent
-    });
-    const origin = options.origin ? options.origin : [extent[0], extent[1]];
-    return new TileGrid({
-        extent,
-        resolutions,
-        tileSize,
-        origin
-    });
-};
-
-const createLayer = (options, map) => {
     const urls = getWMSURLs(isArray(options.url) ? options.url : [options.url]);
     const queryParameters = wmsToOpenlayersOptions(options) || {};
     urls.forEach(url => addAuthenticationParameter(url, queryParameters, options.securityToken));
@@ -266,14 +122,14 @@ const createLayer = (options, map) => {
             })
         });
     }
-    const sourceOptions = addTileLoadFunction({
+    const sourceOptions = {
         attributions: toOLAttributions(options.credits),
         urls: urls,
         crossOrigin: options.crossOrigin,
         params: queryParameters,
         tileGrid: generateTileGrid(options, map),
         tileLoadFunction: loadFunction(options, headers)
-    }, options);
+    };
     const wmsSource = new TileWMS({ ...sourceOptions });
     const layerConfig = {
         msId: options.id,
@@ -308,11 +164,6 @@ const createLayer = (options, map) => {
         if (options.vectorStyle) {
             applyStyle(options.vectorStyle, layer, map);
         }
-    }
-    if (options.useForElevation) {
-        layer.set('nodata', options.nodata);
-        layer.set('littleEndian', options.littleendian ?? false);
-        layer.set('getElevation', getElevation.bind(layer));
     }
     return layer;
 };

--- a/web/client/components/map/openlayers/plugins/index.js
+++ b/web/client/components/map/openlayers/plugins/index.js
@@ -20,5 +20,6 @@ export default {
     WFS3Layer: require('./WFS3Layer').default,
     WMSLayer: require('./WMSLayer').default,
     WMTSLayer: require('./WMTSLayer').default,
-    COGLayer: require('./COGLayer').default
+    COGLayer: require('./COGLayer').default,
+    ElevationLayer: require('./ElevationLayer').default
 };

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -419,7 +419,10 @@ class MapPlugin extends React.Component {
         </div>);
     }
     filterLayer = (layer) => {
-        return !layer.useForElevation || this.props.mapType === 'cesium' || this.props.elevationEnabled;
+        if (layer.useForElevation) {
+            return this.props.mapType === 'cesium' || this.props.elevationEnabled;
+        }
+        return layer.type !== 'elevation' || this.props.elevationEnabled;
     };
     updatePlugins = (props) => {
         this.currentMapType = props.mapType;

--- a/web/client/utils/ElevationUtils.js
+++ b/web/client/utils/ElevationUtils.js
@@ -13,7 +13,17 @@ import { Promise } from 'es6-promise';
 const DEFAULT_SIZE = 100;
 let elevationTiles = new LRUCache(DEFAULT_SIZE);
 
-const addElevationTile = (data, coords, key) => {
+export const getElevationKey = (x, y, z, id) => `${z}:${x}:${y}:${id}`;
+
+export function getTileRelativePixel(position, extent, tileSize) {
+    const ratioW = tileSize[0] / (extent[2] - extent[0]);
+    const ratioH = tileSize[1] / (extent[3] - extent[1]);
+    const x = Math.floor((position[0] - extent[0]) * ratioW);
+    const y = Math.floor((extent[3] - position[1]) * ratioH);
+    return { x, y };
+}
+
+export const addElevationTile = (data, coords, key) => {
     elevationTiles.set(key, {
         data: data,
         dataView: new DataView(data),

--- a/web/client/utils/cesium/WMSUtils.js
+++ b/web/client/utils/cesium/WMSUtils.js
@@ -6,10 +6,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { getAuthenticationHeaders } from "../SecurityUtils";
+import * as Cesium from 'cesium';
+import { isArray } from 'lodash';
+import { addAuthenticationToSLD, getAuthenticationHeaders } from "../SecurityUtils";
 import { getProxyUrl, needProxy } from "../ProxyUtils";
 import ConfigUtils from "../ConfigUtils";
-import {getAuthenticationParam} from "../LayersUtils";
+import { getAuthenticationParam, getURLs, getWMSVendorParams } from "../LayersUtils";
+import { isVectorFormat } from '../VectorTileUtils';
+import { optionsToVendorParams } from '../VendorParamsUtils';
+
+function getQueryString(parameters) {
+    return Object.keys(parameters).map((key) => key + '=' + encodeURIComponent(parameters[key])).join('&');
+}
 
 const PARAM_OPTIONS = ["layers", "styles", "style", "format", "transparent", "version", "tiled", "opacity", "zindex", "srs", "singletile", "_v_", "filterobj" ];
 
@@ -82,8 +90,80 @@ export const wmsToCesiumOptionsBIL = (options) => {
     };
 };
 
+export function wmsToCesiumOptions(options) {
+    var opacity = options.opacity !== undefined ? options.opacity : 1;
+    const params = optionsToVendorParams(options);
+    const cr = options.credits;
+    const credit = cr ? new Cesium.Credit(cr.text || cr.title, cr.imageUrl, cr.link) : options.attribution;
+    // NOTE: can we use opacity to manage visibility?
+    const urls = getURLs(isArray(options.url) ? options.url : [options.url]);
+    const headers = getAuthenticationHeaders(urls[0], options.securityToken);
+
+    return {
+        url: new Cesium.Resource({
+            url: "{s}",
+            headers,
+            proxy: getProxy(options)
+        }),
+        // #7516 this helps Cesium to use CORS requests in a proper way, even when headers are not
+        // present in the Resource
+        tileDiscardPolicy: options.tileDiscardPolicy === "none" ?
+            undefined :
+            (options.tileDiscardPolicy ?? new Cesium.NeverTileDiscardPolicy()),
+        credit,
+        subdomains: urls,
+        layers: options.name,
+        enablePickFeatures: false,
+        parameters: {
+            styles: options.style || "",
+            format: isVectorFormat(options.format) && 'image/png' || options.format || 'image/png',
+            transparent: options.transparent !== undefined ? options.transparent : true,
+            opacity: opacity,
+            tiled: options.tiled !== undefined ? options.tiled : true,
+            width: options.tileSize || 256,
+            height: options.tileSize || 256,
+            ...(options._v_ ? {_v_: options._v_} : {}),
+            ...(params || {}),
+            ...getAuthenticationParam(options)
+
+        }
+    };
+}
+
+export function wmsToCesiumOptionsSingleTile(options) {
+    const opacity = options.opacity !== undefined ? options.opacity : 1;
+    const params = optionsToVendorParams(options);
+    const parameters = {
+        styles: options.style || "",
+        format: isVectorFormat(options.format) && 'image/png' || options.format || 'image/png',
+        transparent: options.transparent !== undefined ? options.transparent : true,
+        opacity: opacity,
+        ...getWMSVendorParams(options),
+        layers: options.name,
+        width: options.size || 2000,
+        height: options.size || 2000,
+        bbox: "-180.0,-90,180.0,90",
+        srs: "EPSG:4326",
+        ...(params || {}),
+        ...getAuthenticationParam(options)
+    };
+
+    const url = (isArray(options.url) ? options.url[Math.round(Math.random() * (options.url.length - 1))] : options.url) + '?service=WMS&version=1.1.0&request=GetMap&'
+        + getQueryString(addAuthenticationToSLD(parameters, options));
+    const headers = getAuthenticationHeaders(url, options.securityToken);
+    return {
+        url: new Cesium.Resource({
+            url,
+            headers,
+            proxy: getProxy(options)
+        })
+    };
+}
+
 export default {
     PARAM_OPTIONS,
     wmsToCesiumOptionsBIL,
+    wmsToCesiumOptions,
+    wmsToCesiumOptionsSingleTile,
     getProxy
 };

--- a/web/client/utils/cesium/__tests__/WMSUtils-test.js
+++ b/web/client/utils/cesium/__tests__/WMSUtils-test.js
@@ -6,7 +6,11 @@
  * LICENSE file in the root directory of this source tree.
 */
 import expect from 'expect';
-import { wmsToCesiumOptionsBIL } from '../WMSUtils';
+import {
+    wmsToCesiumOptionsBIL,
+    wmsToCesiumOptions,
+    wmsToCesiumOptionsSingleTile
+} from '../WMSUtils';
 
 const testLayerConfig = {
     "type": "terrain",
@@ -39,5 +43,34 @@ describe('Test the WMSUtil for Cesium', () => {
         expect(config.proxy.getURL("test")).toBe("test");
         expect(config.layerName).toBe(testConfig.name);
         expect(config.crs).toBe(testConfig.crs);
+    });
+    it('wmsToCesiumOptions', () => {
+        const options = {
+            type: 'wms',
+            url: '/geoserver/wms',
+            name: 'workspace:layer'
+        };
+        const cesiumOptions = wmsToCesiumOptions(options);
+        expect(cesiumOptions.url.url).toBe('{s}');
+        expect(cesiumOptions.subdomains).toEqual([ '/geoserver/wms' ]);
+        expect(cesiumOptions.layers).toBe('workspace:layer');
+        expect(cesiumOptions.parameters).toEqual({
+            styles: '',
+            format: 'image/png',
+            transparent: true,
+            opacity: 1,
+            tiled: true,
+            width: 256,
+            height: 256
+        });
+    });
+    it('wmsToCesiumOptionsSingleTile', () => {
+        const options = {
+            type: 'wms',
+            url: '/geoserver/wms',
+            name: 'workspace:layer'
+        };
+        const cesiumOptions = wmsToCesiumOptionsSingleTile(options);
+        expect(cesiumOptions.url.url).toBe('/geoserver/wms?service=WMS&version=1.1.0&request=GetMap&styles=&format=image%2Fpng&transparent=true&opacity=1&TILED=true&layers=workspace%3Alayer&width=2000&height=2000&bbox=-180.0%2C-90%2C180.0%2C90&srs=EPSG%3A4326');
     });
 });

--- a/web/client/utils/leaflet/WMSUtils.js
+++ b/web/client/utils/leaflet/WMSUtils.js
@@ -5,37 +5,121 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var objectAssign = require('object-assign');
 
-var WMSUtils = {
-    PARAM_OPTIONS: ["layers", "styles", "format", "transparent", "version", "tiled", "zindex", "_v_", "cql_filter", "sld"],
-    wmsToLeafletOptions: function(options) {
-        var opacity = options.opacity !== undefined ? options.opacity : 1;
-        // NOTE: can we use opacity to manage visibility?
-        return objectAssign({
-            layers: options.name,
-            styles: options.style || "",
-            format: options.format || 'image/png',
-            transparent: options.transparent !== undefined ? options.transparent : true,
-            tiled: options.tiled !== undefined ? options.tiled : true,
-            opacity: opacity
-        }, options.params || {});
-    },
-    getWMSURL: function( url ) {
-        return url.split("\?")[0];
-    },
-    filterWMSParamOptions(options) {
-        let paramOptions = {};
-        Object.keys(options).forEach((key) => {
-            if (!key || !key.toLowerCase) {
-                return;
+import L from 'leaflet';
+import assign from 'object-assign';
+import { isNil } from 'lodash';
+import { creditsToAttribution, getWMSVendorParams } from '../LayersUtils';
+import { isVectorFormat } from '../VectorTileUtils';
+import { optionsToVendorParams } from '../VendorParamsUtils';
+import { addAuthenticationToSLD } from '../SecurityUtils';
+
+// implementation used by wms and elevation types
+L.TileLayer.MultipleUrlWMS = L.TileLayer.WMS.extend({
+    initialize: function(urls, options) {
+        this._url = urls[0];
+        this._urls = urls;
+
+        this._urlsIndex = 0;
+
+        let wmsParams = L.extend({}, this.defaultWmsParams);
+        let tileSize = options.tileSize || this.options.tileSize;
+
+        if (options.detectRetina && L.Browser.retina) {
+            wmsParams.width = wmsParams.height = tileSize * 2;
+        } else {
+            wmsParams.width = wmsParams.height = tileSize;
+        }
+        for (let i in options) {
+            // all keys that are not TileLayer options go to WMS params
+            if (!this.options.hasOwnProperty(i) && i.toUpperCase() !== 'CRS' && i !== "maxNativeZoom") {
+                wmsParams[i] = options[i];
             }
-            if (WMSUtils.PARAM_OPTIONS.indexOf(key.toLowerCase()) >= 0) {
-                paramOptions[key] = options[key];
-            }
-        });
-        return paramOptions;
+        }
+        this.wmsParams = wmsParams;
+
+        L.setOptions(this, options);
+    },
+    getTileUrl: function(tilePoint) { // (Point, Number) -> String
+        let map = this._map;
+        let tileSize = this.options.tileSize;
+
+        let nwPoint = tilePoint.multiplyBy(tileSize);
+        let sePoint = nwPoint.add([tileSize, tileSize]);
+
+        let nw = this._crs.project(map.unproject(nwPoint, tilePoint.z));
+        let se = this._crs.project(map.unproject(sePoint, tilePoint.z));
+        let bbox = this._wmsVersion >= 1.3 && this._crs === L.CRS.EPSG4326 ?
+            [se.y, nw.x, nw.y, se.x].join(',') :
+            [nw.x, se.y, se.x, nw.y].join(',');
+        this._urlsIndex++;
+        if (this._urlsIndex === this._urls.length) {
+            this._urlsIndex = 0;
+        }
+        const url = L.Util.template(this._urls[this._urlsIndex], {s: this._getSubdomain(tilePoint)});
+
+        return url + L.Util.getParamString(this.wmsParams, url, true) + '&BBOX=' + bbox;
+    },
+    removeParams: function(params = [], noRedraw) {
+        params.forEach( key => delete this.wmsParams[key]);
+        if (!noRedraw) {
+            this.redraw();
+        }
+        return this;
     }
+});
+
+L.tileLayer.multipleUrlWMS = function(urls, options) {
+    return new L.TileLayer.MultipleUrlWMS(urls, options);
 };
 
-module.exports = WMSUtils;
+export const PARAM_OPTIONS = ["layers", "styles", "format", "transparent", "version", "tiled", "zindex", "_v_", "cql_filter", "sld"];
+
+export const filterWMSParamOptions = (options) => {
+    let paramOptions = {};
+    Object.keys(options).forEach((key) => {
+        if (!key || !key.toLowerCase) {
+            return;
+        }
+        if (PARAM_OPTIONS.indexOf(key.toLowerCase()) >= 0) {
+            paramOptions[key] = options[key];
+        }
+    });
+    return paramOptions;
+};
+
+export function wmsToLeafletOptions(options) {
+    var opacity = options.opacity !== undefined ? options.opacity : 1;
+    const params = optionsToVendorParams(options);
+    // NOTE: can we use opacity to manage visibility?
+    const result = {
+        ...options.baseParams,
+        attribution: options.credits && creditsToAttribution(options.credits),
+        layers: options.name,
+        styles: options.style || "",
+        format: isVectorFormat(options.format) && 'image/png' || options.format || 'image/png',
+        transparent: options.transparent !== undefined ? options.transparent : true,
+        ...getWMSVendorParams(options),
+        opacity: opacity,
+        zIndex: options.zIndex,
+        version: options.version || "1.3.0",
+        tileSize: options.tileSize || 256,
+        maxZoom: options.maxZoom || 23,
+        maxNativeZoom: options.maxNativeZoom || 18,
+        ...(options._v_ ? {_v_: options._v_} : {}),
+        ...(params || {})
+    };
+    return addAuthenticationToSLD(result, options);
+}
+
+export function getWMSURLs( urls ) {
+    return urls.map((url) => url.split("\?")[0]);
+}
+
+export const removeNulls = (obj = {}) => {
+    return Object.keys(obj).reduce((previous, key) => {
+        return isNil(obj[key]) ? previous : assign(previous, {
+            [key]: obj[key]
+        });
+    }, {});
+};

--- a/web/client/utils/leaflet/__tests__/WMSUtils-test.js
+++ b/web/client/utils/leaflet/__tests__/WMSUtils-test.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+import expect from 'expect';
+import {
+    filterWMSParamOptions,
+    wmsToLeafletOptions,
+    removeNulls,
+    getWMSURLs
+} from '../WMSUtils';
+
+describe('Test the WMSUtil for Leaflet', () => {
+    it('filterWMSParamOptions', () => {
+        expect(filterWMSParamOptions({ layers: 'workspace:layer', styles: 'default', opacity: 1 }))
+            .toEqual({ layers: 'workspace:layer', styles: 'default' });
+    });
+    it('wmsToLeafletOptions', () => {
+        const options = {
+            type: 'wms',
+            url: '/geoserver/wms',
+            name: 'workspace:layer'
+        };
+        expect(wmsToLeafletOptions(options)).toEqual({
+            attribution: undefined,
+            layers: 'workspace:layer',
+            styles: '',
+            format: 'image/png',
+            transparent: true,
+            TILED: true,
+            opacity: 1,
+            zIndex: undefined,
+            version: '1.3.0',
+            tileSize: 256,
+            maxZoom: 23,
+            maxNativeZoom: 18
+        });
+    });
+    it('removeNulls', () => {
+        const options = {
+            attribution: undefined,
+            layers: 'workspace:layer',
+            styles: '',
+            format: 'image/png',
+            transparent: true,
+            TILED: true,
+            opacity: 1,
+            zIndex: undefined,
+            version: '1.3.0',
+            tileSize: 256,
+            maxZoom: 23,
+            maxNativeZoom: 18,
+            customProperty: null
+        };
+        expect(removeNulls(options)).toEqual({
+            layers: 'workspace:layer',
+            styles: '',
+            format: 'image/png',
+            transparent: true,
+            TILED: true,
+            opacity: 1,
+            version: '1.3.0',
+            tileSize: 256,
+            maxZoom: 23,
+            maxNativeZoom: 18
+        });
+    });
+    it('getWMSURLs', () => {
+        expect(getWMSURLs([
+            '/a/geoserver/wms?version=1.3.0',
+            '/b/geoserver/wms'
+        ])).toEqual([
+            '/a/geoserver/wms',
+            '/b/geoserver/wms'
+        ]);
+    });
+});

--- a/web/client/utils/openlayers/WMSUtils.js
+++ b/web/client/utils/openlayers/WMSUtils.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import assign from 'object-assign';
+import { get } from 'ol/proj';
+import TileGrid from 'ol/tilegrid/TileGrid';
+
+import CoordinatesUtils from '../CoordinatesUtils';
+import { getProjection } from '../ProjectionUtils';
+import {needProxy, getProxyUrl} from '../ProxyUtils';
+import {optionsToVendorParams} from '../VendorParamsUtils';
+import { addAuthenticationToSLD } from '../SecurityUtils';
+import { creditsToAttribution, getWMSVendorParams } from '../LayersUtils';
+import { getResolutionsForProjection } from '../MapUtils';
+import { generateEnvString } from '../LayerLocalizationUtils';
+import { getTileGridFromLayerOptions } from '../WMSUtils';
+
+/**
+ * Check source and apply proxy
+ * when `forceProxy` is set on layer options
+ * @param {boolean} forceProxy
+ * @param {string} src
+ * @returns {string}
+ */
+export const proxySource = (forceProxy, src) => {
+    let newSrc = src;
+    if (forceProxy && needProxy(src)) {
+        let proxyUrl = getProxyUrl();
+        newSrc = proxyUrl + encodeURIComponent(src);
+    }
+    return newSrc;
+};
+
+export function getWMSURLs( urls ) {
+    return urls.map((url) => url.split("\?")[0]);
+}
+
+export const toOLAttributions = credits => credits && creditsToAttribution(credits) || undefined;
+/**
+    @param {object} options of the layer
+    @return the Openlayers options from the layers ones and/or default.
+    tiled params must be tru if not defined
+*/
+export function wmsToOpenlayersOptions(options) {
+    const params = optionsToVendorParams(options);
+    // NOTE: can we use opacity to manage visibility?
+    const result = assign({}, options.baseParams, {
+        LAYERS: options.name,
+        STYLES: options.style || "",
+        FORMAT: options.format || 'image/png',
+        TRANSPARENT: options.transparent !== undefined ? options.transparent : true,
+        SRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
+        CRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
+        ...getWMSVendorParams(options),
+        VERSION: options.version || "1.3.0"
+    }, assign(
+        {},
+        (options._v_ ? {_v_: options._v_} : {}),
+        (params || {}),
+        (options.localizedLayerStyles &&
+            options.env && options.env.length &&
+            options.group !== 'background' ? {ENV: generateEnvString(options.env) } : {})
+    ));
+    return addAuthenticationToSLD(result, options);
+}
+
+export const generateTileGrid = (options, map) => {
+    const mapSrs = map?.getView()?.getProjection()?.getCode() || 'EPSG:3857';
+    const normalizedSrs = CoordinatesUtils.normalizeSRS(options.srs || mapSrs, options.allowedSRS);
+    const tileSize = options.tileSize ? options.tileSize : 256;
+    const extent = get(normalizedSrs).getExtent() || getProjection(normalizedSrs).extent;
+    const { TILED } = getWMSVendorParams(options);
+    const customTileGrid = TILED && options.tileGridStrategy === 'custom' && options.tileGrids
+        ? getTileGridFromLayerOptions({ tileSize, projection: normalizedSrs, tileGrids: options.tileGrids })
+        : null;
+    if (customTileGrid
+        && (customTileGrid.resolutions || customTileGrid.scales)
+        && (customTileGrid.origins || customTileGrid.origin)
+        && (customTileGrid.tileSizes || customTileGrid.tileSize)) {
+        const {
+            resolutions: customTileGridResolutions,
+            scales,
+            origin,
+            origins,
+            tileSize: customTileGridTileSize,
+            tileSizes
+        } = customTileGrid;
+        const projection = get(normalizedSrs);
+        const metersPerUnit = projection.getMetersPerUnit();
+        const scaleToResolution = s => s * 0.28E-3 / metersPerUnit;
+        const resolutions = customTileGridResolutions
+            ? customTileGridResolutions
+            : scales.map(scale => scaleToResolution(scale));
+        return new TileGrid({
+            extent,
+            resolutions,
+            tileSizes,
+            tileSize: customTileGridTileSize,
+            origin,
+            origins
+        });
+    }
+    const resolutions = options.resolutions || getResolutionsForProjection(normalizedSrs, {
+        tileWidth: tileSize,
+        tileHeight: tileSize,
+        extent
+    });
+    const origin = options.origin ? options.origin : [extent[0], extent[1]];
+    return new TileGrid({
+        extent,
+        resolutions,
+        tileSize,
+        origin
+    });
+};

--- a/web/client/utils/openlayers/__tests__/WMSUtils-test.js
+++ b/web/client/utils/openlayers/__tests__/WMSUtils-test.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import expect from 'expect';
+import {
+    wmsToOpenlayersOptions,
+    generateTileGrid
+} from '../WMSUtils';
+
+describe('Test the WMSUtil for OpenLayers', () => {
+    it('wmsToOpenlayersOptions', () => {
+        const options = {
+            type: 'wms',
+            url: '/geoserver/wms',
+            name: 'workspace:layer'
+        };
+        expect(wmsToOpenlayersOptions(options)).toEqual({
+            LAYERS: 'workspace:layer',
+            STYLES: '',
+            FORMAT: 'image/png',
+            TRANSPARENT: true,
+            SRS: 'EPSG:3857',
+            CRS: 'EPSG:3857',
+            TILED: true,
+            VERSION: '1.3.0'
+        });
+    });
+    it('generateTileGrid', () => {
+        const options = {
+            url: '/geoserver/wms',
+            name: 'workspace:layer',
+            visibility: true,
+            tileGridStrategy: 'custom',
+            tileSize: 256,
+            tileGrids: [
+                {
+                    id: 'EPSG:4326',
+                    crs: 'EPSG:4326',
+                    scales: [ 279541132.0143589, 139770566.00717944, 69885283.00358972 ],
+                    origin: [ 90, -180 ],
+                    tileSize: [ 256, 256 ]
+                },
+                {
+                    id: 'EPSG:900913',
+                    crs: 'EPSG:900913',
+                    scales: [ 559082263.9508929, 279541131.97544646, 139770565.98772323 ],
+                    origin: [ -20037508.34, 20037508 ],
+                    tileSize: [ 256, 256 ]
+                }
+            ]
+        };
+        const tileGrid = generateTileGrid(options);
+        expect(tileGrid.getResolutions().length).toBe(3);
+        expect(tileGrid.getOrigin()).toEqual(options.tileGrids[1].origin);
+        expect().toBe();
+    });
+});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces a new type of layer called `elevation` to get height information to display in the mouse position plugin. This split the concept of terrain for visualization and elevation as data information.

In particular this note included in the documentation:


> Note that in the Cesium 3D viewer all the heights are relative to the WGS84 ellipsoid while usually locally DTM/DEM file could have an elevation value relative to the mean sea level (MSL). So with this new layer it's possible to have a terrain layer with the correct WGS84 ellipsoidal height while querying the mouse position with a MSL height.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x]  Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#8579

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Introduction of a new layer of type elevation

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
