### PR TITLE
#9972 Fix cross layer filter persistence bug

### DIFF
--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -1115,6 +1115,46 @@ describe('Test the queryform reducer', () => {
         const newState2 = queryform(newState1, action2);
         expect(newState2.filters.length).toBe(0);
     });
+    it('test loadFilter when crossLayerExpanded is undefined', () => {
+        const newFilter = {
+            crossLayerFilter: {
+                collectGeometries: {
+                    queryCollection: {
+
+                    }
+                }
+            },
+            filters: [{
+                format: "logic",
+                logic: "AND",
+                filters: [{
+                    format: 'cql',
+                    body: 'ATTRIBUTE1 = \'VALUE1\''
+                }]
+            }],
+            spatialField: {
+                method: "BBOX",
+                operation: "DWITHIN",
+                geometry: '{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-635956.0753326667,5466776.262955805],[-635956.0753326667,4723196.8517976105],[-29351.81886150781,4723196.8517976105],[-29351.81886150781,5466776.262955805],[-635956.0753326667,5466776.262955805]]]},"properties":null}'
+            }
+
+        };
+        const initialState = {
+            crossLayerExpanded: undefined,
+            crossLayerFilter: {
+                attribute: "ATTRIBUTE1"
+            },
+            spatialField: {
+                attribute: "GEOMETRY"
+            }
+        };
+        let action = loadFilter(newFilter);
+        let newState = queryform(initialState, action);
+        expect(newState.crossLayerFilter.attribute).toBe("ATTRIBUTE1");
+        expect(newState.spatialField.attribute).toBe("GEOMETRY");
+        expect(newState.spatialField.method).toBe("BBOX");
+        expect(newState.filters).toEqual(newFilter.filters);
+    });
 
 
     /* it('Open Zones Menu', () => {

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -590,12 +590,17 @@ function queryform(state = initialState, action) {
     case LOAD_FILTER:
         const {attribute, ...other} = initialState.spatialField;
         const cleanInitialState = assign({}, initialState, {spatialField: {...other}});
-        const {spatialField, filterFields, groupFields, crossLayerFilter, attributePanelExpanded, spatialPanelExpanded, crossLayerExpanded, filters} = (action.filter || cleanInitialState);
+        const {spatialField, filterFields, groupFields, crossLayerFilter, attributePanelExpanded, spatialPanelExpanded, filters} = (action.filter || cleanInitialState);
         return {...state,
             ...{
                 attributePanelExpanded,
                 spatialPanelExpanded,
-                crossLayerExpanded,
+                // if callers do not explicitly set crossLayerExpanded flag when making the loadFilter call,
+                // a bug will appear on the second re-render of the QueryPanel.CrossLayerFilter section
+                // specifically the crossLayer is not persisted between repeated accesses to the panel.
+                // Unburden callers to add the flag always, set it if they do and set from initial state as fallback.
+                // Do not let it become undefined.
+                crossLayerExpanded: (action?.filter?.crossLayerExpanded || cleanInitialState.crossLayerExpanded),
                 spatialField: {
                     ...spatialField,
                     // This prevents an empty filter to override attribute settings made before from previous CHANGE_SPATIAL_ATTRIBUTE


### PR DESCRIPTION
## Description
Tweaked LOAD_FILTER reducer state assembly to always set the crossLayerExpanded flag,
either explicitly by the passed action or default.state as fallback. Fixes persistence bug.
Documented decision.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
[#9972](https://github.com/geosolutions-it/MapStore2/issues/9972)

**What is the new behavior?**
The cross layer filter is persisted.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
