### PR TITLE
[Backport 2023.02.xx] #9825: Add an config option to enable mapInfo highlight by default (#9829)

### DIFF
--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -71,9 +71,10 @@ export default props => {
         formatCoord,
         loaded,
         validator = () => null,
-        toggleHighlightFeature = () => {},
         disableCoordinatesRow,
-        disableInfoAlert
+        disableInfoAlert,
+        onInitPlugin = () => {},
+        pluginCfg
     } = props;
     const latlng = point && point.latlng || null;
 
@@ -122,7 +123,9 @@ export default props => {
             draggable={draggable}
             onClose={() => {
                 onClose();
-                toggleHighlightFeature(false);
+                onInitPlugin({
+                    highlight: pluginCfg?.highlightEnabledFromTheStart || false
+                });
             }}
             dock={dock}
             style={dockStyle}

--- a/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
+++ b/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
@@ -257,12 +257,12 @@ describe("test IdentifyContainer", () => {
         expect(glyphIcons.forEach(glyph => glyph.className) !== 'zoom-to').toBeTruthy();
     });
 
-    it('test call toggleHighlightFeature on Close', () => {
+    it('test call onInitPlugin on Close', () => {
         const requests = [{reqId: 1}, {reqId: 2}];
         const callbacks = {
-            toggleHighlightFeature: () => {}
+            onInitPlugin: () => {}
         };
-        const toggleHighlightFeatureSpy = expect.spyOn(callbacks, 'toggleHighlightFeature');
+        const onInitPluginSpy = expect.spyOn(callbacks, 'onInitPlugin');
         const responses = [{layerMetadata: {title: "Layer 1"}}, {layerMetadata: {title: "Layer 2"}}];
         const CMP = (<IdentifyContainer
             enabled
@@ -272,7 +272,7 @@ describe("test IdentifyContainer", () => {
             getFeatureButtons={getFeatureButtons}
             point={{latlng: {lat: 1, lng: 1}}}
             showCoordinateEditor={false}
-            toggleHighlightFeature={callbacks.toggleHighlightFeature}
+            onInitPlugin={callbacks.onInitPlugin}
         />);
         ReactDOM.render(CMP, document.getElementById("container"));
         const container = document.getElementById('container');
@@ -281,7 +281,7 @@ describe("test IdentifyContainer", () => {
         TestUtils.act(() => {
             ReactDOM.render(CMP, document.getElementById("container"));
         });
-        expect(toggleHighlightFeatureSpy).toHaveBeenCalled();
+        expect(onInitPluginSpy).toHaveBeenCalled();
         // Test since when the highlight feature is disabled the zoom Icon is not shown
         const zoomIcon = document.querySelector('.glyphicon-zoom-to');
         expect(zoomIcon).toNotExist();

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -78,7 +78,8 @@ export const identifyLifecycle = compose(
                 onEnableCenterToMarker = () => {},
                 setShowInMapPopup = () => {},
                 checkIdentifyIsMounted = () => {},
-                onInitPlugin = () => {}
+                onInitPlugin = () => {},
+                pluginCfg = {}
             } = this.props;
 
             // Initialize plugin configuration
@@ -87,9 +88,9 @@ export const identifyLifecycle = compose(
                 configuration: {
                     maxItems
                 },
-                showAllResponses
+                showAllResponses,
+                highlight: pluginCfg?.highlightEnabledFromTheStart || false
             });
-
             if (enabled || showInMapPopup) {
                 changeMousePointer('pointer');
                 checkIdentifyIsMounted(true);

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -196,6 +196,7 @@ const identifyDefaultProps = defaultProps({
  * @prop cfg.dock {bool} true shows dock panel, false shows modal
  * @prop cfg.draggable {boolean} draggable info window, when modal
  * @prop cfg.showHighlightFeatureButton {boolean} show the highlight feature button if the interrogation returned valid features (openlayers only)
+ * @prop cfg.highlightEnabledFromTheStart {boolean} the highlight feature button will be activated by default if true
  * @prop cfg.viewerOptions.container {expression} the container of the viewer, expression from the context
  * @prop cfg.viewerOptions.header {expression} the header of the viewer, expression from the context{expression}
  * @prop cfg.disableCenterToMarker {bool} disable zoom to marker action

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -986,4 +986,14 @@ describe('Test the mapInfo reducer', () => {
         expect(state.cfg1).toEqual("test");
         expect(state.configuration).toEqual({maxItems: 3});
     });
+    it('initiateOrResetHighlight via onInitPlugin if highlight default value equal true', () => {
+        const initialState = { configuration: {} };
+        const state = mapInfo(initialState, onInitPlugin({highlight: true}));
+        expect(state.highlight).toEqual(true);
+    });
+    it('initiateOrResetHighlight via onInitPlugin if highlight default value equal false', () => {
+        const initialState = { configuration: {} };
+        const state = mapInfo(initialState, onInitPlugin({highlight: false}));
+        expect(state.highlight).toEqual(false);
+    });
 });


### PR DESCRIPTION
Backport 2023.02.xx - #9825 : Add an config option to enable mapInfo highlight by default (#9829 )