### PR TITLE
Fix #9959 Editing of date/time attributes is not working

### DIFF
--- a/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
@@ -85,11 +85,30 @@ class DateTimeEditor extends AttributeEditor {
             onChange={this.onChange}
             calendar={calendar}
             time={time}
+            onPopoverOpen={(open) => {
+                this.setState({ open });
+                if (!open) {
+                    this.props.onBlur();
+                }
+            }}
             options={{
                 shouldCalendarSetHours: false
             }}
             format={dateFormats[dataType]}
         />);
+    }
+    // when we are using the popover we are using a portal
+    // this makes the current editor component not contained inside the editor container
+    // making this editor directly commit the value causing the issue https://github.com/geosolutions-it/MapStore2/issues/9959
+    // here how the original library is checking relation between editor and editor container to trigger the blur event
+    // https://github.com/adazzle/react-data-grid/blob/v5.0.4/packages/common/editors/EditorContainer.js#L292-L329
+    // ---
+    // Workaround:
+    // we could take advantage of the unused validate method to solve this problem
+    // in this way we prevent to commit the value while the popover is open
+    // see https://github.com/adazzle/react-data-grid/blob/v5.0.4/packages/common/editors/EditorContainer.js#L245
+    validate = () => {
+        return !this.state.open;
     }
 }
 export default DateTimeEditor;

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -104,7 +104,7 @@ const featuresToGrid = compose(
         props => ({typeName: props.typeName})
     ),
     withPropsOnChange(
-        ["features", "newFeatures", "changes"],
+        ["features", "newFeatures", "changes", "dateFormats"],
         props => ({
             rows: (props.newFeatures ? [...props.newFeatures, ...props.features] : props.features)
                 .filter(props.focusOnEdit ? createNewAndEditingFilter(props.changes && Object.keys(props.changes).length > 0, props.newFeatures, props.changes) : () => true)
@@ -113,7 +113,8 @@ const featuresToGrid = compose(
                         ["_!_id_!_"]: result.id,
                         get: key => {
                             return (key === "geometry" || key === "_new") ? result[key] : result.properties && result.properties[key];
-                        }
+                        },
+                        dateFormats: props.dateFormats
                     }))
         })
     ),
@@ -171,7 +172,7 @@ const featuresToGrid = compose(
                             return props.editors(desc.localType, generalProps);
                         },
                         getFilterRenderer: getFilterRendererFunc,
-                        getFormatter: (desc) => getFormatter(desc, (props.fields ?? []).find(f => f.name === desc.name), {dateFormats: props.dateFormats}),
+                        getFormatter: (desc) => getFormatter(desc, (props.fields ?? []).find(f => f.name === desc.name)),
                         isWithinAttrTbl: props.isWithinAttrTbl
                     }))
             });

--- a/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
+++ b/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
@@ -180,27 +180,30 @@ describe("Tests for the formatter functions", () => {
             "date-time": "YYYY DD",
             time: "HH:mm"
         };
-        const DateFormatter = getFormatter({ localType: "date" }, undefined, { dateFormats });
-        const DateTimeFormatter = getFormatter({ localType: "date-time" }, undefined, { dateFormats });
-        const TimeFormatter = getFormatter({ localType: "time" }, undefined, { dateFormats });
+        const row = {
+            dateFormats
+        };
+        const DateFormatter = getFormatter({ localType: "date" });
+        const DateTimeFormatter = getFormatter({ localType: "date-time" });
+        const TimeFormatter = getFormatter({ localType: "time" });
 
         act(() => {
-            ReactDOM.render(<DateFormatter value="2015-02-01T12:45:00Z" />, container);
+            ReactDOM.render(<DateFormatter value="2015-02-01T12:45:00Z" row={row} />, container);
         });
         expect(container.textContent).toBe("2015");
 
         act(() => {
-            ReactDOM.render(<DateTimeFormatter value="2015-02-01Z" />, container);
+            ReactDOM.render(<DateTimeFormatter value="2015-02-01Z" row={row} />, container);
         });
         expect(container.textContent).toBe("2015 01");
 
         act(() => {
-            ReactDOM.render(<TimeFormatter value="12:45:00Z" />, container);
+            ReactDOM.render(<TimeFormatter value="12:45:00Z" row={row} />, container);
         });
         expect(container.textContent).toBe("12:45");
 
         act(() => {
-            ReactDOM.render(<TimeFormatter value="1970-01-01T02:30:00Z" />, container);
+            ReactDOM.render(<TimeFormatter value="1970-01-01T02:30:00Z" row={row} />, container);
         });
         expect(container.textContent).toBe("02:30");
     });
