### PR TITLE
[Backport 2023.02.xx] Fix #9920 Issue editing WMS layers style on 3D view (#9922)

### DIFF
--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -36,7 +36,7 @@ function wmsToCesiumOptionsSingleTile(options) {
         height: options.size || 2000,
         bbox: "-180.0,-90,180.0,90",
         srs: "EPSG:4326"
-    }, params || {}, getAuthenticationParam(options));
+    }, (options._v_ ? {_v_: options._v_} : {}), params || {}, getAuthenticationParam(options));
 
     const url = (isArray(options.url) ? options.url[Math.round(Math.random() * (options.url.length - 1))] : options.url) + '?service=WMS&version=1.1.0&request=GetMap&'
         + getQueryString(addAuthenticationToSLD(parameters, options));


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds _v_ parameter to the WMS single tile implementation of Cesium to correctly update the style 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9920

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The layer is updating as expected while editing the WMS style in 3D visualization

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
