### PR TITLE
#10112 - Fix style editor for raster layer channel block

### DIFF
--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -647,7 +647,7 @@ function Fields({
                 const Component = isPropertyField ? PropertySelector : FieldComponent;
                 const disabled = isDisabled && isDisabled(properties[key], state.current.properties, fieldsConfig);
                 const visible = isVisible ? isVisible(properties[key], state.current.properties, format) : true;
-                return visible ? (<div className={`ms-symbolizer-field-wrapper ${type}`}>
+                return visible ? (<div className={`ms-symbolizer-field-wrapper ${type || ""}`}>
                     <Component
                         {...fieldsConfig}
                         key={key}

--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -647,7 +647,7 @@ function Fields({
                 const Component = isPropertyField ? PropertySelector : FieldComponent;
                 const disabled = isDisabled && isDisabled(properties[key], state.current.properties, fieldsConfig);
                 const visible = isVisible ? isVisible(properties[key], state.current.properties, format) : true;
-                return visible ? (<div className={`ms-symbolizer-field-wrapper ${key}`}>
+                return visible ? (<div className={`ms-symbolizer-field-wrapper ${type}`}>
                     <Component
                         {...fieldsConfig}
                         key={key}

--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -647,7 +647,7 @@ function Fields({
                 const Component = isPropertyField ? PropertySelector : FieldComponent;
                 const disabled = isDisabled && isDisabled(properties[key], state.current.properties, fieldsConfig);
                 const visible = isVisible ? isVisible(properties[key], state.current.properties, format) : true;
-                return visible ? (<div className="ms-symbolizer-field-wrapper">
+                return visible ? (<div className={`ms-symbolizer-field-wrapper ${key}`}>
                     <Component
                         {...fieldsConfig}
                         key={key}

--- a/web/client/themes/default/less/style-editor.less
+++ b/web/client/themes/default/less/style-editor.less
@@ -620,6 +620,9 @@ Ported to CodeMirror by Peter Kroon
 .ms-symbolizer-field-wrapper {
     display: flex;
     align-items: center;
+    &.channel {
+        display: unset;
+    }
 }
 
 .ms-symbolizer-nested-fields {


### PR DESCRIPTION
## Description
This PR fixes the style editor for rater layer's channel block

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10112 

**What is the new behavior?**
<img width="500" alt="image" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/e76bb42e-99c0-4a45-88f4-69b5ff9bbb63">


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
