### PR TITLE
Fix #9920 Issue editing WMS layers style on 3D view

### DIFF
--- a/web/client/utils/cesium/WMSUtils.js
+++ b/web/client/utils/cesium/WMSUtils.js
@@ -145,7 +145,8 @@ export function wmsToCesiumOptionsSingleTile(options) {
         bbox: "-180.0,-90,180.0,90",
         srs: "EPSG:4326",
         ...(params || {}),
-        ...getAuthenticationParam(options)
+        ...getAuthenticationParam(options),
+        ...(options._v_ ? {_v_: options._v_} : {})
     };
 
     const url = (isArray(options.url) ? options.url[Math.round(Math.random() * (options.url.length - 1))] : options.url) + '?service=WMS&version=1.1.0&request=GetMap&'

--- a/web/client/utils/cesium/__tests__/WMSUtils-test.js
+++ b/web/client/utils/cesium/__tests__/WMSUtils-test.js
@@ -68,9 +68,10 @@ describe('Test the WMSUtil for Cesium', () => {
         const options = {
             type: 'wms',
             url: '/geoserver/wms',
-            name: 'workspace:layer'
+            name: 'workspace:layer',
+            _v_: '0123456789'
         };
         const cesiumOptions = wmsToCesiumOptionsSingleTile(options);
-        expect(cesiumOptions.url.url).toBe('/geoserver/wms?service=WMS&version=1.1.0&request=GetMap&styles=&format=image%2Fpng&transparent=true&opacity=1&TILED=true&layers=workspace%3Alayer&width=2000&height=2000&bbox=-180.0%2C-90%2C180.0%2C90&srs=EPSG%3A4326');
+        expect(cesiumOptions.url.url).toBe('/geoserver/wms?service=WMS&version=1.1.0&request=GetMap&styles=&format=image%2Fpng&transparent=true&opacity=1&TILED=true&layers=workspace%3Alayer&width=2000&height=2000&bbox=-180.0%2C-90%2C180.0%2C90&srs=EPSG%3A4326&_v_=0123456789');
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds _v_ parameter to the WMS single tile implementation of Cesium to correctly update the style 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9920

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The layer is updating as expected while editing the WMS style in 3D visualization

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
