### PR TITLE
update maven-war-plugin to 3.4.0 to improve java17 compat (#9850)

### DIFF
--- a/binary/bin-war/pom.xml
+++ b/binary/bin-war/pom.xml
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>3.4.0</version>
                 <configuration>
                     <overlays>
                         <overlay>

--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -126,7 +126,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>3.4.0</version>
             <configuration>
                 <packagingExcludes>WEB-INF/lib/commons-codec-1.2.jar,
                 WEB-INF/lib/commons-io-1.1.jar,

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -245,7 +245,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>3.4.0</version>
             <configuration>
                 <overlays>
                     <overlay>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -362,7 +362,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
+            <version>3.4.0</version>
             <configuration>
                 <packagingExcludes>WEB-INF/lib/commons-codec-1.2.jar,
                 WEB-INF/lib/commons-io-1.1.jar,


### PR DESCRIPTION
## Description

see #9850, doesnt fix tests though, but `-DskipTests` builds fine.