@@ -209,25 +212,28 @@ describe("Tests for the formatter functions", () => {
         const dateFormats = {
             "date-time": "YYYY-MM-DD[Z]"
         };
-        const DateTimeWithZFormatter = getFormatter({ localType: "date-time" }, undefined, { dateFormats });
+        const row = {
+            dateFormats
+        };
+        const DateTimeWithZFormatter = getFormatter({ localType: "date-time" });
 
         act(() => {
-            ReactDOM.render(<DateTimeWithZFormatter value="2015-02-01Z" />, container);
+            ReactDOM.render(<DateTimeWithZFormatter value="2015-02-01Z" row={row} />, container);
         });
         expect(container.textContent).toBe("2015-02-01Z");
 
         act(() => {
-            ReactDOM.render(<DateTimeWithZFormatter value="2015-02-01" />, container);
+            ReactDOM.render(<DateTimeWithZFormatter value="2015-02-01" row={row}/>, container);
         });
         expect(container.textContent).toBe("2015-02-01Z");
 
         act(() => {
-            ReactDOM.render(<DateTimeWithZFormatter value="2015/02/01 03:20:10" />, container);
+            ReactDOM.render(<DateTimeWithZFormatter value="2015/02/01 03:20:10" row={row}/>, container);
         });
         expect(container.textContent).toBe("2015-02-01Z");
 
         act(() => {
-            ReactDOM.render(<DateTimeWithZFormatter value="2015-02-01T12:45:00Z" />, container);
+            ReactDOM.render(<DateTimeWithZFormatter value="2015-02-01T12:45:00Z" row={row}/>, container);
         });
         expect(container.textContent).toBe("2015-02-01Z");
     });

