### PR TITLE
Fix #10000 geodesic lines crash when switching to area measurement

### DIFF
--- a/web/client/components/map/cesium/DrawMeasureSupport.jsx
+++ b/web/client/components/map/cesium/DrawMeasureSupport.jsx
@@ -30,9 +30,9 @@ import {
     computeMiddlePoint,
     computeAngles,
     computeTriangleMiddlePoint,
-    computeSlopes
+    computeSlopes,
+    computeGeodesicCoordinates
 } from '../../../utils/cesium/MathUtils';
-
 function computeAngleLineCoordinates(coordinates) {
     const aDistance = Cesium.Cartesian3.distance(coordinates[1], coordinates[0]);
     const bDistance = Cesium.Cartesian3.distance(coordinates[1], coordinates[2]);
@@ -546,8 +546,10 @@ function DrawMeasureSupport({
 
         const newFeatures = features.map((feature) => {
             const coordinates = measureFeatureToCartesianCoordinates(feature);
+            const geodesicCoordinates = computeGeodesicCoordinates(coordinates);
             return featureToPrimitives({
                 coordinates,
+                geodesicCoordinates,
                 feature,
                 measureType: feature?.properties?.measureType
             });
@@ -587,7 +589,7 @@ function DrawMeasureSupport({
 
     function updateDynamicCoordinates({
         coordinates,
-        geodesicCoordinates,
+        geodesicCoordinates = [],
         area,
         distance
     } = {}) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10000

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
