### PR TITLE
#9858 Fix performance issues with OLStyleParser

### DIFF
--- a/web/client/utils/styleparser/__tests__/OLStyleParser-test.js
+++ b/web/client/utils/styleparser/__tests__/OLStyleParser-test.js
@@ -7,7 +7,7 @@
  */
 
 import expect from 'expect';
-import OLStyleParser from '../OLStyleParser';
+import OLStyleParser, {createGetImagesSrc} from '../OLStyleParser';
 
 const parser = new OLStyleParser();
 
@@ -366,4 +366,32 @@ describe('OLStyleParser', () => {
                 }).catch(done);
         });
     });
+    // this function uses canvas and cache to speed up rendering
+    describe('createGetImagesSrc', () => {
+        it('should create a function that returns an image src', () => {
+
+            const image = document.createElement('canvas');
+            // add data to the canvas
+            image.width = 10;
+            image.height = 10;
+            const ctx = image.getContext('2d');
+            ctx.fillStyle = '#ff0000';
+            ctx.fillRect(0, 0, 10, 10);
+
+            const getImageSrc = createGetImagesSrc([image]);
+            const src = getImageSrc(image, 'imageID');
+            expect(src).toBe(image.toDataURL()); // check returns the same src
+            expect(getImageSrc(image, 'imageID')).toBe(src); // check cache
+            const image2 = document.createElement('canvas');
+            // add data to the canvas
+            image2.width = 10;
+            image2.height = 10;
+            const ctx2 = image2.getContext('2d');
+            ctx2.fillStyle = '#00ff00';
+            ctx2.fillRect(0, 0, 10, 10);
+            expect(getImageSrc(image2, 'imageID2')).toBe(image2.toDataURL()); // check different id
+            expect(getImageSrc(image2, 'imageID2')).toNotBe(src); // check different id
+        });
+    });
+
 });


### PR DESCRIPTION
## Description

This PR fixes performances of OLStyleParser creating a cache for images generates by canvas.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9858

**What is the new behavior?**
Fix #9858

On the left the fix, on the right the current bug

[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2024.01.09-16_12_51.webm](https://github.com/geosolutions-it/MapStore2/assets/1279510/ab1fbda1-b069-4da3-872b-da9fc094605a)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
