### PR TITLE
geosolutions-it#10127: update tests to enable react-redux 7.x upwards

### DIFF
--- a/web/client/components/app/__tests__/StandardAppComponent-test.jsx
+++ b/web/client/components/app/__tests__/StandardAppComponent-test.jsx
@@ -34,17 +34,21 @@ describe('StandardAppComponent', () => {
         setTimeout(done);
     });
 
-    it('creates a default app', () => {
+    it('creates a default app', (done) => {
         const store = {
             dispatch: () => {},
             subscribe: () => {},
             getState: () => ({})
         };
-        const app = ReactDOM.render(<Provider store={store}><StandardAppComponent/></Provider>, document.getElementById("container"));
-        expect(app).toExist();
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(<Provider store={store}><StandardAppComponent/></Provider>, container, () => {
+            expect(container.innerHTML).toExist();
+            done();
+        });
     });
 
-    it('creates a default app with plugins', () => {
+    it('creates a default app with plugins', (done) => {
         const plugins = {
             MyPlugin
         };
@@ -54,11 +58,12 @@ describe('StandardAppComponent', () => {
             subscribe: () => {},
             getState: () => ({})
         };
-        const app = ReactDOM.render(<Provider store={store}><StandardAppComponent plugins={plugins} pluginsConfig={{desktop: ['My']}} /></Provider>, document.getElementById("container"));
-        expect(app).toExist();
-
-        const dom = ReactDOM.findDOMNode(app);
-
-        expect(dom.getElementsByClassName('MyPlugin').length).toBe(1);
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(<Provider store={store}><StandardAppComponent plugins={plugins} pluginsConfig={{desktop: ['My']}} /></Provider>, container, () => {
+            expect(container.innerHTML).toExist();
+            expect(container.getElementsByClassName('MyPlugin').length).toBe(1);
+            done();
+        });
     });
 });

--- a/web/client/components/app/__tests__/StandardContainer-test.jsx
+++ b/web/client/components/app/__tests__/StandardContainer-test.jsx
@@ -49,7 +49,7 @@ describe('StandardContainer', () => {
     });
 
 
-    it('creates a default app with component and plugins', () => {
+    it('creates a default app with component and plugins', (done) => {
         const plugins = {
             MyPlugin: {}
         };
@@ -63,11 +63,13 @@ describe('StandardContainer', () => {
         const componentConfig = {
             component: mycomponent
         };
-
-        const app = ReactDOM.render(<Provider store={store}><StandardContainer plugins={plugins} componentConfig={componentConfig}/></Provider>, document.getElementById("container"));
-        expect(app).toExist();
-        const dom = ReactDOM.findDOMNode(app);
-        expect(dom.getElementsByClassName('mycomponent').length).toBe(1);
-        expect(dom.getElementsByClassName('MyPlugin').length).toBe(1);
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(<Provider store={store}><StandardContainer plugins={plugins} componentConfig={componentConfig}/></Provider>, container, () => {
+            expect(container.innerHTML).toExist();
+            expect(container.getElementsByClassName('mycomponent').length).toBe(1);
+            expect(container.getElementsByClassName('MyPlugin').length).toBe(1);
+            done();
+        });
     });
 });

--- a/web/client/components/app/__tests__/StandardRouter-test.jsx
+++ b/web/client/components/app/__tests__/StandardRouter-test.jsx
@@ -49,7 +49,7 @@ describe('StandardRouter', () => {
         setTimeout(done);
     });
 
-    it('creates a default router app', () => {
+    it('creates a default router app', (done) => {
         const store = {
             dispatch: () => {},
             subscribe: () => {
@@ -58,11 +58,15 @@ describe('StandardRouter', () => {
             unsubscribe: () => {},
             getState: () => ({})
         };
-        const app = ReactDOM.render(<Provider store={store}><StandardRouter/></Provider>, document.getElementById("container"));
-        expect(app).toExist();
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(<Provider store={store}><StandardRouter/></Provider>, container, () => {
+            expect(container.innerHTML).toExist();
+            done();
+        });
     });
 
-    it('creates a default router app with pages', () => {
+    it('creates a default router app with pages', (done) => {
         const store = {
             dispatch: () => {},
             subscribe: () => {
@@ -75,14 +79,16 @@ describe('StandardRouter', () => {
             path: '/',
             component: mycomponent
         }];
-        const app = ReactDOM.render(<Provider store={store}><StandardRouter pages={pages}/></Provider>, document.getElementById("container"));
-        expect(app).toExist();
-        const dom = ReactDOM.findDOMNode(app);
-
-        expect(dom.getElementsByClassName('mycomponent').length).toBe(1);
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(<Provider store={store}><StandardRouter pages={pages}/></Provider>, container, () => {
+            expect(container.innerHTML).toExist();
+            expect(container.getElementsByClassName('mycomponent').length).toBe(1);
+            done();
+        });
     });
 
-    it('creates a default router app with pages and plugins', () => {
+    it('creates a default router app with pages and plugins', (done) => {
         const plugins = {
             MyPlugin: {}
         };
@@ -99,15 +105,16 @@ describe('StandardRouter', () => {
             path: '/',
             component: mycomponent
         }];
-        const app = ReactDOM.render(<Provider store={store}><StandardRouter plugins={plugins} pages={pages}/></Provider>, document.getElementById("container"));
-        expect(app).toExist();
-
-        const dom = ReactDOM.findDOMNode(app);
-
-        expect(dom.getElementsByClassName('MyPlugin').length).toBe(1);
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(<Provider store={store}><StandardRouter plugins={plugins} pages={pages}/></Provider>, container, () => {
+            expect(container.innerHTML).toExist();
+            expect(container.getElementsByClassName('MyPlugin').length).toBe(1);
+            done();
+        });
     });
 
-    it('if we dont wait for theme no spinner is shown', () => {
+    it('if we dont wait for theme no spinner is shown', (done) => {
         const plugins = {
             MyPlugin: {}
         };
@@ -124,14 +131,15 @@ describe('StandardRouter', () => {
             path: '/',
             component: mycomponent
         }];
-        const app = ReactDOM.render(<Provider store={store}><StandardRouter plugins={plugins} pages={pages}  loadAfterTheme={false}/></Provider>, document.getElementById("container"));
-        expect(app).toExist();
-
-        const dom = ReactDOM.findDOMNode(app);
-
-        expect(dom.getElementsByClassName('_ms2_init_spinner').length).toBe(0);
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(<Provider store={store}><StandardRouter plugins={plugins} pages={pages}  loadAfterTheme={false}/></Provider>, container, () => {
+            expect(container.innerHTML).toExist();
+            expect(container.getElementsByClassName('_ms2_init_spinner').length).toBe(0);
+            done();
+        });
     });
-    it('if we wait for theme no spinner is shown if the theme is already loaded', () => {
+    it('if we wait for theme no spinner is shown if the theme is already loaded', (done) => {
         const plugins = {
             MyPlugin: {}
         };
@@ -148,14 +156,15 @@ describe('StandardRouter', () => {
             path: '/',
             component: mycomponent
         }];
-        const app = ReactDOM.render(<Provider store={store}><StandardRouter plugins={plugins} pages={pages} loadAfterTheme themeLoaded/></Provider>, document.getElementById("container"));
-        expect(app).toExist();
-
-        const dom = ReactDOM.findDOMNode(app);
-
-        expect(dom.getElementsByClassName('_ms2_init_spinner').length).toBe(0);
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(<Provider store={store}><StandardRouter plugins={plugins} pages={pages} loadAfterTheme themeLoaded/></Provider>, container, () => {
+            expect(container.innerHTML).toExist();
+            expect(container.getElementsByClassName('_ms2_init_spinner').length).toBe(0);
+            done();
+        });
     });
-    it('if we wait for theme spinner is shown if the theme is not already loaded', () => {
+    it('if we wait for theme spinner is shown if the theme is not already loaded', (done) => {
         const plugins = {
             MyPlugin: {}
         };
@@ -172,12 +181,13 @@ describe('StandardRouter', () => {
             path: '/',
             component: mycomponent
         }];
-        const app = ReactDOM.render(<Provider store={store}><StandardRouter plugins={plugins} pages={pages} loadAfterTheme themeLoaded={false} /></Provider>, document.getElementById("container"));
-        expect(app).toExist();
-
-        const dom = ReactDOM.findDOMNode(app);
-
-        expect(dom.getElementsByClassName('_ms2_init_spinner').length).toBe(1);
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(<Provider store={store}><StandardRouter plugins={plugins} pages={pages} loadAfterTheme themeLoaded={false} /></Provider>, container, () => {
+            expect(container.innerHTML).toExist();
+            expect(container.getElementsByClassName('_ms2_init_spinner').length).toBe(1);
+            done();
+        });
     });
     it('if we wait for theme onThemeLoaded is called when theme is loaded', (done) => {
         const plugins = {
@@ -196,11 +206,10 @@ describe('StandardRouter', () => {
             path: '/',
             component: mycomponent
         }];
-        const app = ReactDOM.render(<Provider store={store}><StandardRouter plugins={plugins} pages={pages} version="VERSION" themeCfg={{
+        ReactDOM.render(<Provider store={store}><StandardRouter plugins={plugins} pages={pages} version="VERSION" themeCfg={{
             theme: "default",
             path: "base/web/client/test-resources/themes"
         }} loadAfterTheme themeLoaded={false} onThemeLoaded={done}/></Provider>, document.getElementById("container"));
-        expect(app).toExist();
     });
 
     it('if we wait for theme onThemeLoaded is called when theme custom is loaded', (done) => {
@@ -220,7 +229,7 @@ describe('StandardRouter', () => {
             path: '/',
             component: mycomponent
         }];
-        const app = ReactDOM.render(
+        ReactDOM.render(
             <Provider store={store}>
                 <StandardRouter plugins={plugins} pages={pages} version="VERSION" themeCfg={{
                     theme: "custom",
@@ -230,6 +239,5 @@ describe('StandardRouter', () => {
                     done();
                 }} />
             </Provider>, document.getElementById("container"));
-        expect(app).toExist();
     });
 });

--- a/web/client/components/buttons/__tests__/ZoomButton-test.jsx
+++ b/web/client/components/buttons/__tests__/ZoomButton-test.jsx
@@ -43,57 +43,59 @@ describe('This test for ZoomButton', () => {
     });
 
     // test DEFAULTS
-    it('test default properties', () => {
-        const zmeBtn = ReactDOM.render(
+    it('test default properties', (done) => {
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(
             <Provider store={store}>
                 <ZoomButton/>
             </Provider>,
-            document.getElementById("container"));
-        expect(zmeBtn).toExist();
-
-        const zmeBtnNode = ReactDOM.findDOMNode(zmeBtn);
-        expect(zmeBtnNode).toExist();
-        expect(zmeBtnNode.id).toBe("mapstore-zoom");
-
-        expect(zmeBtnNode).toExist();
-        expect(zmeBtnNode.className.indexOf('square-button') >= 0).toBe(true);
-        expect(zmeBtnNode.innerHTML).toExist();
+            container, () => {
+                expect(container.innerHTML).toExist();
+                const zmeBtnNode = document.getElementById("mapstore-zoom");
+                expect(zmeBtnNode).toExist();
+                expect(zmeBtnNode.className.indexOf('square-button') >= 0).toBe(true);
+                expect(zmeBtnNode.innerHTML).toExist();
+                done();
+            });
     });
 
-    it('test glyphicon property', () => {
-        const zmeBtn = ReactDOM.render(
+    it('test glyphicon property', (done) => {
+        const container = document.getElementById("container");
+        expect(container.innerHTML).toNotExist();
+        ReactDOM.render(
             <Provider store={store}>
                 <ZoomButton/>
             </Provider>,
-            document.getElementById("container"));
-        expect(zmeBtn).toExist();
-
-        const zmeBtnNode = ReactDOM.findDOMNode(zmeBtn);
-        expect(zmeBtnNode).toExist();
-        expect(zmeBtnNode).toExist();
-        const icons = zmeBtnNode.getElementsByTagName('span');
-        expect(icons.length).toBe(1);
+            container, () => {
+                expect(container.innerHTML).toExist();
+                const zmeBtnNode = document.getElementById("mapstore-zoom");
+                expect(zmeBtnNode).toExist();
+                const icons = zmeBtnNode.getElementsByTagName('span');
+                expect(icons.length).toBe(1);
+                done();
+            });
     });
 
-    it('test glyphicon property with text', () => {
-        const zmeBtn = ReactDOM.render(
+    it('test glyphicon property with text', (done) => {
+        ReactDOM.render(
             <Provider store={store}>
                 <ZoomButton glyphicon="info-sign" text="button"/>
             </Provider>,
-            document.getElementById("container"));
-        expect(zmeBtn).toExist();
+            document.getElementById("container"),
+            () => {
+                const zmeBtnNode = document.getElementById("mapstore-zoom");
+                expect(zmeBtnNode).toExist();
 
-        const zmeBtnNode = ReactDOM.findDOMNode(zmeBtn);
-        expect(zmeBtnNode).toExist();
-        expect(zmeBtnNode).toExist();
+                const btnItems = zmeBtnNode.getElementsByTagName('span');
+                expect(btnItems.length).toBe(1);
 
-        const btnItems = zmeBtnNode.getElementsByTagName('span');
-        expect(btnItems.length).toBe(1);
-
-        expect(zmeBtnNode.innerText.indexOf("button") !== -1).toBe(true);
+                expect(zmeBtnNode.innerText.indexOf("button") !== -1).toBe(true);
+                done();
+            });
     });
 
-    it('test if click on button launches the proper action', () => {
+    it('test if click on button launches the proper action', (done) => {
 
         let genericTest = function() {
             let actions = {
@@ -102,7 +104,7 @@ describe('This test for ZoomButton', () => {
                 }
             };
             let spy = expect.spyOn(actions, "onZoom");
-            var cmp = ReactDOM.render(
+            ReactDOM.render(
                 <ZoomButton
                     {...actions}
                     mapConfig={{
@@ -123,34 +125,37 @@ describe('This test for ZoomButton', () => {
                         }
                     }}
                 />
-                , document.getElementById("container"));
-            expect(cmp).toExist();
+                , document.getElementById("container")
+                , () => {
+                    const cmpDom = document.getElementById("mapstore-zoom");
+                    expect(cmpDom).toExist();
 
-            const cmpDom = document.getElementById("mapstore-zoom");
-            expect(cmpDom).toExist();
+                    cmpDom.click();
 
-            cmpDom.click();
-
-            expect(spy.calls.length).toBe(1);
-            expect(spy.calls[0].arguments.length).toBe(1);
+                    expect(spy.calls.length).toBe(1);
+                    expect(spy.calls[0].arguments.length).toBe(1);
+                    done();
+                });
         };
 
         genericTest();
 
     });
 
-    it('create glyphicon with custom css class', () => {
-        const zmeBtn = ReactDOM.render(
+    it('create glyphicon with custom css class', (done) => {
+        const container = document.getElementById("container");
+        ReactDOM.render(
             <Provider store={store}>
                 <ZoomButton className="custom" glyphicon="info-sign" text="button"/>
             </Provider>,
-            document.getElementById("container"));
-        expect(zmeBtn).toExist();
+            container, () => {
+                expect(container.innerHTML).toExist();
+                const zmeBtnNode = document.getElementById("mapstore-zoom");
+                expect(zmeBtnNode).toExist();
 
-        const zmeBtnNode = ReactDOM.findDOMNode(zmeBtn);
-        expect(zmeBtnNode).toExist();
-
-        expect(zmeBtnNode.className.indexOf('custom') !== -1).toBe(true);
+                expect(zmeBtnNode.className.indexOf('custom') !== -1).toBe(true);
+                done();
+            });
     });
 
     it('test zoom in', () => {

--- a/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
+++ b/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
@@ -43,54 +43,57 @@ describe('This test for ZoomToMaxExtentButton', () => {
     });
 
     // test DEFAULTS
-    it('test default properties', () => {
-        const zmeBtn = ReactDOM.render(
+    it('test default properties', (done) => {
+        const container = document.getElementById("container");
+        ReactDOM.render(
             <Provider store={store}>
                 <ZoomToMaxExtentButton/>
             </Provider>,
-            document.getElementById("container"));
-        expect(zmeBtn).toExist();
-
-        const zmeBtnNode = ReactDOM.findDOMNode(zmeBtn);
-        expect(zmeBtnNode).toExist();
-        expect(zmeBtnNode.id).toBe("mapstore-zoomtomaxextent");
-
-        expect(zmeBtnNode).toExist();
-        expect(zmeBtnNode.className.indexOf('default') >= 0).toBe(true);
-        expect(zmeBtnNode.innerHTML).toExist();
+            container,
+            () => {
+                expect(container.innerHTML).toExist();
+                const zmeBtnNode = document.getElementById("mapstore-zoomtomaxextent");
+                expect(zmeBtnNode).toExist();
+                expect(zmeBtnNode.className.indexOf('default') >= 0).toBe(true);
+                expect(zmeBtnNode.innerHTML).toExist();
+                done();
+            });
     });
 
-    it('test glyphicon property', () => {
-        const zmeBtn = ReactDOM.render(
+    it('test glyphicon property', (done) => {
+        const container = document.getElementById("container");
+        ReactDOM.render(
             <Provider store={store}>
                 <ZoomToMaxExtentButton/>
             </Provider>,
-            document.getElementById("container"));
-        expect(zmeBtn).toExist();
-
-        const zmeBtnNode = ReactDOM.findDOMNode(zmeBtn);
-        expect(zmeBtnNode).toExist();
-        expect(zmeBtnNode).toExist();
-        const icons = zmeBtnNode.getElementsByTagName('span');
-        expect(icons.length).toBe(1);
+            container,
+            () => {
+                expect(container.innerHTML).toExist();
+                const zmeBtnNode = document.getElementById("mapstore-zoomtomaxextent");
+                expect(zmeBtnNode).toExist();
+                const icons = zmeBtnNode.getElementsByTagName('span');
+                expect(icons.length).toBe(1);
+                done();
+            });
     });
 
-    it('test glyphicon property with text', () => {
-        const zmeBtn = ReactDOM.render(
+    it('test glyphicon property with text', (done) => {
+        const container = document.getElementById("container");
+        ReactDOM.render(
             <Provider store={store}>
                 <ZoomToMaxExtentButton glyphicon="info-sign" text="button"/>
             </Provider>,
-            document.getElementById("container"));
-        expect(zmeBtn).toExist();
+            container,
+            () => {
+                expect(container.innerHTML).toExist();
+                const zmeBtnNode = document.getElementById("mapstore-zoomtomaxextent");
+                expect(zmeBtnNode).toExist();
+                const btnItems = zmeBtnNode.getElementsByTagName('span');
+                expect(btnItems.length).toBe(1);
 
-        const zmeBtnNode = ReactDOM.findDOMNode(zmeBtn);
-        expect(zmeBtnNode).toExist();
-        expect(zmeBtnNode).toExist();
-
-        const btnItems = zmeBtnNode.getElementsByTagName('span');
-        expect(btnItems.length).toBe(1);
-
-        expect(zmeBtnNode.innerText.indexOf("button") !== -1).toBe(true);
+                expect(zmeBtnNode.innerText.indexOf("button") !== -1).toBe(true);
+                done();
+            });
     });
 
     it('test if click on button launches the proper action', () => {
@@ -145,18 +148,20 @@ describe('This test for ZoomToMaxExtentButton', () => {
         genericTest("image");
     });
 
-    it('create glyphicon with custom css class', () => {
-        const zmeBtn = ReactDOM.render(
+    it('create glyphicon with custom css class', (done) => {
+        const container = document.getElementById("container");
+        ReactDOM.render(
             <Provider store={store}>
                 <ZoomToMaxExtentButton className="custom" glyphicon="info-sign" text="button"/>
             </Provider>,
-            document.getElementById("container"));
-        expect(zmeBtn).toExist();
-
-        const zmeBtnNode = ReactDOM.findDOMNode(zmeBtn);
-        expect(zmeBtnNode).toExist();
-
-        expect(zmeBtnNode.className.indexOf('custom') !== -1).toBe(true);
+            container,
+            () => {
+                expect(container.innerHTML).toExist();
+                const zmeBtnNode = document.getElementById("mapstore-zoomtomaxextent");
+                expect(zmeBtnNode).toExist();
+                expect(zmeBtnNode.className.indexOf('custom') !== -1).toBe(true);
+                done();
+            });
     });
 
     it('test zoom to initial extent', () => {

--- a/web/client/components/data/identify/viewers/__tests__/viewers-test.jsx
+++ b/web/client/components/data/identify/viewers/__tests__/viewers-test.jsx
@@ -14,6 +14,12 @@ import HTMLViewer from '../HTMLViewer';
 import JSONViewer from '../JSONViewer';
 import TextViewer from '../TextViewer';
 
+import configureStore from 'redux-mock-store';
+import thunkMiddleware from 'redux-thunk';
+import {Provider} from "react-redux";
+const mockStore = configureStore([thunkMiddleware]);
+const store = mockStore({});
+
 const SimpleRowViewer = (props) => {
     return <div>{['name', 'description'].map((key) => <span key={key}>{key}:{props[key]}</span>)}</div>;
 };
@@ -51,7 +57,8 @@ describe('Identity Viewers', () => {
     });
 
     it('test JSONViewer', () => {
-        const cmp = ReactDOM.render(<JSONViewer response={{
+        const container = document.getElementById("container");
+        ReactDOM.render(<Provider store={store}><JSONViewer response={{
             features: [{
                 id: 1,
                 properties: {
@@ -59,10 +66,10 @@ describe('Identity Viewers', () => {
                     description: 'mydescription'
                 }
             }]
-        }} rowViewer={SimpleRowViewer}/>, document.getElementById("container"));
-        expect(cmp).toExist();
+        }} rowViewer={SimpleRowViewer}/></Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        const cmpDom = ReactDOM.findDOMNode(cmp);
+        const cmpDom = container.firstElementChild;
         expect(cmpDom).toExist();
 
         expect(cmpDom.innerHTML.indexOf('myname') !== -1).toBe(true);
@@ -73,7 +80,8 @@ describe('Identity Viewers', () => {
         const MyRowViewer = (props) => {
             return <span>This is my viewer: {props.feature.id}</span>;
         };
-        const cmp = ReactDOM.render(<JSONViewer rowViewer={MyRowViewer} response={{
+        const container = document.getElementById("container");
+        ReactDOM.render(<Provider store={store}><JSONViewer rowViewer={MyRowViewer} response={{
             features: [{
                 id: 1,
                 properties: {
@@ -81,16 +89,17 @@ describe('Identity Viewers', () => {
                     description: 'mydescription'
                 }
             }]
-        }} />, document.getElementById("container"));
-        expect(cmp).toExist();
+        }} /></Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        const cmpDom = ReactDOM.findDOMNode(cmp);
+        const cmpDom = container.firstElementChild;
         expect(cmpDom).toExist();
         expect(cmpDom.innerText.indexOf('This is my viewer: 1') !== -1).toBe(true);
     });
 
     it('test JSONViewer with TEMPLATE', () => {
-        const cmp = ReactDOM.render(
+        const container = document.getElementById("container");
+        ReactDOM.render(<Provider store={store}>
             <JSONViewer
                 layer={{
                     featureInfo: {
@@ -106,10 +115,10 @@ describe('Identity Viewers', () => {
                             description: 'mydescription'
                         }
                     }]
-                }} />, document.getElementById("container"));
-        expect(cmp).toExist();
+                }} /></Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        const cmpDom = ReactDOM.findDOMNode(cmp);
+        const cmpDom = container.firstElementChild;
         expect(cmpDom).toExist();
 
         const templateDOM = document.getElementById('my-template');
@@ -118,7 +127,8 @@ describe('Identity Viewers', () => {
     });
 
     it('test JSONViewer with TEMPLATE and missing properties', () => {
-        const cmp = ReactDOM.render(
+        const container = document.getElementById("container");
+        ReactDOM.render(<Provider store={store}>
             <JSONViewer
                 layer={{
                     featureInfo: {
@@ -134,10 +144,10 @@ describe('Identity Viewers', () => {
                             description: 'mydescription'
                         }
                     }]
-                }} />, document.getElementById("container"));
-        expect(cmp).toExist();
+                }} /></Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        const cmpDom = ReactDOM.findDOMNode(cmp);
+        const cmpDom = container.firstElementChild;
         expect(cmpDom).toExist();
 
         const templateDOM = document.getElementById('my-template');
@@ -146,7 +156,7 @@ describe('Identity Viewers', () => {
     });
 
     it('test JSONViewer with TEMPLATE with tag inside variable', () => {
-        ReactDOM.render(
+        ReactDOM.render(<Provider store={store}>
             <JSONViewer
                 layer={{
                     featureInfo: {
@@ -162,12 +172,12 @@ describe('Identity Viewers', () => {
                             description: 'mydescription'
                         }
                     }]
-                }} />, document.getElementById("container"));
+                }} /></Provider>, document.getElementById("container"));
 
         let templateDOM = document.getElementById('my-template');
         expect(templateDOM.innerHTML).toBe('the property name is myname');
 
-        ReactDOM.render(
+        ReactDOM.render(<Provider store={store}>
             <JSONViewer
                 layer={{
                     featureInfo: {
@@ -183,14 +193,15 @@ describe('Identity Viewers', () => {
                             description: 'mydescription'
                         }
                     }]
-                }} />, document.getElementById("container"));
+                }} /></Provider>, document.getElementById("container"));
 
         templateDOM = document.getElementById('my-template');
         expect(templateDOM.innerHTML).toBe('the property description is mydescription');
     });
 
     it('test JSONViewer with TEMPLATE multiple features', () => {
-        const cmp = ReactDOM.render(
+        const container = document.getElementById("container");
+        ReactDOM.render(<Provider store={store}>
             <JSONViewer
                 layer={{
                     featureInfo: {
@@ -212,10 +223,10 @@ describe('Identity Viewers', () => {
                             description: 'newDescription'
                         }
                     }]
-                }} />, document.getElementById("container"));
-        expect(cmp).toExist();
+                }} /></Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        const cmpDom = ReactDOM.findDOMNode(cmp);
+        const cmpDom = container.firstElementChild;
         expect(cmpDom).toExist();
 
         const templateDOM = document.getElementsByClassName('my-template');
@@ -225,7 +236,7 @@ describe('Identity Viewers', () => {
 
     it('test JSONViewer with TEMPLATE but missing/empty template', () => {
         // when template is missing, undefined or equal to <p><br></p> response is displayed in PROPERTIES format
-        ReactDOM.render(
+        ReactDOM.render(<Provider store={store}>
             <JSONViewer
                 layer={{
                     featureInfo: {
@@ -240,12 +251,12 @@ describe('Identity Viewers', () => {
                             description: 'mydescription'
                         }
                     }]
-                }} />, document.getElementById("container"));
+                }} /></Provider>, document.getElementById("container"));
 
         let propertiesViewer = document.getElementsByClassName('mapstore-json-viewer');
         expect(propertiesViewer.length).toBe(1);
 
-        ReactDOM.render(
+        ReactDOM.render(<Provider store={store}>
             <JSONViewer
                 layer={{
                     featureInfo: {
@@ -261,13 +272,13 @@ describe('Identity Viewers', () => {
                             description: 'mydescription'
                         }
                     }]
-                }} />, document.getElementById("container"));
+                }} /></Provider>, document.getElementById("container"));
 
         propertiesViewer = document.getElementsByClassName('mapstore-json-viewer');
         expect(propertiesViewer.length).toBe(1);
 
         // <p><br></p> is the value of react-quill when empty
-        ReactDOM.render(
+        ReactDOM.render(<Provider store={store}>
             <JSONViewer
                 layer={{
                     featureInfo: {
@@ -283,7 +294,7 @@ describe('Identity Viewers', () => {
                             description: 'mydescription'
                         }
                     }]
-                }} />, document.getElementById("container"));
+                }} /></Provider>, document.getElementById("container"));
 
         propertiesViewer = document.getElementsByClassName('mapstore-json-viewer');
         expect(propertiesViewer.length).toBe(1);

--- a/web/client/components/home/__tests__/Home-test.jsx
+++ b/web/client/components/home/__tests__/Home-test.jsx
@@ -22,18 +22,20 @@ describe("Test Home component", () => {
     });
 
     it('creates component with defaults', () => {
-        const cmp = ReactDOM.render(<Provider store={store}><Home/></Provider>, document.getElementById("container"));
-        expect(cmp).toBeTruthy();
+        const container = document.getElementById("container");
+        ReactDOM.render(<Provider store={store}><Home/></Provider>, container);
+        expect(container.innerHTML).toExist();
         const icons = document.querySelectorAll(".glyphicon-home");
         expect(icons.length).toEqual(1);
         expect(icons[0]).toBeTruthy();
     });
     it('creates component with custom icon text', () => {
-        const cmp = ReactDOM.render(
+        const container = document.getElementById("container");
+        ReactDOM.render(
             <Provider store={store}><Home
                 icon="pencil"
-            /></Provider>, document.getElementById("container"));
-        expect(cmp).toBeTruthy();
+            /></Provider>, container);
+        expect(container.innerHTML).toExist();
         const buttons = document.querySelectorAll("button");
         expect(buttons.length).toEqual(1);
         expect(buttons[0]).toBeTruthy();

--- a/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
+++ b/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
@@ -116,14 +116,15 @@ describe('PluginsContainer', () => {
     });
 
     it('checks filterDisabledPlugins one disabled', () => {
-        const cmp = ReactDOM.render(
+        const container = document.getElementById("container");
+        ReactDOM.render(
             <Provider store={store}>
                 <PluginsContainer mode="desktop" defaultMode="desktop" params={{}}
                     plugins={plugins} pluginsConfig={pluginsCfg}/>
-            </Provider>, document.getElementById("container"));
-        expect(cmp).toExist();
+            </Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        const cmpDom = ReactDOM.findDOMNode(cmp);
+        const cmpDom = container.firstElementChild;
         expect(cmpDom).toExist();
 
         const rendered = cmpDom.getElementsByTagName("div");
@@ -131,14 +132,15 @@ describe('PluginsContainer', () => {
     });
 
     it('checks filterDisabledPlugins no disabled', () => {
-        const cmp = ReactDOM.render(
+        const container = document.getElementById("container");
+        ReactDOM.render(
             <Provider store={store}>
                 <PluginsContainer mode="desktop" defaultMode="desktop" params={{}}
                     plugins={plugins} pluginsConfig={pluginsCfg2} />
-            </Provider>, document.getElementById("container"));
-        expect(cmp).toExist();
+            </Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        const cmpDom = ReactDOM.findDOMNode(cmp);
+        const cmpDom = container.firstElementChild;
         expect(cmpDom).toExist();
 
         const rendered = cmpDom.getElementsByTagName("div");
@@ -146,41 +148,42 @@ describe('PluginsContainer', () => {
     });
     it('test noRoot option disable root rendering of plugins', () => {
         // Not rendered without container
-        let cmp = ReactDOM.render(
+        const container = document.getElementById("container");
+        ReactDOM.render(
             <Provider store={store}>
                 <PluginsContainer mode="desktop" defaultMode="desktop" params={{}}
                     plugins={plugins} pluginsConfig={pluginsCfg3} />
-            </Provider>, document.getElementById("container"));
-        expect(cmp).toExist();
+            </Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        let cmpDom = ReactDOM.findDOMNode(cmp);
+        let cmpDom = container.firstElementChild;
         expect(cmpDom).toExist();
 
         let rendered = cmpDom.getElementsByTagName("div");
 
         // rendered in container
         expect(rendered.length).toBe(1);
-        cmp = ReactDOM.render(
+        ReactDOM.render(
             <Provider store={store}>
                 <PluginsContainer mode="desktop" defaultMode="desktop" params={{}}
                     plugins={plugins} pluginsConfig={pluginsCfg4} />
-            </Provider>, document.getElementById("container"));
-        expect(cmp).toExist();
+            </Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        cmpDom = ReactDOM.findDOMNode(cmp);
+        cmpDom = container.firstElementChild;
         expect(cmpDom).toExist();
 
-        rendered = cmpDom.getElementsByTagName("div");
         expect(document.getElementById('no-impl-item-no-root-plugin')).toNotExist();
         expect(document.getElementById('no-root')).toExist();
     });
     it('checks plugin with forwardRef = true connect option', () => {
-        const app = ReactDOM.render(<Provider store={store}>
+        const container = document.getElementById("container");
+        ReactDOM.render(<Provider store={store}>
             <PluginsContainer mode="desktop" defaultMode="desktop" params={{}}
                 plugins={plugins} pluginsConfig={pluginsCfgRef}/>
-        </Provider>, document.getElementById("container"));
+        </Provider>, container);
 
-        expect(app).toExist();
+        expect(container.innerHTML).toExist();
         expect(window.WithGlobalRefPlugin.myFunc).toExist();
     });
 });

--- a/web/client/plugins/contextmanager/__tests__/PaginationToolbar-test.jsx
+++ b/web/client/plugins/contextmanager/__tests__/PaginationToolbar-test.jsx
@@ -60,13 +60,13 @@ describe("contextmanager PaginationToolbar component", () => {
             }
         });
 
-        const comp = ReactDOM.render(
+        const container = document.getElementById('container');
+        ReactDOM.render(
             <Provider store={store}>
                 <PaginationToolbar/>
-            </Provider>, document.getElementById("container"));
-        expect(comp).toExist();
+            </Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        const container = document.getElementById('container');
         const pagination = container.getElementsByClassName('pagination');
         expect(pagination).toExist();
         expect(pagination.length).toBe(1);

--- a/web/client/plugins/contexts/__tests__/PaginationToolbar-test.jsx
+++ b/web/client/plugins/contexts/__tests__/PaginationToolbar-test.jsx
@@ -60,13 +60,13 @@ describe("contexts PaginationToolbar component", () => {
             }
         });
 
-        const comp = ReactDOM.render(
+        const container = document.getElementById('container');
+        ReactDOM.render(
             <Provider store={store}>
                 <PaginationToolbar/>
-            </Provider>, document.getElementById("container"));
-        expect(comp).toExist();
+            </Provider>, container);
+        expect(container.innerHTML).toExist();
 
-        const container = document.getElementById('container');
         const pagination = container.getElementsByClassName('pagination');
         expect(pagination).toExist();
         expect(pagination.length).toBe(1);

--- a/web/client/product/components/viewer/__tests__/MapViewer-test.jsx
+++ b/web/client/product/components/viewer/__tests__/MapViewer-test.jsx
@@ -20,10 +20,11 @@ const store = mockStore({});
 const location = document.location;
 
 const renderMapViewerComp = (mapViewerPros) => {
-    return ReactDOM.render(
+    const container = document.getElementById("container");
+    ReactDOM.render(
         <Provider store={store}>
             <MapViewerCmp {...mapViewerPros}/>
-        </Provider>, document.getElementById("container"));
+        </Provider>, container);
 };
 
 describe("Test the MapViewerCmp component", () => {
@@ -37,58 +38,75 @@ describe("Test the MapViewerCmp component", () => {
         setTimeout(done);
     });
 
-    it('testing creation with defaults', () => {
-        const mapViewerPros = { wrappedContainer: MapViewerContainer };
-        const cmpMapViewerCmp = renderMapViewerComp(mapViewerPros);
-        expect(cmpMapViewerCmp).toExist();
+    it('testing creation with defaults', (done) => {
+        const mapViewerPros = {
+            wrappedContainer: MapViewerContainer,
+            onLoaded: (res) => {
+                expect(res).toBe(true);
+                done();
+            }
+        };
+        renderMapViewerComp(mapViewerPros);
     });
 
-    it('testing creation with mapId = new', () => {
+    it('testing creation with mapId = new', (done) => {
         const match = {params: {mapId: "new"}};
         const mapViewerPros = { match, location, onInit: () => {},
             wrappedContainer: MapViewerContainer,
             loadMapConfig: (cfgUrl, mapId) => {
                 expect(cfgUrl).toBe("new.json");
                 expect(mapId).toBe(null);
+            },
+            onLoaded: (res) => {
+                expect(res).toBe(true);
+                done();
             }};
-        const cmpMapViewerCmp = renderMapViewerComp(mapViewerPros);
-        expect(cmpMapViewerCmp).toExist();
+        renderMapViewerComp(mapViewerPros);
     });
 
-    it('testing creation with mapId = anyString', () => {
+    it('testing creation with mapId = anyString', (done) => {
         const match = {params: {mapId: "anyString"}};
         const mapViewerPros = { match, location, onInit: () => {},
             wrappedContainer: MapViewerContainer,
             loadMapConfig: (cfgUrl, mapId) => {
                 expect(cfgUrl).toBe("anyString.json");
                 expect(mapId).toBe(null);
+            },
+            onLoaded: (res) => {
+                expect(res).toBe(true);
+                done();
             }};
-        const cmpMapViewerCmp = renderMapViewerComp(mapViewerPros);
-        expect(cmpMapViewerCmp).toExist();
+        renderMapViewerComp(mapViewerPros);
     });
 
-    it('testing creation with mapId = 0', () => {
+    it('testing creation with mapId = 0', (done) => {
         const match = {params: {mapId: 0}};
         const mapViewerPros = { match, location, onInit: () => {},
             wrappedContainer: MapViewerContainer,
             loadMapConfig: (cfgUrl, mapId) => {
                 expect(cfgUrl).toBe("config.json");
                 expect(mapId).toBe(null);
+            },
+            onLoaded: (res) => {
+                expect(res).toBe(true);
+                done();
             }};
-        const component = renderMapViewerComp(mapViewerPros);
-        expect(component).toExist();
+        renderMapViewerComp(mapViewerPros);
     });
 
-    it('testing creation with mapId = 1', () => {
+    it('testing creation with mapId = 1', (done) => {
         const match = {params: {mapId: 1}};
         const mapViewerPros = { match, location, onInit: () => {},
             wrappedContainer: MapViewerContainer,
             loadMapConfig: (cfgUrl, mapId) => {
                 expect(cfgUrl).toBe("/rest/geostore/data/1");
                 expect(mapId).toBe(1);
+            },
+            onLoaded: (res) => {
+                expect(res).toBe(true);
+                done();
             }};
-        const component = renderMapViewerComp(mapViewerPros);
-        expect(component).toExist();
+        renderMapViewerComp(mapViewerPros);
     });
     it('testing update of map on mapId change', (done) => {
         let count = 1;
@@ -112,8 +130,15 @@ describe("Test the MapViewerCmp component", () => {
         renderMapViewerComp({ ...mapViewerPros, location: { ...location }});
         // render second time
         setTimeout(() => {
-            const component = renderMapViewerComp({ ...mapViewerPros, match: match2, location: {...location}});
-            expect(component).toExist();
+            renderMapViewerComp({
+                ...mapViewerPros,
+                match: match2,
+                location: {...location},
+                onLoaded: (res) => {
+                    expect(res).toBe(true);
+                    done();
+                }
+            });
         }, 300);
     });
 

--- a/web/client/utils/__tests__/PluginsUtils-test.js
+++ b/web/client/utils/__tests__/PluginsUtils-test.js
@@ -85,8 +85,9 @@ describe('PluginsUtils', () => {
                 test: "statetest"
             })
         };
-        const app = ReactDOM.render(<Provider store={store}><Connected test="propstest" pluginCfg={{test: "plugintest"}}/></Provider>, document.getElementById("container"));
-        const domElement = ReactDOM.findDOMNode(app);
+        const container = document.getElementById("container");
+        ReactDOM.render(<Provider store={store}><Connected test="propstest" pluginCfg={{test: "plugintest"}}/></Provider>, container);
+        const domElement = container.firstElementChild;
         expect(domElement.innerText).toBe("plugintest");
     });
     it('handleExpression', () => {


### PR DESCRIPTION
## Description

As described in https://github.com/geosolutions-it/MapStore2/issues/10127, 
this PR updates tests relying on 'render' returning a reference to enable
react-redux 7.x upwards (where some components become stateless and render
no longer returns a reference, even though it was successful).

Basically, for those tests, the indicator if the render function was successful is 
no longer that it returns a reference to a class instance, but that the DOM was modified.

For most tests, this basic check is complemented by more in-depth checks, which were
left unchanged.

Rendering the `MapViewerCmp` did not result in measurable changes to the DOM
(the content of the container div stayed an empty string), so instead,
the new test checks that the `onLoad` callback function is being called.

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Refactoring (no functional changes, no api changes)

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10127

**What is the new behavior?**

Tests still run through regardless of whether  `react-redux 6.x` or `7.x` is being used. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
