### PR TITLE
Fix #10121 moving the rendered measure as the normal one

### DIFF
--- a/web/client/components/map/cesium/DrawMeasureSupport.jsx
+++ b/web/client/components/map/cesium/DrawMeasureSupport.jsx
@@ -480,10 +480,10 @@ function DrawMeasureSupport({
                     return [Cesium.Math.toDegrees(longitude), Cesium.Math.toDegrees(latitude)];
                 });
                 const geodesicDistance = calculateDistance(coords4326);
-                infoLabelTextPosition = geodesicCoordinates[geodesicCoordinates.length - 1];
+                infoLabelTextPosition = coordinates[coordinates.length - 1];
                 infoLabelText = infoLabelFormat(convertMeasure(unitOfMeasure, geodesicDistance, 'm'));
-                staticPrimitivesCollection.current.add(createPolylinePrimitive({ ...style?.line, coordinates: [...geodesicCoordinates], geodesic: true }));
-                segments = addSegmentsLabels(staticLabelsCollection.current, geodesicCoordinates, MeasureTypes.LENGTH, true);
+                staticPrimitivesCollection.current.add(createPolylinePrimitive({ ...style?.line, coordinates: [...coordinates], geodesic: true }));
+                segments = addSegmentsLabels(staticLabelsCollection.current, coordinates, MeasureTypes.LENGTH, true);
             }
             break;
 
@@ -672,9 +672,9 @@ function DrawMeasureSupport({
                 });
                 const geodesicDistance = calculateDistance(coords4326);
                 infoLabelText = infoLabelFormat(convertMeasure(unitOfMeasure, geodesicDistance, 'm'));
-                addSegmentsLabels(dynamicLabelsCollection.current, geodesicCoordinates, MeasureTypes.LENGTH, true);
-                geodesicCoordinates.forEach((cartesian, idx) => {
-                    if (idx !== (geodesicCoordinates.length - 1)) {
+                addSegmentsLabels(dynamicLabelsCollection.current, coordinates, MeasureTypes.LENGTH, true);
+                coordinates.forEach((cartesian, idx) => {
+                    if (idx !== (coordinates.length - 1)) {
                         dynamicBillboardCollection.current.add({
                             position: cartesian,
                             image: coordinateNodeImage.current,

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -870,7 +870,7 @@
             "saveMeasure": "Speichern Sie die Messungen in Notizen / Zeichnungen",
             "resetTooltip": "Messung entfernen",
             "addAsLayer": "Als Ebene hinzufügen",
-            "lengthMeasure": "Messen Sie die geodätische Entfernung im 3D-Raum",
+            "lengthMeasure": "Messen Sie die geodätische Entfernung im 3D-Raum, die auf dem Ellipsoid berechnet, aber dort gerendert wird, wo Sie klicken",
             "polylineDistance3DMeasure": "Entfernung im 3D-Raum messen",
             "area3DMeasure": "Fläche im 3D-Raum messen",
             "pointCoordinatesMeasure": "Punktkoordinaten messen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -831,7 +831,7 @@
             "exportToGeoJSON": "Export to GeoJSON",
             "resetTooltip": "Clear measures",
             "addAsLayer": "Add as layer",
-            "lengthMeasure": "Measure geodesic distance in 3D space",
+            "lengthMeasure": "Measure geodesic distance in 3D space which is calculated on the ellipsoid, but rendered where you click",
             "polylineDistance3DMeasure": "Measure distance in 3D space",
             "area3DMeasure": "Measure area in 3D space",
             "pointCoordinatesMeasure": "Measure point coordinates",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -831,7 +831,7 @@
             "saveMeasure": "Guarde las medidas en la anotación",
             "resetTooltip": "Medidas claras",
             "addAsLayer": "Agregar como capa",
-            "lengthMeasure": "Medir la distancia geodésica en el espacio 3D",
+            "lengthMeasure": "Mida la distancia geodésica en el espacio 3D que se calcula en el elipsoide, pero se representa al hacer clic",
             "polylineDistance3DMeasure": "Medir distancia en el espacio 3D",
             "area3DMeasure": "Medir área en espacio 3D",
             "pointCoordinatesMeasure": "Medir las coordenadas del punto",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -831,7 +831,7 @@
             "saveMeasure": "Enregistrer les mesures dans l'annotation",
             "resetTooltip": "Effacer les mesures",
             "addAsLayer": "Ajouter comme couche",
-            "lengthMeasure": "Mesurer la distance géodésique dans l'espace 3D",
+            "lengthMeasure": "Mesurez la distance géodésique dans l'espace 3D qui est calculée sur l'ellipsoïde, mais rendue là où vous cliquez",
             "polylineDistance3DMeasure": "Mesurer la distance dans l'espace 3D",
             "area3DMeasure": "Mesurer la zone dans l'espace 3D",
             "pointCoordinatesMeasure": "Mesurer les coordonnées du point",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -831,7 +831,7 @@
             "saveMeasure": "Salva le misure nell'annotazione",
             "resetTooltip": "Rimuovi Misurazioni",
             "addAsLayer": "Aggiungi come livello",
-            "lengthMeasure": "Misurare la distanza geodesica nello spazio 3D",
+            "lengthMeasure": "Misura la distanza geodesica nello spazio 3D calcolata sull'ellissoide, ma renderizzata nel punto in cui fai click",
             "polylineDistance3DMeasure": "Misurare la distanza nello spazio 3D",
             "area3DMeasure": "Misurare l'area nello spazio 3D",
             "pointCoordinatesMeasure": "Misurare le coordinate di un punto",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

geodesic measures are now placed where they are drawn
![image](https://github.com/geosolutions-it/MapStore2/assets/11991428/b4f4e29c-3a4d-497e-a6ef-40fc9a6e4017)



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10121

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
