### PR TITLE
#9894 Add possibility to configure srs (#9897)

### DIFF
--- a/web/client/plugins/StreetView/StreetView.jsx
+++ b/web/client/plugins/StreetView/StreetView.jsx
@@ -59,7 +59,8 @@ const StreetViewPluginContainer = connect(() => ({}), {
  * - `cyclomedia` provider: The API key is mandatory and can be configured only in the plugin configuration. It is not possible to configure it globally in `localConfig.json`, in `apiKeys.cyclomediaAPIKey`.
  * @property {string} providerSettings The settings specific for the provider. Depending on the `provider` property, the following settings are available:
  * - `cyclomedia` provider:
- *   - `StreetSmartApiURL` (optional). The URL of the StreetSmart API. Default: `https://streetsmart.cyclomedia.com/api/v23.7/StreetSmartApi.js`.
+ *   - `providerSettings.StreetSmartApiURL` (optional). The URL of the StreetSmart API. Default: `https://streetsmart.cyclomedia.com/api/v23.7/StreetSmartApi.js`.
+ *   - `providerSettings.srs` (optional). Coordinate reference system code to use for the API. Default: `EPSG:4326`. Note that the SRS used here must be supported by the StreetSmart API **and** defined in `localConfig.json` file, in `projectionDefs`.
  *
  * Generally speaking, you should prefer general settings in `localConfig.json` over the plugin configuration, in order to reuse the same configuration for default viewer and all the contexts, automatically. This way you will not need to configure the `apiKey` in every context.
  * <br>**Important**: You can use only **one** API-key for a MapStore instance. The api-key can be configured replicated in every plugin configuration or using one of the unique global settings (suggested) in `localConfig.json`). @see {@link https://github.com/googlemaps/js-api-loader/issues/5|here} and @see {@link https://github.com/googlemaps/js-api-loader/issues/100|here}

--- a/web/client/plugins/StreetView/components/CyclomediaView/__tests__/CyclomediaView-test.jsx
+++ b/web/client/plugins/StreetView/components/CyclomediaView/__tests__/CyclomediaView-test.jsx
@@ -37,8 +37,8 @@ describe('Cyclomedia CyclomediaView', () => {
         setCredentials(CYCLOMEDIA_CREDENTIALS_REFERENCE, {username: 'test', password: 'password'});
         // set a default mock
         window.__cyclomedia__mock__ = {
-            init: () => {},
-            open: () => {}
+            init: () => new Promise((resolve) => { resolve(); }),
+            open: () => new Promise((resolve) => { resolve(); })
         };
         setTimeout(done);
     });
@@ -102,5 +102,24 @@ describe('Cyclomedia CyclomediaView', () => {
         expect(div).toExist();
 
     });
-
+    it('srs check for existing projection', () => {
+        const props = {
+            apiKey: testAPIKey
+        };
+        ReactDOM.render(<CyclomediaView {...props} providerSettings={{...mockProviderSettings, srs: "EPSG:4326"}}/>, document.getElementById("container"));
+        // no error shown.
+        const div = emptyStreetView();
+        expect(div).toExist();
+    });
+    it('srs not defined error handling', () => {
+        const props = {
+            apiKey: testAPIKey
+        };
+        ReactDOM.render(<CyclomediaView {...props} providerSettings={{...mockProviderSettings, srs: "UNKNOWN"}}/>, document.getElementById("container"));
+        // no error shown.
+        const div = emptyStreetView();
+        expect(div).toNotExist();
+        // check alert to exist
+        expect(document.querySelector('.alert-danger')).toExist();
+    });
 });

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -3941,7 +3941,8 @@
             "zoomIn": "Bitte zoomen Sie in die Karte, um die Street-View-Abdeckung zu sehen",
             "errorOccurred": "Fehler aufgetreten: ",
             "errors": {
-                "invalidCredentials": "Ungültige Anmeldeinformationen"
+                "invalidCredentials": "Ungültige Anmeldeinformationen",
+                "projectionNotAvailable": "Die konfigurierte Projektion {srs} ist nicht verfügbar. Bitte kontaktieren Sie den Administrator."
             },
             "reloadAPI": "API neu laden"
           }

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -3914,7 +3914,8 @@
             "zoomIn": "Please zoom in the map to see the street view coverage",
             "errorOccurred": "Error occurred: ",
             "errors": {
-              "invalidCredentials": "Invalid credentials"
+              "invalidCredentials": "Invalid credentials",
+              "projectionNotAvailable": "The projection {srs} configured is not available. Please contact the administrator."
             },
             "reloadAPI": "Reload API"
           }

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -3903,7 +3903,8 @@
             "zoomIn": "Por favor, acerque el mapa para ver la cobertura de vista de calle",
             "errorOccurred": "Se produjo un error: ",
             "errors": {
-                "invalidCredentials": "Credenciales inválidas"
+                "invalidCredentials": "Credenciales inválidas",
+                "projectionNotAvailable": "La proyección {srs} configurada no está disponible. Por favor, contacte al administrador."
             },
             "reloadAPI": "Recargar API"
           }

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -3903,7 +3903,8 @@
             "zoomIn": "Veuillez zoomer sur la carte pour voir la couverture Street View",
             "errorOccurred": "Une erreur s'est produite : ",
             "errors": {
-                "invalidCredentials": "Identifiants invalides"
+                "invalidCredentials": "Identifiants invalides",
+                "projectionNotAvailable": "La projection {srs} configurée n'est pas disponible. Veuillez contacter l'administrateur."
             },
             "reloadAPI": "Recharger l'API"
           }

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -3903,7 +3903,8 @@
               "zoomIn": "Effettua un ulteriore zoom sulla mappa per visualizzare dove sono disponibili le immagini",
               "errorOccurred": "Si è verificato un errore: ",
               "errors": {
-                "invalidCredentials": "Credenziali non valide"
+                "invalidCredentials": "Credenziali non valide",
+                "projectionNotAvailable": "La proiezione {srs} configurata non è disponibile. Contattare l'amministratore."
               },
               "reloadAPI": "Ricarica API"
             }


### PR DESCRIPTION
## Description
adds the possibilty to configure in providerSettings the srs to use. This is useful to activate some tools available only on certain projection (e.g. EPSG:7791, see https://github.com/geosolutions-it/MapStore2/pull/9878 ).

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
