### PR TITLE
#10083: Persistence of COG layer's metadata info in catalog service

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -235,7 +235,13 @@ Set `selectedService` value to one of the ID of the services object ("Demo CSW S
   "filter": { // applicable only for CSW service
       "staticFilter": "filter is always applied, even when search text is NOT PRESENT",
       "dynamicFilter": "filter is used when search text is PRESENT and is applied in `AND` with staticFilter. The template is used with ${searchText} placeholder to append search string"
-  }
+  },
+  "fetchMetadata": "if true, the metadata is fetched for the service" // applicable only for COG service
+  "records": [{ "array of the COG layers of the service. COG url separated by comma where each url attributes to a layer" // applicable only for COG service
+    "sourceMetadata": "metadata of the COG layer",
+    "bbox": "bbox formulated for the COG layer",
+    "url": "the url pointing to the COG layer data"
+  }]
 }
 ```
 
@@ -249,6 +255,34 @@ CSW service
         "staticFilter": "<ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>dc:type</ogc:PropertyName><ogc:Literal>dataset</ogc:Literal></ogc:PropertyIsEqualTo><ogc:PropertyIsEqualTo><ogc:PropertyName>dc:type</ogc:PropertyName><ogc:Literal>http://purl.org/dc/dcmitype/Dataset</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Or>",
         "dynamicFilter": "<ogc:PropertyIsLike wildCard='%' singleChar='_' escapeChar='\\'><ogc:PropertyName>csw:AnyText</ogc:PropertyName><ogc:Literal>%${searchText}%</ogc:Literal></ogc:PropertyIsLike>"
     }
+}
+```
+
+COG service
+<br> `fetchMetadata` - By default, the metadata is fetched on saving the COG service for each layer (url) configured<br>
+<br> `records` -  Records of the COG layer <br>
+<br>Example:<br>
+
+```javascript
+{
+    "fetchMetadata": true,
+    "records": [{
+        "url": "https://example.tif",
+        "sourceMetadata": {
+            "crs": "EPSG:32632",
+            "extent": [463560, 5758030, 469410, 5767210],
+            "height": 900,
+            "width": 500,
+            "tileWidth": 256,
+            "tileHeight": 256,
+            "origin": [463560, 5767210, 0],
+            "resolution": [10, -10, 0]
+        },
+        "bbox": {
+            "crs": "EPSG:32632"
+            "bounds": {minx: 463560, miny: 5758030, maxx: 469410, maxy: 5767210}
+        }
+    }]
 }
 ```
 

--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -236,8 +236,8 @@ Set `selectedService` value to one of the ID of the services object ("Demo CSW S
       "staticFilter": "filter is always applied, even when search text is NOT PRESENT",
       "dynamicFilter": "filter is used when search text is PRESENT and is applied in `AND` with staticFilter. The template is used with ${searchText} placeholder to append search string"
   },
