### PR TITLE
#9889: Fix - Unable to export map configuration in context manager

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -246,9 +246,7 @@ export default class ContextCreator extends React.Component {
                         editingAllowedRoles: []
                     }
                 }
-            },
-            "ContextImport",
-            "ContextExport"
+            }
         ],
         ignoreViewerPlugins: false,
         allAvailablePlugins: [],

--- a/web/client/epics/__tests__/contextcreator-test.js
+++ b/web/client/epics/__tests__/contextcreator-test.js
@@ -69,6 +69,7 @@ import {
 import axios from "../../libs/ajax";
 import MockAdapter from "axios-mock-adapter";
 import {TOGGLE_CONTROL} from "../../actions/controls";
+import { EXPORT_CONTEXT } from '../../utils/ControlUtils';
 
 describe('contextcreator epics', () => {
     let mockAxios;
@@ -965,7 +966,7 @@ describe('contextcreator epics', () => {
     it('exportContextEpic, export context with plugins and themes', (done) => {
         testEpic(exportContextEpic, 1, onContextExport('file.json'), ([a]) => {
             expect(a.type).toEqual(TOGGLE_CONTROL);
-            expect(a.control).toEqual("export-context");
+            expect(a.control).toEqual(EXPORT_CONTEXT);
             done();
         }, {
             map: {

--- a/web/client/epics/__tests__/contextcreator-test.js
+++ b/web/client/epics/__tests__/contextcreator-test.js
@@ -965,7 +965,7 @@ describe('contextcreator epics', () => {
     it('exportContextEpic, export context with plugins and themes', (done) => {
         testEpic(exportContextEpic, 1, onContextExport('file.json'), ([a]) => {
             expect(a.type).toEqual(TOGGLE_CONTROL);
-            expect(a.control).toEqual("export");
+            expect(a.control).toEqual("export-context");
             done();
         }, {
             map: {

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -922,7 +922,7 @@ export const exportContextEpic = (action$, { getState }) =>
                 "application/json"
             ])
                 .do((downloadArgs) => download(...downloadArgs))
-                .map(() => toggleControl("export"))
+                .map(() => toggleControl("export-context"))
                 .catch(() =>
                     Rx.Observable.of(
                         error({

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -41,6 +41,7 @@ import { upload, uninstall } from '../api/plugins';
 import { download, readJson } from "../utils/FileUtils";
 import { toggleControl } from "../actions/controls";
 import { mapSelector } from "../selectors/map";
+import { EXPORT_CONTEXT } from '../utils/ControlUtils';
 
 const saveContextErrorStatusToMessage = (status) => {
     switch (status) {
@@ -922,7 +923,7 @@ export const exportContextEpic = (action$, { getState }) =>
                 "application/json"
             ])
                 .do((downloadArgs) => download(...downloadArgs))
-                .map(() => toggleControl("export-context"))
+                .map(() => toggleControl(EXPORT_CONTEXT))
                 .catch(() =>
                     Rx.Observable.of(
                         error({

--- a/web/client/plugins/ContextExport.jsx
+++ b/web/client/plugins/ContextExport.jsx
@@ -20,8 +20,9 @@ import { onContextExport } from "../actions/contextcreator";
 import { toggleControl } from "../actions/controls";
 import Message from "../components/I18N/Message";
 import Button from "../components/misc/Button";
-const EXPORT_CONTROL = "export-context";
-const isEnabled = createControlEnabledSelector(EXPORT_CONTROL);
+import { EXPORT_CONTEXT } from "../utils/ControlUtils";
+
+const isEnabled = createControlEnabledSelector(EXPORT_CONTEXT);
 
 const mapStateToProps = createSelector(
     isEnabled,
@@ -33,7 +34,7 @@ const mapStateToProps = createSelector(
 );
 
 const actions = {
-    onClose: () => toggleControl(EXPORT_CONTROL),
+    onClose: () => toggleControl(EXPORT_CONTEXT),
     onExport: onContextExport
 };
 
@@ -59,7 +60,7 @@ const ExportComponent = connect(mapStateToProps, actions)(Component);
 const ExportButton = connect(
     createSelector(resourceSelector, (resource) => ({ resource })),
     {
-        onExport: () => toggleControl(EXPORT_CONTROL)
+        onExport: () => toggleControl(EXPORT_CONTEXT)
     }
 )(({ resource, onExport }) => (
     <Button

--- a/web/client/plugins/ContextExport.jsx
+++ b/web/client/plugins/ContextExport.jsx
@@ -20,7 +20,8 @@ import { onContextExport } from "../actions/contextcreator";
 import { toggleControl } from "../actions/controls";
 import Message from "../components/I18N/Message";
 import Button from "../components/misc/Button";
-const isEnabled = createControlEnabledSelector("export");
+const EXPORT_CONTROL = "export-context";
+const isEnabled = createControlEnabledSelector(EXPORT_CONTROL);
 
 const mapStateToProps = createSelector(
     isEnabled,
@@ -32,7 +33,7 @@ const mapStateToProps = createSelector(
 );
 
 const actions = {
-    onClose: () => toggleControl("export"),
+    onClose: () => toggleControl(EXPORT_CONTROL),
     onExport: onContextExport
 };
 
@@ -58,7 +59,7 @@ const ExportComponent = connect(mapStateToProps, actions)(Component);
 const ExportButton = connect(
     createSelector(resourceSelector, (resource) => ({ resource })),
     {
-        onExport: () => toggleControl("export")
+        onExport: () => toggleControl(EXPORT_CONTROL)
     }
 )(({ resource, onExport }) => (
     <Button

--- a/web/client/plugins/__tests__/ContextExport-test.jsx
+++ b/web/client/plugins/__tests__/ContextExport-test.jsx
@@ -13,6 +13,7 @@ import expect from 'expect';
 import { getPluginForTest } from './pluginsTestUtils';
 
 import ContextExport from '../ContextExport';
+import { EXPORT_CONTEXT } from '../../utils/ControlUtils';
 
 describe('ContextExport plugin', () => {
     beforeEach((done) => {
@@ -29,7 +30,7 @@ describe('ContextExport plugin', () => {
     it('displays the export panel when enabled', () => {
         const { Plugin } = getPluginForTest(ContextExport, {
             controls: {
-                "export-context": {
+                [EXPORT_CONTEXT]: {
                     enabled: true
                 }
             }

--- a/web/client/plugins/__tests__/ContextExport-test.jsx
+++ b/web/client/plugins/__tests__/ContextExport-test.jsx
@@ -29,7 +29,7 @@ describe('ContextExport plugin', () => {
     it('displays the export panel when enabled', () => {
         const { Plugin } = getPluginForTest(ContextExport, {
             controls: {
-                "export": {
+                "export-context": {
                     enabled: true
                 }
             }

--- a/web/client/utils/ControlUtils.js
+++ b/web/client/utils/ControlUtils.js
@@ -13,6 +13,8 @@ import {CHANGE_DRAWING_STATUS} from "../actions/draw";
 import {REGISTER_EVENT_LISTENER} from "../actions/map";
 import {OPEN_FEATURE_GRID} from "../actions/featuregrid";
 
+export const EXPORT_CONTEXT = "export-context";
+
 /**
  * Common part of the workflow that toggles one plugin off when another plugin intend to perform drawing action
  * @param action$


### PR DESCRIPTION
## Description
This PR addresses the same control key causing issues when exporting context and map in the context viewer. Also, updated the viewer plugin to avoid multiple mounting of export & import context plugin

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9889 

**What is the new behavior?**
- The map export tool can be used properly inside the context viewer page
- Avoids multiple mounting of export/import plugin in viewer page

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
