### PR TITLE
9980 bugfix login collides with user guide

### DIFF
--- a/web/client/components/tutorial/Tutorial.jsx
+++ b/web/client/components/tutorial/Tutorial.jsx
@@ -97,7 +97,7 @@ class Tutorial extends React.Component {
         steps: [],
         run: true,
         autoStart: true,
-        keyboardNavigation: true,
+        keyboardNavigation: false,
         resizeDebounce: false,
         resizeDebounceDelay: 200,
         holePadding: 0,


### PR DESCRIPTION
## Description
Before this merge the tutorial was configured to be forwarded by mouse click or enterkey.
When someone logged in and finished the login with press on the enterkey, the tutorial would automatically be forwarded to the second step, which was quite irritating for new users.
With this merge request the configuration will be changed, so that the tutorial can only be used with the mouse but on the other hand new users are not irritated by a tutorial that steps forward without the user's will.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [-] Tests for the changes have been added (for bug fixes / features) (too small for an own test)
- [-] Docs have been added / updated (for bug fixes / features) (no docs for the map tutorial)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#9980

**What is the new behavior?**
The tutorial can only be forwarded by mouseclick. So, when a user finishes his login by pressing the enter key the tutorial will stay on the introduction step.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
Bugfix on behalf of DB Systel GmbH