-  "fetchMetadata": "if true, the metadata is fetched for the service" // applicable only for COG service
-  "records": [{ "array of the COG layers of the service. COG url separated by comma where each url attributes to a layer" // applicable only for COG service
+  "fetchMetadata": true, // "if true, the metadata is fetched for the service, applicable only for COG service
+  "records": [{ // array of the COG layers of the service, applicable only for COG service
     "sourceMetadata": "metadata of the COG layer",
     "bbox": "bbox formulated for the COG layer",
     "url": "the url pointing to the COG layer data"

--- a/web/client/api/catalog/COG.js
+++ b/web/client/api/catalog/COG.js
@@ -15,8 +15,8 @@ import { fromUrl as fromGeotiffUrl } from 'geotiff';
 import { isValidURL } from '../../utils/URLUtils';
 import ConfigUtils from '../../utils/ConfigUtils';
 import { isProjectionAvailable } from '../../utils/ProjectionUtils';
+import { COG_LAYER_TYPE } from '../../utils/CatalogUtils';
 
-export const COG_LAYER_TYPE = 'cog';
 const searchAndPaginate = (layers, startPosition, maxRecords, text) => {
     const filteredLayers = layers
         .filter(({ title = "" } = {}) => !text
@@ -85,11 +85,11 @@ export const getRecords = (_url, startPosition, maxRecords, text, info = {}) => 
         layers = service.records?.map((record) => {
             const url = record.url;
             let layer = {
-                ...service,
+                ...record,
                 title: record.title,
-                type: COG_LAYER_TYPE,
-                sources: [{url}],
-                options: service.options || {}
+                type: record.type ?? COG_LAYER_TYPE,
+                sources: record.sources ?? [{url}],
+                options: record.options ?? (service.options || {})
             };
             const controller = get(info, 'options.controller');
             const isSave = get(info, 'options.save', false);

--- a/web/client/api/catalog/__tests__/COG-test.js
+++ b/web/client/api/catalog/__tests__/COG-test.js
@@ -5,7 +5,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { getLayerFromRecord, getCatalogRecords, validate, COG_LAYER_TYPE, getProjectionFromGeoKeys} from '../COG';
+import { COG_LAYER_TYPE } from '../../../utils/CatalogUtils';
+import { getLayerFromRecord, getCatalogRecords, validate, getProjectionFromGeoKeys} from '../COG';
 import expect from 'expect';
 
 

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -58,7 +58,8 @@ import { getSelectedLayer, selectedNodesSelector } from '../selectors/layers';
 
 import {
     buildSRSMap,
-    extractOGCServicesReferences
+    extractOGCServicesReferences,
+    updateServiceData
 } from '../utils/CatalogUtils';
 import { getCapabilities, describeLayers, flatLayers } from '../api/WMS';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
@@ -115,7 +116,7 @@ export default (API) => ({
                                 // The records are saved to catalog state on successful saving of the service.
                                 // The flag is used to show/hide records on load in Catalog
                                 setNewServiceStatus(true),
-                                addCatalogService(options.service),
+                                addCatalogService(updateServiceData(options, result)),
                                 success({
                                     title: "notification.success",
                                     message: "catalog.notification.addCatalogService",

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -7,8 +7,9 @@
  */
 
 import assign from 'object-assign';
-import { head, isArray } from 'lodash';
+import { head, isArray, get } from 'lodash';
 import CoordinatesUtils from './CoordinatesUtils';
+export const COG_LAYER_TYPE = 'cog';
 
 export const buildSRSMap = (srs) => {
     return srs.filter(s => CoordinatesUtils.isSRSAllowed(s)).reduce((previous, current) => {
@@ -91,4 +92,20 @@ export const toURLArray = (url) => {
         return url.split(',').map(u => u.trim());
     }
     return url;
+};
+
+export const updateServiceData = (options, result) => {
+    const isCOGService = get(options, 'service.type') === COG_LAYER_TYPE;
+
+    if (isCOGService) {
+        const records = get(options, 'service.records', []);
+        return {
+            ...options.service,
+            records: records.map(record => ({
+                ...record,
+                ...result?.records?.find(_record => _record.url === record.url)
+            }))
+        };
+    }
+    return options.service;
 };

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -46,4 +46,13 @@ describe('Test the CatalogUtils', () => {
         expect(mergedURL3).toBe("https://a.example.com/wms,https://b.example.com/wms,https://c.example.com/wms");
         expect(mergedURL4).toBe("https://a.example.com/wms,https://b.example.com/wms");
     });
+    it("updateServiceData", () => {
+        let records = [{"url": "https://example.tif", sourceMetadata: {crs: "EPSG:3003"}}];
+        let options = {service: {type: CatalogUtils.COG_LAYER_TYPE, records: [{url: "https://example.tif"}]}};
+        expect(CatalogUtils.updateServiceData(options, {records})).toEqual({...options.service, records});
+
+        records = [{"url": "https://example.tif", sourceMetadata: {crs: "EPSG:3003"}}];
+        options = {service: {type: "wms", "autoload": true}};
+        expect(CatalogUtils.updateServiceData(options, {records})).toEqual(options.service);
+    });
 });


### PR DESCRIPTION
## Description
This PR enhances COG catalog service to be persisted on map save/import of exported map json to support projection, zoom to layer and styling (bands) of COG layers

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #10083 

**What is the new behavior?**
The COG layer's metadata is persisted on map reload and import of map json

### Test data
`/viewer/49164`

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
