### PR TITLE
#9937 - Fix: Circle radius is modified when saving the annotation

### DIFF
--- a/web/client/components/map/openlayers/Feature.jsx
+++ b/web/client/components/map/openlayers/Feature.jsx
@@ -89,7 +89,7 @@ export default class Feature extends React.Component {
             });
             this._feature.map(f => {
                 let newF = f;
-                if (f.getProperties().isCircle) {
+                if (f.getProperties().isCircle && !f.getProperties().isGeodesic) {
                     newF = transformPolygonToCircle(f, props.crs || 'EPSG:3857', props.featuresCrs);
                     newF.setGeometry(newF.getGeometry().transform(props.crs || 'EPSG:3857', props.featuresCrs));
                 }

--- a/web/client/components/map/openlayers/__tests__/Feature-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Feature-test.jsx
@@ -120,6 +120,92 @@ describe('Test Feature', () => {
         count = container.getSource().getFeatures().length;
         expect(count).toBe(0);
     });
+    it('adding a feature of type circle and geodesic', () => {
+        let options = {
+            crs: 'EPSG:4326',
+            features: {
+                type: 'FeatureCollection',
+                crs: {
+                    'type': 'name',
+                    'properties': {
+                        'name': 'EPSG:4326'
+                    }
+                },
+                features: [
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Polygon',
+                            coordinates: [[
+                                [13, 43],
+                                [15, 43],
+                                [15, 44],
+                                [13, 44]
+                            ]]
+                        },
+                        properties: {
+                            'name': "some name",
+                            isGeodesic: true,
+                            isCircle: true,
+                            radius: 1000,
+                            center: [13, 43]
+                        }
+                    }
+                ]
+            }
+        };
+        let source = new VectorSource({
+            features: []
+        });
+        const msId = "some value";
+        let container = new VectorLayer({
+            msId,
+            source: source,
+            visible: true,
+            zIndex: 1
+        });
+        const geometry = options.features.features[0].geometry;
+        const type = options.features.features[0].type;
+        let properties = {...options.features.features[0].properties, isGeodesic: false};
+
+        // create layers with feature visible
+        let layer = ReactDOM.render(
+            <Feature
+                options={options}
+                geometry={geometry}
+                type={type}
+                properties={properties}
+                msId={msId}
+                container={container}
+                featuresCrs={"EPSG:4326"}
+                crs={"EPSG:3857"}
+            />, document.getElementById("container"));
+
+        expect(layer).toBeTruthy();
+        // count layers
+        let [feature] = container.getSource().getFeatures();
+        expect(feature).toBeTruthy();
+        expect(feature.getGeometry().getType()).toBe('Circle');
+
+        properties = options.features.features[0].properties;
+        layer = ReactDOM.render(
+            <Feature
+                options={options}
+                geometry={geometry}
+                type={type}
+                properties={properties}
+                msId={msId}
+                container={container}
+                featuresCrs={"EPSG:4326"}
+                crs={"EPSG:3857"}
+            />, document.getElementById("container"));
+
+        expect(layer).toExist();
+
+        [feature] = container.getSource().getFeatures();
+        expect(feature).toBeTruthy();
+        expect(feature.getGeometry().getType()).toBe('Polygon');
+    });
     it('adding a feature without a geometry', () => {
         var options = {
             crs: 'EPSG:4326',


### PR DESCRIPTION
## Description
This PR fixes the circle radius is modified when saving the annotation due to the transformation of the polygon to circle when the circle is geodesic

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9937 

**What is the new behavior?**

https://github.com/geosolutions-it/MapStore2/assets/26929983/7e0fd166-649e-47e8-b889-09f2b01fc47f



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
