### PR TITLE
Fix #9867 background downsampling for thumbnail of backgrounds

### DIFF
--- a/web/client/components/background/BackgroundDialog.jsx
+++ b/web/client/components/background/BackgroundDialog.jsx
@@ -323,6 +323,13 @@ export default class BackgroundDialog extends React.Component {
                     map={{
                         newThumbnail: get(this.state.thumbnail, 'url') || "NODATA"
                     }}
+                    thumbnailOptions={{
+                        width: 98,
+                        height: 98,
+                        type: 'image/jpeg',
+                        quality: 0.5,
+                        contain: false
+                    }}
                 />
                 <FormGroup>
                     <ControlLabel><Message msgId="layerProperties.title"/></ControlLabel>

--- a/web/client/components/background/BackgroundDialog.jsx
+++ b/web/client/components/background/BackgroundDialog.jsx
@@ -324,10 +324,10 @@ export default class BackgroundDialog extends React.Component {
                         newThumbnail: get(this.state.thumbnail, 'url') || "NODATA"
                     }}
                     thumbnailOptions={{
-                        width: 98,
-                        height: 98,
+                        width: 128,
+                        height: 128,
                         type: 'image/jpeg',
-                        quality: 0.5,
+                        quality: 0.8,
                         contain: false
                     }}
                 />

--- a/web/client/themes/default/less/backgroundSelector.less
+++ b/web/client/themes/default/less/backgroundSelector.less
@@ -139,6 +139,16 @@
     padding: 8px;
 }
 
-.background-dialog .dropzone-thumbnail-container label {
-    font-weight: bold
+.background-dialog
+{
+    .dropzone-thumbnail-container {
+        .dropzone{
+            width: 128px;
+            height: 128px;
+        }
+        label {
+            font-weight: bold;
+            width: ~"calc(100% - 128px)"
+        }
+    }
 }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -3107,7 +3107,7 @@
             "title": "Titel",
             "titlePlaceholder": "Den angezeigten Namen eingeben",
             "add": "Hinzufügen",
-            "thumbnailMessage": "Die Größe der Bilder sollte ein Quadrat von 98 x 98 Pixel oder 128 x 128 Pixel sein, maximal 500kb",
+            "thumbnailMessage": "Die Größe der Bilder sollte ein Quadrat von 128 x 128 Pixel sein, maximal 500kb",
             "imageUploadMessage": "Klicken Sie auf oder ziehen Sie sie ab, um ein Bild hinzuzufügen",
             "additionalParameters": "Zusätzliche Parameter",
             "addAdditionalParameterTooltip": "Parameter hinzufügen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -3080,7 +3080,7 @@
             "title": "Title",
             "titlePlaceholder": "Enter displayed name",
             "add": "Add",
-            "thumbnailMessage": "Size of images should be a square of 98px x 98px or 128px x 128px, max 500kb",
+            "thumbnailMessage": "Size of images should be a square of 128px x 128px, max 500kb",
             "imageUploadMessage": "Click, or drag and drop to add an image",
             "additionalParameters": "Additional Parameters",
             "addAdditionalParameterTooltip": "Add parameter",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -3069,7 +3069,7 @@
             "title": "Título",
             "titlePlaceholder": "Ingrese el nombre que se muestra",
             "add": "Añadir",
-            "thumbnailMessage": "El tamaño de las imágenes debe ser un cuadrado de 98 px x 98 px o 128 px x 128 px, máximo 500kb",
+            "thumbnailMessage": "El tamaño de las imágenes debe ser un cuadrado de 128 px x 128 px, máximo 500kb",
             "imageUploadMessage": "Haga clic, o arrastre y suelte para agregar una imagen",
             "additionalParameters": "Parámetros adicionales",
             "addAdditionalParameterTooltip": "Agregar parámetro",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -3070,7 +3070,7 @@
             "title": "Titre",
             "titlePlaceholder": "Entrez le nom affiché",
             "add": "Ajouter",
-            "thumbnailMessage": "La taille des images doit être un carré de 98px x 98px ou 128px x 128px, maximum 500kb",
+            "thumbnailMessage": "La taille des images doit être un carré de 128px x 128px, maximum 500kb",
             "imageUploadMessage": "Cliquez ou faites glisser et déposez pour ajouter une image",
             "additionalParameters": "Paramètres additionnels",
             "addAdditionalParameterTooltip": "Ajouter un paramètre",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -3070,7 +3070,7 @@
             "title": "Titolo",
             "titlePlaceholder": "Inserisci il nome visualizzato",
             "add": "Inserisci",
-            "thumbnailMessage": "Le dimensioni delle immagini devono essere quadrate di 98 px x 98 px o 128 px x 128 px, max 500kb",
+            "thumbnailMessage": "Le dimensioni delle immagini devono essere quadrate di 128 px x 128 px, max 500kb",
             "imageUploadMessage": "Fare clic o trascinare e rilasciare per aggiungere un'immagine",
             "additionalParameters": "Parametri aggiuntivi",
             "addAdditionalParameterTooltip": "Aggiungi parametro",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

- add downsampling of images to 98x98 (preview size)
- make sure that temp layer is updated when editing and saving a thumbnail

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #9867 
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
see description above
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
