### PR TITLE
[Backport c040-2024.01.xx] Fix #9945 WFS legacy style breaks the app in OpenLayers (#9950)

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -2719,6 +2719,43 @@ describe('Openlayers layer', () => {
             map={map} />, document.getElementById("container"));
         expect(layer.layer.getSource()).toBeTruthy();
     });
+    it('render wfs layer with legacy style', (done) => {
+        mockAxios.onGet().reply(r => {
+            expect(r.url.indexOf('SAMPLE_URL') >= 0 ).toBeTruthy();
+            return [200, SAMPLE_FEATURE_COLLECTION];
+        });
+        const options = {
+            type: 'wfs',
+            visibility: true,
+            url: 'SAMPLE_URL',
+            name: 'osm:vector_tile',
+            style: {
+                color: 'rgba(0, 0, 255, 1)',
+                fillColor: 'rgba(0, 0, 255, 0.1)',
+                fillOpacity: 0.1,
+                opacity: 1,
+                radius: 10,
+                weight: 1
+            }
+        };
+        let layer;
+        map.on('rendercomplete', () => {
+            if (layer.layer.getSource().getFeatures().length > 0) {
+                const f = layer.layer.getSource().getFeatures()[0];
+                expect(f.getGeometry().getCoordinates()[0]).toBe(SAMPLE_FEATURE_COLLECTION.features[0].geometry.coordinates[0]);
+                expect(f.getGeometry().getCoordinates()[1]).toBe(SAMPLE_FEATURE_COLLECTION.features[0].geometry.coordinates[1]);
+                done();
+            }
+        });
+        // first render
+        layer = ReactDOM.render(<OpenlayersLayer
+            type="wfs"
+            options={{
+                ...options
+            }}
+            map={map} />, document.getElementById("container"));
+        expect(layer.layer.getSource()).toBeTruthy();
+    });
     it('render wfs layer with error', () => {
         mockAxios.onGet().reply(r => {
             expect(r.url.indexOf('SAMPLE_URL') >= 0 ).toBeTruthy();

--- a/web/client/components/map/openlayers/plugins/WFSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WFSLayer.js
@@ -116,7 +116,8 @@ const getWFSStyle = (layer, options, map) => {
     return getStyle(
         applyDefaultStyleToVectorLayer({
             ...options,
-            features: collection.features
+            features: collection.features,
+            asPromise: true
         })
     )
         .then((style) => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR restores the `asPromise` set to true for WFS layers for the OpenLayers implementation

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9945

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The WFS layer with legacy style will not break the application

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
