### PR TITLE
Backport #9970 url arr bug (#10004)

### DIFF
--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -16,9 +16,10 @@ import { cleanDuplicatedQuestionMarks } from '../utils/ConfigUtils';
 import { extractCrsFromURN, makeBboxFromOWS, makeNumericEPSG, getExtentFromNormalized } from '../utils/CoordinatesUtils';
 import WMS from "../api/WMS";
 import { THREE_D_TILES, getCapabilities } from './ThreeDTiles';
+import { getDefaultUrl } from '../utils/URLUtils';
 
-const parseUrl = (url) => {
-    const parsed = urlUtil.parse(url, true);
+export const parseUrl = (url) => {
+    const parsed = urlUtil.parse(getDefaultUrl(url), true);
     return urlUtil.format(assign({}, parsed, { search: null }, {
         query: assign({
             service: "CSW",
@@ -170,9 +171,9 @@ export const getLayerReferenceFromDc = (dc, options, checkEsri = true) => {
         const refs = castArray(dc.references);
         const wms = head(refs.filter((ref) => { return ref.scheme && REGEX_WMS_EXPLICIT.some(regex => ref.scheme.match(regex)); }));
         if (wms) {
-            let urlObj = urlUtil.parse(wms.value, true);
+            let urlObj = urlUtil.parse(getDefaultUrl(wms.value), true);
             let layerName = urlObj.query && urlObj.query.layers || dc.alternative;
-            return toReference('wms', { ...wms, name: layerName }, options);
+            return toReference('wms', { ...wms, value: urlUtil.format(urlObj), name: layerName }, options);
         }
         if (checkEsri) {
             // checks for esri arcgis in geonode csw

--- a/web/client/api/WCS.js
+++ b/web/client/api/WCS.js
@@ -9,9 +9,10 @@ import axios from '../libs/ajax';
 import urlUtil from 'url';
 import assign from 'object-assign';
 import xml2js from 'xml2js';
+import { getDefaultUrl } from '../utils/URLUtils';
 
 export const describeCoverage = function(url, typeName) {
-    const parsed = urlUtil.parse(url, true);
+    const parsed = urlUtil.parse(getDefaultUrl(url), true);
     const describeLayerUrl = urlUtil.format(assign({}, parsed, {
         query: assign({
             service: "WCS",

--- a/web/client/api/WFS.js
+++ b/web/client/api/WFS.js
@@ -10,9 +10,10 @@ import urlUtil from 'url';
 import assign from 'object-assign';
 import requestBuilder from '../utils/ogc/WFS/RequestBuilder';
 import {toOGCFilterParts} from '../utils/FilterUtils';
+import { getDefaultUrl } from '../utils/URLUtils';
 
 export const toDescribeURL = (url, typeName) => {
-    const parsed = urlUtil.parse(url, true);
+    const parsed = urlUtil.parse(getDefaultUrl(url), true);
     return urlUtil.format(
         {
             ...parsed,
@@ -45,7 +46,7 @@ export const getFeatureSimple = function(baseUrl, params) {
 };
 
 export const getCapabilitiesURL = (url, {version = "1.1.0"} = {}) => {
-    const parsed = urlUtil.parse(url, true);
+    const parsed = urlUtil.parse(getDefaultUrl(url), true);
     return urlUtil.format(assign({}, parsed, {
         query: assign({
             service: "WFS",
@@ -56,7 +57,7 @@ export const getCapabilitiesURL = (url, {version = "1.1.0"} = {}) => {
 };
 
 export const getFeatureURL = (url, typeName, { version = "1.1.0", ...params } = {}) => {
-    const parsed = urlUtil.parse(url, true);
+    const parsed = urlUtil.parse(getDefaultUrl(url), true);
     return urlUtil.format(assign({}, parsed, {
         query: assign({
             service: "WFS",
@@ -130,7 +131,7 @@ export const getCapabilities = function(url) {
  * @deprecated
  */
 export const describeFeatureTypeOGCSchemas = function(url, typeName) {
-    const parsed = urlUtil.parse(url, true);
+    const parsed = urlUtil.parse(getDefaultUrl(url), true);
     const describeLayerUrl = urlUtil.format(assign({}, parsed, {
         query: assign({
             service: "WFS",

--- a/web/client/api/WMTS.js
+++ b/web/client/api/WMTS.js
@@ -16,6 +16,7 @@ const capabilitiesCache = {};
 
 import { castArray } from 'lodash';
 import { getEPSGCode } from '../utils/CoordinatesUtils';
+import { getDefaultUrl } from '../utils/URLUtils';
 
 import {
     getOperations,
@@ -25,8 +26,8 @@ import {
     getDefaultFormat
 } from '../utils/WMTSUtils';
 
-const parseUrl = (url) => {
-    const parsed = urlUtil.parse(url, true);
+export const parseUrl = (url) => {
+    const parsed = urlUtil.parse(getDefaultUrl(url), true);
     return urlUtil.format(assign({}, parsed, {search: null}, {
         query: assign({
             SERVICE: "WMTS",

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -13,7 +13,7 @@ import GRDCResponse from 'raw-loader!../../test-resources/csw/getRecordsResponse
 import GRDCResponseWith3DLayersAt1st from 'raw-loader!../../test-resources/csw/getRecordsResponseDCWith3DLayersAt1st.xml';
 import GRDCResponseWith3DLayersAtMiddle from 'raw-loader!../../test-resources/csw/getRecordsResponseDCWith3DLayersAtMiddle.xml';
 import GRDCResponseWith3DLayersAtLast from 'raw-loader!../../test-resources/csw/getRecordsResponseDCWith3DLayersAtLast.xml';
-import API, {constructXMLBody, getLayerReferenceFromDc } from '../CSW';
+import API, {constructXMLBody, getLayerReferenceFromDc, parseUrl } from '../CSW';
 
 import tileSetResponse from '../../test-resources/3dtiles/tileSetSample2.json';
 
@@ -424,14 +424,14 @@ describe("getLayerReferenceFromDc", () => {
         const layerRef = getLayerReferenceFromDc(dc);
         expect(layerRef.params.name).toBe('some_layer');
         expect(layerRef.type).toBe('OGC:WMS');
-        expect(layerRef.url).toBe('http://wmsurl');
+        expect(layerRef.url).toBe('http://wmsurl/');
     });
     it("test layer reference with dc.references of scheme OGC:WMS-http-get-map", () => {
         const dc = {references: [{value: "http://wmsurl", scheme: 'OGC:WMS-http-get-map'}, {value: "wfsurl", scheme: 'OGC:WFS'}], alternative: "some_layer"};
         const layerRef = getLayerReferenceFromDc(dc);
         expect(layerRef.params.name).toBe('some_layer');
         expect(layerRef.type).toBe('OGC:WMS-http-get-map');
-        expect(layerRef.url).toBe('http://wmsurl');
+        expect(layerRef.url).toBe('http://wmsurl/');
     });
     it("test layer reference with dc.URI of scheme serviceType/ogc/wms and options", () => {
         const dc = {URI: [{value: "wmsurl?service=wms&layers=some_layer&version=1.3.0", protocol: 'serviceType/ogc/wms'}, {value: "wfsurl", protocol: 'OGC:WFS'}]};
@@ -461,7 +461,25 @@ describe("getLayerReferenceFromDc", () => {
         expect(layerRef.type).toBe('arcgis');
         expect(layerRef.url).toBe('http://esri_url');
     });
+    it('parseUrl', () => {
+        const _url = [
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3'
+        ];
 
+        expect(parseUrl(_url).split('?')[0]).toBe(_url[0]);
+    });
+    it('getLayerReferenceFromDc ', () => {
+        const _url = [
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3'
+        ];
+        const dc = {references: [{value: _url, scheme: 'OGC:WMS'}, {value: "wfsurl", scheme: 'OGC:WFS'}], alternative: "some_layer"};
+
+        expect(getLayerReferenceFromDc(dc).url).toBe(_url[0]);
+    });
 });
 
 

--- a/web/client/api/__tests__/WCS-test.js
+++ b/web/client/api/__tests__/WCS-test.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { describeCoverage } from '../WCS';
+import axios from '../../libs/ajax';
+import expect from 'expect';
+
+import MockAdapter from "axios-mock-adapter";
+let mockAxios;
+
+let _xmlSample = `<wcs>
+<enabled>true</enabled>
+<name>WCS</name>
+<title>Web Coverage Service</title>
+<maintainer>http://geoserver.org/comm</maintainer>
+<abstrct>This server implements the WCS specification 1.0 and 1.1.1, it's reference implementation of WCS 1.1.1. All layers published by this service are available on WMS also.
+   </abstrct>
+<accessConstraints>NONE</accessConstraints>
+<fees>NONE</fees>
+<versions>
+  <org.geotools.util.Version>
+    <version>1.0.0</version>
+  </org.geotools.util.Version>
+  <org.geotools.util.Version>
+    <version>1.1.1</version>
+  </org.geotools.util.Version>
+  <org.geotools.util.Version>
+    <version>2.0.1</version>
+  </org.geotools.util.Version>
+</versions>
+<keywords>
+  <string>WCS</string>
+  <string>WMS</string>
+  <string>GEOSERVER</string>
+</keywords>
+<metadataLink>
+  <type>undef</type>
+  <about>http://geoserver.sourceforge.net/html/index.php</about>
+  <metadataType>other</metadataType>
+</metadataLink>
+<citeCompliant>false</citeCompliant>
+<onlineResource>http://geoserver.org</onlineResource>
+<schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
+<verbose>false</verbose>
+<gmlPrefixing>false</gmlPrefixing>
+<latLon>false</latLon>
+<maxInputMemory>0</maxInputMemory>
+<maxOutputMemory>0</maxOutputMemory>
+</wcs>`;
+
+describe('Test WCS API', () => {
+    beforeEach(done => {
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+
+    afterEach(done => {
+        mockAxios.restore();
+        setTimeout(done);
+    });
+    it('describeCoverage', (done) => {
+        mockAxios.onGet().reply(200, _xmlSample);
+        describeCoverage([
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver/services/wcs/settings',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2/services/wcs/settings',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3/services/wcs/settings'
+        ], 'testName').then((result) => {
+            try {
+                expect(result).toExist();
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+});

--- a/web/client/api/__tests__/WFS-test.js
+++ b/web/client/api/__tests__/WFS-test.js
@@ -4,7 +4,10 @@ import expect from 'expect';
 import MockAdapter from 'axios-mock-adapter';
 import axios from '../../libs/ajax';
 import {
-    getFeatureLayer
+    getFeatureLayer,
+    toDescribeURL,
+    getCapabilitiesURL,
+    getFeatureURL
 } from '../WFS';
 
 let mockAxios;
@@ -118,6 +121,33 @@ describe('Test WFS ogc API functions', () => {
                 done();
             });
         });
+    });
+    it('toDescribeURL with URL array', () => {
+        const _url = [
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3'
+        ];
+
+        expect(toDescribeURL(_url, 'testName').split('?')[0]).toBe(_url[0]);
+    });
+    it('getCapabilitiesURL with URL array', () => {
+        const _url = [
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3'
+        ];
+
+        expect(getCapabilitiesURL(_url).split('?')[0]).toBe(_url[0]);
+    });
+    it('getFeatureURL with URL array', () => {
+        const _url = [
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3'
+        ];
+
+        expect(getFeatureURL(_url).split('?')[0]).toBe(_url[0]);
     });
 
 });

--- a/web/client/api/__tests__/WMTS-test.js
+++ b/web/client/api/__tests__/WMTS-test.js
@@ -8,7 +8,7 @@
 
 import expect from 'expect';
 
-import API, { getLayerTileMatrixSetsInfo } from '../WMTS';
+import API, { getLayerTileMatrixSetsInfo, parseUrl } from '../WMTS';
 import { getGetTileURL } from '../../utils/WMTSUtils';
 import MockAdapter from 'axios-mock-adapter';
 import axios from '../../libs/ajax';
@@ -249,5 +249,14 @@ describe('Test correctness of the WMTS APIs (mock axios)', () => {
                 done();
             })
             .catch(done);
+    });
+    it('parseUrl', () => {
+        const _url = [
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3'
+        ];
+
+        expect(parseUrl(_url).split('?')[0]).toBe(_url[0]);
     });
 });

--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -1475,5 +1475,66 @@ describe('Test styleeditor epics, with mock axios', () => {
             state);
 
     });
+    it('test toggleStyleEditorEpic style service where layer url is array', (done) => {
+        mockAxios.onGet(/\/manifest/).reply(() => {
+            return [ 200, { about: { resource: [{ '@name': 'gt-css-2.16' }]} }];
+        });
 
+        mockAxios.onGet(/\/version/).reply(() => {
+            return [ 200, { about: { resource: [{ '@name': 'GeoServer', version: '2.16' }] } }];
+        });
+
+        mockAxios.onGet(/\/fonts/).reply(() => {
+            return [ 200, { fonts: ['Arial'] }];
+        });
+
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'layerId',
+                        name: 'layerWorkspace:layerName',
+                        url: ['/geoserver1/', '/geoserver2/', '/geoserver3/']
+                    }
+                ],
+                selected: [
+                    'layerId'
+                ],
+                settings: {
+                    options: {
+                        opacity: 1
+                    }
+                }
+            }
+        };
+
+        const NUMBER_OF_ACTIONS = 3;
+        const results = (actions) => {
+            try {
+                const service = actions.pop()?.service;
+
+                expect(service).toEqual({
+                    baseUrl: state.layers.flat[0].url[0],
+                    version: '2.16',
+                    formats: [ 'css', 'sld' ],
+                    availableUrls: [],
+                    fonts: ['Arial'],
+                    classificationMethods: {
+                        vector: [ 'equalInterval', 'quantile', 'jenks' ],
+                        raster: [ 'equalInterval', 'quantile', 'jenks' ]
+                    }
+                });
+            } catch (e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            toggleStyleEditorEpic,
+            NUMBER_OF_ACTIONS,
+            toggleStyleEditor(undefined, true),
+            results,
+            state);
+    });
 });

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -59,6 +59,7 @@ import {
 import { getSelectedLayer, layerSettingSelector } from '../selectors/layers';
 import { generateTemporaryStyleId, generateStyleId, STYLE_OWNER_NAME, getNameParts, detectStyleCodeChanges } from '../utils/StyleEditorUtils';
 import { updateStyleService } from '../api/StyleEditor';
+import { getDefaultUrl } from '../utils/URLUtils';
 
 /*
  * Observable to get code of a style, it works only in edit status
@@ -258,7 +259,7 @@ export const toggleStyleEditorEpic = (action$, store) =>
                 return getAvailableStylesFromLayerCapabilities(layer);
             }
 
-            const layerUrl = layer.url.split(geoserverName);
+            const layerUrl = getDefaultUrl(layer.url).split(geoserverName);
             const baseUrl = `${layerUrl[0]}${geoserverName}`;
             const lastStyleService = styleServiceSelector(state);
 

--- a/web/client/observables/__tests__/wfs-test.js
+++ b/web/client/observables/__tests__/wfs-test.js
@@ -1,22 +1,15 @@
 /*
- * Copyright 2020, GeoSolutions Sas.
+ * Copyright 2024, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { extractGeometryAttributeName, extractGeometryType, toDescribeURL } from '../WFSLayerUtils';
-import describePois from '../../test-resources/wfs/describe-pois.json';
+import { toDescribeURL, getFeatureUtilities } from '../wfs';
 import expect from 'expect';
 
-describe("WFSLayerUtils", () => {
-    it('extractGeometryAttributeName', () => {
-        expect(extractGeometryAttributeName(describePois)).toBe("the_geom");
-    });
-    it('extractGeometryType', () => {
-        expect(extractGeometryType(describePois)).toBe("Point");
-    });
+describe("WFS Observables", () => {
     it('toDescribeURL', () => {
         const _url = [
             'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
@@ -25,5 +18,14 @@ describe("WFSLayerUtils", () => {
         ];
 
         expect(toDescribeURL({ name: 'testName', search: { url: _url }}).split('?')[0]).toBe(_url[0]);
+    });
+    it('getFeatureUtilities', () => {
+        const _url = [
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3'
+        ];
+
+        expect(getFeatureUtilities(_url, 'filterObject').queryString.split('?')[0]).toBe(_url[0]);
     });
 });

--- a/web/client/observables/__tests__/wms-test.js
+++ b/web/client/observables/__tests__/wms-test.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { toDescribeLayerURL } from '../wms';
+import expect from 'expect';
+
+describe("WMS Observables", () => {
+    it('toDescribeLayerURL', () => {
+        const _url = [
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3'
+        ];
+
+        expect(toDescribeLayerURL({ name: 'testName', search: { url: _url }}).split('?')[0]).toBe(_url[0]);
+    });
+});

--- a/web/client/observables/wfs.js
+++ b/web/client/observables/wfs.js
@@ -18,11 +18,12 @@ import { createFeatureFilter, getWFSFilterData } from '../utils/FilterUtils';
 import { getCapabilitiesUrl } from '../utils/LayersUtils';
 import { interceptOGCError } from '../utils/ObservableUtils';
 import requestBuilder from '../utils/ogc/WFS/RequestBuilder';
+import { getDefaultUrl } from '../utils/URLUtils';
 
 const {getFeature, query, sortBy, propertyName} = requestBuilder({ wfsVersion: "1.1.0" });
 
 export const toDescribeURL = ({ name, search = {}, url, describeFeatureTypeURL} = {}) => {
-    const parsed = urlUtil.parse(describeFeatureTypeURL || search.url || url, true);
+    const parsed = urlUtil.parse(getDefaultUrl(describeFeatureTypeURL || search.url || url), true);
     return urlUtil.format(
         {
             ...parsed,
@@ -126,10 +127,10 @@ const getFeaturesFiltered = (features, filterObj) => {
  * @param {*} downloadOption selected format for query
  * @returns {Object} The data and query string
  */
-const getFeatureUtilities = (searchUrl, filterObj, options = {}, downloadOption = 'json') => {
+export const getFeatureUtilities = (searchUrl, filterObj, options = {}, downloadOption = 'json') => {
     const data = getWFSFilterData(filterObj, options);
 
-    const urlParsedObj = urlUtil.parse(searchUrl, true);
+    const urlParsedObj = urlUtil.parse(getDefaultUrl(searchUrl), true);
     let params = isObject(urlParsedObj.query) ? urlParsedObj.query : {};
     params.service = 'WFS';
     params.outputFormat = downloadOption;

--- a/web/client/observables/wms.js
+++ b/web/client/observables/wms.js
@@ -18,11 +18,12 @@ import { determineCrs, fetchProjRemotely, getProjUrl } from '../utils/Coordinate
 import { getCapabilitiesUrl } from '../utils/LayersUtils';
 import { interceptOGCError } from '../utils/ObservableUtils';
 import { cleanAuthParamsFromURL } from '../utils/SecurityUtils';
+import { getDefaultUrl } from '../utils/URLUtils';
 
 const proj4 = Proj4js;
 
 export const toDescribeLayerURL = ({name, search = {}, url} = {}) => {
-    const parsed = urlUtil.parse(search.url || url, true);
+    const parsed = urlUtil.parse(getDefaultUrl(search.url || url), true);
     return urlUtil.format(
         {
             ...parsed,

--- a/web/client/selectors/__tests__/cswtocatalog-test.js
+++ b/web/client/selectors/__tests__/cswtocatalog-test.js
@@ -62,6 +62,31 @@ const sampleCSWRecord2 = {
         }]
     }
 };
+const sampleRecordName = 'workspace:layername1';
+const sampleCSWRecord3 = {
+    boundingBox: {
+        extent: [10.686,
+            44.931,
+            46.693,
+            12.54],
+        crs: "EPSG:4326"
+
+    },
+    dc: {
+        identifier: "test-identifier",
+        title: "sample title",
+        subject: ["subject1", "subject2"],
+        "abstract": "sample abstract",
+        "references": [{
+            scheme: "OGC:WMS-1.1.1-http-get-map",
+            value: [
+                'http://wms.sample.service:80/geoserver/wms?SERVICE=WMS&layers=' + sampleRecordName,
+                'http://wms.sample.service:80/geoserver/wms?SERVICE=WMS&layers=workspace:layername2',
+                'http://wms.sample.service:80/geoserver/wms?SERVICE=WMS&layers=workspace:layername3'
+            ]
+        }]
+    }
+};
 const sampleRecord = {
     identifier: "test-identifier",
     title: "sample title",
@@ -121,5 +146,25 @@ describe('Test csw to catalog selector', () => {
         expect(records).toExist();
         expect(records[0]).toExist();
         expect(isEqual(records[0], sampleRecord)).toBe(true);
+    });
+    it('test correct conversion for multiple urls in dc.references', () => {
+        const testState = {
+            catalog: {
+                searchOptions: {
+                    catalogURL: "http://sample.com"
+                },
+                result: {
+                    records: [sampleCSWRecord3],
+                    numberOfRecordsMatched: 1,
+                    numberOfRecordsReturned: 1
+                }
+
+            }
+        };
+        const records = cswToCatalogSelector(testState.catalog);
+        const name = records[0].references[0].params.name;
+        expect(records).toExist();
+        expect(records[0]).toExist();
+        expect(name).toBe(sampleRecordName);
     });
 });

--- a/web/client/selectors/cswtocatalog.js
+++ b/web/client/selectors/cswtocatalog.js
@@ -10,6 +10,7 @@ import assign from 'object-assign';
 
 import { head } from 'lodash';
 import urlUtil from 'url';
+import { getDefaultUrl } from '../utils/URLUtils';
 
 
 export const getBaseCatalogUrl = (url) => {
@@ -38,7 +39,7 @@ export const cswToCatalogSelector = (catalog) => {
             if (!wms && dc.references) {
                 let refs = Array.isArray(dc.references) ? dc.references : [dc.references];
                 wms = head([].filter.call( refs, (ref) => { return ref.scheme === "OGC:WMS-1.1.1-http-get-map" || ref.scheme === "OGC:WMS"; }));
-                let urlObj = urlUtil.parse(wms.value, true);
+                let urlObj = urlUtil.parse(getDefaultUrl(wms.value), true);
                 let layerName = urlObj.query && urlObj.query.layers;
                 wms = assign({}, wms, {name: layerName} );
             }

--- a/web/client/utils/URLUtils.js
+++ b/web/client/utils/URLUtils.js
@@ -111,3 +111,15 @@ export const isValidURLTemplate = (url, params, regexp = /^(http(s{0,1}):\/\/)+?
     return false;
 
 };
+
+/**
+ * Helper for working with a single string url.
+ * Use when calling implementations that do not know about array of urls, such as the `urlUtil` library,
+ * while still supporting our implementation of domain aliases and domain sharding.
+ *
+ * @param {string || array} url - Either a string representing a valid url or an array of strings which are all valid urls.
+ * @returns {string} Returns the argument if the argument is string, otherwise if the argument is an array, returns the first element.
+ */
+export const getDefaultUrl = (url) => {
+    return isArray(url) ? url[0] : url;
+};

--- a/web/client/utils/WFSLayerUtils.js
+++ b/web/client/utils/WFSLayerUtils.js
@@ -9,6 +9,7 @@
 import { optionsToVendorParams } from './VendorParamsUtils';
 import urlUtil from 'url';
 import {get, head} from 'lodash';
+import { getDefaultUrl } from './URLUtils';
 
 
 export const needsReload = (oldOptions, newOptions) => {
@@ -23,7 +24,7 @@ export const needsReload = (oldOptions, newOptions) => {
 };
 
 export const toDescribeURL = ({ name, search = {}, url, describeFeatureTypeURL } = {}) => {
-    const parsed = urlUtil.parse(describeFeatureTypeURL || search.url || url, true);
+    const parsed = urlUtil.parse(getDefaultUrl(describeFeatureTypeURL || search.url || url), true);
     return urlUtil.format(
         {
             ...parsed,

--- a/web/client/utils/__tests__/URLUtils-test.js
+++ b/web/client/utils/__tests__/URLUtils-test.js
@@ -7,7 +7,7 @@
  */
 import expect from 'expect';
 
-import { urlParts, isSameUrl, sameQueryParams, isValidURL, isValidURLTemplate } from '../URLUtils';
+import { urlParts, isSameUrl, sameQueryParams, isValidURL, isValidURLTemplate, getDefaultUrl } from '../URLUtils';
 
 const url1 = "https://demo.geo-solutions.it:443/geoserver/wfs";
 const url2 = "https://demo.geo-solutions.it/geoserver/wfs";
@@ -169,6 +169,15 @@ describe('URLUtils', () => {
     ];
     it('isValidURLTemplate', () => {
         SAMPLE_URL_TEMPLATES.map(url => expect(isValidURLTemplate(url)).toBeTruthy());
+    });
+    it('getDefaultUrl', () => {
+        const _url = [
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3'
+        ];
+
+        expect(getDefaultUrl(_url)).toBe(_url[0]);
     });
 });
 


### PR DESCRIPTION
* Added getDefaultUrl helper in URLUtils.js Fixed callers into urlUtils library, make sure a string is passed for the url argument. FIxed impl which assumes that layer.url can only be string.

* Fix typo, actually fix the reported problem

* Added tests where getDefaultUrl change is introduced.

* Fixed multiple url test in styleeditor-test.js

* Added missing tests in WFS-test.js Fixed license year in new files.
Adjusted styleeditor-test.js to more appropriately test the bugfix.

Tweaked wms dc.references in CSW.js to always default to a single URL string.

(cherry picked from commit c9eae7d52d9ce91062751d941bb6f0ff43d753ea)

## Description
This PR backports #10004, fix for url array bug into 2024.01.xx

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#10004 

**What is the new behavior?**
URL arrays will always default to a single string before calling the underlining library.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
