### PR TITLE
Fixes basic authentication form show for streetview

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -3036,16 +3036,16 @@ describe('Openlayers layer', () => {
 
     describe('WFS', () => {
         // this function create a WFS layer with the given options.
-        const createWFSLayerTest = (options, done, onRenderComplete = () => {}) => {
+        const createWFSLayerTest = (options, done, onRenderComplete = () => {}, checkFeatures = true) => {
             let layer;
             map.on('rendercomplete', () => {
-                if (layer.layer.getSource().getFeatures().length > 0) {
+                if (layer.layer.getSource().getFeatures().length > 0 && checkFeatures) {
                     const f = layer.layer.getSource().getFeatures()[0];
                     expect(f.getGeometry().getCoordinates()[0]).toBe(SAMPLE_FEATURE_COLLECTION.features[0].geometry.coordinates[0]);
                     expect(f.getGeometry().getCoordinates()[1]).toBe(SAMPLE_FEATURE_COLLECTION.features[0].geometry.coordinates[1]);
                     onRenderComplete(layer);
-                    done();
                 }
+                done();
             });
             // first render
             layer = ReactDOM.render(<OpenlayersLayer
@@ -3165,6 +3165,28 @@ describe('Openlayers layer', () => {
                 }, done, () => {
                     setCredentials("TEST_SOURCE", undefined);
                 });
+            });
+            it('test security basic authentication with no credentials', (done) => {
+                mockAxios.onPost().reply(({
+
+                }) => {
+                    done("should not be called"); // request should not be performed to avoid basic authentication popup
+                    return [200, SAMPLE_FEATURE_COLLECTION];
+                });
+                setCredentials("TEST_SOURCE", undefined);
+                createWFSLayerTest({
+                    type: 'wfs',
+                    visibility: true,
+                    url: 'SAMPLE_URL',
+                    name: 'osm:vector_tile',
+                    serverType: ServerTypes.NO_VENDOR,
+                    security: {
+                        type: 'basic',
+                        sourceId: 'TEST_SOURCE'
+                    }
+                }, done, () => {
+                    setCredentials("TEST_SOURCE", undefined);
+                }, false);
             });
         });
     });

--- a/web/client/components/map/openlayers/plugins/WFSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WFSLayer.js
@@ -22,6 +22,12 @@ import { optionsToVendorParams } from '../../../../utils/VendorParamsUtils';
 import { getCredentials } from '../../../../utils/SecurityUtils';
 import { needsReload, extractGeometryType } from '../../../../utils/WFSLayerUtils';
 import { applyDefaultStyleToVectorLayer } from '../../../../utils/StyleUtils';
+const needsCredentials = (options) => {
+    const security = options?.security || {};
+    const {type, sourceId} = security;
+    const {username, password} = getCredentials(sourceId) ?? {};
+    return type?.toLowerCase?.() === "basic" && (!username || !password);
+};
 const getConfig = (options) => {
     const security = options?.security || {};
     const config = {};
@@ -55,25 +61,29 @@ const createLoader = (source, options) => (extent, resolution, projection) => {
         source.dispatchEvent('vectorerror');
     };
     if (options.serverType === ServerTypes.NO_VENDOR) {
-        if (options?.strategy === 'bbox') {
-            // here bbox filter is
-            const [left, bottom, right, top] = extent;
 
-            filters = [{
-                spatialField: {
-                    operation: 'BBOX',
-                    geometry: {
-                        projection: proj,
-                        extent: [[left, bottom, right, top]] // use array because bbox is buggy
+        if (needsCredentials(options)) {
+            req = new Promise((resolve, reject) => {reject();});
+        } else {
+            if (options?.strategy === 'bbox') {
+            // here bbox filter is
+                const [left, bottom, right, top] = extent;
+
+                filters = [{
+                    spatialField: {
+                        operation: 'BBOX',
+                        geometry: {
+                            projection: proj,
+                            extent: [[left, bottom, right, top]] // use array because bbox is buggy
+                        }
                     }
-                }
-            }];
+                }];
+            }
+            req = getFeatureLayer(options, {filters, proj}, getConfig(options));
         }
-        req = getFeatureLayer(options, {filters, proj}, getConfig(options));
     } else {
         const params = optionsToVendorParams(options);
         const config = getConfig(options);
-
         req = getFeature(options.url, options.name, {
             // bbox: extent.join(',') + ',' + proj,
             outputFormat: "application/json",
@@ -82,6 +92,7 @@ const createLoader = (source, options) => (extent, resolution, projection) => {
             ...params
         }, config);
     }
+
     req.then(response => {
         if (response.status === 200) {
             source.addFeatures(

--- a/web/client/plugins/StreetView/actions/__tests__/streetView-test.js
+++ b/web/client/plugins/StreetView/actions/__tests__/streetView-test.js
@@ -6,7 +6,8 @@ import {
     setPov, SET_POV,
     configure, CONFIGURE,
     reset, RESET,
-    toggleStreetView
+    toggleStreetView,
+    updateStreetViewLayer, UPDATE_STREET_VIEW_LAYER
 
 } from '../streetView';
 import { TOGGLE_CONTROL } from '../../../../actions/controls';
@@ -90,5 +91,12 @@ describe('StreetView actions', () => {
             }
         });
         ret(dispatch, getState);
+    });
+    it('updateStreetViewLayer', () => {
+        const updates = {_v_: 1};
+        const ret = updateStreetViewLayer(updates);
+        expect(ret).toExist();
+        expect(ret.type).toBe(UPDATE_STREET_VIEW_LAYER);
+        expect(ret.updates).toBe(updates);
     });
 });

--- a/web/client/plugins/StreetView/actions/streetView.js
+++ b/web/client/plugins/StreetView/actions/streetView.js
@@ -19,6 +19,7 @@ export const SET_LOCATION = "STREET_VIEW:SET_LOCATION";
 export const SET_POV = "STREET_VIEW:SET_POV";
 export const CONFIGURE = "STREET_VIEW:CONFIGURE";
 export const RESET = "STREET_VIEW:RESET";
+export const UPDATE_STREET_VIEW_LAYER = "STREET_VIEW:UPDATE_STREET_VIEW_LAYER";
 
 export function setAPILoading(loading) {
     return {
@@ -57,7 +58,17 @@ export function toggleStreetView() {
 
     };
 }
-
+/**
+ * Updates the properties of the street view layer.
+ * @param {object} updates properties to update
+ * @returns {object}
+ */
+export function updateStreetViewLayer(updates) {
+    return {
+        type: UPDATE_STREET_VIEW_LAYER,
+        updates
+    };
+}
 export function setLocation(location) {
     return {
         type: SET_LOCATION,

--- a/web/client/plugins/StreetView/components/CyclomediaView/Credentials.jsx
+++ b/web/client/plugins/StreetView/components/CyclomediaView/Credentials.jsx
@@ -4,28 +4,30 @@ import { Form, Button, ControlLabel, FormControl, Glyphicon } from 'react-bootst
 import tooltip from '../../../../components/misc/enhancers/tooltip';
 const ButtonT = tooltip(Button);
 /**
- * Component to insert Smart API Credentials
+ * Component to insert Smart API Credentials.
+ * If showCredentialsForm is false, it shows only a button to open the form.
+ * When showCredentialsForm is true, it shows the form to insert credentials.
  * @prop {function} setCredentials function to set credentials
  * @prop {object} credentials object with username and password
+ * @prop {boolean} showCredentialsForm show form
+ * @prop {function} setShowCredentialsForm function to set showCredentialsForm
  * @returns {JSX.Element} The rendered component
  */
-export default ({setCredentials = () => {}, credentials}) => {
-    const [hasCredentials, setHasCredentials] = useState(credentials?.username && credentials?.password);
+export default ({setCredentials = () => {}, credentials, showCredentialsForm, setShowCredentialsForm = () => {}}) => {
     const [username, setUsername] = useState(credentials?.username || '');
     const [password, setPassword] = useState(credentials?.password || '');
     const onSubmit = () => {
         setCredentials({username, password});
-        setHasCredentials(true);
+        setShowCredentialsForm(false);
     };
-    if (hasCredentials) {
+    if (!showCredentialsForm) {
         // show only button to reset credentials.
         return (<div style={{textAlign: "right"}}>
             <ButtonT
                 style={{marginRight: 10, border: "none", background: "none"}}
                 tooltipId="streetView.cyclomedia.changeCredentials"
                 onClick={() => {
-                    setCredentials(null);
-                    setHasCredentials(false);
+                    setShowCredentialsForm(true);
                 }}><Glyphicon glyph="1-user-mod" /></ButtonT>
         </div>);
     }
@@ -38,6 +40,12 @@ export default ({setCredentials = () => {}, credentials}) => {
             <FormControl type="password"  value={password} onChange={e => setPassword(e.target.value)}/>
             <div className="street-view-credentials-form-buttons">
                 <Button disabled={!username || !password} onClick={() => onSubmit()}><Message msgId="streetView.cyclomedia.submit" /></Button>
+                {
+                    credentials?.username && credentials?.password && <Button onClick={() => {
+                        setCredentials({username: credentials.username, password: credentials.password});
+                        setShowCredentialsForm(false);
+                    } }><Message msgId="cancel" /></Button>
+                }
             </div>
         </Form>
     </div>);

--- a/web/client/plugins/StreetView/components/CyclomediaView/__tests__/Credentials-test.jsx
+++ b/web/client/plugins/StreetView/components/CyclomediaView/__tests__/Credentials-test.jsx
@@ -19,7 +19,7 @@ describe('Cyclomedia Credentials', () => {
         return document.getElementsByClassName('street-view-credentials')[0];
     };
     it('Test for default props', () => {
-        ReactDOM.render(<Credentials/>, document.getElementById("container"));
+        ReactDOM.render(<Credentials showCredentialsForm />, document.getElementById("container"));
         const div = getMainDiv();
         // check inputs are present
         expect(div.querySelector('input[type="text"]')).toExist();
@@ -29,25 +29,39 @@ describe('Cyclomedia Credentials', () => {
         expect(div.querySelector('.street-view-credentials-form-buttons button').disabled).toBe(true);
         expect(div).toExist();
     });
-    it('Form interactions', () => {
-        const handers = {
-            setCredentials: () => {}
-        };
-        const spy = expect.spyOn(handers, 'setCredentials');
-        act(() => {
-            ReactDOM.render(<Credentials setCredentials={handers.setCredentials} credentials={{username: 'test', password: 'password'}}/>, document.getElementById("container"));
-        });
-        const div1 = getMainDiv();
-        expect(div1).toNotExist();
+    it('not show if showCredentialsForm is false', () => {
+        ReactDOM.render(<Credentials showCredentialsForm={false}/>, document.getElementById("container"));
+        const div = getMainDiv();
+        expect(div).toNotExist();
+        // check cancel button is present
+
         const button = document.getElementsByClassName('glyphicon')[0];
         expect(button).toExist();
-        // click on button resets credentials
+    });
+    it('cancel calls setShowCredentialsForm with false', () => {
+        const handlers = {
+            setShowCredentialsForm: () => {}
+        };
+        const spy = expect.spyOn(handlers, 'setShowCredentialsForm');
+        ReactDOM.render(<Credentials showCredentialsForm setShowCredentialsForm={handlers.setShowCredentialsForm} credentials={{username: 'test', password: 'password'}}/>, document.getElementById("container"));
+        const div = getMainDiv();
+        expect(div.querySelector('.street-view-credentials-form-buttons button')).toExist();
+        // click on cancel button calls setHasCredentials
         act(() => {
-            button.click();
-        });
-        // check credentials are reset
+            div.querySelector('.street-view-credentials-form-buttons button').click();
+        }
+        );
         expect(spy).toHaveBeenCalled();
-        expect(spy.calls[0].arguments[0]).toEqual(null);
+        expect(spy.calls[0].arguments[0]).toEqual(false);
+    });
+    it('Form interactions', () => {
+        const handlers = {
+            setCredentials: () => {}
+        };
+        const spy = expect.spyOn(handlers, 'setCredentials');
+        act(() => {
+            ReactDOM.render(<Credentials showCredentialsForm setCredentials={handlers.setCredentials} credentials={{username: 'test', password: 'password'}}/>, document.getElementById("container"));
+        });
         const div2 = getMainDiv();
         // credentials are maintained internally
         expect(div2.querySelector('input[type="text"]').value).toBe('test');
@@ -64,7 +78,8 @@ describe('Cyclomedia Credentials', () => {
         act(() => {
             div2.querySelector('.street-view-credentials-form-buttons button').click();
         });
-        expect(spy.calls[1].arguments[0]).toEqual({username: 'test', password: 'newPassword'});
+        expect(spy).toHaveBeenCalled();
+        expect(spy.calls[0].arguments[0]).toEqual({username: 'test', password: 'newPassword'});
 
 
     });

--- a/web/client/plugins/StreetView/components/CyclomediaView/__tests__/CyclomediaView-test.jsx
+++ b/web/client/plugins/StreetView/components/CyclomediaView/__tests__/CyclomediaView-test.jsx
@@ -92,6 +92,7 @@ describe('Cyclomedia CyclomediaView', () => {
 
             }
         };
+
         const props = {
             apiKey: testAPIKey
         };

--- a/web/client/plugins/StreetView/containers/CyclomediaViewPanel.jsx
+++ b/web/client/plugins/StreetView/containers/CyclomediaViewPanel.jsx
@@ -3,7 +3,7 @@ import {createStructuredSelector, createSelector} from 'reselect';
 import {connect} from 'react-redux';
 import {PROVIDERS, CYCLOMEDIA_DEFAULT_MAX_RESOLUTION} from '../constants';
 import { getAPI } from '../api/cyclomedia';
-import {setLocation, setPov} from '../actions/streetView';
+import {setLocation, setPov, updateStreetViewLayer} from '../actions/streetView';
 import {apiLoadedSelectorCreator, streetViewAPIKeySelector, locationSelector} from '../selectors/streetView';
 import CyclomediaView from '../components/CyclomediaView/CyclomediaView';
 import { currentResolutionSelector } from '../../../selectors/map';
@@ -23,7 +23,8 @@ const CyclomediaViewPanel = connect(createStructuredSelector({
     mapPointVisible: mapPointVisibleSelector
 }), {
     setLocation,
-    setPov
+    setPov,
+    refreshLayer: () => updateStreetViewLayer({_v_: Date.now()})
 })(({enabled, apiLoaded, ...props}) => {
     const api = useMemo(() => getAPI(), [apiLoaded]);
     if (enabled) {

--- a/web/client/plugins/StreetView/epics/__tests__/streetview-test.js
+++ b/web/client/plugins/StreetView/epics/__tests__/streetview-test.js
@@ -6,7 +6,7 @@ import { UPDATE_ADDITIONAL_LAYER } from '../../../../actions/additionallayers';
 import { setControlProperty } from '../../../../actions/controls';
 
 import { streetViewSyncLayer, streetViewSetupTearDown } from '../streetView';
-import { setPov, setLocation } from '../../actions/streetView';
+import { setPov, setLocation, updateStreetViewLayer } from '../../actions/streetView';
 import {REGISTER_EVENT_LISTENER} from '../../../../actions/map';
 
 
@@ -45,6 +45,16 @@ describe('StreetView epics', () => {
             expect(timeout.type).toBe(TEST_TIMEOUT);
             done();
         }, {layers: {flat: [{name: "layerName", url: "clearlyNotAUrl", visibility: true, queryable: false, type: "wms"}]}});
+    });
+    it('updateStreetViewLayer', (done) => {
+        let action = updateStreetViewLayer({_v_: 1});
+        const NUM_ACTIONS = 1;
+        testEpic(streetViewSyncLayer, NUM_ACTIONS, action, ([update]) => {
+            expect(update).toExist();
+            expect(update.type).toBe(UPDATE_ADDITIONAL_LAYER);
+            expect(update.options._v_).toEqual(1); // the update is applied to the default layer.
+            done();
+        });
     });
     it('streetViewSetupTearDown', (done) => {
         let action = setControlProperty(CONTROL_NAME, 'enabled', false);

--- a/web/client/plugins/StreetView/epics/streetView.js
+++ b/web/client/plugins/StreetView/epics/streetView.js
@@ -22,12 +22,13 @@ import {
     currentProviderApiLoadedSelector,
     enabledSelector,
     getStreetViewMarkerLayer,
+    getStreetViewDataLayer,
     locationSelector,
     povSelector,
     useStreetViewDataLayerSelector,
     streetViewDataLayerSelector
 } from "../selectors/streetView";
-import {setLocation, SET_LOCATION, SET_POV } from '../actions/streetView';
+import {setLocation, SET_LOCATION, SET_POV, UPDATE_STREET_VIEW_LAYER } from '../actions/streetView';
 import API from '../api';
 import {shutdownToolOnAnotherToolDrawing} from "../../../utils/ControlUtils";
 
@@ -172,7 +173,7 @@ export const streetViewMapClickHandler = (action$, {getState = () => {}}) => {
 /**
  * On location update events updates the map layer.
  * the state.
- * @param {external:Observable} action$ manages `SET_LOCATION`
+ * @param {external:Observable} action$ manages `SET_LOCATION`, `UPDATE_STREET_VIEW_LAYER`
  * @param getState
  * @return {external:Observable}
  */
@@ -217,7 +218,15 @@ export const streetViewSyncLayer = (action$, {getState = () => {}}) => {
                 "overlay", {...options, features: [feature]}
             );
         });
-    });
+    })
+        .merge(action$.ofType(UPDATE_STREET_VIEW_LAYER).switchMap(({updates = {}}) => {
+            const options = getStreetViewDataLayer(getState());
+            return Rx.Observable.of(updateAdditionalLayer(
+                STREET_VIEW_DATA_LAYER_ID,
+                STREET_VIEW_OWNER,
+                'overlay',
+                {...options, ...updates}));
+        }));
 };
 
 /**

--- a/web/client/plugins/StreetView/selectors/streetView.js
+++ b/web/client/plugins/StreetView/selectors/streetView.js
@@ -1,7 +1,7 @@
 import {createSelector} from 'reselect';
 import { ServerTypes } from '../../../utils/LayersUtils';
 
-import { PROVIDERS, CONTROL_NAME, MARKER_LAYER_ID, CYCLOMEDIA_CREDENTIALS_REFERENCE, CYCLOMEDIA_DEFAULT_MAX_RESOLUTION } from '../constants';
+import { PROVIDERS, CONTROL_NAME, MARKER_LAYER_ID, STREET_VIEW_DATA_LAYER_ID, CYCLOMEDIA_CREDENTIALS_REFERENCE, CYCLOMEDIA_DEFAULT_MAX_RESOLUTION } from '../constants';
 import { createControlEnabledSelector } from '../../../selectors/controls';
 import { additionalLayersSelector } from '../../../selectors/additionallayers';
 import { localConfigSelector } from '../../../selectors/localConfig';
@@ -24,10 +24,23 @@ export const locationSelector = createSelector(streetViewStateSelector, ({locati
  * @returns {object} the current street view point of view ( minimal is `{heading, pitch}`. The rest of the properties are provider specific )
  */
 export const povSelector = createSelector(streetViewStateSelector, ({pov} = {}) => pov);
-
+/**
+ * Selector for the current street view marker layer configuration
+ * @param {object} state the application state
+ * @returns {object} the current street view configuration
+ */
 export function getStreetViewMarkerLayer(state) {
     const additionalLayers = additionalLayersSelector(state) ?? [];
     return additionalLayers.filter(({ id }) => id === MARKER_LAYER_ID)?.[0]?.options;
+}
+/**
+ * Selector for street view data layer configuration
+ * @param {object} state the application state
+ * @returns {object} the street view data layer configuration
+ */
+export function getStreetViewDataLayer(state) {
+    const additionalLayers = additionalLayersSelector(state) ?? [];
+    return additionalLayers.filter(({ id }) => id === STREET_VIEW_DATA_LAYER_ID)?.[0]?.options;
 }
 export function streetViewConfigurationSelector(state) {
     return streetViewStateSelector(state)?.configuration ?? {};

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -3940,6 +3940,9 @@
             "submit": "Senden",
             "zoomIn": "Bitte zoomen Sie in die Karte, um die Street-View-Abdeckung zu sehen",
             "errorOccurred": "Fehler aufgetreten: ",
+            "errors": {
+                "invalidCredentials": "Ungültige Anmeldeinformationen"
+            },
             "reloadAPI": "API neu laden"
           }
         },

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -3913,6 +3913,9 @@
             "submit": "Submit",
             "zoomIn": "Please zoom in the map to see the street view coverage",
             "errorOccurred": "Error occurred: ",
+            "errors": {
+              "invalidCredentials": "Invalid credentials"
+            },
             "reloadAPI": "Reload API"
           }
         },

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -3902,6 +3902,9 @@
             "submit": "Enviar",
             "zoomIn": "Por favor, acerque el mapa para ver la cobertura de vista de calle",
             "errorOccurred": "Se produjo un error: ",
+            "errors": {
+                "invalidCredentials": "Credenciales inválidas"
+            },
             "reloadAPI": "Recargar API"
           }
         },

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -3902,6 +3902,9 @@
             "submit": "Soumettre",
             "zoomIn": "Veuillez zoomer sur la carte pour voir la couverture Street View",
             "errorOccurred": "Une erreur s'est produite : ",
+            "errors": {
+                "invalidCredentials": "Identifiants invalides"
+            },
             "reloadAPI": "Recharger l'API"
           }
         },

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -3902,6 +3902,9 @@
               "submit": "Invia",
               "zoomIn": "Effettua un ulteriore zoom sulla mappa per visualizzare dove sono disponibili le immagini",
               "errorOccurred": "Si è verificato un errore: ",
+              "errors": {
+                "invalidCredentials": "Credenziali non valide"
+              },
               "reloadAPI": "Ricarica API"
             }
         },


### PR DESCRIPTION
Draft because I need to test if we can refresh when user inserts credentials. Panning the map will load data anyway.

## Description

This PR prevents the basic auth form is prompted when the credentials are not present in street view. 



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
- When open street view and zoom, the basic authentication form is shown (only on deployed it shows).

[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2024.01.16-18_55_13.webm](https://github.com/geosolutions-it/MapStore2/assets/1279510/7b83bf51-72b4-4e63-9010-ba57ca04c8ec)



**What is the new behavior?**

- Now it is not shown anymore.  (at least, it should be, I prevented the application to do requests when credentials are invalid).
- Credentials form can now be cancelled.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
