### PR TITLE
[Backport 2024.01.xx] #8871 Improve getLegendGraphic compatibility for print (#10041)

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -576,13 +576,13 @@ export const specCreators = {
                                 SERVICE: "WMS",
                                 REQUEST: "GetLegendGraphic",
                                 LAYER: layer.name,
-                                LANGUAGE: spec.language || '',
                                 STYLE: layer.style || '',
                                 SCALE: spec.scale,
                                 ...getLegendIconsSize(spec, layer),
                                 LEGEND_OPTIONS: "forceLabels:" + (spec.forceLabels ? "on" : "") + ";fontAntialiasing:" + spec.antiAliasing + ";dpi:" + spec.legendDpi + ";fontStyle:" + (spec.bold && "bold" || (spec.italic && "italic") || '') + ";fontName:" + spec.fontFamily + ";fontSize:" + spec.fontSize,
                                 format: "image/png",
-                                ...assign({}, layer.params)
+                                ...(spec.language ? {LANGUAGE: spec.language} : {}),
+                                ...layer?.params
                             })
                         })
                     ]

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -395,6 +395,17 @@ describe('PrintUtils', () => {
         const specs = getMapfishLayersSpecification([layer], { projection: "EPSG:3857" }, {}, 'legend');
         expect(specs).toExist();
         expect(specs.length).toBe(1);
+        expect(specs[0].classes.length).toBe(1);
+        // legendURL is a GetLegendGraphic request
+        expect(specs[0].classes[0].icons[0].indexOf('GetLegendGraphic') !== -1).toBe(true);
+        // LANGUAGE, if not included, should not be a parameter of the legend URL
+        expect(specs[0].classes[0].icons[0].indexOf('LANGUAGE')).toBe(-1);
+        const specs2 = getMapfishLayersSpecification([layer], { projection: "EPSG:3857", language: 'de' }, {}, 'legend');
+        expect(specs2).toExist();
+        expect(specs2.length).toBe(1);
+        expect(specs2[0].classes.length).toBe(1);
+        // LANGUAGE, if included, should be a parameter of the legend URL
+        expect(specs2[0].classes[0].icons[0].indexOf('LANGUAGE=de')).toBeGreaterThan(0);
     });
     it('toOpenLayers2Style for vector layer wich contains a FeatureCollection using the default style', () => {
         const style = toOpenLayers2Style(vectorWithFtCollInside, null, "FeatureCollection");


### PR DESCRIPTION
[Backport 2024.01.xx] #8871 Improve getLegendGraphic compatibility for print (#10041)
fix  #8871 