### PR TITLE
fixing .geojson file not supported with mac os

### DIFF
--- a/web/client/components/import/dragZone/enhancers/__tests__/testData.js
+++ b/web/client/components/import/dragZone/enhancers/__tests__/testData.js
@@ -16,7 +16,8 @@ export const getFile = (url, fileName = "file") =>
         responseType: 'arraybuffer'
     }))
         .map( res => {
-            return new File([new Blob([res.data], {type: res.headers['response-type']})], fileName);
+            const contentType = res.headers['content-type'] === 'null' ? undefined : res.headers['content-type'];
+            return new File([res.data], fileName, {type: contentType});
         });
 
 // PDF_FILE: new File(b64toBlob('UEsDBAoAAAAAACGPaktDvrfoAQAAAAEAAAAKAAAAc2FtcGxlLnR4dGFQSwECPwAKAAAAAAAhj2pLQ7636AEAAAABAAAACgAkAAAAAAAAACAAAAAAAAAAc2FtcGxlLnR4dAoAIAAAAAAAAQAYAGILh+1EWtMBy3f86URa0wHLd/zpRFrTAVBLBQYAAAAAAQABAFwAAAApAAAAAAA=', 'application/pdf'), "file.pdf"),

--- a/web/client/components/import/dragZone/enhancers/processFiles.jsx
+++ b/web/client/components/import/dragZone/enhancers/processFiles.jsx
@@ -41,7 +41,7 @@ const tryUnzip = (file) => {
 const checkFileType = (file) => {
     return new Promise((resolve, reject) => {
         const ext = recognizeExt(file.name);
-        const type = file.type || MIME_LOOKUPS[ext];
+        const type = MIME_LOOKUPS[ext] || file.type;
         if (type === 'application/x-zip-compressed'
             || type === 'application/zip'
             || type === 'application/vnd.google-earth.kml+xml'
@@ -63,7 +63,7 @@ const checkFileType = (file) => {
  */
 const readFile = (onWarnings) => (file) => {
     const ext = recognizeExt(file.name);
-    const type = file.type || MIME_LOOKUPS[ext];
+    const type = MIME_LOOKUPS[ext] || file.type;
     const projectionDefs = ConfigUtils.getConfigProp('projectionDefs') || [];
     const supportedProjections = (projectionDefs.length && projectionDefs.map(({code})  => code) || []).concat(["EPSG:4326", "EPSG:3857", "EPSG:900913"]);
     if (type === 'application/vnd.google-earth.kml+xml') {


### PR DESCRIPTION
FixBug .geojson file not supported in macos.
- In macOS .geojson file will be identified as type of "application/geo+json". So in checkFileType and readFile functions, they will not go into MIME_LOOKUPS list to find the corresponding type.
- Check first in MIME_LOOKUPS list and then the file.type will solve this problem. On behalf of DB Systel GmbH

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- This is a minimal change in code, so a test and doc was not added

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10081 

**What is the new behavior?**
now import geojson is also supported with macOS

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
“On behalf of DB Systel GmbH”