### PR TITLE
#9995: Fix features with no visibility prop when using print tool

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -545,7 +545,7 @@ export default {
                         return !background;
                     };
                     filterAnnotationFeaturesByVisibility = (layer) => {
-                        return {...layer, ...(!isNil(layer.features) ? {features: layer.features?.filter(ft => ft?.properties?.visibility)} : {})};
+                        return {...layer, ...(!isNil(layer.features) ? {features: layer.features?.filter(ft => isNil(ft?.properties?.visibility) ? true : ft?.properties?.visibility)} : {})};
                     }
                     filterLayers = (layers, zoom, projection) => {
                         const resolution = this.getPreviewResolution(zoom, projection);

--- a/web/client/plugins/__tests__/Print-test.jsx
+++ b/web/client/plugins/__tests__/Print-test.jsx
@@ -522,4 +522,41 @@ describe('Print Plugin', () => {
             }
         });
     });
+    it("print features that are missing visibility property", (done) => {
+        const layers = [{
+            features: [
+                {type: "FeatureCollection", properties: {id: "1"}},
+                {type: "FeatureCollection", properties: {id: "2"}}
+            ],
+            disableResolutionLimits: true,
+            visibility: true,
+            type: "vector"
+        }];
+        const printingService = {
+            print() {},
+            getMapConfiguration() {
+                return {
+                    layers
+                };
+            },
+            validate() { return {};}
+        };
+        const spy = expect.spyOn(printingService, "print");
+        getPrintPlugin().then(({ Plugin }) => {
+            try {
+                ReactDOM.render(<Plugin printingService={printingService}/>, document.getElementById("container"));
+                const submit = document.getElementsByClassName("print-submit").item(0);
+                expect(submit).toExist();
+                submit.click();
+                setTimeout(() => {
+                    expect(spy.calls.length).toBe(1);
+                    expect(spy.calls[0].arguments[0].layers.length).toBe(1);
+                    expect(spy.calls[0].arguments[0].layers[0].features.length).toBe(2);
+                    done();
+                }, 0);
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
 });


### PR DESCRIPTION
## Description
This PR fixes the print tool to include feature that doesn't have `visibility` property

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #9995 

**What is the new behavior?**
Print tool factors in visibility property when present and doesn't skip feature when visibility property is undefined|null. So the features are printed properly along with annotation features if any

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
