### PR TITLE
#10064: Limit group permission for anonymous user

### DIFF
--- a/web/client/actions/users.js
+++ b/web/client/actions/users.js
@@ -16,6 +16,8 @@ export const USERS_SEARCH_TEXT_CHANGED = 'USERS_SEARCH_TEXT_CHANGED';
 
 import API from '../api/GeoStoreDAO';
 import { get, assign } from 'lodash';
+import SecurityUtils from '../utils/SecurityUtils';
+
 export function getUsersloading(text, start, limit) {
     return {
         type: USERMANAGER_GETUSERS,
@@ -259,7 +261,7 @@ export function saveUser(user, options = {}) {
         let userToPost = {...newUser};
         if (newUser && newUser.groups) {
             userToPost = {...newUser, groups: { group: newUser.groups.filter((g) => {
-                return g.groupName !== "everyone"; // see:https://github.com/geosolutions-it/geostore/issues/149
+                return g.groupName !== SecurityUtils.USER_GROUP_ALL; // see:https://github.com/geosolutions-it/geostore/issues/149
             })}};
         }
         return API.createUser(userToPost, options).then((id) => {

--- a/web/client/components/manager/users/GroupGrid.jsx
+++ b/web/client/components/manager/users/GroupGrid.jsx
@@ -14,6 +14,7 @@ import Spinner from 'react-spinkit';
 import PropTypes from 'prop-types';
 import Message from '../../I18N/Message';
 import { getMessageById } from '../../../utils/LocaleUtils';
+import SecurityUtils from '../../../utils/SecurityUtils';
 
 class GroupsGrid extends React.Component {
     static propTypes = {
@@ -85,7 +86,7 @@ class GroupsGrid extends React.Component {
                 glyph: "remove-circle",
                 tooltip: getMessageById(this.context.messages, "usergroups.deleteGroup")
             }];
-            if ( group && group.groupName === "everyone") {
+            if ( group && group.groupName === SecurityUtils.USER_GROUP_ALL) {
                 actions = [];
             }
 

--- a/web/client/components/manager/users/UserGroups.jsx
+++ b/web/client/components/manager/users/UserGroups.jsx
@@ -15,6 +15,7 @@ import Select from 'react-select';
 
 import Message from '../../I18N/Message';
 import { findIndex } from 'lodash';
+import SecurityUtils from '../../../utils/SecurityUtils';
 
 // const ConfirmModal = require('./modals/ConfirmModal');
 // const GroupManager = require('./GroupManager');
@@ -44,14 +45,14 @@ class UserCard extends React.Component {
     };
 
     getDefaultGroups = () => {
-        return this.props.groups.filter((group) => group.groupName === "everyone");
+        return this.props.groups.filter((group) => group.groupName === SecurityUtils.USER_GROUP_ALL);
     };
 
     getOptions = () => {
         return this.props.groups.map((group) => ({
             label: group.groupName,
             value: group.id,
-            clearableValue: group.groupName !== "everyone"
+            clearableValue: group.groupName !== SecurityUtils.USER_GROUP_ALL
         }));
     };
 

--- a/web/client/components/resources/modals/fragments/__tests__/PermissionEditor-test.jsx
+++ b/web/client/components/resources/modals/fragments/__tests__/PermissionEditor-test.jsx
@@ -12,6 +12,7 @@ import ReactDOM from "react-dom";
 import ReactTestUtils from "react-dom/test-utils";
 
 import PermissionEditor from "../PermissionEditor";
+import { USER_GROUP_ALL } from "../../../../../utils/SecurityUtils";
 
 describe("PermissionEditor component", () => {
     beforeEach((done) => {
@@ -48,5 +49,39 @@ describe("PermissionEditor component", () => {
         });
         const selectMenuOuter = ReactDOM.findDOMNode(permissionsTable).querySelector('.insert-row .Select-menu-outer');
         expect(selectMenuOuter).toExist();
+    });
+    it('test group name all and permission', () => {
+        const availableGroups = [
+            { groupName: USER_GROUP_ALL, id: 'group1' },
+            { groupName: 'somegroup', id: 'group2' }
+        ];
+
+        // selecting write permission first and then selecting all user group
+        ReactDOM.render(<PermissionEditor newPermission="canWrite" availableGroups={availableGroups} />, document.getElementById('container'));
+        let permissionsTable = document.getElementsByClassName('permissions-table')[0];
+        let input = ReactDOM.findDOMNode(permissionsTable).querySelector('input');
+        expect(input).toBeTruthy();
+        ReactTestUtils.act(() => {
+            ReactTestUtils.Simulate.focus(input);
+            ReactTestUtils.Simulate.click(input);
+            ReactTestUtils.Simulate.keyDown(input, { key: 'ArrowDown', keyCode: 40 });
+        });
+        const selectMenuOuter = ReactDOM.findDOMNode(permissionsTable).querySelector('.insert-row .Select-menu-outer');
+        expect(selectMenuOuter).toBeTruthy();
+        let options = ReactDOM.findDOMNode(permissionsTable).querySelectorAll('.Select-option');
+        expect(options.length).toBe(1);
+
+        // selecting USER_GROUP_ALL
+        ReactDOM.render(<PermissionEditor newGroup={availableGroups[0]} availableGroups={availableGroups} />, document.getElementById('container'));
+        permissionsTable = document.getElementsByClassName('permissions-table')[0];
+        input = ReactDOM.findDOMNode(permissionsTable).querySelectorAll('input')?.[1];
+        expect(input).toBeTruthy();
+        ReactTestUtils.act(() => {
+            ReactTestUtils.Simulate.focus(input);
+            ReactTestUtils.Simulate.click(input);
+            ReactTestUtils.Simulate.keyDown(input, { key: 'ArrowDown', keyCode: 40 });
+        });
+        options = document.querySelectorAll('.Select')[1].querySelectorAll('.Select-option');
+        expect(options.length).toBe(1);
     });
 });

--- a/web/client/epics/permalink.js
+++ b/web/client/epics/permalink.js
@@ -33,6 +33,7 @@ import { isAdminUserSelector, isLoggedIn, userSelector } from "../selectors/secu
 import { widgetsConfig } from "../selectors/widgets";
 import { pathnameSelector } from "../selectors/router";
 import { wrapStartStop } from "../observables/epics";
+import SecurityUtils from "../utils/SecurityUtils";
 
 const PERMALINK = "PERMALINK";
 const PERMALINK_RESOURCES = {
@@ -134,7 +135,7 @@ export const savePermalinkEpic = (action$, { getState = () => {} }) =>
                 : Observable.of([])
         ).switchMap((groups) => {
             const publicGroup = groups.find(
-                ({groupName} = {}) => groupName === "everyone"
+                ({groupName} = {}) => groupName === SecurityUtils.USER_GROUP_ALL
             );
             if (allowAllUser && publicGroup) {
                 const permission = [

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -16,6 +16,8 @@ import isArray from "lodash/isArray";
 
 import {setStore as stateSetStore, getState} from "./StateUtils";
 
+export const USER_GROUP_ALL = 'everyone';
+
 /**
  * Stores the logged user security information.
  */
@@ -264,7 +266,8 @@ const SecurityUtils = {
     addAuthenticationToSLD,
     getAuthKeyParameter,
     cleanAuthParamsFromURL,
-    getAuthenticationHeaders
+    getAuthenticationHeaders,
+    USER_GROUP_ALL
 };
 
 export default SecurityUtils;


### PR DESCRIPTION
## Description
This PR limits write permission to anonymous group `everyone`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10064 

**What is the new behavior?**
When anonymous group is selected permission is limited to only `can view`.

<img width="490" alt="image" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/ae0fee55-1707-4db7-afb7-a749e141d139">


> [!NOTE]
> Existing rules for anonymous group updated with `can edit` will now be empty allowing user to select only `can view`

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
