### PR TITLE
#9974: Add permission validation to manage catalog service

### DIFF
--- a/web/client/actions/__tests__/catalog-test.js
+++ b/web/client/actions/__tests__/catalog-test.js
@@ -70,7 +70,9 @@ import {
     FORMAT_OPTIONS_LOADING,
     formatsLoading,
     SET_FORMAT_OPTIONS,
-    setSupportedFormats, addLayerAndDescribe, ADD_LAYER_AND_DESCRIBE
+    setSupportedFormats, addLayerAndDescribe, ADD_LAYER_AND_DESCRIBE,
+    INIT_PLUGIN,
+    initPlugin
 } from '../catalog';
 
 import { SHOW_NOTIFICATION } from '../notifications';
@@ -372,5 +374,11 @@ describe('Test correctness of the catalog actions', () => {
         expect(action.type).toBe(SET_FORMAT_OPTIONS);
         expect(action.formats).toEqual(formats);
         expect(action.url).toEqual(url);
+    });
+    it('test initPlugin', () => {
+        const options = {editingAllowedRoles: ['test']};
+        const action = initPlugin(options);
+        expect(action.type).toBe(INIT_PLUGIN);
+        expect(action.options).toEqual(options);
     });
 });

--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -53,6 +53,7 @@ export const FORMAT_OPTIONS_FETCH = 'CATALOG:FORMAT_OPTIONS_FETCH';
 export const FORMAT_OPTIONS_LOADING = 'CATALOG:FORMAT_OPTIONS_LOADING';
 export const SET_FORMAT_OPTIONS = 'CATALOG:SET_FORMAT_OPTIONS';
 export const NEW_SERVICE_STATUS = 'CATALOG:NEW_SERVICE_STATUS';
+export const INIT_PLUGIN = 'CATALOG:INIT_PLUGIN';
 
 /**
  * Adds a list of layers from the given catalogs to the map
@@ -301,5 +302,12 @@ export const setNewServiceStatus = (status) => {
     return {
         type: NEW_SERVICE_STATUS,
         status
+    };
+};
+
+export const initPlugin = (options) => {
+    return {
+        type: INIT_PLUGIN,
+        options
     };
 };

--- a/web/client/actions/dashboard.js
+++ b/web/client/actions/dashboard.js
@@ -28,6 +28,7 @@ export const DASHBOARD_DELETE_SERVICE = "DASHBOARD:DELETE_SERVICE";
 export const DASHBOARD_SAVE_SERVICE_LOADING = "DASHBOARD:SAVE_SERVICE_LOADING";
 export const DASHBOARD_EXPORT = "DASHBOARD:EXPORT";
 export const DASHBOARD_IMPORT = "DASHBOARD:IMPORT";
+export const INIT_PLUGIN = "DASHBOARD:INIT_PLUGIN";
 
 export const setEditing = (editing) => ({type: SET_EDITING, editing });
 
@@ -92,3 +93,8 @@ export const dashboardDeleteService = (service, services) => ({ type: DASHBOARD_
  * @param {bolean} loading the loading state of the dashboard catalog saving
 */
 export const setDashboardServiceSaveLoading = loading => ({ type: DASHBOARD_SAVE_SERVICE_LOADING, loading});
+
+/**
+ * @param {options} options the options to be updated on plugin initialization
+*/
+export const initPlugin = (options) => ({ type: INIT_PLUGIN, options });

