### PR TITLE
[Backport 2023.02.xx] #9889: Fix - Unable to export map configuration in context manager (#9896)

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -245,9 +245,7 @@ export default class ContextCreator extends React.Component {
                         editingAllowedRoles: []
                     }
                 }
-            },
-            "ContextImport",
-            "ContextExport"
+            }
         ],
         ignoreViewerPlugins: false,
         allAvailablePlugins: [],

--- a/web/client/epics/__tests__/contextcreator-test.js
+++ b/web/client/epics/__tests__/contextcreator-test.js
@@ -69,6 +69,7 @@ import {
 import axios from "../../libs/ajax";
 import MockAdapter from "axios-mock-adapter";
 import {TOGGLE_CONTROL} from "../../actions/controls";
+import { EXPORT_CONTEXT } from '../../utils/ControlUtils';
 
 describe('contextcreator epics', () => {
     let mockAxios;
@@ -965,7 +966,7 @@ describe('contextcreator epics', () => {
     it('exportContextEpic, export context with plugins and themes', (done) => {
         testEpic(exportContextEpic, 1, onContextExport('file.json'), ([a]) => {
             expect(a.type).toEqual(TOGGLE_CONTROL);
-            expect(a.control).toEqual("export");
+            expect(a.control).toEqual(EXPORT_CONTEXT);
             done();
         }, {
             map: {

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -41,6 +41,7 @@ import { upload, uninstall } from '../api/plugins';
 import { download, readJson } from "../utils/FileUtils";
 import { toggleControl } from "../actions/controls";
 import { mapSelector } from "../selectors/map";
+import { EXPORT_CONTEXT } from '../utils/ControlUtils';
 
 const saveContextErrorStatusToMessage = (status) => {
     switch (status) {
@@ -922,7 +923,7 @@ export const exportContextEpic = (action$, { getState }) =>
                 "application/json"
             ])
                 .do((downloadArgs) => download(...downloadArgs))
-                .map(() => toggleControl("export"))
+                .map(() => toggleControl(EXPORT_CONTEXT))
                 .catch(() =>
                     Rx.Observable.of(
                         error({

--- a/web/client/plugins/ContextExport.jsx
+++ b/web/client/plugins/ContextExport.jsx
@@ -20,7 +20,9 @@ import { onContextExport } from "../actions/contextcreator";
 import { toggleControl } from "../actions/controls";
 import Message from "../components/I18N/Message";
 import Button from "../components/misc/Button";
-const isEnabled = createControlEnabledSelector("export");
+import { EXPORT_CONTEXT } from "../utils/ControlUtils";
+
+const isEnabled = createControlEnabledSelector(EXPORT_CONTEXT);
 
 const mapStateToProps = createSelector(
     isEnabled,
@@ -32,7 +34,7 @@ const mapStateToProps = createSelector(
 );
 
 const actions = {
-    onClose: () => toggleControl("export"),
+    onClose: () => toggleControl(EXPORT_CONTEXT),
     onExport: onContextExport
 };
 
@@ -58,7 +60,7 @@ const ExportComponent = connect(mapStateToProps, actions)(Component);
 const ExportButton = connect(
     createSelector(resourceSelector, (resource) => ({ resource })),
     {
-        onExport: () => toggleControl("export")
+        onExport: () => toggleControl(EXPORT_CONTEXT)
     }
 )(({ resource, onExport }) => (
     <Button

--- a/web/client/plugins/__tests__/ContextExport-test.jsx
+++ b/web/client/plugins/__tests__/ContextExport-test.jsx
@@ -13,6 +13,7 @@ import expect from 'expect';
 import { getPluginForTest } from './pluginsTestUtils';
 
 import ContextExport from '../ContextExport';
+import { EXPORT_CONTEXT } from '../../utils/ControlUtils';
 
 describe('ContextExport plugin', () => {
     beforeEach((done) => {
@@ -29,7 +30,7 @@ describe('ContextExport plugin', () => {
     it('displays the export panel when enabled', () => {
         const { Plugin } = getPluginForTest(ContextExport, {
             controls: {
-                "export": {
+                [EXPORT_CONTEXT]: {
                     enabled: true
                 }
             }

--- a/web/client/utils/ControlUtils.js
+++ b/web/client/utils/ControlUtils.js
@@ -14,6 +14,8 @@ import {CHANGE_DRAWING_STATUS} from "../actions/draw";
 import {REGISTER_EVENT_LISTENER} from "../actions/map";
 import {OPEN_FEATURE_GRID} from "../actions/featuregrid";
 
+export const EXPORT_CONTEXT = "export-context";
+
 /**
  * Common part of the workflow that toggles one plugin off when another plugin intend to perform drawing action
  * @param action$


### PR DESCRIPTION
#9889: Fix - Unable to export map configuration in context manager (#9896)