### PR TITLE
Fix #9941 The defaultPointType and defaultShape configurations are not working as expected on Annotations

### DIFF
--- a/web/client/plugins/Annotations/containers/AnnotationsEditor.jsx
+++ b/web/client/plugins/Annotations/containers/AnnotationsEditor.jsx
@@ -130,7 +130,7 @@ function AnnotationsEditor({
     defaultShape,
     defaultShapeStrokeColor,
     defaultShapeFillColor,
-    defaultShapeSize,
+    defaultShapeSize = 64,
     geodesic,
     activeClickEventListener,
     fonts,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR restores the default fallback value of defaultShapeSize at 64px

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9941

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The default style for point annotation is visible when defaultShape and defaultPointType are configured for symbol type

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
