### PR TITLE
#10049 Add authenticationRules header method support

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -46,7 +46,7 @@ This is the main structure:
   "authenticationRules": [
   { // every rule has a `urlPattern` regex to match
     "urlPattern": ".*geostore.*",
-    // and a authentication `method` to use (basic, authkey, browserWithCredentials)
+    // and a authentication `method` to use (basic, authkey, browserWithCredentials, header)
     "method": "basic"
   }, {
     "urlPattern": "\\/geoserver.*",
@@ -142,9 +142,26 @@ For configuring plugins, see the [Configuring Plugins Section](plugins-documenta
 
 ## Explanation of some config properties
 
-- **loadAfterTheme** is a flag that allows to load mapstore.js after the theme which can be versioned or not(default.css). default is false
-- **initialState** is an object that will initialize the state with some default values and this WILL OVERRIDE the initialState imposed by plugins & reducers.
-- **projectionDefs** is an array of objects that contain definitions for Coordinate Reference Systems
+- `loadAfterTheme`: is a flag that allows to load mapstore.js after the theme which can be versioned or not(default.css). default is false
+- `initialState`: is an object that will initialize the state with some default values and this WILL OVERRIDE the initialState imposed by plugins & reducers.
+- `projectionDefs`: is an array of objects that contain definitions for Coordinate Reference Systems
+- `useAuthenticationRules`: if this flag is set to true, the `authenticationRules` will be used to authenticate every ajax and mapping request. If the flag is set to false, the `authenticationRules` will be ignored.
+- `authenticationRules`: is an array of objects that contain rules to match for authentication. Each rule has a `urlPattern` regex to match and a `method` to use (`basic`, `authkey`, `header`, `browserWithCredentials`). If the URL of a request matches the `urlPattern` of a rule, the `method` will be used to authenticate the request. The `method` can be:
+  - `basic` will use the basic authentication method getting the credentials from the user that logged in (adding the header `Authorization` `Basic <base64(username:password)>` to the request). ***Note**: this method is not implemented for image tile requests (e.g. layers) but only for ajax requests.*
+  - `authkey` will use the authkey method getting the credentials from the user that logged in. The token of the current MapStore session will be used as the authkey value, so this works only with the geoserver integration.
+  - `bearer` will use the header `Authorization` `Bearer <token>` getting the credentials from the user that logged in. The token of the current MapStore session will be used as the bearer value, so this works only with the geoserver integration.
+  - `header` will use the header method getting the credentials from the user that logged in. You can add an `headers` object containing the static headers to this rule to specify witch headers to use. e.g.
+  - `browserWithCredentials` will add the `withCredentials` parameter to ajax requests, so the browser will send the cookies and the authentication headers to the server. This method is useful when you have a proxy that needs to authenticate the user. ***Note**: this method is not implemented for image tile requests (e.g. layers) but only for ajax requests.*
+
+  ```json
+    {
+        "urlPattern": ".*geostore.*",
+        "method": "header",
+        "headers": {
+            "X-Auth-Token": "mytoken"
+        }
+    }
+    ```
 
 ### initialState configuration
 

--- a/web/client/libs/__tests__/ajax-test.js
+++ b/web/client/libs/__tests__/ajax-test.js
@@ -329,7 +329,7 @@ describe('Tests ajax library', () => {
             done();
         });
     });
-    it.only('adds generic headers', (done) => {
+    it('adds generic headers', (done) => {
         ConfigUtils.setConfigProp("useAuthenticationRules", true);
         ConfigUtils.setConfigProp("authenticationRules", authenticationRules);
         axios.get('header-site.com').then(() => {

--- a/web/client/libs/__tests__/ajax-test.js
+++ b/web/client/libs/__tests__/ajax-test.js
@@ -91,6 +91,11 @@ const authenticationRules = [
     {
         "urlPattern": ".*sitetocheck.*",
         "method": "bearer"
+    },
+    {
+        method: "header",
+        urlPattern: ".*header-site.com",
+        headers: {"X-Test-Token": "test"}
     }
 ];
 
@@ -322,6 +327,20 @@ describe('Tests ajax library', () => {
             expect(exception.config).toExist().toIncludeKey('url');
             expect(exception.config.url.indexOf('authkey')).toBe(-1);
             done();
+        });
+    });
+    it.only('adds generic headers', (done) => {
+        ConfigUtils.setConfigProp("useAuthenticationRules", true);
+        ConfigUtils.setConfigProp("authenticationRules", authenticationRules);
+        axios.get('header-site.com').then(() => {
+            done("Axios actually reached the fake url");
+        }).catch((exception) => {
+            expect(exception.config).toExist().toIncludeKey('headers');
+
+            expect(exception.config.headers["X-Test-Token"]).toBe('test');
+            done();
+        }).catch(e => {
+            done(e);
         });
     });
 

--- a/web/client/libs/ajax.js
+++ b/web/client/libs/ajax.js
@@ -88,6 +88,10 @@ function addAuthenticationToAxios(axiosConfig) {
         addHeaderToAxiosConfig(axiosConfig, 'Authorization', "Bearer " + token);
         return axiosConfig;
     }
+    case 'header': {
+        Object.entries(rule.headers).map(([headerName, headerValue]) => addHeaderToAxiosConfig(axiosConfig, headerName, headerValue));
+        return axiosConfig;
+    }
     default:
         // we cannot handle the required authentication method
         return axiosConfig;

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -156,6 +156,10 @@ export function getAuthenticationHeaders(url, securityToken) {
             "Authorization": `Bearer ${token}`
         };
     }
+    case 'header': {
+        const rule = getAuthenticationRule(url);
+        return rule.headers;
+    }
     default:
         // we cannot handle the required authentication method
         return null;

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -90,6 +90,16 @@ const tokenAuthenticationRules = [
     }
 ];
 
+const headerAuthenticationRules = [
+    {
+        "urlPattern": ".*header-site.*",
+        "method": "header",
+        "headers": {
+            "X-Auth-Token": "goodtoken"
+        }
+    }
+];
+
 describe('Test security utils methods', () => {
     afterEach(() => {
         expect.restoreSpies();
@@ -223,6 +233,12 @@ describe('Test security utils methods', () => {
         ConfigUtils.setConfigProp("useAuthenticationRules", true);
         ConfigUtils.setConfigProp('authenticationRules', tokenAuthenticationRules);
         expect(SecurityUtils.addAuthenticationParameter("a test url", null)).toEqual({'authkey': 'goodtoken'});
+    });
+    it('test getAuthenticationHeaders for header rule', () => {
+        setSecurityInfo(securityInfoToken);
+        ConfigUtils.setConfigProp("useAuthenticationRules", true);
+        ConfigUtils.setConfigProp('authenticationRules', headerAuthenticationRules);
+        expect(SecurityUtils.getAuthenticationHeaders("http://header-site.com/something", null)).toEqual({'X-Auth-Token': 'goodtoken'});
     });
     it('cleanAuthParamsFromURL', () => {
         // mocking the authentication rules


### PR DESCRIPTION
## Description

This PR adds the support to the `header` support as described in #10049 and documents more the authentication methods and the current existing support.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#10049

**What is the new behavior?**
Fix #10049

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
