### PR TITLE
Fix #9916: handle Stat Query Engine integration in Visual Style Editor

### DIFF
--- a/web/client/api/StyleEditor.js
+++ b/web/client/api/StyleEditor.js
@@ -224,16 +224,19 @@ const defaultClassificationRequest = ({
     styleService
 }) => {
 
-    const viewparams = Object.keys(params.customParams || {})
+    const viewparams = Object.keys(params.msViewParams || {})
         .map((key) => {
-            const property = params.customParams[key];
+            const property = params.msViewParams[key];
+            if (property === undefined) {
+                return null;
+            }
             // arrays need escaped comma
             // strings need sourronding single quotes
             const value = castArray(property)
                 .map(val => isString(val) ? `'${val}'` : val)
                 .join('\\,');
             return `${key}:${value}`;
-        }).join(';');
+        }).filter((value) => value).join(';');
 
     let paramSLDService = {
         intervals: params.intervals,
@@ -272,7 +275,7 @@ export function classificationVector({
         'attribute',
         'ramp',
         'intervalsForUnique',
-        'customParams'
+        'msViewParams'
     ];
     let params = { ...properties, ...values };
     const { ruleId } = properties;
@@ -301,7 +304,7 @@ export function classificationVector({
 
     const previousParams = paramsKeys.reduce((acc, key) => ({ ...acc, [key]: properties[key] }), {});
     const currentParams = paramsKeys.reduce((acc, key) => ({ ...acc, [key]: params[key] }), {});
-    const validParameters = !paramsKeys.find(key => params[key] === undefined);
+    const validParameters = !paramsKeys.filter((key) => key !== 'msViewParams').find(key => params[key] === undefined);
     const needsRequest = validParameters && !isEqual(previousParams, currentParams)
         // not request if the entries are updated manually
         && values?.ramp !== 'custom'

--- a/web/client/api/StyleEditor.js
+++ b/web/client/api/StyleEditor.js
@@ -223,12 +223,20 @@ const defaultClassificationRequest = ({
     params,
     styleService
 }) => {
-    const paramSLDService = {
+    let paramSLDService = {
         intervals: params.intervals,
         method: params.method,
         attribute: params.attribute,
         intervalsForUnique: params.intervalsForUnique
     };
+    let isCustomParamExist = typeof params.customParams === 'object';
+    if (isCustomParamExist) {
+        Object.entries(params.customParams).forEach((item) => {
+            if (item[1]) {
+                paramSLDService[item[0]] = item[1];
+            }
+        });
+    }
     return axios.get(SLDService.getStyleMetadataService(layer, paramSLDService, styleService));
 };
 /**
@@ -252,13 +260,15 @@ export function classificationVector({
     classificationRequest = defaultClassificationRequest
 }) {
 
+    // maybe need to add customParams in this keys
     let paramsKeys = [
         'intervals',
         'method',
         'reverse',
         'attribute',
         'ramp',
-        'intervalsForUnique'
+        'intervalsForUnique',
+        'customParams'
     ];
     let params = { ...properties, ...values };
     const { ruleId } = properties;

--- a/web/client/api/__tests__/StyleEditor-test.js
+++ b/web/client/api/__tests__/StyleEditor-test.js
@@ -21,7 +21,7 @@ import CLASSIFY_VECTOR_RESPONSE from './classifyVectorResponse.json';
 import CLASSIFY_RASTER_RESPONSE from './classifyRaterResponse.json';
 
 describe('StyleEditor API', () => {
-    const DEFAULT_CONFIG = { intervalsForUnique: 10 };
+    const DEFAULT_CONFIG = { intervalsForUnique: 10, customParams: {} };
     describe('classificationVector', () => {
         beforeEach(done => {
             mockAxios = new MockAdapter(axios);
@@ -551,6 +551,7 @@ describe('StyleEditor API', () => {
                 attribute: 'ATTRIBUTE',
                 type: 'classificationVector',
                 classification: [1, 2, 3, 4, 5],
+                ...DEFAULT_CONFIG,
                 ...param
             };
             const rules = [

--- a/web/client/api/__tests__/StyleEditor-test.js
+++ b/web/client/api/__tests__/StyleEditor-test.js
@@ -21,7 +21,7 @@ import CLASSIFY_VECTOR_RESPONSE from './classifyVectorResponse.json';
 import CLASSIFY_RASTER_RESPONSE from './classifyRaterResponse.json';
 
 describe('StyleEditor API', () => {
-    const DEFAULT_CONFIG = { intervalsForUnique: 10, customParams: {} };
+    const DEFAULT_CONFIG = { intervalsForUnique: 10, msViewParams: {} };
     describe('classificationVector', () => {
         beforeEach(done => {
             mockAxios = new MockAdapter(axios);

--- a/web/client/components/TOC/fragments/settings/ThematicLayer.jsx
+++ b/web/client/components/TOC/fragments/settings/ThematicLayer.jsx
@@ -250,7 +250,7 @@ class ThematicLayer extends React.Component {
                         title={this.localizedItem('toc.thematic.data_panel', '')}
                         buttons={[{
                             glyph: 'cog',
-                            tooltip: this.localizedItem('toc.thematic.go_to_cfg', ''),
+                            tooltip: this.localizedItem('toc.thematic.goToCfg', ''),
                             visible: this.props.canEditThematic,
                             onClick: this.toggleCfg
                         }]}

--- a/web/client/components/misc/codeEditors/JSONEditor.jsx
+++ b/web/client/components/misc/codeEditors/JSONEditor.jsx
@@ -10,7 +10,7 @@ import Message from '../../I18N/Message';
 
 import CodeMirror from '../../../libs/codemirror/react-codemirror-suspense';
 
-export default ({onValid, onError, json = {}}) => {
+export default ({onValid, onError, json = {}, editorWillUnmount = () => {} }) => {
     const [code, setCode] = useState(JSON.stringify(json, true, 2));
     const [error, setError] = useState();
     // parse code and set options
@@ -27,6 +27,7 @@ export default ({onValid, onError, json = {}}) => {
     }, [code]);
     return (<div className="code-editor">
         <CodeMirror
+            editorWillUnmount={() => editorWillUnmount(code)}
             value={code}
             onBeforeChange={(_, __, value) => {
                 setCode(value);

--- a/web/client/components/misc/codeEditors/JSONEditor.jsx
+++ b/web/client/components/misc/codeEditors/JSONEditor.jsx
@@ -10,7 +10,7 @@ import Message from '../../I18N/Message';
 
 import CodeMirror from '../../../libs/codemirror/react-codemirror-suspense';
 
-export default ({onValid, onError, json = {}, editorWillUnmount = () => {} }) => {
+export default ({onValid, onError, editorRef, json = {}, editorWillUnmount = () => {} }) => {
     const [code, setCode] = useState(JSON.stringify(json, true, 2));
     const [error, setError] = useState();
     // parse code and set options
@@ -27,6 +27,7 @@ export default ({onValid, onError, json = {}, editorWillUnmount = () => {} }) =>
     }, [code]);
     return (<div className="code-editor">
         <CodeMirror
+            ref={editorRef}
             editorWillUnmount={() => editorWillUnmount(code)}
             value={code}
             onBeforeChange={(_, __, value) => {

--- a/web/client/components/misc/toolbar/Toolbar.jsx
+++ b/web/client/components/misc/toolbar/Toolbar.jsx
@@ -18,7 +18,6 @@ import ToolbarButton from './ToolbarButton';
 * @param  {object[]} [buttons=[]] Array of buttons. Button objects support the following properties:
 *  - *visible*: true by default, set to `false` to make the button disappear
 *  - *Element*: a component to render instead of the ToolbarButton, it can be a DropdownToolbarOptions
-*  - *DirectElement*: a direct component to render instead of the ToolbarButton/ Element to prevent continious mount/unmount
 *  - All the react-bootstrap buttons properties.
 *  - All the properties for @see components.misc.enhancers
 *  - All properties for @see components.misc.toolbar.ToolbarButton and react-bootstrap button
@@ -36,8 +35,8 @@ export default ({
         transitionLeaveTimeout: 300
     }} = {}) => {
     const renderButtons = () => buttons.map(
-        ({ visible = true, Element, renderButton, DirectElement, ...props }, index) => visible
-            ? (renderButton ? renderButton : (Element && <Element key={props.key || index} {...props} /> || (DirectElement && DirectElement) || <ToolbarButton key={props.key || index} {...btnDefaultProps} {...props} />))
+        ({ visible = true, Element, renderButton, ...props }, index) => visible
+            ? (renderButton ? renderButton : (Element && <Element key={props.key || index} {...props} /> || <ToolbarButton key={props.key || index} {...btnDefaultProps} {...props} />))
             : null
     );
     return (<ButtonGroup {...btnGroupProps}>

--- a/web/client/components/misc/toolbar/Toolbar.jsx
+++ b/web/client/components/misc/toolbar/Toolbar.jsx
@@ -18,6 +18,7 @@ import ToolbarButton from './ToolbarButton';
 * @param  {object[]} [buttons=[]] Array of buttons. Button objects support the following properties:
 *  - *visible*: true by default, set to `false` to make the button disappear
 *  - *Element*: a component to render instead of the ToolbarButton, it can be a DropdownToolbarOptions
+*  - *DirectElement*: a direct component to render instead of the ToolbarButton/ Element to prevent continious mount/unmount
 *  - All the react-bootstrap buttons properties.
 *  - All the properties for @see components.misc.enhancers
 *  - All properties for @see components.misc.toolbar.ToolbarButton and react-bootstrap button
@@ -35,8 +36,8 @@ export default ({
         transitionLeaveTimeout: 300
     }} = {}) => {
     const renderButtons = () => buttons.map(
-        ({ visible = true, Element, renderButton, ...props }, index) => visible
-            ? (renderButton ? renderButton : (Element && <Element key={props.key || index} {...props} /> || <ToolbarButton key={props.key || index} {...btnDefaultProps} {...props} />))
+        ({ visible = true, Element, renderButton, DirectElement, ...props }, index) => visible
+            ? (renderButton ? renderButton : (Element && <Element key={props.key || index} {...props} /> || (DirectElement && DirectElement) || <ToolbarButton key={props.key || index} {...btnDefaultProps} {...props} />))
             : null
     );
     return (<ButtonGroup {...btnGroupProps}>

--- a/web/client/components/misc/toolbar/__tests__/Toolbar-test.jsx
+++ b/web/client/components/misc/toolbar/__tests__/Toolbar-test.jsx
@@ -9,7 +9,6 @@
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ClassificationLayerSettings from "../../../styleeditor/ClassificationLayerSettings";
 import Toolbar from '../Toolbar';
 
 describe("Toolbar component", () => {
@@ -69,24 +68,5 @@ describe("Toolbar component", () => {
         // this allows vertical toolbar with bootstrap css (animation group add internal span)
         const el = document.querySelector(".btn-group > button");
         expect(el).toExist();
-    });
-    it('creates component with buttons and defaultProps and these buttons include a direct React component', () => {
-        ReactDOM.render(<Toolbar key={"toolbar"} btnDefaultProps={{className: "TEST_CLASS"}} buttons={[{
-            id: "button",
-            tooltip: "hello",
-            text: "hello",
-            tooltipPosition: "right",
-            glyph: "plus"
-        }, {
-            visible: true,
-            DirectElement: <ClassificationLayerSettings onUpdate={() => {}} thematicCustomParams={{}} />
-        }]}/>, document.getElementById("container"));
-        const el = document.getElementsByClassName("btn-group");
-        expect(el).toExist();
-        const btn = document.getElementById("button");
-        expect(btn).toExist();
-        const cofBtn = document.querySelector(".square-button-md.no-border");
-        expect(cofBtn).toExist();
-        expect(document.getElementsByClassName("TEST_CLASS").length > 0).toBe(true);
     });
 });

--- a/web/client/components/misc/toolbar/__tests__/Toolbar-test.jsx
+++ b/web/client/components/misc/toolbar/__tests__/Toolbar-test.jsx
@@ -9,7 +9,7 @@
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
-
+import ClassificationLayerSettings from "../../../styleeditor/ClassificationLayerSettings";
 import Toolbar from '../Toolbar';
 
 describe("Toolbar component", () => {
@@ -69,5 +69,24 @@ describe("Toolbar component", () => {
         // this allows vertical toolbar with bootstrap css (animation group add internal span)
         const el = document.querySelector(".btn-group > button");
         expect(el).toExist();
+    });
+    it('creates component with buttons and defaultProps and these buttons include a direct React component', () => {
+        ReactDOM.render(<Toolbar key={"toolbar"} btnDefaultProps={{className: "TEST_CLASS"}} buttons={[{
+            id: "button",
+            tooltip: "hello",
+            text: "hello",
+            tooltipPosition: "right",
+            glyph: "plus"
+        }, {
+            visible: true,
+            DirectElement: <ClassificationLayerSettings onUpdate={() => {}} thematicCustomParams={{}} />
+        }]}/>, document.getElementById("container"));
+        const el = document.getElementsByClassName("btn-group");
+        expect(el).toExist();
+        const btn = document.getElementById("button");
+        expect(btn).toExist();
+        const cofBtn = document.querySelector(".square-button-md.no-border");
+        expect(cofBtn).toExist();
+        expect(document.getElementsByClassName("TEST_CLASS").length > 0).toBe(true);
     });
 });

--- a/web/client/components/styleeditor/ClassificationLayerSettings.jsx
+++ b/web/client/components/styleeditor/ClassificationLayerSettings.jsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState, memo } from 'react';
+import { Alert, Glyphicon } from 'react-bootstrap';
+import { compose, getContext } from 'recompose';
+import PropTypes from 'prop-types';
+
+import { ControlledPopover } from './Popover';
+import Toolbar from '../misc/toolbar/Toolbar';
+import tooltip from '../misc/enhancers/tooltip';
+import ButtonRB from '../misc/Button';
+import JSONEditor from '../misc/codeEditors/JSONEditor';
+import { isEqual } from 'lodash';
+import Message from '../I18N/Message';
+import {getMessageById} from '../../utils/LocaleUtils';
+
+const Button = tooltip(ButtonRB);
+
+const INITIAL_CODE_VALUE = {
+    "params": []
+};
+/**
+ * Component select the wellKnownName property of a Mark symbolizer
+ * @memberof components.styleeditor
+ * @name ClassificationLayerSettings
+ * @prop {string} value well know name or svg link
+ * @prop {function} onChange returns the updated value
+ * @prop {string} svgSymbolsPath path to symbols list (`index.json` or `symbol.json` endpoint)
+ */
+function ClassificationLayerSettings({
+    onUpdate,
+    thematicCustomParams,
+    messages
+}) {
+    const [open, setOpen] = useState(false);
+    const [isValidJson, setValid] = useState(true);
+    const [alert, setAlert] = useState(false);
+
+    const validateEnteredParams = (jsonParams) =>{
+        let valid = true;
+        jsonParams.params.forEach((item) => {
+            let isObject = typeof item === 'object';
+            let hasFieldProp = item?.field;
+            let hasValues = item?.values?.length && item?.values?.length >= 1;
+            let hasCorrectValues = hasValues ? item?.values.every(val => val?.value && val?.name) : false;
+            if (!(isObject && hasFieldProp && hasCorrectValues)) {
+                valid = false;
+            }
+        });
+        return valid;
+    };
+
+    // onValid handler: validate teh written json in run-time
+    const onValid = (config) => {
+        if (!config?.params?.length) return;
+        let isValid = validateEnteredParams(config);
+        if (!isValid) {
+            setValid(false);
+            throw new Error(getMessageById(messages, "styleeditor.wrongFormatMsg"));
+        } else {
+            !isValidJson && setValid(true);
+        }
+        return;
+    };
+    const onError = () => {
+        setValid(false);
+    };
+
+    // fired on editorWillUnmount
+    const saveChanges = (code) => {
+        try {
+            const config = JSON.parse(code);
+            let isValid = validateEnteredParams(config);
+            if (isValid) {
+
+                if (!isEqual(config, thematicCustomParams )) {
+                    onUpdate(config);
+                }
+                onValid(config);
+            } else return;
+        } catch (e) {
+            onError(e);
+            setAlert(true);
+        }
+    };
+
+
+    return (
+        <ControlledPopover
+            open={open}
+            onClick={() => {
+                // info: showing an alert if entered json not valid
+                if (isValidJson) setOpen(prev => !prev);
+                else setAlert(true);
+            }}
+            placement={'right'}
+            content={
+                <div style={{background: 'white', border: 'solid 3px gray'}}>
+                    <h4 style={{ margin: '0.5rem'}}>
+                        <Message msgId="styleeditor.customParams" />
+                    </h4>
+                    <div style={{
+                        position: 'relative',
+                        width: '450px',
+                        background: 'white'
+                    }}>
+                        <JSONEditor json={thematicCustomParams?.params ? thematicCustomParams : INITIAL_CODE_VALUE} editorWillUnmount={saveChanges} onValid={onValid} onError={onError} />
+                        {alert &&
+                        <div
+                            className="ms-style-editor-alert"
+                            style={{
+                                position: 'absolute',
+                                top: 0,
+                                left: 0,
+                                width: '100%',
+                                height: '100%',
+                                zIndex: 10,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                padding: 16,
+                                backgroundColor: 'rgba(0, 0, 0, 0.6)'
+                            }}>
+                            <Alert bsStyle="warning" style={{ textAlign: 'center' }}>
+                                <p style={{ padding: 8 }}><Message msgId="styleeditor.alertCustomParamsNotValid" /></p>
+                                <p>
+                                    <Toolbar
+                                        buttons={[
+                                            {
+                                                text: <Message msgId="styleeditor.stayInTextareaEditor" />,
+                                                onClick: () => {
+                                                    setAlert(false);
+                                                    setOpen(true);
+                                                },
+                                                style: { marginRight: 4 }
+                                            },
+                                            {
+                                                bsStyle: 'primary',
+                                                text: <Message msgId="styleeditor.closeCustomParamsEditor" />,
+                                                onClick: () => {
+                                                    setOpen(false);
+                                                    setValid(true);
+                                                    setAlert(false);
+                                                }
+                                            }
+                                        ]}
+                                    />
+                                </p>
+                            </Alert>
+                        </div>}
+                    </div>
+                </div>}
+        >
+            <Button
+                className="square-button-md no-border"
+                tooltipId="toc.thematic.go_to_cfg">
+                <Glyphicon
+                    glyph="cog"
+                />
+            </Button>
+        </ControlledPopover>
+    );
+}
+
+export default  compose(getContext({
+    messages: PropTypes.object
+}))(memo(ClassificationLayerSettings));

--- a/web/client/components/styleeditor/ClassificationLayerSettings.jsx
+++ b/web/client/components/styleeditor/ClassificationLayerSettings.jsx
@@ -144,7 +144,7 @@ function ClassificationLayerSettings({
         >
             <Button
                 className="square-button-md no-border"
-                tooltipId="toc.thematic.go_to_cfg">
+                tooltipId="toc.thematic.goToCfg">
                 <Glyphicon
                     glyph="cog"
                 />

--- a/web/client/components/styleeditor/ClassificationLayerSettings.jsx
+++ b/web/client/components/styleeditor/ClassificationLayerSettings.jsx
@@ -6,11 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, memo } from 'react';
+import React, { useState } from 'react';
 import { Alert, Glyphicon } from 'react-bootstrap';
-import { compose, getContext } from 'recompose';
-import PropTypes from 'prop-types';
-
 import { ControlledPopover } from './Popover';
 import Toolbar from '../misc/toolbar/Toolbar';
 import tooltip from '../misc/enhancers/tooltip';
@@ -26,18 +23,16 @@ const INITIAL_CODE_VALUE = {
     "params": []
 };
 /**
- * Component select the wellKnownName property of a Mark symbolizer
+ * Component to change the layer classification options
  * @memberof components.styleeditor
  * @name ClassificationLayerSettings
- * @prop {string} value well know name or svg link
- * @prop {function} onChange returns the updated value
- * @prop {string} svgSymbolsPath path to symbols list (`index.json` or `symbol.json` endpoint)
+ * @prop {object} thematicCustomParams parameters to update
+ * @prop {function} onUpdate returns the updated value
  */
 function ClassificationLayerSettings({
     onUpdate,
-    thematicCustomParams,
-    messages
-}) {
+    thematicCustomParams
+}, { messages }) {
     const [open, setOpen] = useState(false);
     const [isValidJson, setValid] = useState(true);
     const [alert, setAlert] = useState(false);
@@ -77,58 +72,49 @@ function ClassificationLayerSettings({
         try {
             const config = JSON.parse(code);
             let isValid = validateEnteredParams(config);
-            if (isValid) {
+            if (isValid && !isEqual(config, thematicCustomParams)) {
+                onUpdate(config);
+            }
+        } catch (e) { /**/ }
+    };
 
-                if (!isEqual(config, thematicCustomParams )) {
-                    onUpdate(config);
-                }
-                onValid(config);
-            } else return;
-        } catch (e) {
-            onError(e);
+    const onToggle = () => {
+        // info: showing an alert if entered json not valid
+        if (isValidJson) {
+            setOpen(prev => !prev);
+        } else {
             setAlert(true);
         }
     };
 
-
     return (
         <ControlledPopover
             open={open}
-            onClick={() => {
-                // info: showing an alert if entered json not valid
-                if (isValidJson) setOpen(prev => !prev);
-                else setAlert(true);
-            }}
+            onClick={() => onToggle()}
             placement={'right'}
             content={
-                <div style={{background: 'white', border: 'solid 3px gray'}}>
-                    <h4 style={{ margin: '0.5rem'}}>
+                <div className="ms-classification-layer-settings">
+                    <div className="ms-classification-layer-settings-title">
                         <Message msgId="styleeditor.customParams" />
-                    </h4>
-                    <div style={{
-                        position: 'relative',
-                        width: '450px',
-                        background: 'white'
-                    }}>
-                        <JSONEditor json={thematicCustomParams?.params ? thematicCustomParams : INITIAL_CODE_VALUE} editorWillUnmount={saveChanges} onValid={onValid} onError={onError} />
-                        {alert &&
-                        <div
-                            className="ms-style-editor-alert"
-                            style={{
-                                position: 'absolute',
-                                top: 0,
-                                left: 0,
-                                width: '100%',
-                                height: '100%',
-                                zIndex: 10,
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                padding: 16,
-                                backgroundColor: 'rgba(0, 0, 0, 0.6)'
-                            }}>
-                            <Alert bsStyle="warning" style={{ textAlign: 'center' }}>
-                                <p style={{ padding: 8 }}><Message msgId="styleeditor.alertCustomParamsNotValid" /></p>
+                        <Button
+                            className="square-button-md no-border"
+                            onClick={() => onToggle()}
+                        >
+                            <Glyphicon
+                                glyph="1-close"
+                            />
+                        </Button>
+                    </div>
+                    <JSONEditor
+                        json={thematicCustomParams?.params ? thematicCustomParams : INITIAL_CODE_VALUE}
+                        editorWillUnmount={saveChanges}
+                        onValid={onValid}
+                        onError={onError}
+                    />
+                    {alert &&
+                        <div className="ms-style-editor-alert">
+                            <Alert bsStyle="warning">
+                                <p><Message msgId="styleeditor.alertCustomParamsNotValid" /></p>
                                 <p>
                                     <Toolbar
                                         buttons={[
@@ -144,9 +130,9 @@ function ClassificationLayerSettings({
                                                 bsStyle: 'primary',
                                                 text: <Message msgId="styleeditor.closeCustomParamsEditor" />,
                                                 onClick: () => {
-                                                    setOpen(false);
                                                     setValid(true);
                                                     setAlert(false);
+                                                    setOpen(false);
                                                 }
                                             }
                                         ]}
@@ -154,7 +140,6 @@ function ClassificationLayerSettings({
                                 </p>
                             </Alert>
                         </div>}
-                    </div>
                 </div>}
         >
             <Button
@@ -168,6 +153,4 @@ function ClassificationLayerSettings({
     );
 }
 
-export default  compose(getContext({
-    messages: PropTypes.object
-}))(memo(ClassificationLayerSettings));
+export default ClassificationLayerSettings;

--- a/web/client/components/styleeditor/ClassificationLayerSettings.jsx
+++ b/web/client/components/styleeditor/ClassificationLayerSettings.jsx
@@ -31,7 +31,8 @@ const INITIAL_CODE_VALUE = {
  */
 function ClassificationLayerSettings({
     onUpdate,
-    thematicCustomParams
+    thematicCustomParams,
+    editorRef
 }, { messages }) {
     const [open, setOpen] = useState(false);
     const [isValidJson, setValid] = useState(true);
@@ -110,6 +111,7 @@ function ClassificationLayerSettings({
                         editorWillUnmount={saveChanges}
                         onValid={onValid}
                         onError={onError}
+                        editorRef={editorRef}
                     />
                     {alert &&
                         <div className="ms-style-editor-alert">

--- a/web/client/components/styleeditor/ClassificationSymbolizer.jsx
+++ b/web/client/components/styleeditor/ClassificationSymbolizer.jsx
@@ -30,9 +30,9 @@ function ClassificationSymbolizer({
     supportedSymbolizerMenuOptions,
     fonts,
     enableFieldExpression,
+    thematicCustomParamsProperty,           // property:  [ { YEAR: 2024 }, { MONTH: 5 } ]
     ...props
 }) {
-
     const {
         ramp,
         method,
@@ -42,7 +42,8 @@ function ClassificationSymbolizer({
         intervalsForUnique = config?.intervalsForUnique || 100,
         reverse,
         continuous,
-        format
+        format,
+        customParams        // customParams values: e.g: { YEAR: 2024, MONTH: 5 }
     } = props;
 
     // needed for slider
@@ -58,7 +59,8 @@ function ClassificationSymbolizer({
         reverse,
         ramp,
         continuous,
-        classification
+        classification,
+        customParams: customParams || {}
     };
 
     function handleColors() {
@@ -108,7 +110,8 @@ function ClassificationSymbolizer({
                     method,
                     methodEdit: props?.methodEdit,
                     fonts,
-                    enableFieldExpression
+                    enableFieldExpression,
+                    thematicCustomParams: thematicCustomParamsProperty
                 }}
                 params={mergedParams}
                 onChange={(values) => onUpdate({

--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -536,6 +536,54 @@ export const fields = {
                 />
             </PropertyField>
         );
+    },
+    customParams: (props) => {
+        const {
+            label,
+            value,
+            config: {
+                isValid
+            },
+            thematicCustomParams,
+            onChange
+        } = props;
+        if (!(thematicCustomParams?.length)) return null;         // if there is no params it will be hidden
+        const valid = !isValid || isValid({ value });
+        const handleCustomParamChange = (key, selectedVal) => {
+            onChange({
+                [key]: selectedVal
+            });
+        };
+        return (
+            <>
+                <div style={{width: '100%', borderTop: 'solid 2px grey', marginTop: '0.5rem'}}>
+                    <h5><strong><Message msgId={label} /> </strong></h5>
+                    <div>
+                        {thematicCustomParams?.map(param=>(
+                            <PropertyField
+                                label={param?.title || param?.field}
+                                invalid={!valid}>
+                                <SelectInput
+                                    {...props}
+                                    value={ value ? value[param?.field] : undefined}
+                                    onChange={(val)=>handleCustomParamChange(param.field, val)}
+                                    config={{...props.config, getOptions: () => {
+                                        return param?.values?.map(val => {
+                                            return {
+                                                labelId: val.value,
+                                                value: val.value,
+                                                label: val.name
+                                            };
+                                        });
+                                    }}}
+                                />
+                            </PropertyField>
+                        ))
+                        }
+                    </div>
+                </div>
+            </>
+        );
     }
 };
 

--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -547,30 +547,39 @@ export const fields = {
             thematicCustomParams,
             onChange
         } = props;
-        if (!(thematicCustomParams?.length)) return null;         // if there is no params it will be hidden
+        // if there is no params it will be hidden
+        if (!(thematicCustomParams?.length)) {
+            return null;
+        }
         const valid = !isValid || isValid({ value });
         const handleCustomParamChange = (key, selectedVal) => {
             onChange({
                 [key]: selectedVal
             });
         };
+
         return (
-            <>
-                <div style={{width: '100%', borderTop: 'solid 2px grey', marginTop: '0.5rem'}}>
-                    <h5><strong><Message msgId={label} /> </strong></h5>
-                    <div>
-                        {thematicCustomParams?.map(param=>(
+            <div style={{ width: '100%' }}>
+                <hr />
+                <div className="ms-symbolizer-field"><Message msgId={label} /></div>
+                <div>
+                    {thematicCustomParams?.map(param=> {
+                        const currentValue = value ? value[param?.field] : undefined;
+                        const valueObj = param?.values?.find(val => val.value === currentValue);
+                        return (
                             <PropertyField
+                                key={param?.field}
                                 label={param?.title || param?.field}
                                 invalid={!valid}>
                                 <SelectInput
                                     {...props}
-                                    value={ value ? value[param?.field] : undefined}
-                                    onChange={(val)=>handleCustomParamChange(param.field, val)}
+                                    value={valueObj?.value
+                                        ? { value: valueObj.value, label: valueObj.name ?? valueObj.value }
+                                        : currentValue }
+                                    onChange={(val)=> handleCustomParamChange(param.field, val)}
                                     config={{...props.config, getOptions: () => {
                                         return param?.values?.map(val => {
                                             return {
-                                                labelId: val.value,
                                                 value: val.value,
                                                 label: val.name
                                             };
@@ -578,11 +587,11 @@ export const fields = {
                                     }}}
                                 />
                             </PropertyField>
-                        ))
-                        }
-                    </div>
+                        );
+                    })}
                 </div>
-            </>
+                <hr />
+            </div>
         );
     }
 };

--- a/web/client/components/styleeditor/RulesEditor.jsx
+++ b/web/client/components/styleeditor/RulesEditor.jsx
@@ -99,7 +99,8 @@ const RulesEditor = forwardRef(({
         svgSymbolsPath,
         lineDashOptions,
         supportedSymbolizerMenuOptions,
-        enableFieldExpression
+        enableFieldExpression,
+        thematicCustomParams            // layer.thematic.params in layers state
     } = config;
 
     // needed for slider
@@ -373,6 +374,7 @@ const RulesEditor = forwardRef(({
                                     onReplace={handleReplaceRule}
                                     format={format}
                                     enableFieldExpression={enableFieldExpression}
+                                    thematicCustomParamsProperty={thematicCustomParams}     // layer.thematic.params in layers state
                                 />
                                 : symbolizers.map(({ kind = '', symbolizerId, ...properties }) => {
                                     const { params, glyph, hideMenu } = getSymbolizerInfo(kind);

--- a/web/client/components/styleeditor/SelectInput.jsx
+++ b/web/client/components/styleeditor/SelectInput.jsx
@@ -91,7 +91,7 @@ function SelectInput({
                         : undefined);
                 }
                 setNewOptions(updateOptions(newOptions, option));
-                return onChange(option.value);
+                return onChange(option?.value);
             }}
         />
     );

--- a/web/client/components/styleeditor/VisualStyleEditor.jsx
+++ b/web/client/components/styleeditor/VisualStyleEditor.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useRef, useReducer, useState } from 'react';
+import React, { useEffect, useRef, useReducer, useState, memo } from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
 import find from 'lodash/find';
@@ -29,6 +29,7 @@ import undoable from 'redux-undo';
 
 import InfoPopover from '../widgets/widget/InfoPopover';
 import Message from '../I18N/Message';
+import ClassificationLayerSettings from './ClassificationLayerSettings';
 
 const UPDATE_STYLE = 'UPDATE_STYLE';
 const UNDO_STYLE = 'UNDO_STYLE';
@@ -172,7 +173,8 @@ function VisualStyleEditor({
     debounceTime,
     styleService,
     exactMatchGeometrySymbol,
-    enable3dStyleOptions
+    enable3dStyleOptions,
+    onUpdateNode
 }) {
     const { symbolizerBlock, ruleBlock } = getBlocks({ exactMatchGeometrySymbol, enable3dStyleOptions });
     const [updating, setUpdating] = useState(false);
@@ -304,6 +306,14 @@ function VisualStyleEditor({
                             onClick: () => dispatch({ type: REDO_STYLE })
                         },
                         {
+                            visible: !!find(state.current?.style?.rules, ({ kind }) => (kind === 'Classification')),
+                            DirectElement: (<ClassificationLayerSettings thematicCustomParams={layer?.thematic} onUpdate={(params) => {
+                                onUpdateNode(layer.id, "layers", {thematic: {
+                                    ...params
+                                }});
+                            }} />)
+                        },
+                        {
                             visible: !!error,
                             Element: () => <div
                                 className="square-button-md"
@@ -356,6 +366,7 @@ function VisualStyleEditor({
                 methods,
                 getColors,
                 format,
+                thematicCustomParams: layer?.thematic?.params,      // layer.thematic.params in layers state
                 ...config
             }}
             // reverse rules order to show top rendered style
@@ -404,7 +415,8 @@ VisualStyleEditor.propTypes = {
     methods: PropTypes.array,
     getColors: PropTypes.func,
     styleUpdateTypes: PropTypes.object,
-    debounceTime: PropTypes.number
+    debounceTime: PropTypes.number,
+    onUpdateNode: PropTypes.func
 };
 
 VisualStyleEditor.defaultProps = {
@@ -414,7 +426,8 @@ VisualStyleEditor.defaultProps = {
     getColors: () => {},
     styleUpdateTypes: {},
     debounceTime: 300,
-    defaultStyleJSON: null
+    defaultStyleJSON: null,
+    onUpdateNode: () => {}
 };
 
-export default VisualStyleEditor;
+export default memo(VisualStyleEditor);

--- a/web/client/components/styleeditor/VisualStyleEditor.jsx
+++ b/web/client/components/styleeditor/VisualStyleEditor.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useRef, useReducer, useState, memo } from 'react';
+import React, { useEffect, useRef, useReducer, useState } from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
 import find from 'lodash/find';
@@ -306,12 +306,14 @@ function VisualStyleEditor({
                             onClick: () => dispatch({ type: REDO_STYLE })
                         },
                         {
-                            visible: !!find(state.current?.style?.rules, ({ kind }) => (kind === 'Classification')),
-                            DirectElement: (<ClassificationLayerSettings thematicCustomParams={layer?.thematic} onUpdate={(params) => {
+                            visible: ['wms'].includes(layer?.type) && !!find(state.current?.style?.rules, ({ kind }) => (kind === 'Classification')),
+                            thematicCustomParams: layer?.thematic,
+                            onUpdate: (params) => {
                                 onUpdateNode(layer.id, "layers", {thematic: {
                                     ...params
                                 }});
-                            }} />)
+                            },
+                            Element: ClassificationLayerSettings
                         },
                         {
                             visible: !!error,
@@ -430,4 +432,4 @@ VisualStyleEditor.defaultProps = {
     onUpdateNode: () => {}
 };
 
-export default memo(VisualStyleEditor);
+export default VisualStyleEditor;

--- a/web/client/components/styleeditor/__tests__/ClassificationLayerSettings-test.jsx
+++ b/web/client/components/styleeditor/__tests__/ClassificationLayerSettings-test.jsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+import ReactDOM from 'react-dom';
+import ClassificationLayerSettings from '../ClassificationLayerSettings';
+import { Simulate, act } from 'react-dom/test-utils';
+import expect from 'expect';
+import { waitFor } from '@testing-library/dom';
+
+describe('ClassificationLayerSettings', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render with default', () => {
+        ReactDOM.render(<ClassificationLayerSettings />, document.getElementById("container"));
+        const button = document.querySelector('button');
+        const settings = document.querySelector('.ms-classification-layer-settings');
+        expect(button).toBeTruthy();
+        expect(settings).toBeFalsy();
+    });
+    it('should open popover on click', () => {
+        ReactDOM.render(<ClassificationLayerSettings />, document.getElementById("container"));
+        const button = document.querySelector('button');
+        expect(button).toBeTruthy();
+        Simulate.click(button);
+        const settings = document.querySelector('.ms-classification-layer-settings');
+        expect(settings).toBeTruthy();
+    });
+    it('should prevent close when params are invalid', (done) => {
+        act(() => {
+            ReactDOM.render(
+                <ClassificationLayerSettings
+                    editorRef={(ref) => {
+                        if (ref?.editor) {
+                            expect(ref.editor.doc).toBeTruthy();
+                            ref.editor.setValue('params: [');
+                            waitFor(() => document.querySelector('.error-area'))
+                                .then(() => {
+                                    const settings = document.querySelector('.ms-classification-layer-settings');
+                                    const button = settings.querySelector('button');
+                                    Simulate.click(button);
+                                    const alert = document.querySelector('.ms-style-editor-alert');
+                                    expect(alert).toBeTruthy();
+                                    done();
+                                });
+                        }
+                    }}
+                />, document.getElementById("container"));
+        });
+        const button = document.querySelector('button');
+        expect(button).toBeTruthy();
+        Simulate.click(button);
+        const settings = document.querySelector('.ms-classification-layer-settings');
+        expect(settings).toBeTruthy();
+    });
+});

--- a/web/client/components/styleeditor/__tests__/RulesEditor-test.jsx
+++ b/web/client/components/styleeditor/__tests__/RulesEditor-test.jsx
@@ -350,8 +350,7 @@ describe('RulesEditor', () => {
         const ruleHeadButtonNodes = ruleHeadNode.querySelectorAll('button');
         expect([...ruleHeadButtonNodes].map(btn => btn.children[0].getAttribute('class'))).toEqual([
             'glyphicon glyphicon-next',
-            'glyphicon glyphicon-trash',
-            'glyphicon glyphicon-cog'
+            'glyphicon glyphicon-trash'
         ]);
 
         const symbolizersNode = rulesNode[0].querySelectorAll('.ms-symbolizer');

--- a/web/client/components/styleeditor/__tests__/RulesEditor-test.jsx
+++ b/web/client/components/styleeditor/__tests__/RulesEditor-test.jsx
@@ -350,7 +350,8 @@ describe('RulesEditor', () => {
         const ruleHeadButtonNodes = ruleHeadNode.querySelectorAll('button');
         expect([...ruleHeadButtonNodes].map(btn => btn.children[0].getAttribute('class'))).toEqual([
             'glyphicon glyphicon-next',
-            'glyphicon glyphicon-trash'
+            'glyphicon glyphicon-trash',
+            'glyphicon glyphicon-cog'
         ]);
 
         const symbolizersNode = rulesNode[0].querySelectorAll('.ms-symbolizer');

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -938,8 +938,7 @@ const getBlocks = ({
                     customParams: property.customParams({
                         key: 'customParams',
                         label: 'styleeditor.customParams',
-                        disablePropertySelection: true,
-                        isValid: ({ value }) => value !== undefined
+                        disablePropertySelection: true
                     }),
                     classification: property.colorMap({
                         key: 'classification',

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -935,6 +935,12 @@ const getBlocks = ({
                     }
                 },
                 {
+                    customParams: property.customParams({
+                        key: 'customParams',
+                        label: 'styleeditor.customParams',
+                        disablePropertySelection: true,
+                        isValid: ({ value }) => value !== undefined
+                    }),
                     classification: property.colorMap({
                         key: 'classification',
                         rampKey: 'ramp'

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -935,8 +935,8 @@ const getBlocks = ({
                     }
                 },
                 {
-                    customParams: property.customParams({
-                        key: 'customParams',
+                    msViewParams: property.customParams({
+                        key: 'msViewParams',
                         label: 'styleeditor.customParams',
                         disablePropertySelection: true
                     }),

--- a/web/client/components/styleeditor/config/property.js
+++ b/web/client/components/styleeditor/config/property.js
@@ -547,7 +547,28 @@ const property = {
                 contrastEnhancement: value.contrastEnhancement
             };
         }
-    })
+    }),
+    customParams: ({ label, key = '', getOptions = () => [], selectProps, isValid, isDisabled, isVisible, setValue, getValue, disablePropertySelection }) => {
+        return ({
+            type: 'customParams',
+            valueType: 'string',
+            label,
+            config: {
+                getOptions,
+                selectProps: { ...selectProps, clearable: true},
+                isValid,
+                disablePropertySelection
+            },
+            getValue: getValue ? getValue : (value, props) => {
+                return {
+                    [key]: {...(props[key] || {}), ...value}
+                };
+            },
+            isDisabled,
+            isVisible,
+            setValue
+        });
+    }
 };
 
 export default property;

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -347,13 +347,13 @@ export const toggleStyleEditorEpic = (action$, store) =>
  */
 export const updateLayerOnStatusChangeEpic = (action$, store) =>
     action$.ofType(UPDATE_STATUS)
-        .filter(({ status }) => !!status)
         .switchMap((action) => {
-
             const state = store.getState();
-
             const layer = getUpdatedLayer(state);
-
+            if (!action.status) {
+                // incase of canceling edit mode, reset layer.thematic object
+                return Rx.Observable.of(updateNode(layer.id, 'layers', {thematic: {}}));
+            }
             const query = layer && layer.params || {};
             const describeAction = layer && !layer.describeFeatureType && getDescribeLayer(layer.url, layer, { query });
             const selectedStyle = selectedStyleSelector(state);
@@ -385,6 +385,7 @@ export const updateLayerOnStatusChangeEpic = (action$, store) =>
                 baseUrl
             });
         });
+
 /**
  * Gets every `SELECT_STYLE_TEMPLATE`, `EDIT_STYLE_CODE` events.
  * Creates/Updates a temporary style used to preview templates or edits of style code.

--- a/web/client/plugins/styleeditor/StyleCodeEditor.jsx
+++ b/web/client/plugins/styleeditor/StyleCodeEditor.jsx
@@ -18,6 +18,7 @@ import {
     errorStyle,
     updateEditorMetadata
 } from '../../actions/styleeditor';
+import { updateNode } from '../../actions/layers';
 import SLDService from '../../api/SLDService';
 import {
     classificationRaster,
@@ -143,7 +144,6 @@ export function StyleEditor({
     editors: editorsProp = [],
     ...props
 }) {
-
     const [alert, setAlert] = useState();
 
     const centeredChildStyle = {
@@ -308,7 +308,8 @@ const StyleCodeEditor = connect(
     ),
     {
         onUpdateMetadata: updateEditorMetadata,
-        onChange: editStyleCode
+        onChange: editStyleCode,
+        onUpdateNode: updateNode
     }
 )(StyleEditor);
 

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -159,7 +159,7 @@ export const StyleToolbar = compose(
                 selectedStyleFormatSelector,
                 getSelectedLayer
             ],
-            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit, { defaultStyle }, { formats = [ 'sld' ] } = {}, format, layerId) => ({
+            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit, { defaultStyle }, { formats = [ 'sld' ] } = {}, format) => ({
                 status,
                 templateId,
                 error,
@@ -169,8 +169,7 @@ export const StyleToolbar = compose(
                 selectedStyle: defaultStyle === selectedStyle ? '' : selectedStyle,
                 editEnabled: canEdit,
                 // enable edit only if service support current format
-                disableCodeEditing: formats.indexOf(format) === -1,
-                layerId
+                disableCodeEditing: formats.indexOf(format) === -1
             })
         ),
         {

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -48,6 +48,7 @@ import {
     styleServiceSelector,
     templateIdSelector
 } from '../../selectors/styleeditor';
+import {getSelectedLayer } from "../../selectors/layers";
 import {
     STYLE_OWNER_NAME,
     getStyleTemplates
@@ -155,9 +156,10 @@ export const StyleToolbar = compose(
                 canEditStyleSelector,
                 getAllStyles,
                 styleServiceSelector,
-                selectedStyleFormatSelector
+                selectedStyleFormatSelector,
+                getSelectedLayer
             ],
-            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit, { defaultStyle }, { formats = [ 'sld' ] } = {}, format) => ({
+            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit, { defaultStyle }, { formats = [ 'sld' ] } = {}, format, layerId) => ({
                 status,
                 templateId,
                 error,
@@ -167,7 +169,8 @@ export const StyleToolbar = compose(
                 selectedStyle: defaultStyle === selectedStyle ? '' : selectedStyle,
                 editEnabled: canEdit,
                 // enable edit only if service support current format
-                disableCodeEditing: formats.indexOf(format) === -1
+                disableCodeEditing: formats.indexOf(format) === -1,
+                layerId
             })
         ),
         {

--- a/web/client/themes/default/less/style-editor.less
+++ b/web/client/themes/default/less/style-editor.less
@@ -146,6 +146,10 @@
     .ms-rule-collapse * {
         .color-var(@theme-vars[main-color]);
     }
+    .ms-classification-layer-settings {
+        .color-var(@theme-vars[main-color]);
+        .background-color-var(@theme-vars[main-bg]);
+    }
 }
 
 // **************
@@ -791,5 +795,42 @@ Ported to CodeMirror by Peter Kroon
     svg {
         width: 16px;
         height: 16px;
+    }
+}
+
+.ms-classification-layer-settings {
+    display: flex;
+    flex-direction: column;
+    width: 450px;
+    height: 450px;
+    .shadow();
+    .ms-classification-layer-settings-title {
+        display: flex;
+        padding: 8px;
+        > span {
+            flex: 1;
+        }
+    }
+    .code-editor {
+        flex: 1;
+        width: 100%;
+        height: 100%;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        .react-codemirror2 {
+            flex: 1;
+            width: 100%;
+            height: 100%;
+            position: relative;
+        }
+        .CodeMirror {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+        }
+    }
+    .alert {
+        margin: 0;
     }
 }

--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -655,7 +655,7 @@
         "configuration": "Configuration",
         "apply": "Apply classification",
         "restore": "Reset customizations",
-        "go_to_cfg": "Configure...",
+        "goToCfg": "Configure...",
         "go_to_thema": "Use this configuration",
         "cfgError": "Error in configuration JSON",
         "classify": "Classify",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2675,7 +2675,8 @@
             "msExtrusionColor": "Extrusionsfarbe",
             "msExtrusionType": "Extrusionstyp",
             "wall": "Wand",
-            "customParams": "Benutzerdefinierte Parameter"
+            "customParams": "Benutzerdefinierte Parameter",
+            "wrongFormatMsg": "Die eingegebene Konfiguration ist in falschem Format !!"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -719,7 +719,7 @@
                 "configuration": "Konfiguration",
                 "apply": "Klassifizierung anwenden",
                 "restore": "Anpassungen zurücksetzen",
-                "go_to_cfg": "Konfigurieren...",
+                "goToCfg": "Konfigurieren...",
                 "go_to_thema": "Verwenden Sie diese Konfiguration",
                 "cfgError": "Fehler in der Konfigurations-JSON",
                 "classify": "Klassifizieren",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2595,6 +2595,8 @@
             "alertForceTranslate": "Sie verlieren alle im Code-Editor gemachten Änderungen, wenn Sie zum visuellen Editor wechseln. Sind Sie sicher, dass Sie zum visuellen Stil-Editor wechseln?",
             "stayInTextareaEditor": "Nein, weiter im Code-Editor",
             "useLatestValidStyle": "Ja, zum visuellen Editor wechseln",
+            "alertCustomParamsNotValid": "Sie verlieren alle im Textmodus hinzugefügten Änderungen, indem Sie den benutzerdefinierten Params -Editor schließen. Sind Sie sicher, den Herausgeber zu schließen?",
+            "closeCustomParamsEditor": "Ja, schließen Sie den Herausgeber",
             "validationError": "Validierungsfehler",
             "incorrectPropertyInputError": "Dies liegt wahrscheinlich an einem fehlenden oder ungültigen Wert in den Eigenschaftseingaben des Stileditors.",
             "emptyRuleEditorTitle": "Neue Regeln hinzufügen",
@@ -2672,7 +2674,8 @@
             "msExtrudedHeight": "Extrudierte Höhe",
             "msExtrusionColor": "Extrusionsfarbe",
             "msExtrusionType": "Extrusionstyp",
-            "wall": "Wand"
+            "wall": "Wand",
+            "customParams": "Benutzerdefinierte Parameter"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2566,6 +2566,8 @@
             "alertForceTranslate": "You will lose all the changes added in the text mode by switching to visual editor. Are you sure to switch to visual style editor mode?",
             "stayInTextareaEditor": "No, continue with text editor",
             "useLatestValidStyle": "Yes, switch to visual editor",
+            "alertCustomParamsNotValid": "You will lose all the changes added in the text mode by closing the custom params editor. Are you sure to close the editor?",
+            "closeCustomParamsEditor": "Yes, close the editor",
             "validationError": "Validation error",
             "incorrectPropertyInputError": "This is probably due to missing or invalid value in the property inputs of the style editor.",
 
@@ -2644,7 +2646,9 @@
             "msExtrudedHeight": "Extruded height",
             "msExtrusionColor": "Extrusion color",
             "msExtrusionType": "Extrusion type",
-            "wall": "Wall"
+            "wall": "Wall",
+            "customParams": "Custom Parameters",
+            "wrongFormatMsg": "The entered configration is in wrong format !!"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -680,7 +680,7 @@
                 "configuration": "Configuration",
                 "apply": "Apply classification",
                 "restore": "Reset customizations",
-                "go_to_cfg": "Configure...",
+                "goToCfg": "Configure...",
                 "go_to_thema": "Use this configuration",
                 "cfgError": "Error in configuration JSON",
                 "classify": "Classify",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2648,7 +2648,7 @@
             "msExtrusionType": "Extrusion type",
             "wall": "Wall",
             "customParams": "Custom Parameters",
-            "wrongFormatMsg": "The entered configration is in wrong format !!"
+            "wrongFormatMsg": "The entered configuration is in wrong format !!"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2637,7 +2637,8 @@
             "msExtrusionColor": "Color de extrusión",
             "msExtrusionType": "Tipo de extrusión",
             "wall": "Muro",
-            "customParams": "Parámetros personalizados"
+            "customParams": "Parámetros personalizados",
+            "wrongFormatMsg": "¡La configuración ingresada está en formato incorrecto!"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2557,6 +2557,8 @@
             "alertForceTranslate": "Perderá todos los cambios agregados en el texto al cambiar al editor visual. ¿Está seguro de cambiar al modo editor de estilo visual?",
             "stayInTextareaEditor": "No, continuar en textarea",
             "useLatestValidStyle": "Sí, cambie al editor visual",
+            "alertCustomParamsNotValid": "Perderá todos los cambios agregados en el modo de texto cerrando el editor de parámetros personalizados. ¿Estás seguro de cerrar el editor?",
+            "closeCustomParamsEditor": "Sí, cierre el editor",
             "validationError": "Error de validación",
             "incorrectPropertyInputError": "Esto probablemente se deba a un valor faltante o no válido en las entradas de propiedad del editor de estilos",
             "emptyRuleEditorTitle": "Agregar nuevas reglas",
@@ -2634,7 +2636,8 @@
             "msExtrudedHeight": "Altura extruida",
             "msExtrusionColor": "Color de extrusión",
             "msExtrusionType": "Tipo de extrusión",
-            "wall": "Muro"
+            "wall": "Muro",
+            "customParams": "Parámetros personalizados"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -680,7 +680,7 @@
                 "configuration": "Configuración",
                 "apply": "Aplicar clasificación",
                 "restore": "Restablecer personalizaciones",
-                "go_to_cfg": "Configurar ...",
+                "goToCfg": "Configurar ...",
                 "go_to_thema": "Utilizar esta configuración",
                 "cfgError": "Error en la configuración JSON",
                 "classify": "Clasificar",

--- a/web/client/translations/data.fi-FI.json
+++ b/web/client/translations/data.fi-FI.json
@@ -490,7 +490,7 @@
         "configuration": "Kokoonpano",
         "apply": "Käytä luokitusta",
         "restore": "Palauta mukautukset",
-        "go_to_cfg": "Määritä...",
+        "goToCfg": "Määritä...",
         "go_to_thema": "Käytä tätä kokoonpanoa",
         "cfgError": "Virhe JSON-asetuksissa",
         "classify": "Luokittele",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -680,7 +680,7 @@
                 "configuration": "Configuration",
                 "apply": "Appliquer la classification",
                 "restore": "Réinitialiser les personnalisations",
-                "go_to_cfg": "Configurer...",
+                "goToCfg": "Configurer...",
                 "go_to_thema": "Utilisez cette configuration",
                 "cfgError": "Erreur dans la configuration JSON",
                 "classify": "Classer",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2557,6 +2557,8 @@
             "alertForceTranslate": "Vous perdrez toutes les modifications ajoutées dans le texte en passant à l'éditeur visuel. Êtes-vous sûr de passer en mode éditeur de style visuel?",
             "stayInTextareaEditor": "Non, continuez dans la zone de texte",
             "useLatestValidStyle": "Oui, passez à l'éditeur visuel",
+            "alertCustomParamsNotValid": "Vous perdrez toutes les modifications ajoutées en mode texte en fermant l'éditeur de paramètres personnalisés. Êtes-vous sûr de fermer l'éditeur?",
+            "closeCustomParamsEditor": "Oui, fermez l'éditeur",
             "validationError": "Erreur de validation",
             "incorrectPropertyInputError": "Ceci est probablement dû à une valeur manquante ou non valide dans les entrées de propriétés de l'éditeur de style.",
             "emptyRuleEditorTitle": "Ajouter de nouvelles règles",
@@ -2634,7 +2636,8 @@
             "msExtrudedHeight": "Hauteur extrudée",
             "msExtrusionColor": "Couleur d'extrusion",
             "msExtrusionType": "Type d'extrusion",
-            "wall": "Mur"
+            "wall": "Mur",
+            "customParams": "Paramètres personnalisés"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2637,7 +2637,8 @@
             "msExtrusionColor": "Couleur d'extrusion",
             "msExtrusionType": "Type d'extrusion",
             "wall": "Mur",
-            "customParams": "Paramètres personnalisés"
+            "customParams": "Paramètres personnalisés",
+            "wrongFormatMsg": "La configuration entrée est en mauvais format !!"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.hr-HR.json
+++ b/web/client/translations/data.hr-HR.json
@@ -474,7 +474,7 @@
                 "configuration": "Prilagodba",
                 "apply": "Primijeni klasifikaciju",
                 "restore": "Reset prilagodbe",
-                "go_to_cfg": "Prilagodi...",
+                "goToCfg": "Prilagodi...",
                 "go_to_thema": "Koristi ovu prilagodbu",
                 "cfgError": "Greška u konfiguracijskom JSON-u",
                 "classify": "Klasificiraj",

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -655,7 +655,7 @@
         "configuration": "Configuration",
         "apply": "Apply classification",
         "restore": "Reset customizations",
-        "go_to_cfg": "Configure...",
+        "goToCfg": "Configure...",
         "go_to_thema": "Use this configuration",
         "cfgError": "Error in configuration JSON",
         "classify": "Classify",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2638,7 +2638,8 @@
             "msExtrusionColor": "Colore estrusione",
             "msExtrusionType": "Tipo estrusione",
             "wall": "Muro",
-            "customParams": "Parametri personalizzati"
+            "customParams": "Parametri personalizzati",
+            "wrongFormatMsg": "La configurazione immessa è in formato sbagliato !!"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2558,6 +2558,8 @@
             "alertForceTranslate": "Passando all'editor visuale perderai tutte le modifiche applicate con l'editor testuale. Sei sicuro di passare alla modalità editor visuale?",
             "stayInTextareaEditor": "No, continua con l'editor testuale",
             "useLatestValidStyle": "Sì, passa all'editor visuale",
+            "alertCustomParamsNotValid": "Perderai tutte le modifiche aggiunte nella modalità di testo chiudendo l'editor parametri personalizzati. Sei sicuro di chiudere l'editor?",
+            "closeCustomParamsEditor": "Sì, chiudi l'editore",
             "validationError": "Errore di validazione",
             "incorrectPropertyInputError": "Questo è probabilmente dovuto ad un valore mancante o non valido negli input delle proprietà dell'editor di stile.",
             "emptyRuleEditorTitle": "Aggiungi nuove regole",
@@ -2635,7 +2637,8 @@
             "msExtrudedHeight": "Altezza estrusa",
             "msExtrusionColor": "Colore estrusione",
             "msExtrusionType": "Tipo estrusione",
-            "wall": "Muro"
+            "wall": "Muro",
+            "customParams": "Parametri personalizzati"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -680,7 +680,7 @@
                 "configuration": "Configurazione",
                 "apply": "Applicare la classificazione",
                 "restore": "Annulla le personalizzazioni",
-                "go_to_cfg": "Configura ...",
+                "goToCfg": "Configura ...",
                 "go_to_thema": "Usa questa configurazione",
                 "cfgError": "Errore nella configurazione JSON",
                 "classify": "Classificazione",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -678,7 +678,7 @@
                 "configuration": "Configuratie",
                 "apply": "Classificatie toepassen",
                 "restore": "Reset aanpassingen",
-                "go_to_cfg": "Configureren...",
+                "goToCfg": "Configureren...",
                 "go_to_thema": "Gebruik deze configuratie",
                 "cfgError": "Fout in JSON configuratie",
                 "classify": "Classificeren",

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -465,7 +465,7 @@
                 "configuration": "Configuração",
                 "apply": "Aplicar classificação",
                 "restore": "Reverter costumizações",
-                "go_to_cfg": "Configurar...",
+                "goToCfg": "Configurar...",
                 "go_to_thema": "Utilizar esta configuração",
                 "cfgError": "Erro na configuração JSON",
                 "classify": "Classificar",

--- a/web/client/translations/data.sk-SK.json
+++ b/web/client/translations/data.sk-SK.json
@@ -621,7 +621,7 @@
                 "configuration": "Konfigurácia",
                 "apply": "Použiť konfiguráciu",
                 "restore": "Obnoviť prispôsobenie",
-                "go_to_cfg": "Konfigurujem...",
+                "goToCfg": "Konfigurujem...",
                 "go_to_thema": "Použiť túto konfiguráciu",
                 "cfgError": "Chyba v konfigurácii JSON",
                 "classify": "Klasifikovať",

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -591,7 +591,7 @@
                 "configuration": "Konfiguration",
                 "apply": "Tillämpa klassificering",
                 "restore": "Återställ anpassningar",
-                "go_to_cfg": "Konfigurera ...",
+                "goToCfg": "Konfigurera ...",
                 "go_to_thema": "Använd den här konfigurationen",
                 "cfgError": "Fel i konfigurationen JSON",
                 "classify": "Klassificera",

--- a/web/client/translations/data.vi-VN.json
+++ b/web/client/translations/data.vi-VN.json
@@ -1504,7 +1504,7 @@
                 "configuration": "Cấu hình",
                 "data_panel": "Dữ liệu",
                 "fields_error": "Lỗi khi tải danh sách các trường: {message}",
-                "go_to_cfg": "Cấu hình",
+                "goToCfg": "Cấu hình",
                 "go_to_thema": "Sử dụng cấu hình này",
                 "interval_limit": "Các khoảng nên là một số trong khoảng từ {min} đến {max}",
                 "invalid_classes": "Tối đa phải lớn hơn tối thiểu trong mỗi lớp",

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -444,7 +444,7 @@
                 "configuration": "Configuration",
                 "apply": "Apply classification",
                 "restore": "Reset customizations",
-                "go_to_cfg": "Configure...",
+                "goToCfg": "Configure...",
                 "go_to_thema": "Use this configuration",
                 "cfgError": "Error in configuration JSON",
                 "classify": "Classify",


### PR DESCRIPTION
## Description
In this PR, these following points are handled: 
- Integration thematic layer logic into visual style editor by adding cog icon into classification style rule to enable user to enter custom parameters
- Integrate the view parameters configuration UI component in the visual style editor and showing the entered custom parameters above the color palette.
- When a user selects one of this input custom parameters the associated view parameter is included in the classify.json request to the SLD service.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

**What is the current behavior?**
#9916 

**What is the new behavior?**
Enable adding custom parameters into classification style rule for vector classification like using the thematic property.
The thematic property provides an array of fields where each one represents a select input, once a user selects one of this input the associated view parameter is included in the classify.json request to the SLD service.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

Removing the thematic layer is not implemented yet until finishing the complete review.
