### PR TITLE
Update mapfish-print to 2.4-SNAPSHOT

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -153,7 +153,7 @@ For this reason, if you are using the printing plugin in your project you have t
                     <groupId>org.mapfish.print</groupId>
                     <artifactId>print-lib</artifactId>
 -                    <version>geosolutions-2.3-SNAPSHOT</version>
-+                    <version>2.3-SNAPSHOT</version>
++                    <version>2.4-SNAPSHOT</version>
 
 ```
 

--- a/java/printing/pom.xml
+++ b/java/printing/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -349,7 +349,7 @@
         <dependency>
             <groupId>org.mapfish.print</groupId>
             <artifactId>print-lib</artifactId>
-            <version>2.3-SNAPSHOT</version>
+            <version>2.4-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -474,7 +474,7 @@
                 <dependency>
                     <groupId>org.mapfish.print</groupId>
                     <artifactId>print-lib</artifactId>
-                    <version>2.3-SNAPSHOT</version>
+                    <version>2.4-SNAPSHOT</version>
                     <exclusions>
                         <exclusion>
                             <groupId>commons-codec</groupId>


### PR DESCRIPTION
## Description
This PR updates MS to use `mapfish-print` `2.4-SNAPSHOT` that contains some library updates.

### note: 
-  `mapfish-print` `2.4-SNAPSHOT` is actually deployed only on `maven.geo-solutions.it`. It will be later updated on other official repositories.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
https://github.com/geosolutions-it/MapStore2/issues/9925

**What is the new behavior?**
Updated lib as explained in the issue 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
