### PR TITLE
#9840: StreetView plugin ability to set parameters for the default size of panel

### DIFF
--- a/web/client/plugins/StreetView/StreetView.jsx
+++ b/web/client/plugins/StreetView/StreetView.jsx
@@ -49,7 +49,7 @@ const StreetViewPluginContainer = connect(() => ({}), {
  * @property {boolean} [cfg.useDataLayer=true] If true, adds to the map a layer for street view data availability when the plugin is turned on.
  * @property {object} [cfg.dataLayerConfig] configuration for the data layer. By default `{provider: 'custom', type: "tileprovider", url: "https://mts1.googleapis.com/vt?hl=en-US&lyrs=svv|cb_client:apiv3&style=40,18&x={x}&y={y}&z={z}"}`
  * @property {object} [cfg.panoramaOptions] options to configure the panorama. {@link https://developers.google.com/maps/documentation/javascript/reference/street-view#panoramaOptions|Reference for google maps API}
- * @property {object} [cfg.panelSize] option to configure default street view modal panel size i.e `width` and `height`
+ * @property {object} [cfg.panelSize] option to configure default street view modal panel size `width` and `height`. Example: `{"width": 500, "height": 500}`.
  * @class
  */
 export default createPlugin(

--- a/web/client/plugins/StreetView/StreetView.jsx
+++ b/web/client/plugins/StreetView/StreetView.jsx
@@ -20,14 +20,14 @@ import streetView from './reducers/streetview';
 import * as epics from './epics/streetView';
 import './css/style.css';
 
-const StreetViewPluginComponent = ({onMount, onUnmount, apiKey, useDataLayer, dataLayerConfig, panoramaOptions}) => {
+const StreetViewPluginComponent = ({onMount, onUnmount, apiKey, useDataLayer, dataLayerConfig, panoramaOptions, panelSize}) => {
     useEffect(() => {
         onMount({apiKey, useDataLayer, dataLayerConfig, panoramaOptions});
         return () => {
             onUnmount();
         };
     }, [apiKey, useDataLayer, dataLayerConfig, JSON.stringify(panoramaOptions ?? {})]);
-    return <StreetViewContainer />;
+    return <StreetViewContainer panelSize={panelSize} />;
 };
 
 const StreetViewPluginContainer = connect(() => ({}), {
@@ -49,6 +49,7 @@ const StreetViewPluginContainer = connect(() => ({}), {
  * @property {boolean} [cfg.useDataLayer=true] If true, adds to the map a layer for street view data availability when the plugin is turned on.
  * @property {object} [cfg.dataLayerConfig] configuration for the data layer. By default `{provider: 'custom', type: "tileprovider", url: "https://mts1.googleapis.com/vt?hl=en-US&lyrs=svv|cb_client:apiv3&style=40,18&x={x}&y={y}&z={z}"}`
  * @property {object} [cfg.panoramaOptions] options to configure the panorama. {@link https://developers.google.com/maps/documentation/javascript/reference/street-view#panoramaOptions|Reference for google maps API}
+ * @property {object} [cfg.panelSize] option to configure default street view modal panel size i.e `width` and `height`
  * @class
  */
 export default createPlugin(

--- a/web/client/plugins/StreetView/components/EmptyStreetView.js
+++ b/web/client/plugins/StreetView/components/EmptyStreetView.js
@@ -3,6 +3,14 @@ import Message from '../../../components/I18N/Message';
 
 import EmptyView from '../../../components/misc/EmptyView';
 const EmptyStreetView = () => {
-    return <EmptyView iconFit={false} glyph="road" title={<Message msgId="streetView.emptyTitle"/>} description={<Message msgId="streetView.emptyDescription"/>} />;
+    return (
+        <EmptyView
+            style={{display: "flex", justifyContent: "center"}}
+            iconFit={false}
+            glyph="road"
+            title={<Message msgId="streetView.emptyTitle"/>}
+            description={<Message msgId="streetView.emptyDescription"/>}
+        />
+    );
 };
 export default EmptyStreetView;

--- a/web/client/plugins/StreetView/containers/StreetViewContainer.jsx
+++ b/web/client/plugins/StreetView/containers/StreetViewContainer.jsx
@@ -17,9 +17,9 @@ import { toggleStreetView } from '../actions/streetView';
  * @param {*} param0
  * @returns
  */
-function Panel({enabled, onClose = () => {}}) {
+function Panel({enabled, onClose = () => {}, panelSize}) {
     const margin = 10;
-    const [size, setSize] = useState({width: 400, height: 300});
+    const [size, setSize] = useState({width: 400, height: 300, ...panelSize});
     if (!enabled) {
         return null;
     }


### PR DESCRIPTION
## Description
This PR introduces a configuration property `panelSize` to set default size of the street view panel, allowing user to see more info **Ex**: when configuring panoramaOptions like `imageDateControl`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #9840 

**What is the new behavior?**

https://github.com/geosolutions-it/MapStore2/assets/26929983/4acb26d5-ddd6-42c7-a278-8a150bbbbdb9

## Testing
`/context/street-view`

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