--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -81,7 +81,8 @@ class Catalog extends React.Component {
         layerBaseConfig: PropTypes.object,
         service: PropTypes.object,
         isNewServiceAdded: PropTypes.bool,
-        setNewServiceStatus: PropTypes.func
+        setNewServiceStatus: PropTypes.func,
+        canEdit: PropTypes.func
     };
 
     static contextTypes = {
@@ -323,7 +324,7 @@ class Catalog extends React.Component {
                         <ControlLabel><Message msgId="catalog.service" /></ControlLabel>
                     </FormGroup>
                     <FormGroup controlId="service" key="service">
-                        <InputGroup>
+                        <InputGroup style={{width: '100%'}}>
                             <Select
                                 clearValueText={getMessageById(this.context.messages, "catalog.clearValueText")}
                                 noResultsText={getMessageById(this.context.messages, "catalog.noResultsText")}
@@ -332,13 +333,13 @@ class Catalog extends React.Component {
                                 value={this.props.selectedService}
                                 onChange={(val) => this.props.onChangeSelectedService(val && val.value ? val.value : "")}
                                 placeholder={getMessageById(this.context.messages, "catalog.servicePlaceholder")} />
-                            {this.isValidServiceSelected() && !this.props.services[this.props.selectedService].readOnly ? (<InputGroup.Addon className="btn"
+                            {this.props.canEdit && this.isValidServiceSelected() && !this.props.services[this.props.selectedService].readOnly ? (<InputGroup.Addon className="btn"
                                 onClick={() => this.props.onChangeCatalogMode("edit", false)}>
                                 <Glyphicon glyph="pencil" />
                             </InputGroup.Addon>) : null}
-                            <InputGroup.Addon className="btn" onClick={() => this.props.onChangeCatalogMode("edit", true)}>
+                            {this.props.canEdit && <InputGroup.Addon className="btn" onClick={() => this.props.onChangeCatalogMode("edit", true)}>
                                 <Glyphicon glyph="plus" />
-                            </InputGroup.Addon>
+                            </InputGroup.Addon>}
                         </InputGroup>
                     </FormGroup>
                     {this.props.services?.[this.props.selectedService]?.type !== '3dtiles' && <FormGroup controlId="searchText" key="searchText">

--- a/web/client/components/catalog/CatalogForm.jsx
+++ b/web/client/components/catalog/CatalogForm.jsx
@@ -15,14 +15,16 @@ const SearchInput = localizeProps("placeholder")(FormControl);
 
 export default ({ onSearchTextChange = () => { }, onChangeSelectedService = () => {}, searchText, title = <Message msgId={"catalog.title"} />, services, showCatalogSelector,
     selectedService,
-    onChangeCatalogMode}) =>
+    onChangeCatalogMode,
+    canEditService }) =>
     ( <Grid className="catalog-form" fluid><Row><Col xs={12}>
         <h4 className="text-center">{title}</h4>
         {showCatalogSelector
             ? (<FormGroup>
                 <CatalogServiceSelector onChangeCatalogMode={onChangeCatalogMode} services={services} onChangeSelectedService={onChangeSelectedService}
                     selectedService={{label: selectedService?.title ?? "", value: selectedService ?? {}}}
-                    isValidServiceSelected={selectedService} />
+                    isValidServiceSelected={selectedService}
+                    canEdit={canEditService} />
             </FormGroup>) : null}
         <FormGroup controlId="catalog-form">
             <SearchInput type="text" placeholder="catalog.textSearchPlaceholder" value={searchText} onChange={(e) => onSearchTextChange(e.currentTarget.value)}/>

--- a/web/client/components/catalog/CatalogServiceSelector.jsx
+++ b/web/client/components/catalog/CatalogServiceSelector.jsx
@@ -15,8 +15,9 @@ export default ({
     selectedService,
     onChangeSelectedService = () => {},
     onChangeCatalogMode = () => {},
-    isValidServiceSelected
-}) => (<InputGroup>
+    isValidServiceSelected,
+    canEdit
+}) => (<InputGroup style={{ width: '100%' }}>
     <Select
         clearValueText={"catalog.clearValueText"}
         noResultsText={"catalog.noResultsText"}
@@ -25,12 +26,12 @@ export default ({
         value={selectedService}
         onChange={(val) => onChangeSelectedService(val && val.value ? val.value : "")}
         placeholder={"catalog.servicePlaceholder"} />
-    {isValidServiceSelected ? (<InputGroup.Addon className="btn"
+    {canEdit && isValidServiceSelected ? (<InputGroup.Addon className="btn"
         onClick={() => onChangeCatalogMode("edit", false)}>
         <Glyphicon glyph="pencil"/>
     </InputGroup.Addon>) : null}
-    <InputGroup.Addon className="btn" onClick={() => onChangeCatalogMode("edit", true)}>
+    {canEdit && <InputGroup.Addon className="btn" onClick={() => onChangeCatalogMode("edit", true)}>
         <Glyphicon glyph="plus"/>
-    </InputGroup.Addon>
+    </InputGroup.Addon>}
 </InputGroup>
 );

--- a/web/client/components/catalog/CompactCatalog.jsx
+++ b/web/client/components/catalog/CompactCatalog.jsx
@@ -130,7 +130,9 @@ export default compose(
     onChangeSelectedService = () => {},
     selectedService, onChangeCatalogMode = () => {},
     getItems = (_items) => getCatalogItems(_items, selected),
-    onItemClick = ({record} = {}) => onRecordSelected(record, catalog)}) => {
+    onItemClick = ({record} = {}) => onRecordSelected(record, catalog),
+    canEditService
+}) => {
     return (<BorderLayout
         className="compat-catalog"
         header={<CatalogForm onChangeCatalogMode={onChangeCatalogMode} onChangeSelectedService={onChangeSelectedService}
@@ -138,7 +140,8 @@ export default compose(
             selectedService={services[selectedService]} showCatalogSelector={showCatalogSelector}
             title={title}
             searchText={searchText}
-            onSearchTextChange={setSearchText}/>}
+            onSearchTextChange={setSearchText}
+            canEditService={canEditService}/>}
         footer={<div className="catalog-footer">
             {loading ? <LoadingSpinner /> : null}
             {!isNil(total) ? <span className="res-info"><Message msgId="catalog.pageInfoInfinite" msgParams={{loaded: items.length, total}}/></span> : null}

--- a/web/client/components/catalog/__tests__/Catalog-test.jsx
+++ b/web/client/components/catalog/__tests__/Catalog-test.jsx
@@ -182,4 +182,46 @@ describe('Test Catalog panel', () => {
         expect(spyOnSearch.calls[0].arguments[0]).toEqual({ format: 'csw', url: 'url', startPosition: 1, maxRecords: 4, text: '', options: {service: SERVICE} });
         expect(catalogPagination.length).toBe(1); // Pagination is displayed
     });
+    it('test manage service with permission', () => {
+        const SERVICE = {
+            type: "csw",
+            url: "url",
+            title: "csw"
+        };
+        ReactDOM.render(<Catalog
+            services={{ "csw": SERVICE}}
+            canEdit
+            selectedService="csw"
+            isNewServiceAdded={false}
+            result={{numberOfRecordsMatched: 4, numberOfRecordsReturned: 10}}
+            searchOptions={{startPosition: 1}}
+        />, document.getElementById("container"));
+        const container = document.getElementById("container");
+        expect(container).toBeTruthy();
+        let editEl = document.querySelector('.glyphicon-pencil');
+        let addEl = document.querySelector('.glyphicon-plus');
+        expect(editEl).toBeTruthy();
+        expect(addEl).toBeTruthy();
+    });
+    it('test manage service with no permission', () => {
+        const SERVICE = {
+            type: "csw",
+            url: "url",
+            title: "csw"
+        };
+        ReactDOM.render(<Catalog
+            services={{ "csw": SERVICE}}
+            canEdit={false}
+            selectedService="csw"
+            isNewServiceAdded={false}
+            result={{numberOfRecordsMatched: 4, numberOfRecordsReturned: 10}}
+            searchOptions={{startPosition: 1}}
+        />, document.getElementById("container"));
+        const container = document.getElementById("container");
+        expect(container).toBeTruthy();
+        let editEl = document.querySelector('.glyphicon-pencil');
+        let addEl = document.querySelector('.glyphicon-plus');
+        expect(editEl).toBeFalsy();
+        expect(addEl).toBeFalsy();
+    });
 });

--- a/web/client/components/catalog/__tests__/CatalogServiceSelector-test.jsx
+++ b/web/client/components/catalog/__tests__/CatalogServiceSelector-test.jsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+import CatalogServiceSelector from '../CatalogServiceSelector';
+
+describe('Test CatalogServiceEditor', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates the component with defaults', () => {
+        ReactDOM.render(<CatalogServiceSelector services={[]} />, document.getElementById("container"));
+        expect(document.getElementById('container')).toBeTruthy();
+        expect(document.querySelector('input')).toBeTruthy();
+        expect(document.querySelector('.glyphicon-pencil')).toBeFalsy();
+        expect(document.querySelector('.glyphicon-plus')).toBeFalsy();
+    });
+    it('test isValidServiceSelected', () => {
+        ReactDOM.render(<CatalogServiceSelector services={[]} canEdit />, document.getElementById("container"));
+        expect(document.getElementById('container')).toBeTruthy();
+        expect(document.querySelector('input')).toBeTruthy();
+        expect(document.querySelector('.glyphicon-pencil')).toBeFalsy();
+        expect(document.querySelector('.glyphicon-plus')).toBeTruthy();
+    });
+    it('test isValidServiceSelected & canEdit', () => {
+        ReactDOM.render(<CatalogServiceSelector services={[]} isValidServiceSelected canEdit />, document.getElementById("container"));
+        expect(document.getElementById('container')).toBeTruthy();
+        expect(document.querySelector('input')).toBeTruthy();
+        expect(document.querySelector('.glyphicon-pencil')).toBeTruthy();
+        expect(document.querySelector('.glyphicon-plus')).toBeTruthy();
+    });
+});

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -39,7 +39,8 @@ import {
     toggleAdvancedSettings,
     toggleTemplate,
     toggleThumbnail,
-    setNewServiceStatus
+    setNewServiceStatus,
+    initPlugin
 } from '../actions/catalog';
 import { setControlProperty, toggleControl } from '../actions/controls';
 import { changeLayerProperties } from '../actions/layers';
@@ -74,7 +75,8 @@ import {
     getSupportedFormatsSelector,
     getSupportedGFIFormatsSelector,
     getNewServiceStatusSelector,
-    showFormatErrorSelector
+    showFormatErrorSelector,
+    canEditServiceSelector
 } from '../selectors/catalog';
 import { layersSelector } from '../selectors/layers';
 import { currentLocaleSelector, currentMessagesSelector } from '../selectors/locale';
@@ -121,7 +123,8 @@ const metadataExplorerSelector = createStructuredSelector({
     formatsLoading: formatsLoadingSelector,
     formatOptions: getSupportedFormatsSelector,
     infoFormatOptions: getSupportedGFIFormatsSelector,
-    isNewServiceAdded: getNewServiceStatusSelector
+    isNewServiceAdded: getNewServiceStatusSelector,
+    canEdit: canEditServiceSelector
 });
 
 
@@ -174,7 +177,10 @@ class MetadataExplorerComponent extends React.Component {
         // side panel properties
         width: PropTypes.number,
         dockStyle: PropTypes.object,
-        group: PropTypes.string
+        group: PropTypes.string,
+        onInitPlugin: PropTypes.func,
+        editingAllowedRoles: PropTypes.array,
+        editingAllowedGroups: PropTypes.array
     };
 
     static defaultProps = {
@@ -191,6 +197,7 @@ class MetadataExplorerComponent extends React.Component {
         },
         panelClassName: "catalog-panel",
         closeCatalog: () => {},
+        onInitPlugin: () => {},
         closeGlyph: "1-close",
         zoomToLayer: true,
 
@@ -205,8 +212,16 @@ class MetadataExplorerComponent extends React.Component {
         dockStyle: {},
         group: null,
         services: {},
-        servicesWithBackgrounds: {}
+        servicesWithBackgrounds: {},
+        editingAllowedRoles: ["ADMIN"]
     };
+
+    componentDidMount() {
+        this.props.onInitPlugin({
+            editingAllowedRoles: this.props.editingAllowedRoles,
+            editingAllowedGroups: this.props.editingAllowedGroups
+        });
+    }
 
     componentWillUnmount() {
         this.props.closeCatalog();
@@ -275,7 +290,8 @@ const MetadataExplorerPlugin = connect(metadataExplorerSelector, {
     onToggle: toggleControl.bind(null, 'backgroundSelector', null),
     onLayerChange: setControlProperty.bind(null, 'backgroundSelector'),
     onStartChange: setControlProperty.bind(null, 'backgroundSelector', 'start'),
-    setNewServiceStatus
+    setNewServiceStatus,
+    onInitPlugin: initPlugin
 })(MetadataExplorerComponent);
 
 /**

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -213,7 +213,7 @@ class MetadataExplorerComponent extends React.Component {
         group: null,
         services: {},
         servicesWithBackgrounds: {},
-        editingAllowedRoles: ["ADMIN"]
+        editingAllowedRoles: ["ALL"]
     };
 
     componentDidMount() {

--- a/web/client/plugins/__tests__/DashboardEditor-test.jsx
+++ b/web/client/plugins/__tests__/DashboardEditor-test.jsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import DashboardEditorPlugin from '../DashboardEditor';
+import { getPluginForTest } from './pluginsTestUtils';
+
+describe('DashboardEditorPlugin Plugin', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="container"></div>';
+    });
+
+    afterEach(() => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+    });
+    it('test DashboardEditorPlugin plugin on mount', () => {
+        const {Plugin, actions} = getPluginForTest(DashboardEditorPlugin, {});
+        ReactDOM.render(<Plugin pluginCfg={{}}/>, document.getElementById("container"));
+
+        expect(actions.length).toBeTruthy();
+        const actionTypes = actions.map(a => a.type);
+        expect(actionTypes.includes("DASHBOARD:INIT_PLUGIN")).toBeTruthy();
+        expect(actionTypes.includes("DASHBOARD:SET_AVAILABLE")).toBeTruthy();
+    });
+    it('test DashboardEditorPlugin plugin on unmount', () => {
+        const {Plugin, actions} = getPluginForTest(DashboardEditorPlugin, {});
+        ReactDOM.render(<Plugin pluginCfg={{}}/>, document.getElementById("container"));
+
+        ReactDOM.render(<div/>, document.getElementById("container"));
+        expect(actions).toBeTruthy();
+        expect(actions.find(a => a.type === "DASHBOARD:SET_AVAILABLE")).toBeTruthy();
+    });
+});

--- a/web/client/plugins/__tests__/MetadataExplorer-test.jsx
+++ b/web/client/plugins/__tests__/MetadataExplorer-test.jsx
@@ -26,17 +26,19 @@ describe('MetadataExplorer Plugin', () => {
         ReactDOM.render(<Plugin/>, document.getElementById("container"));
         expect(document.getElementById('catalog-root')).toBeTruthy();
     });
+    it('test MetadataExplorerPlugin plugin on mount', () => {
+        const {Plugin, actions} = getPluginForTest(MetadataExplorerPlugin, {});
+        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+
+        expect(actions.length).toBeTruthy();
+        expect(actions.map(a => a.type).includes("CATALOG:INIT_PLUGIN")).toBeTruthy();
+    });
     it('test MetadataExplorerPlugin plugin on unmount', () => {
         const {Plugin, actions} = getPluginForTest(MetadataExplorerPlugin, {});
         ReactDOM.render(<Plugin/>, document.getElementById("container"));
 
         ReactDOM.render(<div/>, document.getElementById("container"));
-        expect(actions.length).toBe(4);
-        expect(actions[0].type).toBe("CATALOG:CATALOG_CLOSE");
-        expect(actions[1].type).toBe("SET_CONTROL_PROPERTIES");
-        expect(actions[1].control).toBe("metadataexplorer");
-        expect(actions[2].type).toBe("CATALOG:CHANGE_CATALOG_MODE");
-        expect(actions[2].mode).toBe("view");
-        expect(actions[3].type).toBe("CATALOG:RESET_CATALOG");
+        expect(actions.length).toBeTruthy();
+        expect(actions.map(a => a.type).includes("CATALOG:CATALOG_CLOSE")).toBeTruthy();
     });
 });

--- a/web/client/plugins/widgetbuilder/ChartLayerSelector.jsx
+++ b/web/client/plugins/widgetbuilder/ChartLayerSelector.jsx
@@ -56,7 +56,8 @@ export default connect((state) =>({
     onItemClick,
     showLayers,
     toggleLayerSelector,
-    selectedCatalog
+    selectedCatalog,
+    canEditService
 }) => {
     const _canProceed = showLayers ? canProceed && !isEmpty(layer) : canProceed && selected && layer && castArray(selected).length === castArray(layer).length;
     const getProcessArguments = () => {
@@ -111,6 +112,7 @@ export default connect((state) =>({
                     <Glyphicon glyph="info-sign" />
                 </Button>
             </>}
+            canEditService={canEditService}
         />
     </BorderLayout>);
 });

--- a/web/client/plugins/widgetbuilder/LayerSelector.jsx
+++ b/web/client/plugins/widgetbuilder/LayerSelector.jsx
@@ -31,7 +31,7 @@ const Catalog = compose(
  * @prop {function} [layerValidationStream]
  */
 export default ({ onClose = () => { }, setSelected = () => { }, onLayerChoice = () => { }, stepButtons, selected, error, canProceed, layer, catalog, defaultServices,
-    onChangeSelectedService, defaultSelectedService, onChangeCatalogMode, dashboardServices, dashboardSelectedService} = {}) =>
+    onChangeSelectedService, defaultSelectedService, onChangeCatalogMode, dashboardServices, dashboardSelectedService, canEditService} = {}) =>
     (<BorderLayout
         className="bg-body layer-selector"
         header={<BuilderHeader onClose={onClose}>
@@ -47,5 +47,6 @@ export default ({ onClose = () => { }, setSelected = () => { }, onLayerChoice = 
         <Catalog
             onChangeCatalogMode={onChangeCatalogMode}
             selectedService={dashboardSelectedService === "" ? dashboardSelectedService : dashboardSelectedService === undefined ? defaultSelectedService : dashboardSelectedService}
-            onChangeSelectedService={(service) => onChangeSelectedService(service, dashboardServices || defaultServices)} services={ dashboardServices || defaultServices} selected={selected} catalog={catalog} onRecordSelected={r => setSelected(r)} />
+            onChangeSelectedService={(service) => onChangeSelectedService(service, dashboardServices || defaultServices)} services={ dashboardServices || defaultServices} selected={selected} catalog={catalog} onRecordSelected={r => setSelected(r)}
+            canEditService={canEditService}/>
     </BorderLayout>);

--- a/web/client/plugins/widgetbuilder/MapLayerSelector.jsx
+++ b/web/client/plugins/widgetbuilder/MapLayerSelector.jsx
@@ -30,7 +30,7 @@ const Catalog = compose(
  */
 export default ({ onClose = () => { }, setSelected = () => { }, onLayerChoice = () => { }, toggleLayerSelector = () => {}, selected, canProceed, layer,
     catalog, onChangeSelectedService, defaultServices,
-    defaultSelectedService, onChangeCatalogMode, dashboardServices, dashboardSelectedService} = {}) =>
+    defaultSelectedService, onChangeCatalogMode, dashboardServices, dashboardSelectedService, canEditService} = {}) =>
     (<BorderLayout
         className="bg-body layer-selector"
         header={<BuilderHeader onClose={onClose}>
@@ -62,5 +62,6 @@ export default ({ onClose = () => { }, setSelected = () => { }, onLayerChoice = 
             onChangeSelectedService={(service) => onChangeSelectedService(service, dashboardServices || defaultServices)} services={ dashboardServices || defaultServices}
             catalog={catalog}
             selected={selected}
-            onRecordSelected={r => setSelected(r)} />
+            onRecordSelected={r => setSelected(r)}
+            canEditService={canEditService} />
     </BorderLayout>);

--- a/web/client/reducers/__tests__/catalog-test.js
+++ b/web/client/reducers/__tests__/catalog-test.js
@@ -55,7 +55,8 @@ import {
     changeServiceFormat,
     setLoading,
     formatsLoading,
-    setSupportedFormats
+    setSupportedFormats,
+    initPlugin
 } from '../../actions/catalog';
 
 import { MAP_CONFIG_LOADED } from '../../actions/config';
@@ -343,5 +344,24 @@ describe('Test the catalog reducer', () => {
         }, setSupportedFormats(formats, url));
         expect(state.newService.formatUrlUsed).toBe(url);
         expect(state.newService.supportedFormats).toEqual(formats);
+    });
+    it('INIT_PLUGIN ', () => {
+        const option = {
+            editingAllowedRoles: ["ADMIN"],
+            editingAllowedGroups: []
+        };
+        let state = catalog({
+            newService: {}
+        }, initPlugin(option));
+        expect(state.editingAllowedRoles).toEqual(option.editingAllowedRoles);
+        expect(state.editingAllowedGroups).toEqual(option.editingAllowedGroups);
+
+        state = catalog({
+            newService: {},
+            editingAllowedRoles: ["ADMIN"],
+            editingAllowedGroups: []
+        }, initPlugin());
+        expect(state.editingAllowedRoles).toEqual(option.editingAllowedRoles);
+        expect(state.editingAllowedGroups).toEqual(option.editingAllowedGroups);
     });
 });

--- a/web/client/reducers/__tests__/dashboard-test.js
+++ b/web/client/reducers/__tests__/dashboard-test.js
@@ -22,7 +22,8 @@ import {
     setDashboardCatalogMode,
     setDashboardServiceSaveLoading,
     dashboardDeleteService,
-    updateDashboardService
+    updateDashboardService,
+    initPlugin
 } from '../../actions/dashboard';
 
 import { insertWidget, updateWidget, deleteWidget } from '../../actions/widgets';
@@ -146,5 +147,14 @@ describe('Test the dashboard reducer', () => {
         expect(state.selectedService).toBe('test');
 
     });
+    it('dashboard onInitPlugin', () => {
+        let action = initPlugin({option: "test"});
+        let state = dashboard({}, action);
+        expect(state.option).toBeTruthy();
+        expect(state.option).toBe("test");
 
+        action = initPlugin();
+        state = dashboard({serviceStarted: false}, action);
+        expect(state).toEqual({serviceStarted: false});
+    });
 });

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -32,7 +32,8 @@ import {
     FORMAT_OPTIONS_LOADING,
     SHOW_FORMAT_ERROR,
     SET_FORMAT_OPTIONS,
-    NEW_SERVICE_STATUS
+    NEW_SERVICE_STATUS,
+    INIT_PLUGIN
 } from '../actions/catalog';
 
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -68,6 +69,12 @@ function catalog(state = {
     newService: {}
 }, action) {
     switch (action.type) {
+    case INIT_PLUGIN:
+        return {
+            ...state,
+            editingAllowedRoles: action?.options?.editingAllowedRoles || state.editingAllowedRoles,
+            editingAllowedGroups: action?.options?.editingAllowedGroups || state.editingAllowedGroups
+        };
     case SAVING_SERVICE:
         return {
             ...state,

--- a/web/client/reducers/dashboard.js
+++ b/web/client/reducers/dashboard.js
@@ -23,7 +23,8 @@ import {
     DASHBOARD_ADD_NEW_SERVICE,
     DASHBOARD_CATALOG_MODE,
     DASHBOARD_DELETE_SERVICE,
-    DASHBOARD_SAVE_SERVICE_LOADING
+    DASHBOARD_SAVE_SERVICE_LOADING,
+    INIT_PLUGIN
 } from '../actions/dashboard';
 
 import { INSERT, UPDATE, DELETE } from '../actions/widgets';
@@ -36,6 +37,9 @@ function dashboard(state = {
     saveServiceLoading: false
 }, action) {
     switch (action.type) {
+    case INIT_PLUGIN: {
+        return { ...state, ...action?.options };
+    }
     case SET_EDITOR_AVAILABLE: {
         return set("editor.available", action.available, state);
     }

--- a/web/client/selectors/__tests__/catalog-test.js
+++ b/web/client/selectors/__tests__/catalog-test.js
@@ -33,7 +33,8 @@ import {
     formatsLoadingSelector,
     getSupportedFormatsSelector,
     getSupportedGFIFormatsSelector,
-    getFormatUrlUsedSelector
+    getFormatUrlUsedSelector,
+    canEditServiceSelector
 } from '../catalog';
 
 import { set } from '../../utils/ImmutableUtils';
@@ -348,5 +349,103 @@ describe('Test catalog selectors', () => {
             }
         });
         expect(toolState).toBe(true);
+    });
+    describe("canEditServiceSelector", () => {
+        it('test ADMIN role ', () => {
+            const canEdit = canEditServiceSelector({
+                catalog: {
+                    editingAllowedRoles: ['ADMIN'],
+                    editingAllowedGroups: []
+                },
+                security: {
+                    user: {
+                        role: "ADMIN"
+                    }
+                }
+            });
+            expect(canEdit).toBe(true);
+        });
+        it("test ALL user role", () => {
+            const canEdit = canEditServiceSelector({
+                catalog: {
+                    editingAllowedRoles: ['ALL'],
+                    editingAllowedGroups: []
+                },
+                security: {
+                    user: {
+                        role: "ADMIN"
+                    }
+                }
+            });
+            expect(canEdit).toBe(true);
+        });
+        it("test custom user role", () => {
+            const canEdit = canEditServiceSelector({
+                catalog: {
+                    editingAllowedRoles: ['ROLE1'],
+                    editingAllowedGroups: []
+                },
+                security: {
+                    user: {
+                        role: "ROLE1"
+                    }
+                }
+            });
+            expect(canEdit).toBe(true);
+        });
+        it("test user role not matching", () => {
+            const canEdit = canEditServiceSelector({
+                catalog: {
+                    editingAllowedRoles: ['ADMIN'],
+                    editingAllowedGroups: []
+                },
+                security: {
+                    user: {
+                        role: "ROLE1"
+                    }
+                }
+            });
+            expect(canEdit).toBe(false);
+        });
+        it("test group matching", () => {
+            const canEdit = canEditServiceSelector({
+                catalog: {
+                    editingAllowedRoles: [],
+                    editingAllowedGroups: ['group1']
+                },
+                security: {
+                    user: {
+                        role: "ROLE1",
+                        groups: {
+                            group: {
+                                enabled: true,
+                                groupName: "group1"
+                            }
+                        }
+                    }
+                }
+            });
+            expect(canEdit).toBe(true);
+        });
+        it("test group not matching", () => {
+            const canEdit = canEditServiceSelector({
+                catalog: {
+                    editingAllowedRoles: [],
+                    editingAllowedGroups: ['group1']
+                },
+                security: {
+                    user: {
+                        role: "ROLE1",
+                        groups: {
+                            group: {
+                                enabled: true,
+                                groupName: "geo"
+                            }
+                        }
+                    }
+                }
+            });
+            expect(canEdit).toBe(false);
+        });
     });
 });

--- a/web/client/selectors/__tests__/dashboard-test.js
+++ b/web/client/selectors/__tests__/dashboard-test.js
@@ -25,7 +25,8 @@ import {
     dashboardSaveServiceSelector,
     dashboardResourceInfoSelector,
     dashbaordInfoDetailsUriFromIdSelector,
-    dashboardInfoDetailsSettingsFromIdSelector
+    dashboardInfoDetailsSettingsFromIdSelector,
+    canEditServiceSelector
 } from '../dashboard';
 
 describe('dashboard selectors', () => {
@@ -148,5 +149,115 @@ describe('dashboard selectors', () => {
                 }
             }
         }})).toBe("detailsSettings");
+    });
+    describe("canEditServiceSelector", () => {
+        it('test ADMIN role ', () => {
+            const canEdit = canEditServiceSelector({
+                dashboard: {
+                    servicesPermission: {
+                        editingAllowedRoles: ['ADMIN'],
+                        editingAllowedGroups: []
+                    }
+                },
+                security: {
+                    user: {
+                        role: "ADMIN"
+                    }
+                }
+            });
+            expect(canEdit).toBe(true);
+        });
+        it("test ALL user role", () => {
+            const canEdit = canEditServiceSelector({
+                dashboard: {
+                    servicesPermission: {
+                        editingAllowedRoles: ['ALL'],
+                        editingAllowedGroups: []
+                    }
+                },
+                security: {
+                    user: {
+                        role: "ADMIN"
+                    }
+                }
+            });
+            expect(canEdit).toBe(true);
+        });
+        it("test custom user role", () => {
+            const canEdit = canEditServiceSelector({
+                dashboard: {
+                    servicesPermission: {
+                        editingAllowedRoles: ['ROLE1'],
+                        editingAllowedGroups: []
+                    }
+                },
+                security: {
+                    user: {
+                        role: "ROLE1"
+                    }
+                }
+            });
+            expect(canEdit).toBe(true);
+        });
+        it("test user role not matching", () => {
+            const canEdit = canEditServiceSelector({
+                dashboard: {
+                    servicesPermission: {
+                        editingAllowedRoles: ['ADMIN'],
+                        editingAllowedGroups: []
+                    }
+                },
+                security: {
+                    user: {
+                        role: "ROLE1"
+                    }
+                }
+            });
+            expect(canEdit).toBe(false);
+        });
+        it("test group matching", () => {
+            const canEdit = canEditServiceSelector({
+                dashboard: {
+                    servicesPermission: {
+                        editingAllowedRoles: [],
+                        editingAllowedGroups: ['group1']
+                    }
+                },
+                security: {
+                    user: {
+                        role: "ROLE1",
+                        groups: {
+                            group: {
+                                enabled: true,
+                                groupName: "group1"
+                            }
+                        }
+                    }
+                }
+            });
+            expect(canEdit).toBe(true);
+        });
+        it("test group not matching", () => {
+            const canEdit = canEditServiceSelector({
+                dashboard: {
+                    servicesPermission: {
+                        editingAllowedRoles: [],
+                        editingAllowedGroups: ['group1']
+                    }
+                },
+                security: {
+                    user: {
+                        role: "ROLE1",
+                        groups: {
+                            group: {
+                                enabled: true,
+                                groupName: "geo"
+                            }
+                        }
+                    }
+                }
+            });
+            expect(canEdit).toBe(false);
+        });
     });
 });

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -11,6 +11,7 @@ import { get } from 'lodash';
 
 import { projectionSelector } from './map';
 import { getDefaultSupportedGetFeatureInfoFormats } from '../utils/WMSUtils';
