### PR TITLE
#9830: fix mardown linting error in DEV build due to web-ifc files in dist folder (fix_9830)

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,4 @@
 .github
 node_modules
 product
+web/client/dist


### PR DESCRIPTION
## Description
- Add the path of dist of client build into .markdownlintignore to ignore lint error in build process

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: add dist path into '.markdownlintignore' file

## Issue
#9830 

**What is the current behavior?**
#9830 

**What is the new behavior?**
Now, there is no error occurred for markdown linting in build process.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

