### PR TITLE
Fix #9884 Issue with style symbolizer assignment for WFS layer

### DIFF
--- a/web/client/api/catalog/WFS.js
+++ b/web/client/api/catalog/WFS.js
@@ -17,7 +17,6 @@ import {
     testService as commonTestService,
     preprocess as commonPreprocess
 } from './common';
-import { createDefaultStyle } from '../../utils/StyleUtils';
 import { get, castArray } from 'lodash';
 
 const capabilitiesCache = {};
@@ -91,7 +90,6 @@ const recordToLayer = (record) => {
         description: record.description || "",
         bbox: record.boundingBox,
         links: getRecordLinks(record),
-        style: createDefaultStyle({}),
         ...record.layerOptions
     };
 };

--- a/web/client/components/map/cesium/plugins/WFSLayer.js
+++ b/web/client/components/map/cesium/plugins/WFSLayer.js
@@ -56,7 +56,11 @@ const createLayer = (options, map) => {
             styledFeatures.setFeatures(collection.features);
             layerToGeoStylerStyle(options)
                 .then((style) => {
-                    getStyle(applyDefaultStyleToVectorLayer({ ...options, style }), 'cesium')
+                    getStyle(applyDefaultStyleToVectorLayer({
+                        ...options,
+                        features: collection.features,
+                        style
+                    }), 'cesium')
                         .then((styleFunc) => {
                             styledFeatures.setStyleFunction(styleFunc);
                         });
@@ -84,7 +88,11 @@ Layers.registerType('wfs', {
         if (layer?.styledFeatures && !isEqual(newOptions.style, oldOptions.style)) {
             layerToGeoStylerStyle(newOptions)
                 .then((style) => {
-                    getStyle(applyDefaultStyleToVectorLayer({ ...newOptions, style }), 'cesium')
+                    getStyle(applyDefaultStyleToVectorLayer({
+                        ...newOptions,
+                        features: layer?.styledFeatures?._originalFeatures,
+                        style
+                    }), 'cesium')
                         .then((styleFunc) => {
                             layer.styledFeatures.setStyleFunction(styleFunc);
                         });

--- a/web/client/components/map/leaflet/plugins/WFSLayer.jsx
+++ b/web/client/components/map/leaflet/plugins/WFSLayer.jsx
@@ -24,7 +24,12 @@ import { applyDefaultStyleToVectorLayer } from '../../../../utils/StyleUtils';
 const setStyle = (layer, options) => {
     layerToGeoStylerStyle(options)
         .then((style) => {
-            getStyle(applyDefaultStyleToVectorLayer({ ...options, style }), 'leaflet')
+            const collection = layer['@wfsFeatureCollection'];
+            getStyle(applyDefaultStyleToVectorLayer({
+                ...options,
+                features: collection.features,
+                style
+            }), 'leaflet')
                 .then((styleUtils) => {
                     styleUtils({ opacity: options.opacity, layer, features: layer?.['@wfsFeatureCollection']?.features })
                         .then(({

--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -910,6 +910,190 @@ describe('catalog Epics', () => {
         });
     });
 
+    describe('addLayerAndDescribeEpic wfs layer', () => {
+
+        beforeEach(done => {
+            mockAxios = new MockAdapter(axios);
+            setTimeout(done);
+        });
+
+        afterEach(done => {
+            mockAxios.restore();
+            setTimeout(done);
+        });
+
+        it('wfs layer polygon', (done) => {
+            const layer = {
+                type: 'wfs',
+                url: '/geoserver/wfs',
+                visibility: true,
+                name: 'workspace:vector_layer',
+                title: 'workspace:vector_layer',
+                bbox: {"crs": "EPSG:4326", "bounds": {"minx": "-103.87791475407893", "miny": "44.37246687108142", "maxx": "-103.62278893469492", "maxy": "44.50235105543566"}}
+            };
+            mockAxios.onGet().reply(() => ([ 200, {
+                "elementFormDefault": "qualified",
+                "targetNamespace": "/geoserver/geoserver",
+                "targetPrefix": "gs",
+                "featureTypes": [
+                    {
+                        "typeName": "workspace:vector_layer",
+                        "properties": [
+                            {
+                                "name": "the_geom",
+                                "maxOccurs": 1,
+                                "minOccurs": 0,
+                                "nillable": true,
+                                "type": "gml:MultiPolygon",
+                                "localType": "MultiPolygon"
+                            }
+                        ]
+                    }
+                ]
+            } ]));
+            const NUM_ACTIONS = 3;
+            testEpic(addTimeoutEpic(addLayerAndDescribeEpic, 0), NUM_ACTIONS,
+                addLayerAndDescribe(layer),
+                (actions) => {
+                    expect(actions.length).toBe(NUM_ACTIONS);
+                    actions.map((action) => {
+                        switch (action.type) {
+                        case ADD_LAYER:
+                            expect(action.layer.name).toBe("workspace:vector_layer");
+                            expect(action.layer.title).toBe("workspace:vector_layer");
+                            expect(action.layer.type).toBe("wfs");
+                            expect(action.layer.url).toEqual(layer.url);
+                            break;
+                        case CHANGE_LAYER_PROPERTIES:
+                            expect(action.newProperties.style).toBeTruthy();
+                            expect(action.newProperties.style.body.rules.length).toBe(1);
+                            expect(action.newProperties.style.body.rules[0].symbolizers.length).toBe(1);
+                            expect(action.newProperties.style.body.rules[0].symbolizers[0].kind).toBe('Fill');
+                            break;
+                        case TEST_TIMEOUT:
+                            break;
+                        default:
+                            expect(true).toBe(false);
+                        }
+                    });
+                    done();
+                }, {});
+        });
+        it('wfs layer line', (done) => {
+            const layer = {
+                type: 'wfs',
+                url: '/geoserver/wfs',
+                visibility: true,
+                name: 'workspace:vector_layer',
+                title: 'workspace:vector_layer',
+                bbox: {"crs": "EPSG:4326", "bounds": {"minx": "-103.87791475407893", "miny": "44.37246687108142", "maxx": "-103.62278893469492", "maxy": "44.50235105543566"}}
+            };
+            mockAxios.onGet().reply(() => ([ 200, {
+                "elementFormDefault": "qualified",
+                "targetNamespace": "/geoserver/geoserver",
+                "targetPrefix": "gs",
+                "featureTypes": [
+                    {
+                        "typeName": "workspace:vector_layer",
+                        "properties": [
+                            {
+                                "name": "the_geom",
+                                "maxOccurs": 1,
+                                "minOccurs": 0,
+                                "nillable": true,
+                                "type": "gml:LineString",
+                                "localType": "LineString"
+                            }
+                        ]
+                    }
+                ]
+            } ]));
+            const NUM_ACTIONS = 3;
+            testEpic(addTimeoutEpic(addLayerAndDescribeEpic, 0), NUM_ACTIONS,
+                addLayerAndDescribe(layer),
+                (actions) => {
+                    expect(actions.length).toBe(NUM_ACTIONS);
+                    actions.map((action) => {
+                        switch (action.type) {
+                        case ADD_LAYER:
+                            expect(action.layer.name).toBe("workspace:vector_layer");
+                            expect(action.layer.title).toBe("workspace:vector_layer");
+                            expect(action.layer.type).toBe("wfs");
+                            expect(action.layer.url).toEqual(layer.url);
+                            break;
+                        case CHANGE_LAYER_PROPERTIES:
+                            expect(action.newProperties.style).toBeTruthy();
+                            expect(action.newProperties.style.body.rules.length).toBe(1);
+                            expect(action.newProperties.style.body.rules[0].symbolizers.length).toBe(1);
+                            expect(action.newProperties.style.body.rules[0].symbolizers[0].kind).toBe('Line');
+                            break;
+                        case TEST_TIMEOUT:
+                            break;
+                        default:
+                            expect(true).toBe(false);
+                        }
+                    });
+                    done();
+                }, {});
+        });
+        it('wfs layer point', (done) => {
+            const layer = {
+                type: 'wfs',
+                url: '/geoserver/wfs',
+                visibility: true,
+                name: 'workspace:vector_layer',
+                title: 'workspace:vector_layer',
+                bbox: {"crs": "EPSG:4326", "bounds": {"minx": "-103.87791475407893", "miny": "44.37246687108142", "maxx": "-103.62278893469492", "maxy": "44.50235105543566"}}
+            };
+            mockAxios.onGet().reply(() => ([ 200, {
+                "elementFormDefault": "qualified",
+                "targetNamespace": "/geoserver/geoserver",
+                "targetPrefix": "gs",
+                "featureTypes": [
+                    {
+                        "typeName": "workspace:vector_layer",
+                        "properties": [
+                            {
+                                "name": "the_geom",
+                                "maxOccurs": 1,
+                                "minOccurs": 0,
+                                "nillable": true,
+                                "type": "gml:Point",
+                                "localType": "Point"
+                            }
+                        ]
+                    }
+                ]
+            } ]));
+            const NUM_ACTIONS = 3;
+            testEpic(addTimeoutEpic(addLayerAndDescribeEpic, 0), NUM_ACTIONS,
+                addLayerAndDescribe(layer),
+                (actions) => {
+                    expect(actions.length).toBe(NUM_ACTIONS);
+                    actions.map((action) => {
+                        switch (action.type) {
+                        case ADD_LAYER:
+                            expect(action.layer.name).toBe("workspace:vector_layer");
+                            expect(action.layer.title).toBe("workspace:vector_layer");
+                            expect(action.layer.type).toBe("wfs");
+                            expect(action.layer.url).toEqual(layer.url);
+                            break;
+                        case CHANGE_LAYER_PROPERTIES:
+                            expect(action.newProperties.style).toBeTruthy();
+                            expect(action.newProperties.style.body.rules.length).toBe(1);
+                            expect(action.newProperties.style.body.rules[0].symbolizers.length).toBe(1);
+                            expect(action.newProperties.style.body.rules[0].symbolizers[0].kind).toBe('Mark');
+                            break;
+                        case TEST_TIMEOUT:
+                            break;
+                        default:
+                            expect(true).toBe(false);
+                        }
+                    });
+                    done();
+                }, {});
+        });
+    });
     describe('addLayersFromCatalogsEpic geojson', () => {
         it('should add layer with title from geojson', (done) => {
             const NUM_ACTIONS = 1;

--- a/web/client/plugins/StreetView/selectors/streetView.js
+++ b/web/client/plugins/StreetView/selectors/streetView.js
@@ -68,7 +68,6 @@ const CYCLOMEDIA_DATA_LAYER_DEFAULTS = {
     strategy: 'bbox', // loads data only in the current extent
     maxResolution: CYCLOMEDIA_DEFAULT_MAX_RESOLUTION,
     serverType: ServerTypes.NO_VENDOR, // do not support CQL filters
-    geometryType: 'point', // this is required to avoid style to ask for capabilities
     url: "https://atlasapi.cyclomedia.com/api/Recordings/wfs",
     name: "atlas:Recording",
     style: {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces following changes:

- remove describe feature type from WFS layer and rely to features to align the behaviour of vector and wfs types
- perform describe type when adding a wfs layer from catalog and assigning the correct style symbolizer

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9884

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

WFS layer will get the correct style symbolizer when added from catalog

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