+import { isUserAllowedSelectorCreator } from './security';
 
 export const staticServicesSelector = (state) => get(state, "catalog.default.staticServices");
 export const servicesSelector = (state) => get(state, "catalog.services");
@@ -65,3 +66,19 @@ export const getSupportedGFIFormatsSelector = (state) => get(state, "catalog.new
 export const getFormatUrlUsedSelector = (state) => get(state, "catalog.newService.formatUrlUsed", '');
 export const getNewServiceStatusSelector = (state) => get(state, "catalog.isNewServiceAdded", false);
 export const showFormatErrorSelector = (state) => get(state, "catalog.showFormatError", false);
+export const editingAllowedRolesSelector = (state) => get(state, "catalog.editingAllowedRoles", []);
+export const editingAllowedGroupsSelector = (state) => get(state, "catalog.editingAllowedGroups", []);
+/**
+ * selects canEdit status of styleeditor service from state
+ * @memberof selectors.styleeditor
+ * @param  {object} state the state
+ * @return {bool}
+ */
+export const canEditServiceSelector = (state) => {
+    const allowedRoles = editingAllowedRolesSelector(state);
+    const allowedGroups = editingAllowedGroupsSelector(state);
+    return isUserAllowedSelectorCreator({
+        allowedRoles,
+        allowedGroups
+    })(state);
+};

--- a/web/client/selectors/dashboard.js
+++ b/web/client/selectors/dashboard.js
@@ -8,6 +8,7 @@
 import { createSelector } from 'reselect';
 import {get} from 'lodash';
 import { pathnameSelector } from './router';
+import { isUserAllowedSelectorCreator } from './security';
 
 export const getDashboardId = state => state?.dashboard?.resource?.id;
 export const isDashboardAvailable = state => state && state.dashboard && state.dashboard.editor && state.dashboard.editor.available;
@@ -31,4 +32,14 @@ export const dashboardSaveServiceSelector =  state => state.dashboard?.saveServi
 export const dashboardResourceInfoSelector = state => get(state, "dashboard.resource");
 export const dashbaordInfoDetailsUriFromIdSelector = state => state?.dashboard?.resource?.attributes?.details;
 export const dashboardInfoDetailsSettingsFromIdSelector = state => get(dashboardResource(state), "attributes.detailsSettings");
+export const editingAllowedRolesSelector = state => get(state, "dashboard.servicesPermission.editingAllowedRoles", []);
+export const editingAllowedGroupsSelector = state => get(state, "dashboard.servicesPermission.editingAllowedGroups", []);
+export const canEditServiceSelector = state => {
+    const allowedRoles = editingAllowedRolesSelector(state);
+    const allowedGroups = editingAllowedGroupsSelector(state);
+    return isUserAllowedSelectorCreator({
+        allowedRoles,
+        allowedGroups
+    })(state);
+};
 


### PR DESCRIPTION
## Description
This PR adds configurable options to MetadataExplorer plugin (applicable for Map, Geostory, Context) and DashboardEditor's catalog component to configure permissible roles and groups via `editingAllowedRoles` and `editingAllowedGroups`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] New Feature

## Issue

**What is the current behavior?**
- #9974 

**What is the new behavior?**
Based on the configured roles and groups permissible, the catalog services buttons are hidden/shown. By default editingAllowedRoles is "ADMIN"

```json
{
  "name": "MetadataExplorer",
  "cfg": {
    ...
    "editingAllowedRoles": [
      "some-role"
    ]"editingAllowedGroups": [
      "some-group"
    ]
  }
}
```

```json
{
  "name": "DashboardEditor",
  "cfg": {
    ...
    "servicesPermission": {
      "editingAllowedRoles": [
        "some-role"
      ]"editingAllowedGroups": [
        "some-group"
      ]
    }
  }
}
```

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
