### PR TITLE
[Backport #10037] Updating backgrounds to 512 tile size #9382

### DIFF
--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -117,6 +117,7 @@
 							"https://maps5.geosolutionsgroup.com/geoserver/wms",
 							"https://maps6.geosolutionsgroup.com/geoserver/wms"
 						],
+            "tileSize": 512,
 						"visibility": false,
 						"singleTile": false,
 						"credits": {
@@ -138,6 +139,7 @@
 							"https://maps2.geosolutionsgroup.com/geoserver/wms",
 							"https://maps5.geosolutionsgroup.com/geoserver/wms"
 						],
+            "tileSize": 512,
 						"visibility": false,
 						"singleTile": false,
 						"credits": {
@@ -159,6 +161,7 @@
 							"https://maps5.geosolutionsgroup.com/geoserver/wms",
 							"https://maps6.geosolutionsgroup.com/geoserver/wms"
 						],
+            "tileSize": 512,
 						"visibility": true,
 						"singleTile": false,
 						"credits": {
@@ -180,6 +183,7 @@
 							"https://maps5.geosolutionsgroup.com/geoserver/wms",
 							"https://maps6.geosolutionsgroup.com/geoserver/wms"
 						],
+            "tileSize": 512,
 						"visibility": false,
 						"singleTile": false,
 						"credits": {
@@ -200,6 +204,7 @@
 							"https://maps5.geosolutionsgroup.com/geoserver/wms",
 							"https://maps6.geosolutionsgroup.com/geoserver/wms"
 						],
+            "tileSize": 512,
 						"source": "s2cloudless",
 						"singleTile": false,
 						"visibility": false

--- a/web/client/configs/new.json
+++ b/web/client/configs/new.json
@@ -25,6 +25,7 @@
                     "https://maps5.geosolutionsgroup.com/geoserver/wms",
                     "https://maps6.geosolutionsgroup.com/geoserver/wms"
                 ],
+                "tileSize":512,
                 "visibility": false,
                 "singleTile": false,
                 "credits": {
@@ -46,6 +47,7 @@
                     "https://maps2.geosolutionsgroup.com/geoserver/wms",
                     "https://maps5.geosolutionsgroup.com/geoserver/wms"
                 ],
+                "tileSize":512,
                 "visibility": false,
                 "singleTile": false,
                 "credits": {
@@ -67,6 +69,7 @@
                     "https://maps5.geosolutionsgroup.com/geoserver/wms",
                     "https://maps6.geosolutionsgroup.com/geoserver/wms"
                 ],
+                "tileSize":512,
                 "visibility": true,
                 "singleTile": false,
                 "credits": {
@@ -88,6 +91,7 @@
                     "https://maps5.geosolutionsgroup.com/geoserver/wms",
                     "https://maps6.geosolutionsgroup.com/geoserver/wms"
                 ],
+                "tileSize":512,
                 "visibility": false,
                 "singleTile": false,
                 "credits": {
@@ -108,6 +112,7 @@
                     "https://maps5.geosolutionsgroup.com/geoserver/wms",
                     "https://maps6.geosolutionsgroup.com/geoserver/wms"
                 ],
+                "tileSize":512,
                 "source": "s2cloudless",
                 "singleTile": false,
                 "visibility": false


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
[Backport #10037] Updating backgrounds to 512 tile size #9382

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#9382 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Default background layers now use tiles of size 521x512.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
