### PR TITLE
Fix #9883 UI Style Editor - Pattern mark style and Pattern icon style

### DIFF
--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -57,7 +57,7 @@ export const fields = {
             const blockConfig = config?.getGroupConfig(value.kind) || {};
             const properties = value;
             return (
-                <>
+                <div className="ms-symbolizer-nested-fields">
                     <Fields
                         properties={properties}
                         params={blockConfig.omittedKeys ? omit(params, blockConfig.omittedKeys) : params}
@@ -68,7 +68,7 @@ export const fields = {
                         format={format}
                     />
                     <PropertyField divider/>
-                </>
+                </div>
             );
         }
 

--- a/web/client/themes/default/less/style-editor.less
+++ b/web/client/themes/default/less/style-editor.less
@@ -610,6 +610,13 @@ Ported to CodeMirror by Peter Kroon
     align-items: center;
 }
 
+.ms-symbolizer-nested-fields {
+    width: 100%;
+    .ms-symbolizer-field-wrapper {
+        width: 100%;
+    }
+}
+
 .ms-symbolizer-field {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds a class wrapper on pattern properties to correctly display them

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9883

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The style for pattern properties is correctly displayed

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
