### PR TITLE
Disable plugin SaveAs for non-ADMIN role users in Contexts

### DIFF
--- a/project/standard/templates/configs/pluginsConfig.json
+++ b/project/standard/templates/configs/pluginsConfig.json
@@ -491,16 +491,21 @@
       "denyUserSelection": true,
       "title": "plugins.Save.title",
       "description": "plugins.Save.description",
-      "dependencies": [
-        "SidebarMenu",
+      "children": [
         "SaveAs"
+      ],
+      "autoEnableChildren": [
+        "SaveAs"
+      ],
+      "dependencies": [
+        "SidebarMenu"
       ]
     },
     {
       "name": "SaveAs",
       "glyph": "floppy-open",
       "title": "plugins.SaveAs.title",
-      "hidden": true,
+      "hidden": false,
       "description": "plugins.SaveAs.description",
       "dependencies": [
         "SidebarMenu"

--- a/web/client/configs/pluginsConfig.json
+++ b/web/client/configs/pluginsConfig.json
@@ -490,16 +490,21 @@
       "denyUserSelection": true,
       "title": "plugins.Save.title",
       "description": "plugins.Save.description",
-      "dependencies": [
-        "SidebarMenu",
+      "children": [
         "SaveAs"
+      ],
+      "autoEnableChildren": [
+        "SaveAs"
+      ],
+      "dependencies": [
+        "SidebarMenu"
       ]
     },
     {
       "name": "SaveAs",
       "glyph": "floppy-open",
       "title": "plugins.SaveAs.title",
-      "hidden": true,
+      "hidden": false,
       "description": "plugins.SaveAs.description",
       "dependencies": [
         "SidebarMenu"

--- a/web/client/plugins/SaveAs.jsx
+++ b/web/client/plugins/SaveAs.jsx
@@ -24,6 +24,8 @@ const showMapSaveAsSelector = state => state.controls && state.controls.mapSaveA
 /**
  * Plugin for Create/Clone a Map. Saves the map as a new Resource (using the persistence API).
  * @prop {boolean} [cfg.disablePermission=false] disable the permission selector in the tool. Can be used in context when permissions are not needed (resources are private only/using plugin with another API)
+ * @prop {object} [cfg.disablePluginIf=Boolean(expression)] disable the plugin with a custom expression that evaluates to a boolean. Can be configured in context creation or when editing a context.
+ * You may use an expression that evaluates a particular state of the program. For example: `"disablePluginIf": "{state('userrole') !== 'ADMIN'}"`. In the example, the plugin is disabled for users that do not have the role of ADMIN.
  * @name SaveAs
  * @class
  * @memberof plugins

--- a/web/client/plugins/SaveAs.jsx
+++ b/web/client/plugins/SaveAs.jsx
@@ -24,8 +24,6 @@ const showMapSaveAsSelector = state => state.controls && state.controls.mapSaveA
 /**
  * Plugin for Create/Clone a Map. Saves the map as a new Resource (using the persistence API).
  * @prop {boolean} [cfg.disablePermission=false] disable the permission selector in the tool. Can be used in context when permissions are not needed (resources are private only/using plugin with another API)
- * @prop {object} [cfg.disablePluginIf=Boolean(expression)] disable the plugin with a custom expression that evaluates to a boolean. Can be configured in context creation or when editing a context.
- * You may use an expression that evaluates a particular state of the program. For example: `"disablePluginIf": "{state('userrole') !== 'ADMIN'}"`. In the example, the plugin is disabled for users that do not have the role of ADMIN.
  * @name SaveAs
  * @class
  * @memberof plugins


### PR DESCRIPTION
## Description
This PR enables visualizing the SaveAs plugin as a child of Save plugin in the list of available plugins in the context creation wizard. The SaveAs plugin is enabled by default. The visualization of the plugin allows for the context creator to configure it. Given the requirements of the issue noted below, the configuration is simply `cfg.disablePluginIf": "{state('userrole') !== 'ADMIN'}`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

[SaveAs plugin configuration docs](https://mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins#plugins.SaveAs)


## Issue

**What is the current behavior?**
[#9919 ](https://github.com/geosolutions-it/MapStore2/issues/9919)



**What is the new behavior?**
SaveAs plugin is now a child of Save plugin in the list of available plugins in the context creation wizard. The SaveAs plugin is enabled by default. The visualization of the plugin allows for the context creator to configure it. Given the requirements of the issue noted below, the configuration is simply `cfg.disablePluginIf": "{state('userrole') !== 'ADMIN'}`.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
