### PR TITLE
#10002 Fix timeline snap issue

### DIFF
--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -78,7 +78,7 @@ import {
 import { getDatesInRange } from '../utils/TimeUtils';
 import pausable from '../observables/pausable';
 import { wrapStartStop } from '../observables/epics';
-import { getTimeDomainsObservable } from '../observables/multidim';
+import { getNearestTimesObservable } from '../observables/multidim';
 import { getDomainValues } from '../api/MultiDim';
 import Rx from 'rxjs';
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -98,15 +98,14 @@ const domainArgs = (getState, paginationOptions = {}) => {
     const layerUrl = selectedLayerUrl(getState());
     const { startPlaybackTime, endPlaybackTime } = playbackRangeSelector(getState()) || {};
     const shouldFilter = statusSelector(getState()) === STATUS.PLAY || statusSelector(getState()) === STATUS.PAUSE;
+    const bboxOptions = multidimOptionsSelectorCreator(id)(getState());
     const fromEnd = snapTypeSelector(getState()) === 'end';
     return [layerUrl, layerName, "time", {
         limit: BUFFER_SIZE, // default, can be overridden by pagination options
         time: startPlaybackTime && endPlaybackTime && shouldFilter ? toAbsoluteInterval(startPlaybackTime, endPlaybackTime) : undefined,
         fromEnd,
         ...paginationOptions
-    },
-    multidimOptionsSelectorCreator(id)(getState())
-    ];
+    }, bboxOptions ];
 };
 
 /**
@@ -194,7 +193,7 @@ const getAnimationFrames = (getState, options) => {
         return domainValues.map(res => {
             const domainsArray =  res.DomainValues.Domain.split(",");
             // if there is a selected layer check for time intervals (start/end)
-            // and filter-out domain dates falling outisde the start/end playBack time
+            // and filter-out domain dates falling outside the start/end playBack time
             const selectedLayer = selectedLayerSelector(getState());
             const x = selectedLayer ? getTimeIntervalDomains(getState, domainsArray) : domainsArray;
             return x;
@@ -361,7 +360,7 @@ export const playbackCacheNextPreviousTimes = (action$, { getState = () => { } }
             // get current time in case of SELECT_LAYER or INIT_SELECT_LAYER
             const time = actionTime || currentTimeSelector(getState());
             const snapType = snapTypeSelector(getState());
-            return getTimeDomainsObservable(domainArgs, false, getState, snapType, time).map(([next, previous]) => {
+            return getNearestTimesObservable(domainArgs, false, getState, snapType, time).map(([next, previous]) => {
                 return updateMetadata({
                     forTime: time,
                     next,
@@ -381,7 +380,7 @@ export const setIsIntervalData = (action$, { getState = () => { } } = {}) =>
         .switchMap(({time: actionTime}) => {
             const time = actionTime || currentTimeSelector(getState());
             const snapType = snapTypeSelector(getState());
-            return getTimeDomainsObservable(domainArgs, true, getState, snapType, time)
+            return getNearestTimesObservable(domainArgs, true, getState, snapType, time)
                 .map(([next, previous]) => {
                     const isTimeIntervalData = next.indexOf('/') !== -1 || previous.indexOf('/') !== -1;
                     return setIntervalData(isTimeIntervalData);

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -63,7 +63,7 @@ import {
 
 import { getNearestDate, roundRangeResolution, isTimeDomainInterval, getStartEndDomainValues } from '../utils/TimeUtils';
 import { getHistogram, describeDomains } from '../api/MultiDim';
-import { getTimeDomainsObservable } from '../observables/multidim';
+import { getNearestTimesObservable } from '../observables/multidim';
 import { MAP_CONFIG_LOADED } from '../actions/config';
 
 const TIME_DIMENSION = "time";
@@ -98,7 +98,7 @@ const snapTime = (getState, group, time) => {
     const state = getState();
     if (selectedLayerName(state)) {
         const snapType = snapTypeSelector(state);
-        return getTimeDomainsObservable(domainArgs, false, getState, snapType, time).map(values => {
+        return getNearestTimesObservable(domainArgs, true, getState, snapType, time).map(values => {
             return getNearestDate(values.filter(v => !!v), time, snapType) || time;
         });
     }
@@ -474,7 +474,7 @@ export const setRangeOnInit = (action$, { getState = () => { } } = {}) =>
             };
             const { domain } = layerDimensionDataSelectorCreator(layerId, "time")(state) || {};
             const currentTime = currentTimeSelector(state);
-            const getTimeDomain = (time) => getTimeDomainsObservable(domainArgs, false, getState, snapType, time);
+            const getTimeDomain = (time) => getNearestTimesObservable(domainArgs, false, getState, snapType, time);
             const updateRangeObs = (time) => getTimeDomain().switchMap((values) => updateRangeOnInit(rangeState, values, time));
 
             if (!isEmpty(domain) && !isEmpty(currentTime)) {

--- a/web/client/observables/multidim.js
+++ b/web/client/observables/multidim.js
@@ -12,21 +12,21 @@ import { getDomainValues } from '../api/MultiDim';
 import { getBufferedTime } from '../utils/TimeUtils';
 
 /**
+ * Creates an observable that gets the nearest time domains for the selected layer in timeline redux state.
+ * **note**: this function should be moved in utils and refactored to not take domainArgs and state,but only the arguments to send and override.
  * @param {Function} domainArgs function that returns an object with the settings and params for the getDomainValues request
  * @param {Boolean} useBuffer if set to true applies or removes 1 millisecond buffer to current time
  * @param {Function} getState function that returns the current state
  * @param {String} snapType in case of time intervals whether snapping is set to "start" or "end"
- * @param {String} time the submitted time to claculate the domains for
- * @returns {[String, String]} [previous, next] next and previous time domains of the submitted reference time
+ * @param {String} time the submitted time to calculate the domains for
+ * @returns {Observable<[String, String]>} an observable that emits an array with the nearest time values in domain.
  */
