### PR TITLE
fix importing geojson files on firefox on linux (#9912)

### DIFF
--- a/web/client/plugins/longitudinalProfile/constants.js
+++ b/web/client/plugins/longitudinalProfile/constants.js
@@ -15,6 +15,7 @@ export const LONGITUDINAL_VECTOR_LAYER_ID_POINT = 'longitudinal_profile_tool_poi
 export const LONGITUDINAL_OWNER = 'LongitudinalTool';
 export const FILE_TYPE_ALLOWED = [
     "application/json",
+    "application/geo+json",
     "image/x-dxf",
     "image/vnd.dxf",
     "application/x-zip-compressed",

--- a/web/client/plugins/longitudinalProfile/enhancers/processFile.js
+++ b/web/client/plugins/longitudinalProfile/enhancers/processFile.js
@@ -51,7 +51,7 @@ const readFile = (onWarnings) => (file) => {
     const projectionDefs = getConfigProp('projectionDefs') || [];
     const supportedProjections = (projectionDefs.length && projectionDefs.map(({code})  => code) || []).concat(["EPSG:4326", "EPSG:3857", "EPSG:900913"]);
     // [ ] change this to use filterCRSList
-    if (type === 'application/json') {
+    if (type === 'application/json' || type === 'application/geo+json') {
         return readJson(file).then(f => {
             const projection = get(f, 'map.projection') ?? parseURN(get(f, 'crs'));
             if (projection) {


### PR DESCRIPTION
for some reason mimetype is detected as application/geo+json

## Description
cf #9912

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9912

**What is the new behavior?**

importing geojson files in the 'add data' & 'import data' item of profile tool passes mimetype check
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No