### PR TITLE
geosolutions-it#9688: Make DOMUtils tests less dependent on platform-varying browser default stylesheet

### DIFF
--- a/web/client/utils/__tests__/DOMUtil-test.js
+++ b/web/client/utils/__tests__/DOMUtil-test.js
@@ -24,6 +24,8 @@ describe('Test the DOMUtils', () => {
         expect(spy.calls.length).toEqual(1);
     });
     it('test getOffsetTop', function() {
+        const desiredOffset = 8;
+        document.body.style.cssText = `margin: ${desiredOffset} px;`;
         document.body.innerHTML = `
         <div id="container">
             <div id="content">
@@ -31,12 +33,13 @@ describe('Test the DOMUtils', () => {
             </div>
         </div>`;
         const offset = getOffsetTop(document.querySelector("#content"));
-        expect(offset).toEqual(8);
+        expect(offset).toEqual(desiredOffset);
     });
     it('test getOffsetBottom', function() {
+        document.body.style.cssText = `margin: 8 px;`;
         document.body.innerHTML = `
         <div id="container">
-            <div id="content">
+            <div id="content" style="height: 18px">
             test
             </div>
         </div>`;


### PR DESCRIPTION
## Description

Better define DOMUtils tests so they do not break on MacOS, as described in issue #9688 .

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ not applicable - the bug was in the test ] Tests for the changes have been added (for bug fixes / features)
- [ not applicable ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9688

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
`DOMUtils` test works reliably cross-platform.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