--- a/web/client/components/misc/datetimepicker/DateTimePicker.js
+++ b/web/client/components/misc/datetimepicker/DateTimePicker.js
@@ -129,7 +129,7 @@ class DateTimePicker extends Component {
                     <div className="date-time-container">
                         <Calendar
                             tabIndex="-1"
-                            ref={(elem) => {this.attachCalRef = elem;}}
+                            ref={this.attachCalRef}
                             onMouseDown={this.handleMouseDown}
                             onChange={this.handleCalendarChange}
                             {...props}
@@ -145,7 +145,7 @@ class DateTimePicker extends Component {
                                 </span>
                             </div>
                             <div className="dateTime-picker-hours" style={{display: timeVisible ? 'block' : 'none', background: 'white', position: 'relative', zIndex: 1}}>
-                                <Hours style={{maxHeight: "120px"}} ref={elem => {this.attachTimeRef = elem; }} value={inputValue} {...props} onClose={this.close} onSelect={(time) => this.handleTimeSelect(time, type)} />
+                                <Hours style={{maxHeight: "120px"}} ref={this.attachTimeRef} value={inputValue} {...props} onClose={this.close} onSelect={(time) => this.handleTimeSelect(time, type)} />
                             </div>
                         </div>
                     </div>
@@ -221,7 +221,7 @@ class DateTimePicker extends Component {
                                 <div className="shadow-soft" style={{position: "relative", width: 300, height: 'fit-content', overflow: "auto" }}>
                                     <div className="dateTime-picker-hours" style={{display: 'block', background: 'white', position: 'relative', zIndex: 1}}>
                                         <div style={{ height: '120px' }}>
-                                            <Hours style={{maxHeight: "120px"}} ref={elem => { this.attachTimeRef = elem;}} value={inputValue} onMouseDown={this.handleMouseDown} {...props} onClose={this.close} onSelect={this.handleTimeSelect} />
+                                            <Hours style={{maxHeight: "120px"}} ref={this.attachTimeRef} value={inputValue} onMouseDown={this.handleMouseDown} {...props} onClose={this.close} onSelect={this.handleTimeSelect} />
                                         </div>
                                     </div>
                                 </div>
@@ -250,7 +250,7 @@ class DateTimePicker extends Component {
                                 <div className="shadow-soft picker-container">
                                     <Calendar
                                         tabIndex="-1"
-                                        ref={(elem) => {this.attachCalRef = elem;}}
+                                        ref={this.attachCalRef}
                                         onMouseDown={this.handleMouseDown}
                                         onChange={this.handleCalendarChange}
                                         {...props}

--- a/web/client/components/misc/datetimepicker/DateTimePicker.js
+++ b/web/client/components/misc/datetimepicker/DateTimePicker.js
@@ -70,7 +70,8 @@ class DateTimePicker extends Component {
         tabIndex: PropTypes.string,
         options: PropTypes.object,
         isWithinAttrTbl: PropTypes.bool,
-        disabled: PropTypes.bool
+        disabled: PropTypes.bool,
+        onPopoverOpen: PropTypes.func
     }
     static contextTypes = {
         messages: PropTypes.object,
@@ -83,7 +84,8 @@ class DateTimePicker extends Component {
         onChange: () => { },
         value: null,
         popupPosition: 'bottom',
-        isWithinAttrTbl: false
+        isWithinAttrTbl: false,
+        onPopoverOpen: () => {}
     }
 
     state = {
@@ -190,6 +192,7 @@ class DateTimePicker extends Component {
                         onClick={this.toggleDateTime}
                         disabled={false}
                         placement={popupPosition}
+                        onOpen={this.props.onPopoverOpen}
                         triggerScrollableElement={document.querySelector('.feature-grid-container .react-grid-Container .react-grid-Canvas')}
                         content={
                             <div className="shadow-soft picker-container date-time">
@@ -212,6 +215,7 @@ class DateTimePicker extends Component {
                             onClick={this.toggleTime}
                             disabled={false}
                             placement={popupPosition}
+                            onOpen={this.props.onPopoverOpen}
                             triggerScrollableElement={document.querySelector('.feature-grid-container .react-grid-Container .react-grid-Canvas')}
                             content={
                                 <div className="shadow-soft" style={{position: "relative", width: 300, height: 'fit-content', overflow: "auto" }}>
@@ -240,6 +244,7 @@ class DateTimePicker extends Component {
                             onClick={this.toggleCalendar}
                             disabled={false}
                             placement={popupPosition}
+                            onOpen={this.props.onPopoverOpen}
                             triggerScrollableElement={document.querySelector('.feature-grid-container .react-grid-Container .react-grid-Canvas')}       // table element to trigger its scroll
                             content={
                                 <div className="shadow-soft picker-container">

--- a/web/client/themes/default/less/react-data-grid.less
+++ b/web/client/themes/default/less/react-data-grid.less
@@ -328,3 +328,12 @@
         }
     }
 }
+
+// we are using the validate function to prevent
+// to lose focus on the editing of date/time inside a popover
+// for this reason we are going to hide the error status icon
+.rdg-editor-container.has-error {
+    .rw-datetimepicker ~ .glyphicon-remove {
+        display: none;
+    }
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

There PR fixes following problems:

- ensure the formatters function of attribute table does not create component on the fly to avoid continuous mount/unmount that was preventing the double click in the center of the cell
- apply a workaround to the DateTimeEditor component to prevent to blur while the popover is open

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#9959

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The editing of date, date-time and time properties inside of the attribute table works with the new popover component

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
