### PR TITLE
#10034: Shown exception text from Catalog in the notification

### DIFF
--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -179,7 +179,7 @@ class Catalog extends React.Component {
             }
             return this.renderRecords();
         } else if (this.props.loadingError) {
-            return this.renderError();
+            return this.renderError(this.props.loadingError);
         }
         return null;
     };

--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -321,7 +321,7 @@ describe('catalog Epics', () => {
             newService: service
         } });
     });
-    it('recordSearchEpic with exception', (done) => {
+    it('recordSearchEpic with network error', (done) => {
         const NUM_ACTIONS = 2;
         testEpic(addTimeoutEpic(recordSearchEpic), NUM_ACTIONS, textSearch({
             format: "csw",
@@ -338,8 +338,62 @@ describe('catalog Epics', () => {
                     expect(action.loading).toBe(true);
                     break;
                 case RECORD_LIST_LOAD_ERROR:
-                    expect(action.error.status).toBe(404);
-                    expect(action.error.statusText).toBe("Not Found");
+                    break;
+                case TEST_TIMEOUT:
+                    break;
+                default:
+                    expect(true).toBe(false);
+                }
+            });
+            done();
+        }, { });
+    });
+    it('recordSearchEpic with exception', (done) => {
+        const NUM_ACTIONS = 2;
+        testEpic(addTimeoutEpic(recordSearchEpic), NUM_ACTIONS, textSearch({
+            format: "csw",
+            url: "base/web/client/test-resources/csw/getRecordsResponseException.xml",
+            startPosition: 1,
+            maxRecords: 1,
+            text: "a",
+            options: {}
+        }), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case SET_LOADING:
+                    expect(action.loading).toBe(true);
+                    break;
+                case RECORD_LIST_LOAD_ERROR:
+                    expect(action.error).toContain('IllegalArgumentException');
+                    break;
+                case TEST_TIMEOUT:
+                    break;
+                default:
+                    expect(true).toBe(false);
+                }
+            });
+            done();
+        }, { });
+    });
+    it('recordSearchEpic with exception with new service', (done) => {
+        const NUM_ACTIONS = 2;
+        testEpic(addTimeoutEpic(recordSearchEpic), NUM_ACTIONS, textSearch({
+            format: "csw",
+            url: "base/web/client/test-resources/csw/getRecordsResponseEsxception.xml",
+            startPosition: 1,
+            maxRecords: 1,
+            text: "a",
+            options: {isNewService: true}
+        }), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case SAVING_SERVICE:
+                    expect(action.status).toBe(true);
+                    break;
+                case SHOW_NOTIFICATION:
+                    expect(action.message).toBe('catalog.notification.errorServiceUrl');
                     break;
                 case TEST_TIMEOUT:
                     break;

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -72,10 +72,16 @@ import { getResolutions, METERS_PER_UNIT } from "../utils/MapUtils";
 import { describeFeatureType } from '../api/WFS';
 import { extractGeometryType } from '../utils/WFSLayerUtils';
 import { createDefaultStyle } from '../utils/StyleUtils';
+import { removeDuplicateLines } from '../utils/StringUtils';
+
 const onErrorRecordSearch = (isNewService, errObj) => {
     // Exception text is shown as is while the network errors are shown
     // with generic error message in the notification
-    const [errorMsg] = castArray(errObj?.error);
+    let [errorMsg] = castArray(errObj?.error);
+    if (errorMsg) {
+        // Remove any instance of duplicated line string from the exception text
+        errorMsg = removeDuplicateLines(errorMsg);
+    }
     console.warn("Catalog error", errorMsg);
 
     if (isNewService) {

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -76,6 +76,8 @@ import { removeDuplicateLines } from '../utils/StringUtils';
 import { logError } from '../utils/DebugUtils';
 
 const onErrorRecordSearch = (isNewService, errObj) => {
+    logError({message: errObj});
+
     // Exception text is shown as is while the network errors are shown
     // with generic error message in the notification
     let [errorMsg] = castArray(errObj?.error);
@@ -83,8 +85,6 @@ const onErrorRecordSearch = (isNewService, errObj) => {
         // Remove any instance of duplicated line string from the exception text
         errorMsg = removeDuplicateLines(errorMsg);
     }
-    logError({message: errorMsg});
-
     if (isNewService) {
         const message = errorMsg
             ? truncate(errorMsg, { length: 400 })

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -9,7 +9,7 @@
 import * as Rx from 'rxjs';
 import axios from 'axios';
 import xpathlib from 'xpath';
-import {head, get, find, isArray, isString, isObject, keys, toPairs, merge, castArray} from 'lodash';
+import {head, get, find, isArray, isString, isObject, keys, toPairs, merge, castArray, truncate} from 'lodash';
 
 import {
     ADD_SERVICE,
@@ -73,18 +73,26 @@ import { describeFeatureType } from '../api/WFS';
 import { extractGeometryType } from '../utils/WFSLayerUtils';
 import { createDefaultStyle } from '../utils/StyleUtils';
 const onErrorRecordSearch = (isNewService, errObj) => {
+    // Exception text is shown as is while the network errors are shown
+    // with generic error message in the notification
+    const [errorMsg] = castArray(errObj?.error);
+    console.warn("Catalog error", errorMsg);
+
     if (isNewService) {
+        const message = errorMsg
+            ? truncate(errorMsg, { length: 200 })
+            : "catalog.notification.errorServiceUrl";
         return Rx.Observable.of(
             error({
                 title: "notification.warning",
-                message: "catalog.notification.errorServiceUrl",
+                message,
                 autoDismiss: 6,
                 position: "tc"
             }),
             savingService(false)
         );
     }
-    return Rx.Observable.of(recordsLoadError(errObj));
+    return Rx.Observable.of(recordsLoadError(errorMsg));
 };
 /**
     * Epics for CATALOG

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -73,6 +73,7 @@ import { describeFeatureType } from '../api/WFS';
 import { extractGeometryType } from '../utils/WFSLayerUtils';
 import { createDefaultStyle } from '../utils/StyleUtils';
 import { removeDuplicateLines } from '../utils/StringUtils';
+import { logError } from '../utils/DebugUtils';
 
 const onErrorRecordSearch = (isNewService, errObj) => {
     // Exception text is shown as is while the network errors are shown
@@ -82,11 +83,11 @@ const onErrorRecordSearch = (isNewService, errObj) => {
         // Remove any instance of duplicated line string from the exception text
         errorMsg = removeDuplicateLines(errorMsg);
     }
-    console.warn("Catalog error", errorMsg);
+    logError({message: errorMsg});
 
     if (isNewService) {
         const message = errorMsg
-            ? truncate(errorMsg, { length: 200 })
+            ? truncate(errorMsg, { length: 400 })
             : "catalog.notification.errorServiceUrl";
         return Rx.Observable.of(
             error({

--- a/web/client/utils/StringUtils.js
+++ b/web/client/utils/StringUtils.js
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import isEmpty from "lodash/isEmpty";
+
 /**
  * Utility functions for String manipulations.
  * @memberof utils
@@ -31,3 +33,21 @@ export const isValidEmail = (str, regexp = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-
     return regexp.test(str);
 };
 
+/**
+ * Remove duplicate lines in a sentence
+ * @param {string} value
+ * @returns string with unique lines
+ */
+export const removeDuplicateLines = (value) => {
+    const lines = value.split('\n');
+    const uniqueLines = [];
+
+    lines.forEach((line) => {
+        const trimmedLine = line.trim();
+        if (isEmpty(uniqueLines) || !uniqueLines.some(l => l.includes(trimmedLine))) {
+            uniqueLines.push(trimmedLine);
+        }
+    });
+
+    return uniqueLines.join(' ');
+};

--- a/web/client/utils/__tests__/StringUtils-test.js
+++ b/web/client/utils/__tests__/StringUtils-test.js
@@ -7,7 +7,7 @@
  */
 import expect from 'expect';
 
-import { containsHTML } from '../StringUtils';
+import { containsHTML, removeDuplicateLines } from '../StringUtils';
 
 describe('StringUtils test', () => {
     it('test contains html', () => {
@@ -16,6 +16,28 @@ describe('StringUtils test', () => {
 
         expect(containsHTML(withHtml)).toBe(true);
         expect(containsHTML(withoutHtml)).toBe(false);
+    });
+    it('removeDuplicateLines', () => {
+        let test = "line1 \nline2 \nlin2 \nline1";
+        expect(removeDuplicateLines(test)).toBe('line1 line2 lin2');
+
+        test = "line1 \nline2 \nlin2 \n line1";
+        expect(removeDuplicateLines(test)).toBe('line1 line2 lin2');
+
+        test = "some:line1\nline1";
+        expect(removeDuplicateLines(test)).toBe('some:line1');
+
+        test = "s.o.m.e:line1. \nline2.\nline2";
+        expect(removeDuplicateLines(test)).toBe('s.o.m.e:line1. line2.');
+
+        test = "s-o-m-e:line1. \n\n line1. \n line1";
+        expect(removeDuplicateLines(test)).toBe('s-o-m-e:line1.');
+
+        test = "s-o-m-e:line1.line2.line1";
+        expect(removeDuplicateLines(test)).toBe(test);
+
+        test = "";
+        expect(removeDuplicateLines(test)).toBe(test);
     });
 
 });


### PR DESCRIPTION
## Description
This PR enhances the error notifications in Catalog. The exception texts of the response are shown in the notification and network error are shown with generic error

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- https://github.com/geosolutions-it/MapStore2/issues/10034#issuecomment-1997759268

**What is the new behavior?**
### Exception text
<img width="500" alt="Screenshot 2024-03-18 at 7 33 05 PM" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/2233f653-8a8f-4652-9094-83a46f641e2c">
<img width="500" alt="Screenshot 2024-03-18 at 7 32 42 PM" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/ae53d066-512d-4ac6-81d8-eb6b3490aac2">


### Generic error
<img width="500" alt="image" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/f7da705e-0ec4-4f85-82b0-60d3783a0b4f">



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