-export const getTimeDomainsObservable = (domainArgs, useBuffer, getState, snapType, time) => (
-    // TODO: find out a way to optimize and do only one request
+export const getNearestTimesObservable = (domainArgs, useBuffer, getState, snapType, time) =>
     Rx.Observable.forkJoin(
-        getDomainValues(...domainArgs(getState, { sort: "asc", ...(time && {fromValue: useBuffer ? getBufferedTime(time, 0.0001, 'remove') : time}), ...(snapType === 'end' ? {fromEnd: true} : {}) }))
+        getDomainValues(...domainArgs(getState, { sort: "asc", limit: 1, ...(time && {fromValue: useBuffer ? getBufferedTime(time, 0.001, 'remove') : time}), ...(snapType === 'end' ? {fromEnd: true} : {}) }))
             .map(res => res.DomainValues.Domain.split(","))
             .map(([tt]) => tt).catch(err => err && Rx.Observable.of(null)),
-        getDomainValues(...domainArgs(getState, { sort: "desc", ...(time && {fromValue: useBuffer ? getBufferedTime(time, 0.0001, 'add') : time}), ...(snapType === 'end' ? {fromEnd: true} : {}) }))
+        getDomainValues(...domainArgs(getState, { sort: "desc", limit: 1, ...(time && {fromValue: useBuffer ? getBufferedTime(time, 0.001, 'add') : time}), ...(snapType === 'end' ? {fromEnd: true} : {}) }))
             .map(res => res.DomainValues.Domain.split(","))
             .map(([tt]) => tt).catch(err => err && Rx.Observable.of(null))
-    )
-);
+    );

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -168,8 +168,8 @@ export const loadingSelector = state => get(state, "timeline.loading");
 export const selectedLayerSelector = state => get(state, "timeline.selectedLayer");
 
 export const selectedLayerData = state => getLayerFromId(state, selectedLayerSelector(state));
-export const selectedLayerName = state => selectedLayerData(state) && selectedLayerData(state).name;
-export const selectedLayerTimeDimensionConfiguration = state => selectedLayerData(state) && selectedLayerData(state).dimensions && head(selectedLayerData(state).dimensions.filter((x) => x.name === "time"));
+export const selectedLayerName = state => selectedLayerData(state)?.name;
+export const selectedLayerTimeDimensionConfiguration = state => selectedLayerData(state)?.dimensions && head(selectedLayerData(state).dimensions.filter((x) => x.name === "time"));
 export const selectedLayerUrl = state => get(selectedLayerTimeDimensionConfiguration(state), "source.url");
 
 export const currentTimeRangeSelector = createSelector(


### PR DESCRIPTION
## Description

With this PR I fixed the issue #10002 . It was caused by: 
- Buffer not applied, so the current time was not taken
- Buffer calculated with `0.0001` seconds was not always working, I think because of `moment` or limit of ISO representation. Sometimes it was simply approximated to 0, that was the thing we wanted to avoid. 

Moreover I : 
- renamed the function used to get nearest value with a better way. (I added also a comment because the arguments are not so understandable and it should be refactored). 
- added a forced limit = 1 for next/previous request (In playback epics, it was not applied, so it downloaded 20 instants, it was not necessary)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10002 

**What is the new behavior?**

The snapping works correctly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
