### PR TITLE
Refactor and simplify the format validator utility logic

### DIFF
--- a/web/client/utils/FeatureInfoUtils.js
+++ b/web/client/utils/FeatureInfoUtils.js
@@ -57,15 +57,16 @@ export function parseXMLResponse(res) {
     }
     return false;
 }
-
-const textNotEmptyAndValid = (res) => res.response !== "" && (typeof res.response === "string" && res.response.indexOf("no features were found") !== 0) && (typeof res.response === "string" && res.response.indexOf("<?xml") !== 0);
-const featuresPresent = (res) => res.response?.features?.length;
+const htmlResponseValid = (res) => !!parseHTMLResponse(res);
+const xmlResponseValid = (res) => !!parseXMLResponse(res);
+const textNotEmptyAndValid = (res) => !!(res.response !== "" && (typeof res.response === "string" && res.response.indexOf("no features were found") !== 0) && (typeof res.response === "string" && res.response.indexOf("<?xml") !== 0));
+const featuresPresent = (res) => !!(res.response?.features?.length);
 const truePredicate = () => true;
 
 const predicate = (format) => {
     switch (format) {
-    case "HTML": return parseHTMLResponse;
-    case "GML3": return parseXMLResponse;
+    case "HTML": return htmlResponseValid;
+    case "GML3": return xmlResponseValid;
     case "TEXT": return textNotEmptyAndValid;
     case "JSON": return featuresPresent;
     case "GEOJSON": return featuresPresent;

--- a/web/client/utils/FeatureInfoUtils.js
+++ b/web/client/utils/FeatureInfoUtils.js
@@ -58,78 +58,25 @@ export function parseXMLResponse(res) {
     return false;
 }
 
-export const Validator = {
-    HTML: {
-        /**
-         *Parse the HTML to get only the valid html responses
-         */
-        getValidResponses(responses) {
-            return responses.filter(parseHTMLResponse);
-        },
-        /**
-         * Parse the HTML to get only the NOT valid html responses
-         */
-        getNoValidResponses(responses) {
-            return responses.filter((res) => {return !parseHTMLResponse(res); });
-        }
-    },
-    TEXT: {
-        /**
-         *Parse the TEXT to get only the valid text responses
-         */
-        getValidResponses(responses) {
-            return responses.filter((res) => res.response !== "" && (typeof res.response === "string" && res.response.indexOf("no features were found") !== 0) && (typeof res.response === "string" && res.response.indexOf("<?xml") !== 0));
-        },
-        /**
-         * Parse the TEXT to get only the NOT valid text responses
-         */
-        getNoValidResponses(responses) {
-            return responses.filter((res) => res.response === "" || typeof res.response === "string" && res.response.indexOf("no features were found") === 0 || res.response && (typeof res.response === "string" && res.response.indexOf("<?xml") === 0));
-        }
-    },
-    JSON: {
-        /**
-         *Parse the JSON to get only the valid json responses
-         */
-        getValidResponses(responses) {
-            return responses.filter((res) => res.response && res.response.features && res.response.features.length);
-        },
-        /**
-         * Parse the JSON to get only the NOT valid json responses
-         */
-        getNoValidResponses(responses) {
-            return responses.filter((res) => res.response && res.response.features && res.response.features.length === 0);
-        }
-    },
-    GEOJSON: {
-        /**
-         *Parse the GEOJSON to get only the valid json responses
-         */
-        getValidResponses(responses) {
-            return responses.filter((res) => res.response && res.response.features && res.response.features.length);
-        },
-        /**
-         * Parse the GEOJSON to get only the NOT valid json responses
-         */
-        getNoValidResponses(responses) {
-            return responses.filter((res) => res.response && res.response.features && res.response.features.length === 0);
-        }
-    },
-    GML3: {
-        /**
-         *Parse the HTML to get only the valid html responses
-         */
-        getValidResponses(responses) {
-            return responses.filter(parseXMLResponse);
-        },
-        /**
-         * Parse the HTML to get only the NOT valid html responses
-         */
-        getNoValidResponses(responses) {
-            return responses.filter((res) => {return !parseXMLResponse(res); });
-        }
+const textNotEmptyAndValid = (res) => res.response !== "" && (typeof res.response === "string" && res.response.indexOf("no features were found") !== 0) && (typeof res.response === "string" && res.response.indexOf("<?xml") !== 0);
+const featuresPresent = (res) => res.response?.features?.length;
+const truePredicate = () => true;
+
+const predicate = (format) => {
+    switch (format) {
+    case "HTML": return parseHTMLResponse;
+    case "GML3": return parseXMLResponse;
+    case "TEXT": return textNotEmptyAndValid;
+    case "JSON": return featuresPresent;
+    case "GEOJSON": return featuresPresent;
+    default: return truePredicate;
     }
 };
+
+export const validator = (format) => {
+    return { isValidResponse: predicate(format) };
+};
+
 export const Parser = {
     HTML: {
         getBody(html) {

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { INFO_FORMATS, INFO_FORMATS_BY_MIME_TYPE, JSON_MIME_TYPE, GEOJSON_MIME_TYPE, Validator } from './FeatureInfoUtils';
+import { INFO_FORMATS, INFO_FORMATS_BY_MIME_TYPE, JSON_MIME_TYPE, GEOJSON_MIME_TYPE, validator } from './FeatureInfoUtils';
 
 import pointOnSurface from 'turf-point-on-surface';
 import { findIndex } from 'lodash';
@@ -300,11 +300,6 @@ const deduceInfoFormat = (response) => {
     return infoFormat;
 };
 
-const defaultValidator = {
-    getValidResponses: (responses) => responses,
-    getNoValidResponses: () => []
-};
-
 const determineValidatorFormat = (response, format) => {
     if (response.format) return response.format;
 
@@ -314,7 +309,7 @@ const determineValidatorFormat = (response, format) => {
 
 const determineValidator = (response, format) => {
     const validatorFormat = determineValidatorFormat(response, format);
-    return Validator[validatorFormat] || defaultValidator;
+    return validator(validatorFormat);
 };
 
 export const getValidator = (format) => {
@@ -322,8 +317,7 @@ export const getValidator = (format) => {
         getValidResponses: (responses) => {
             return responses.filter((current) => {
                 if (current) {
-                    const valid = determineValidator(current, format).getValidResponses([current]);
-                    return valid.length;
+                    return determineValidator(current, format).isValidResponse(current);
                 }
                 return false;
             });
@@ -331,8 +325,7 @@ export const getValidator = (format) => {
         getNoValidResponses: (responses) => {
             return responses.filter((current) => {
                 if (current) {
-                    const valid = determineValidator(current, format).getNoValidResponses([current]);
-                    return valid.length;
+                    return !determineValidator(current, format).isValidResponse(current);
                 }
                 return false;
             });

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -320,22 +320,22 @@ const determineValidator = (response, format) => {
 export const getValidator = (format) => {
     return {
         getValidResponses: (responses) => {
-            return responses.reduce((previous, current) => {
+            return responses.filter((current) => {
                 if (current) {
                     const valid = determineValidator(current, format).getValidResponses([current]);
-                    return [...previous, ...valid];
+                    return valid.length;
                 }
-                return [...previous];
-            }, []);
+                return false;
+            });
         },
         getNoValidResponses: (responses) => {
-            return responses.reduce((previous, current) => {
+            return responses.filter((current) => {
                 if (current) {
                     const valid = determineValidator(current, format).getNoValidResponses([current]);
-                    return [...previous, ...valid];
+                    return valid.length;
                 }
-                return [...previous];
-            }, []);
+                return false;
+            });
         }
     };
 };

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -286,6 +286,20 @@ export const getIdentifyFlow = (layer, baseURL, params) => {
     }
     return null;
 };
+
+const deduceInfoFormat = (response) => {
+    let infoFormat;
+    // Handle WMS, WMTS
+    if (response.queryParams && response.queryParams.hasOwnProperty('info_format')) {
+        infoFormat = response.queryParams.info_format;
+    }
+    // handle WFS
+    if (response.queryParams && response.queryParams.hasOwnProperty('outputFormat')) {
+        infoFormat = response.queryParams.outputFormat;
+    }
+    return infoFormat;
+};
+
 export const getValidator = (format) => {
     const defaultValidator = {
         getValidResponses: (responses) => responses,
@@ -295,15 +309,7 @@ export const getValidator = (format) => {
         getValidResponses: (responses) => {
             return responses.reduce((previous, current) => {
                 if (current) {
-                    let infoFormat;
-                    // Handle WMS, WMTS
-                    if (current.queryParams && current.queryParams.hasOwnProperty('info_format')) {
-                        infoFormat = current.queryParams.info_format;
-                    }
-                    // handle WFS
-                    if (current.queryParams && current.queryParams.hasOwnProperty('outputFormat')) {
-                        infoFormat = current.queryParams.outputFormat;
-                    }
+                    const infoFormat = deduceInfoFormat(current);
                     const valid = (Validator[current.format || INFO_FORMATS_BY_MIME_TYPE[infoFormat] || INFO_FORMATS_BY_MIME_TYPE[format]] || defaultValidator).getValidResponses([current]);
                     return [...previous, ...valid];
                 }
@@ -313,13 +319,7 @@ export const getValidator = (format) => {
         getNoValidResponses: (responses) => {
             return responses.reduce((previous, current) => {
                 if (current) {
-                    let infoFormat;
-                    if (current.queryParams && current.queryParams.hasOwnProperty('info_format')) {
-                        infoFormat = current.queryParams.info_format;
-                    }
-                    if (current.queryParams && current.queryParams.hasOwnProperty('outputFormat')) {
-                        infoFormat = current.queryParams.outputFormat;
-                    }
+                    const infoFormat = deduceInfoFormat(current);
                     const valid = (Validator[current.format || INFO_FORMATS_BY_MIME_TYPE[infoFormat] || INFO_FORMATS_BY_MIME_TYPE[format]] || defaultValidator).getNoValidResponses([current]);
                     return [...previous, ...valid];
                 }

--- a/web/client/utils/__tests__/FeatureInfoUtils-test.js
+++ b/web/client/utils/__tests__/FeatureInfoUtils-test.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import {Parser, Validator} from '../FeatureInfoUtils';
+import {Parser, validator} from '../FeatureInfoUtils';
 
 describe('FeatureInfoUtils', () => {
     // **********************************
@@ -36,41 +36,28 @@ describe('FeatureInfoUtils', () => {
 
     });
     it('HTML Validator', () => {
-        // Default fetch all values
-        let results = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML}]);
-        expect(results.length).toBe(1);
+        const responseValidator = validator("HTML");
+        let valid;
 
-        let notValidResults = Validator.HTML.getNoValidResponses([{response: emptyHTML}, {response: rowHTML}]);
-        expect(notValidResults.length).toBe(1);
-        expect(notValidResults[0].response).toBe(emptyHTML);
+        // Default fetch all values
+        expect(responseValidator.isValidResponse({response: rowHTML})).toBe(true);
+        expect(responseValidator.isValidResponse({response: emptyHTML})).toBe(false);
 
         // test regex
         let validRegex = "<div[^>]*>[\\s\\S]*<\\/div>";
         let invalidRegex = "<table[^>]*>[\\s\\S]*<\\/table>";
 
-        let validRegexResults = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: validRegex }}]);
-        expect(validRegexResults.length).toBe(1);
-        expect(validRegexResults[0].response).toBe(rowHTML);
+        valid = responseValidator.isValidResponse({response: rowHTML, layerMetadata: {regex: validRegex }});
+        expect(valid).toBe(true);
 
-        validRegexResults = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: validRegex }}]);
-        expect(validRegexResults.length).toBe(1);
-
-        let invalidRegexResults = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: invalidRegex }}]);
-        expect(invalidRegexResults.length).toBe(0);
-
-        validRegexResults = Validator.HTML.getNoValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: validRegex }}]);
-        expect(validRegexResults.length).toBe(1); // only the empty is not valid
-
-        invalidRegexResults = Validator.HTML.getNoValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: invalidRegex }}]);
-        expect(invalidRegexResults.length).toBe(2); // both are not valid
-
-
+        valid = responseValidator.isValidResponse({response: rowHTML, layerMetadata: {regex: invalidRegex }});
+        expect(valid).toBe(false);
     });
 
     it('HTML valid html contained in xml',  () => {
         const htmlInXML =  '<?xml version="1.0" encoding="ISO-8859-1"?>' + rowHTML;
-        const validResults = Validator.HTML.getValidResponses([{response: htmlInXML}]);
-        expect(validResults.length).toBe(1);
+        const valid = validator("HTML").isValidResponse({response: htmlInXML});
+        expect(valid).toBe(true);
     });
 
     it("HTML should return invalid if html is not valid", () => {
@@ -91,32 +78,34 @@ describe('FeatureInfoUtils', () => {
             layers (AD.ADDRESSA) No soportada.]]>
            </ServiceException>
         </ServiceExceptionReport>`;
-        const validResults = Validator.HTML.getNoValidResponses([{response: inValidXML}]);
-        expect(validResults.length).toBe(1);
+        const valid = validator("HTML").isValidResponse({response: inValidXML});
+        expect(valid).toBe(false);
     });
 
     // **********************************
     // TEXT
     // **********************************
     const baseTextGFI = 'GetFeatureInfo results:\n';
-    const notValid = '';
     const validTEXT = baseTextGFI
         + '\n'
         + "Layer 'LimiteRegionale''\n"
         + "Feature 0:'\n"
         + "uuid = 'fc1132ee-cf89-4fb0-a25d-315bb3c34568''\n";
+    const notValid = '';
+    const noFeaturesFoundText = 'no features were found';
 
     it('TEXT Validator', () => {
-        let results = Validator.TEXT.getValidResponses([{response: notValid}, {response: validTEXT}]);
-        expect(results.length).toBe(1);
-        expect(results[0].response).toBe(validTEXT);
+        const responseValidator = validator("TEXT");
+        let valid;
 
-        results = Validator.TEXT.getValidResponses([{response: "no features were found"}, {response: validTEXT}]);
-        expect(results.length).toBe(1);
+        valid = responseValidator.isValidResponse({response: validTEXT});
+        expect(valid).toBe(true);
 
-        let notValidResults = Validator.TEXT.getNoValidResponses([{response: notValid}, {response: validTEXT}]);
-        expect(notValidResults.length).toBe(1);
-        expect(notValidResults[0].response).toBe(notValid);
+        valid = responseValidator.isValidResponse({response: notValid});
+        expect(valid).toBe(false);
+
+        valid = responseValidator.isValidResponse({response: noFeaturesFoundText});
+        expect(valid).toBe(false);
     });
 
     // **********************************
@@ -125,13 +114,14 @@ describe('FeatureInfoUtils', () => {
     const validJSON = {"type": "FeatureCollection", "totalFeatures": "unknown", "features": [{"type": "Feature", "id": "", "geometry": null, "properties": {"precip30min": 816}}], "crs": null};
     const emptyJSON = {"type": "FeatureCollection", "totalFeatures": "unknown", "features": [], "crs": null};
     it('PROPERTIES Validator', () => {
-        let results = Validator.JSON.getValidResponses([{response: validJSON}, {response: emptyJSON}]);
-        expect(results.length).toBe(1);
-        expect(results[0].response).toBe(validJSON);
+        const responseValidator = validator("JSON");
+        let valid;
 
-        let notValidResults = Validator.JSON.getNoValidResponses([{response: validJSON}, {response: emptyJSON}]);
-        expect(notValidResults.length).toBe(1);
-        expect(notValidResults[0].response).toBe(emptyJSON);
+        valid = responseValidator.isValidResponse({response: validJSON});
+        expect(valid).toBe(true);
+
+        valid = responseValidator.isValidResponse({response: emptyJSON});
+        expect(valid).toBe(false);
     });
 
 });

--- a/web/client/utils/__tests__/FeatureInfoUtils-test.js
+++ b/web/client/utils/__tests__/FeatureInfoUtils-test.js
@@ -37,7 +37,6 @@ describe('FeatureInfoUtils', () => {
     });
     it('HTML Validator', () => {
         const responseValidator = validator("HTML");
-        let valid;
 
         // Default fetch all values
         expect(responseValidator.isValidResponse({response: rowHTML})).toBe(true);
@@ -47,6 +46,7 @@ describe('FeatureInfoUtils', () => {
         let validRegex = "<div[^>]*>[\\s\\S]*<\\/div>";
         let invalidRegex = "<table[^>]*>[\\s\\S]*<\\/table>";
 
+        let valid;
         valid = responseValidator.isValidResponse({response: rowHTML, layerMetadata: {regex: validRegex }});
         expect(valid).toBe(true);
 

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -638,7 +638,7 @@ describe('MapInfoUtils', () => {
 
         let validator = getValidator();
         let noValidResponses = validator.getNoValidResponses(response);
-        expect(noValidResponses.length).toBe(1);
+        expect(noValidResponses.length).toBe(3);
 
         // Validate format 'JSON'
         response.filter(r=> r !== undefined).forEach(res => {res.format = "JSON"; return res;});

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -643,7 +643,7 @@ describe('MapInfoUtils', () => {
         // Validate format 'JSON'
         response.filter(r=> r !== undefined).forEach(res => {res.format = "JSON"; return res;});
         noValidResponses = validator.getNoValidResponses(response);
-        expect(noValidResponses.length).toBe(1);
+        expect(noValidResponses.length).toBe(2);
 
     });
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
When working with MapStore2 in a client project I discovered that the format validator logic is more complicated than necessary. I simplified the code in various tiny-sliced commits for clarity that can be squashed when pulled.

This is Code Style Update and Refactoring (except that the API of the validators was changed, but it was only used in the tests).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
I am submitting this Pull Request as an external developer on behalf of DB Systel GmbH.

I found various other code segments where the build-in JS Array method "reduce(method, aggregator)" was used in a way that .filter(predicate) would have sufficed, making it more difficult than necessary to read. This was the starting point for this PR.
Is there a specific reason why this is used? Do you wish more refactorings of this sort?

Kind regards!
