### PR TITLE
Remove xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,7 +312,6 @@
     "webfontloader": "1.6.28",
     "wellknown": "0.5.0",
     "xml2js": "0.4.17",
-    "xmldom": "0.3.0",
     "xpath": "0.0.27"
   },
   "scripts": {

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -467,7 +467,9 @@ export default (API) => ({
 
                         const metadataFlow = Rx.Observable.defer(() => axios.get(metadataUrl, {headers: {'Accept': 'application/xml'}}))
                             .pluck('data')
-                            .map(metadataXml => new DOMParser().parseFromString(metadataXml))
+                            .map(metadataXml => {
+                                return (new DOMParser()).parseFromString(metadataXml, "text/xml");
+                            })
                             .map(metadataDoc => {
                                 const selectXpath = xpathlib.useNamespaces(metadataOptions.xmlNamespaces || {});
 

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -9,7 +9,6 @@
 import * as Rx from 'rxjs';
 import axios from 'axios';
 import xpathlib from 'xpath';
-import { DOMParser } from 'xmldom';
 import {head, get, find, isArray, isString, isObject, keys, toPairs, merge, castArray} from 'lodash';
 
 import {


### PR DESCRIPTION
## Description
[This](https://github.com/geosolutions-it/MapStore2/pull/9990) PR wanted to  update xmldom. anyway for a client application xmldom is not needed at all.
I replace it with the DOMParser functionalities of the browser. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: dependency cleanup

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
no issue

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
