### PR TITLE
#9583 unadvertised resources

### DIFF
--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -18,12 +18,13 @@ import { registerErrorParser } from '../utils/LocaleUtils';
 import { encodeUTF8 } from '../utils/EncodeUtils';
 
 
-const generateMetadata = (name = "", description = "") =>
+const generateMetadata = (name = "", description = "", advertised = true) =>
     "<description><![CDATA[" + description + "]]></description>"
     + "<metadata></metadata>"
-    + "<name><![CDATA[" + (name) + "]]></name>";
+    + "<name><![CDATA[" + (name) + "]]></name>"
+    + "<advertised>" + advertised + "</advertised>";
 const createAttributeList = (metadata = {}) => {
-    const attributes = metadata.attributes || omit(metadata, ["name", "description", "id"]);
+    const attributes = metadata.attributes || omit(metadata, ["name", "description", "id", "advertised"]);
 
     const xmlAttrs = Object.keys(attributes).map((key) => {
         return "<attribute><name>" + key + "</name><value>" + attributes[key] + "</value><type>STRING</type></attribute>";
@@ -266,10 +267,10 @@ const Api = {
             .then(rl => castArray( withSelector ? get(rl, 'SecurityRuleList.SecurityRule') : rl))
             .then(rules => (rules && rules[0] && rules[0] !== "") ? rules : []);
     },
-    putResourceMetadata: function(resourceId, newName, newDescription, options) {
+    putResourceMetadata: function(resourceId, newName, newDescription, advertised, options) {
         return axios.put(
             "resources/resource/" + resourceId,
-            "<Resource>" + generateMetadata(newName, newDescription) + "</Resource>",
+            "<Resource>" + generateMetadata(newName, newDescription, advertised) + "</Resource>",
             this.addBaseUrl(merge({
                 headers: {
                     'Content-Type': "application/xml"
@@ -279,7 +280,7 @@ const Api = {
     putResourceMetadataAndAttributes: function(resourceId, metadata, options) {
         return axios.put(
             "resources/resource/" + resourceId,
-            "<Resource>" + generateMetadata(metadata.name, metadata.description) + createAttributeList(metadata) + "</Resource>",
+            "<Resource>" + generateMetadata(metadata.name, metadata.description, metadata.advertised) + createAttributeList(metadata) + "</Resource>",
             this.addBaseUrl(merge({
                 headers: {
                     'Content-Type': "application/xml"
@@ -337,7 +338,7 @@ const Api = {
         const attributesSection = createAttributeList(metadata);
         return axios.post(
             "resources/",
-            "<Resource>" + generateMetadata(name, description) + "<category><name>" + (category || "") + "</name></category>" +
+            "<Resource>" + generateMetadata(name, description, metadata.advertised) + "<category><name>" + (category || "") + "</name></category>" +
                 attributesSection +
                 "<store><data><![CDATA[" + (
                 data

--- a/web/client/api/__tests__/GeoStoreDAO-test.jsx
+++ b/web/client/api/__tests__/GeoStoreDAO-test.jsx
@@ -127,8 +127,8 @@ describe('Test correctness of the GeoStore APIs', () => {
         expect(payload).toBe(SAMPLE_XML_RULES);
     });
     it('test generate meatadata', () => {
-        const payload = API.generateMetadata("Special & chars", "&<>'\"");
-        expect(payload).toBe('<description><![CDATA[&<>\'"]]></description><metadata></metadata><name><![CDATA[Special & chars]]></name>');
+        const payload = API.generateMetadata("Special & chars", "&<>'\"", false);
+        expect(payload).toBe('<description><![CDATA[&<>\'"]]></description><metadata></metadata><name><![CDATA[Special & chars]]></name><advertised>false</advertised>');
     });
 
     it('test login without credentials', (done) => {
@@ -176,13 +176,15 @@ describe('Test correctness of the GeoStore APIs', () => {
         const metadata = API.generateMetadata();
         const name = "";
         const description = "";
-        expect(metadata).toEqual(`<description><![CDATA[${description}]]></description><metadata></metadata><name><![CDATA[${name}]]></name>`);
+        const advertised = true;
+        expect(metadata).toEqual(`<description><![CDATA[${description}]]></description><metadata></metadata><name><![CDATA[${name}]]></name><advertised>${advertised}</advertised>`);
     });
-    it("test generateMetadata with name and desc", () => {
+    it("test generateMetadata with name, desc and advertised", () => {
         const name = "Map 1";
         const description = "this map shows high traffic zones";
-        const metadata = API.generateMetadata(name, description);
-        expect(metadata).toEqual(`<description><![CDATA[${description}]]></description><metadata></metadata><name><![CDATA[${name}]]></name>`);
+        const advertised = false;
+        const metadata = API.generateMetadata(name, description, advertised);
+        expect(metadata).toEqual(`<description><![CDATA[${description}]]></description><metadata></metadata><name><![CDATA[${name}]]></name><advertised>${advertised}</advertised>`);
     });
     it("test createAttributeList default", () => {
         expect(API.createAttributeList()).toEqual("");

--- a/web/client/components/resources/forms/Metadata.jsx
+++ b/web/client/components/resources/forms/Metadata.jsx
@@ -16,7 +16,7 @@
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { FormControl as BFormControl, ControlLabel, FormGroup } from 'react-bootstrap';
+import { FormControl as BFormControl, ControlLabel, FormGroup, Checkbox } from 'react-bootstrap';
 import get from 'lodash/get';
 
 import ConfigUtils from '../../../utils/ConfigUtils';
@@ -42,7 +42,8 @@ class Metadata extends React.Component {
         descriptionPlaceholderText: PropTypes.string,
         titlePlaceholderText: PropTypes.string,
         createdAtFieldText: PropTypes.string,
-        modifiedAtFieldText: PropTypes.string
+        modifiedAtFieldText: PropTypes.string,
+        unadvertisedText: PropTypes.string
     };
 
     static contextTypes = {
@@ -58,7 +59,8 @@ class Metadata extends React.Component {
         descriptionFieldText: "Description",
         nameFieldFilter: () => {},
         namePlaceholderText: "Map Name",
-        descriptionPlaceholderText: "Map Description"
+        descriptionPlaceholderText: "Map Description",
+        unadvertisedText: "Unadvertised"
     };
 
     renderDate = (date) => {
@@ -120,6 +122,12 @@ class Metadata extends React.Component {
                     <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.modifiedAt || this.props.resource.createdAt) || ""}</ControlLabel>
                 </FormGroup>
             }
+            {
+                <FormGroup>
+                    <ControlLabel>{this.props.unadvertisedText}</ControlLabel>
+                    <Checkbox checked={!this.props.resource?.metadata?.advertised} onChange={this.changeAdvertised} aria-label="advertisedResource"/>
+                </FormGroup>
+            }
         </form>);
     }
 
@@ -133,6 +141,9 @@ class Metadata extends React.Component {
 
     changeTitle = (e) => {
         this.props.onChange('attributes.title', e.target.value);
+    };
+    changeAdvertised = (e) => {
+        this.props.onChange('metadata.advertised', !e.target.checked);
     };
 }
 

--- a/web/client/components/resources/forms/__tests__/Metadata-test.jsx
+++ b/web/client/components/resources/forms/__tests__/Metadata-test.jsx
@@ -26,7 +26,7 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata />, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
-        expect(el.length).toBe(2);
+        expect(el.length).toBe(3);
     });
     it('Metadata rendering with meta-data', () => {
         const resource = {
@@ -34,16 +34,20 @@ describe('Metadata component', () => {
             createdAt: new Date(),
             metadata: {
                 name: "NAME",
-                description: "DESCRIPTION"
+                description: "DESCRIPTION",
+                advertised: true
             }
         };
         ReactDOM.render(<Metadata resource={resource}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
         const labels = container.querySelectorAll('label');
-        expect(labels.length).toBe(6);
+        expect(labels.length).toBe(8);
         expect(el[0].value).toBe("NAME");
         expect(el[1].value).toBe("DESCRIPTION");
+        // the visualisation of the advertised resource attribute is represented as "Unadvertised"
+        // so, it should be always visualized as the opposite boolean of the value processed by the app.
+        expect(el[2].checked).toBe(false);
     });
     it('Metadata rendering with attributes', () => {
         const resource = {
@@ -57,7 +61,7 @@ describe('Metadata component', () => {
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
         const labels = container.querySelectorAll('label');
-        expect(labels.length).toBe(7);
+        expect(labels.length).toBe(9);
         expect(el[1].value).toBe("TITLE");
     });
     it('Metadata rendering without timestamp', () => {
@@ -70,7 +74,7 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata resource={resource}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const labels = container.querySelectorAll('label');
-        expect(labels.length).toBe(2);
+        expect(labels.length).toBe(4);
     });
 
     it('Test Metadata onChange', () => {
@@ -110,7 +114,7 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata resource={resource} titleFieldText="Title" createdAtFieldText="Created" modifiedAtFieldText="Modified"/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const labels = container.querySelectorAll('label');
-        expect(labels.length).toBe(6);
+        expect(labels.length).toBe(8);
         expect(labels[2].innerText).toBe('Created');
         expect(labels[4].innerText).toBe('Modified');
     });

--- a/web/client/components/resources/modals/enhancers/handleResourceData.jsx
+++ b/web/client/components/resources/modals/enhancers/handleResourceData.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {isString} from 'lodash';
+import {isString, isUndefined} from 'lodash';
 import React from 'react';
 import { branch, compose, renderComponent, withHandlers, withState, withStateHandlers } from 'recompose';
 
@@ -54,10 +54,12 @@ export default compose(
                     },
                     metadata: {
                         name: resource.name,
-                        description: resource.description
+                        description: resource.description,
+                        advertised: isUndefined(resource.advertised) ? true : resource.advertised
                     },
                     createdAt: resource.creation,
-                    modifiedAt: resource.lastUpdate
+                    modifiedAt: resource.lastUpdate,
+                    creator: resource.creator
                 },
                 linkedResources
             };

--- a/web/client/components/resources/modals/fragments/MainForm.jsx
+++ b/web/client/components/resources/modals/fragments/MainForm.jsx
@@ -75,6 +75,7 @@ class MainForm extends React.Component {
                     namePlaceholderText={"saveDialog.namePlaceholder"}
                     descriptionPlaceholderText={"saveDialog.descriptionPlaceholder"}
                     titlePlaceholderText={"saveDialog.titlePlaceholder"}
+                    unadvertisedText={<Message msgId="saveDialog.unadvertised" />}
                 />
             </Col>
         </Row>);

--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -2839,7 +2839,8 @@
       "saveSuccessTitle": "Success",
       "saveSuccessMessage": "Saved successfully",
       "saveTooltip": "Save",
-      "saveAsTooltip": "Save As"
+      "saveAsTooltip": "Save As",
+      "unadvertised": "Unadvertised"
     },
     "mapEditor": {
       "modalTitle": "Map Editor",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -3057,7 +3057,8 @@
             "saveSuccessTitle": "Erfolg",
             "saveSuccessMessage": "Erfolgreich gespeichert",
             "saveTooltip": "Speichern",
-            "saveAsTooltip": "Speichern als"
+            "saveAsTooltip": "Speichern als",
+            "unadvertised": "Nicht geworben"
         },
         "mapEditor": {
             "modalTitle": "Karteneditor",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -3030,7 +3030,8 @@
             "saveSuccessTitle": "Success",
             "saveSuccessMessage": "Saved successfully",
             "saveTooltip": "Save",
-            "saveAsTooltip": "Save As"
+            "saveAsTooltip": "Save As",
+            "unadvertised": "Unadvertised"
         },
         "mapEditor": {
             "modalTitle": "Map Editor",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -3019,7 +3019,8 @@
             "saveSuccessTitle": "éxito",
             "saveSuccessMessage": "Guardado con éxito",
             "saveTooltip": "Salvar",
-            "saveAsTooltip": "Guardar como"
+            "saveAsTooltip": "Guardar como",
+            "unadvertised": "Sin publicidad"
         },
         "mapEditor": {
             "modalTitle": "Map Editor",

--- a/web/client/translations/data.fi-FI.json
+++ b/web/client/translations/data.fi-FI.json
@@ -2114,7 +2114,8 @@
       "close": "Sulje",
       "cancel": "Peruuta",
       "saveSuccessTitle": "Tallennus onnistui",
-      "saveSuccessMessage": "Tallennettu onnistuneesti"
+      "saveSuccessMessage": "Tallennettu onnistuneesti",
+      "unadvertised": "Mainostamaton"
     },
     "mapEditor": {
       "modalTitle": "Karttaeditori",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -3020,7 +3020,8 @@
             "saveSuccessTitle": "Succès",
             "saveSuccessMessage": "Enregistré avec succès",
             "saveTooltip": "Enregistrer",
-            "saveAsTooltip": "Enregistrer sous"
+            "saveAsTooltip": "Enregistrer sous",
+            "unadvertised": "Non annoncé"
         },
         "mapEditor": {
             "modalTitle": "Editeur de carte",

--- a/web/client/translations/data.hr-HR.json
+++ b/web/client/translations/data.hr-HR.json
@@ -1632,7 +1632,8 @@
                 "close": "Zatvori",
                 "cancel": "Odustani",
                 "saveSuccessTitle": "Uspješno",
-                "saveSuccessMessage": "Ploča je uspješno spremljena"
+                "saveSuccessMessage": "Ploča je uspješno spremljena",
+                "unadvertised": "Nenamjerno"
             },
             "errors":{
                 "loading": {

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -2859,7 +2859,8 @@
       "saveSuccessTitle": "Success",
       "saveSuccessMessage": "Saved successfully",
       "saveTooltip": "Save",
-      "saveAsTooltip": "Save As"
+      "saveAsTooltip": "Save As",
+      "unadvertised": "Óauglýst"
     },
     "mapEditor": {
       "modalTitle": "Map Editor",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -3020,7 +3020,8 @@
             "saveSuccessTitle": "Successo",
             "saveSuccessMessage": "Salvata con successo",
             "saveTooltip": "Salva",
-            "saveAsTooltip": "Salva con nome"
+            "saveAsTooltip": "Salva con nome",
+            "unadvertised": "Non pubblicizzato"
         },
         "mapEditor": {
             "modalTitle": "Editor di Mappa",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -2942,7 +2942,8 @@
             "saveSuccessTitle": "Succes",
             "saveSuccessMessage": "Succesvol opgeslagen",
             "saveTooltip": "Opslaan",
-            "saveAsTooltip": "Opslaan als"
+            "saveAsTooltip": "Opslaan als",
+            "unadvertised": "Niet geadverteerd"
         },
         "mapEditor": {
             "modalTitle": "Kaarteditor",

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -1599,7 +1599,8 @@
                 "close": "Close",
                 "cancel": "Cancel",
                 "saveSuccessTitle": "Success",
-                "saveSuccessMessage": "Dashboard saved successfully"
+                "saveSuccessMessage": "Dashboard saved successfully",
+                "unadvertised": "Não anunciado"
             },
             "errors":{
                 "loading": {

--- a/web/client/translations/data.sk-SK.json
+++ b/web/client/translations/data.sk-SK.json
@@ -2598,7 +2598,8 @@
             "close": "Zatvoriť",
             "cancel": "Zrušiť",
             "saveSuccessTitle": "Úspech",
-            "saveSuccessMessage": "Úspešne uložené"
+            "saveSuccessMessage": "Úspešne uložené",
+            "unadvertised": "Neinzerované"
         },
         "mapEditor": {
             "modalTitle": "Mapový editor",

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -2610,7 +2610,8 @@
             "saveSuccessTitle": "Framgång",
             "saveSuccessMessage": "Sparad framgångsrikt",
             "saveTooltip": "Spara",
-            "saveAsTooltip": "Spara som"
+            "saveAsTooltip": "Spara som",
+            "unadvertised": "Oannonserad"
         },
         "mapEditor": {
             "modalTitle": "Kartredigerare",


### PR DESCRIPTION
## Description
This PR introduces the "Unadvertised" field on creation / edit of resources. Resources which are tagged as unadvertised are viewable and editable only by the owner or admin role users.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
[#9583 Unadvertised Resources ](https://github.com/geosolutions-it/MapStore2/issues/9583)

**What is the new behavior?**
The "Unadvertised" field is viewable and togglable inside the resource modal on creation/editing. Its value is processed and persisted and resources are filtered accordingly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
