### PR TITLE
Fix #9905 Clamp to ground issue found with WFS layer

### DIFF
--- a/web/client/utils/cesium/GeoJSONStyledFeatures.js
+++ b/web/client/utils/cesium/GeoJSONStyledFeatures.js
@@ -4,6 +4,14 @@ import omit from 'lodash/omit';
 import isArray from 'lodash/isArray';
 import uuid from 'uuid/v1';
 
+/**
+ * validate the coordinates and ensure:
+ * - values inside are not nested arrays
+ * - the current coordinate are not a duplication of the previous one
+ * @param {number[]} coords array of coordinates [longitude, latitude, height]
+ * @param {number[]} prevCoords array of coordinates [longitude, latitude, height]
+ * @returns the coordinates if valid and null if invalid
+ */
 const validateCoordinatesValue = (coords, prevCoords) => {
     if (!isArray(coords[0]) && !isArray(coords[1]) && !isArray(coords[2])) {
         // remove duplicated points

--- a/web/client/utils/cesium/GeoJSONStyledFeatures.js
+++ b/web/client/utils/cesium/GeoJSONStyledFeatures.js
@@ -4,9 +4,13 @@ import omit from 'lodash/omit';
 import isArray from 'lodash/isArray';
 import uuid from 'uuid/v1';
 
-const validateCoordinatesValue = (coords) => {
+const validateCoordinatesValue = (coords, prevCoords) => {
     if (!isArray(coords[0]) && !isArray(coords[1]) && !isArray(coords[2])) {
-        return coords;
+        // remove duplicated points
+        // to avoid normalization errors
+        return prevCoords && (prevCoords[0] === coords[0] && prevCoords[1] === coords[1] && prevCoords[2] === coords[2])
+            ? null
+            : coords;
     }
     return null;
 };
@@ -25,8 +29,8 @@ const featureToCartesianPositions = (feature) => {
         )]] : null;
     }
     if (feature.geometry.type === 'LineString') {
-        const positions = feature.geometry.coordinates.map(coords =>
-            validateCoordinatesValue(coords)
+        const positions = feature.geometry.coordinates.map((coords, idx) =>
+            validateCoordinatesValue(coords, feature.geometry.coordinates[idx - 1])
                 ? Cesium.Cartesian3.fromDegrees(coords[0], coords[1], coords[2])
                 : null
         ).filter(coords => coords !== null);
@@ -34,8 +38,8 @@ const featureToCartesianPositions = (feature) => {
     }
     if (feature.geometry.type === 'Polygon') {
         const positions = feature.geometry.coordinates.map(ring => {
-            const ringPositions = ring.map(coords =>
-                validateCoordinatesValue(coords)
+            const ringPositions = ring.map((coords, idx) =>
+                validateCoordinatesValue(coords, ring[idx - 1])
                     ? Cesium.Cartesian3.fromDegrees(coords[0], coords[1], coords[2])
                     : null
             ).filter(coords => coords !== null);
@@ -60,8 +64,10 @@ class GeoJSONStyledFeatures {
         this._dataSource = new Cesium.CustomDataSource(options.id);
         this._primitives = new Cesium.PrimitiveCollection({ destroyPrimitives: true });
         this._map = options.map;
-        this._map.scene.primitives.add(this._primitives);
-        this._map.dataSources.add(this._dataSource);
+        if (this._map) {
+            this._map.scene.primitives.add(this._primitives);
+            this._map.dataSources.add(this._dataSource);
+        }
         this._styledFeatures = [];
         this._entities = [];
         this._opacity = options.opacity ?? 1;

--- a/web/client/utils/cesium/__tests__/GeoJSONStyledFeatures-test.js
+++ b/web/client/utils/cesium/__tests__/GeoJSONStyledFeatures-test.js
@@ -22,4 +22,24 @@ describe('Test GeoJSONStyledFeatures', () => {
         });
         expect(styledFeatures._features.length).toBe(0);
     });
+    it('it should include valid features', () => {
+        const styledFeatures = new GeoJSONStyledFeatures({
+            features: [{
+                type: 'Feature',
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [[[7, 41], [7, 41], [7, 41], [7, 41]]]
+                },
+                properties: {}
+            }, {
+                type: 'Feature',
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [[[7, 41], [14, 41], [14, 46], [7, 46]]]
+                },
+                properties: {}
+            }]
+        });
+        expect(styledFeatures._features.length).toBe(1);
+    });
 });

--- a/web/client/utils/cesium/__tests__/GeoJSONStyledFeatures-test.js
+++ b/web/client/utils/cesium/__tests__/GeoJSONStyledFeatures-test.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+import expect from 'expect';
+import GeoJSONStyledFeatures from '../GeoJSONStyledFeatures';
+
+describe('Test GeoJSONStyledFeatures', () => {
+    it('it should exclude invalid features', () => {
+        const styledFeatures = new GeoJSONStyledFeatures({
+            features: [{
+                type: 'Feature',
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [[[7, 41], [7, 41], [7, 41], [7, 41]]]
+                },
+                properties: {}
+            }]
+        });
+        expect(styledFeatures._features.length).toBe(0);
+    });
+});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The problem happens when a polygon has all the coordinates with the exact same values, eg:

![image](https://github.com/geosolutions-it/MapStore2/assets/19175505/35301f7a-ee19-4701-aca0-c6d6976fc061)

This PR adds an additional validation steps that remove all duplicated consecutive coordinates in this way polygons with all the same coordinates will be removed from the rendering. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9905

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Polygons with all the same coordinates will be removed from the rendering to prevent errors

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
