### PR TITLE
[Backport c040-2024.01.xx] Fix #9944 Map connected to table with date attribute breaks the app (#9947)

### DIFF
--- a/web/client/components/data/featuregrid/filterRenderers/BaseDateTimeFilter.js
+++ b/web/client/components/data/featuregrid/filterRenderers/BaseDateTimeFilter.js
@@ -30,7 +30,7 @@ const UTCDateTimePickerWithRange = utcDateWrapper({
 })(RangedDateTimePicker );
 
 
-class DateFilter extends AttributeFilter {
+export class DateFilter extends AttributeFilter {
     static propTypes = {
         type: PropTypes.string,
         disabled: PropTypes.bool,
@@ -55,7 +55,9 @@ class DateFilter extends AttributeFilter {
         const operator = this.props.value && this.props.value.operator || this.state.operator;
         const format = getDateTimeFormat(this.context.locale, this.props.type);
         const placeholder = getMessageById(this.context.messages, this.props.placeholderMsgId) || "Insert date";
-        const toolTip = this.props.intl && this.props.intl.formatMessage({id: `${this.props.tooltipMsgId}`}, {format}) || `Insert date in ${format} format`;
+        const toolTip = this.props.intl && this.props.tooltipMsgId
+            ? this.props.intl.formatMessage({id: `${this.props.tooltipMsgId}`}, {format})
+            : `Insert date in ${format} format`;
 
         const inputKey = 'header-filter-' + this.props.column.key;
         let val;

--- a/web/client/components/data/featuregrid/filterRenderers/__tests__/BaseDateTimeFilter-test.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/__tests__/BaseDateTimeFilter-test.jsx
@@ -7,12 +7,28 @@
   */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import BaseDateTimeFilter from '../BaseDateTimeFilter';
+import BaseDateTimeFilter, { DateFilter } from '../BaseDateTimeFilter';
 import expect from 'expect';
 import Moment from 'moment';
 import momentLocalizer from 'react-widgets/lib/localizers/moment';
 
 momentLocalizer(Moment);
+const intlMock = {
+    formatMessage: ({ id }) => {
+        // intl library throws an error when id is undefined, null or an empty string
+        if (!id) {
+            throw new Error();
+        }
+        return 'any message';
+    },
+    formatDate: () => {},
+    formatTime: () => {},
+    formatRelative: () => {},
+    formatNumber: () => {},
+    formatPlural: () => {},
+    formatHTMLMessage: () => {},
+    now: () => {}
+};
 describe('Test for BaseDateTimeFilter component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -72,5 +88,10 @@ describe('Test for BaseDateTimeFilter component', () => {
         expect(el).toExist();
         dateTimePickerWithRangeElement = document.getElementsByClassName('rw-datetimepicker range-time-input rw-widget')[0];
         expect(dateTimePickerWithRangeElement).toExist();
+    });
+    it('render with intl when tooltipMsgId is an empty string', () => {
+        ReactDOM.render(<DateFilter intl={intlMock} tooltipMsgId=""/>, document.getElementById("container"));
+        const el = document.getElementsByTagName("input")[0];
+        expect(el).toBeTruthy();
     });
 });

--- a/web/client/components/data/featuregrid/filterRenderers/index.js
+++ b/web/client/components/data/featuregrid/filterRenderers/index.js
@@ -16,38 +16,38 @@ import StringFilter from './StringFilter';
 
 const types = {
     "defaultFilter": (props) => withProps(({disabled, tooltipMsgId: editTooltipMsgId}) =>{
-        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.default" : '';
-        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.default" : "";
+        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.default" : props.placeholderMsgId;
+        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.default" : props.tooltipMsgId;
         return { type: props.type, isWithinAttrTbl: props.isWithinAttrTbl || false, placeholderMsgId, tooltipMsgId };
     })(DefaultFilter),
     "string": (props) => withProps(({disabled, tooltipMsgId: editTooltipMsgId}) =>{
-        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.string" : '';
-        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.string" : "";
+        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.string" : props.placeholderMsgId;
+        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.string" : props.tooltipMsgId;
         return { type: 'string', isWithinAttrTbl: props.isWithinAttrTbl || false, placeholderMsgId, tooltipMsgId };
     })(StringFilter),
     "number": (props) => withProps(({disabled, tooltipMsgId: editTooltipMsgId}) =>{
-        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.number" : '';
-        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.number" : "";
+        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.number" : props.placeholderMsgId;
+        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.number" : props.tooltipMsgId;
         return { type: 'number', isWithinAttrTbl: props.isWithinAttrTbl || false,  placeholderMsgId, tooltipMsgId };
     })(NumberFilter),
     "int": (props) => withProps(({disabled, tooltipMsgId: editTooltipMsgId}) =>{
-        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.number" : '';
-        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.number" : "";
+        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.number" : props.placeholderMsgId;
+        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.number" : props.tooltipMsgId;
         return { type: 'integer', isWithinAttrTbl: props.isWithinAttrTbl || false,  placeholderMsgId, tooltipMsgId };
     })(NumberFilter),
     "date": (props) => withProps(({disabled, tooltipMsgId: editTooltipMsgId}) =>{
-        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.date" : '';
-        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.date" : "";
+        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.date" : props.placeholderMsgId;
+        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.date" : props.tooltipMsgId;
         return { type: "date", isWithinAttrTbl: props.isWithinAttrTbl || false,  placeholderMsgId, tooltipMsgId };
     })(DateTimeFilter),
     "time": (props) => withProps(({disabled, tooltipMsgId: editTooltipMsgId}) =>{
-        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.date" : '';
-        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.date" : "";
+        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.date" : props.placeholderMsgId;
+        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.date" : props.tooltipMsgId;
         return { type: "time", isWithinAttrTbl: props.isWithinAttrTbl || false,  placeholderMsgId, tooltipMsgId };
     })(DateTimeFilter),
     "date-time": (props) => withProps(({disabled, tooltipMsgId: editTooltipMsgId}) =>{
-        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.date" : '';
-        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.date" : "";
+        let placeholderMsgId = props.isWithinAttrTbl ? "featuregrid.attributeFilter.placeholders.date" : props.placeholderMsgId;
+        let tooltipMsgId = props.isWithinAttrTbl ? disabled ? editTooltipMsgId : "featuregrid.attributeFilter.tooltips.date" : props.tooltipMsgId;
         return { type: "date-time", isWithinAttrTbl: props.isWithinAttrTbl || false,  placeholderMsgId, tooltipMsgId };
     })(DateTimeFilter),
     "geometry": () => GeometryFilter

--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -246,6 +246,19 @@
                     font-size: @font-size-small;
                 }
             }
+            .rw-select {
+                .ms-popover {
+                    &,
+                    & > button {
+                        position: relative;
+                        width: 100%;
+                        height: 100%;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                    }
+                }
+            }
         }
         .mapstore-widget-default-content {
             // avoid editor defaults for text-widget


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Some changes applied to date time filter were providing an empty string as message id and this was causing problem with intl library that expects always a valid id.

This PR restore fallbacks message id when date filters are not used by the attribute table and it adds an additional check to ensure the message id is valid before the intl formatting

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9944

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Application is not breaking when a map is connected to a table with date/time attributes

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
