### PR TITLE
#9613: Fix for layer filtering resulting in lowercase titles

### DIFF
--- a/web/client/components/TOC/fragments/Title.jsx
+++ b/web/client/components/TOC/fragments/Title.jsx
@@ -38,14 +38,19 @@ class Title extends React.Component {
     };
 
     getFilteredTitle = (title) => {
-        const splitTitle = title.toLowerCase().split(this.props.filterText.toLowerCase());
+        const regularExpression = new RegExp(this.props.filterText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&'), 'gi');
+        const matches = title.match(regularExpression);
 
-        return this.props.filterText ? splitTitle.reduce((a, b, idx) => {
-            if (idx === splitTitle.length - 1) {
-                return [...a, b];
+        if (!this.props.filterText || !matches) {
+            return title;
+        }
+
+        return title.split(regularExpression).map((split, key) => {
+            if (key < matches.length) {
+                return [...split, <strong>{matches[key]}</strong>];
             }
-            return [...a, b, <strong key={idx}>{this.props.filterText.toLowerCase()}</strong>];
-        }, []) : title;
+            return split;
+        });
     };
 
     renderTitle = () => {

--- a/web/client/components/TOC/fragments/Title.jsx
+++ b/web/client/components/TOC/fragments/Title.jsx
@@ -45,9 +45,9 @@ class Title extends React.Component {
             return title;
         }
 
-        return title.split(regularExpression).map((split, key) => {
-            if (key < matches.length) {
-                return [...split, <strong>{matches[key]}</strong>];
+        return title.split(regularExpression).map((split, idx) => {
+            if (idx < matches.length) {
+                return [...split, <strong key={idx}>{matches[idx]}</strong>];
             }
             return split;
         });


### PR DESCRIPTION
## Description
Should fix #9613: After filtering Layers, all Layer names are lower case

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) (too small for specific test)
- [ ] Docs have been added / updated (for bug fixes / features) (too small for documentation)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix

## Issue

**What is the current behavior?**
#9613

**What is the new behavior?**
After filtering layers the titles keep their lower and uppercase as before.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

## Other useful information
