### PR TITLE
Update German translation to resolve input field issue

### DIFF
--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -58,8 +58,8 @@
             "404": "Übersetzungsdatei nicht gefunden"
         },
         "details": {
-            "title": "Infos zu dieser Inhalt",
-            "tooltip": "Infos zu dieser Inhalt"
+            "title": "Infos zu diesem Inhalt",
+            "tooltip": "Infos zu diesem Inhalt"
         },
         "showEmptyMessageGFI": "Nachricht mit leeren Ergebnissen anzeigen",
         "remove": "Löschen",
@@ -238,8 +238,8 @@
           "title": "Text lokalisieren",
           "default": "Standard"
         },
-        "longitude": "Längengrad",
-        "latitude": "Breitengrad",
+        "longitude": "Lon",
+        "latitude": "Lat",
         "notification": {
             "update": "Aktualisierung",
             "warning": "Warnung",
@@ -484,14 +484,14 @@
                 "titleNoCount": "Dashboards",
                 "create": "Dashboard erstellen",
                 "noDashboardAvailable": "Kein Dashboard verfügbar",
-                "createANewOne": "Erstelle ein neues",
+                "createANewOne": "Erstelle ein neues Dashboard",
                 "deleteError": "Beim Löschen der Ressource ist ein Fehler aufgetreten",
                 "errorLoadingDashboards": "Beim Laden des Dashboards ist ein Fehler aufgetreten"
             },
             "maps": {
                 "title": "Karten ({count})",
                 "noMapAvailable": "Keine Karte verfügbar",
-                "createNewOne": "Erstelle eine neue",
+                "createNewOne": "Erstelle eine neue Karte",
                 "unsavedMapConfirmTitle": "Nicht gespeicherte Änderungen",
                 "unsavedMapConfirmMessage": "Möchten Sie nicht gespeicherte Änderungen wirklich verwerfen?",
                 "unsavedMapConfirmButtonText": "Verwerfen",
@@ -503,7 +503,7 @@
                 "titleNoCount": "GeoStories",
                 "create": "GeoStory erstellen",
                 "noGeostoryAvailable": "Kein GeoStory verfügbar",
-                "createANewOne": "Erstelle eine neue",
+                "createANewOne": "Erstelle eine neue GeoStory",
                 "deleteError": "Beim Löschen der GeoStory ist ein Fehler aufgetreten",
                 "errorLoadingGeostories": "Beim Laden der GeoStories ist ein Fehler aufgetreten"
             },
@@ -704,7 +704,7 @@
                 "metadataUrl": "Metadaten-URL",
                 "role": "Rolle",
                 "hoursOfService": "Öffnungszeiten",
-                "electronicMailAddress": "E-Mail-Addresse",
+                "electronicMailAddress": "E-Mail-Adresse",
                 "subject": "Betreff",
                 "type": "Typ",
                 "creator": "Ersteller",
@@ -820,7 +820,7 @@
         "identifyZoomToFeature": "Auf Objekt zoomen",
         "identifyStopHighlightingFeatures": "Objekte in Karte nicht mehr hervorheben",
         "identifyHighlightFeatures": "Objekte in Karte hervorheben",
-        "identifyRevGeocodeModalTitle": "Addresse",
+        "identifyRevGeocodeModalTitle": "Adresse",
         "identifyRevGeocodeSubmitText": "Mehr Informationen",
         "identifyRevGeocodeCloseText": "Schliessen",
         "identifyRevGeocodeError": "Konnte nicht geocodiert werden",
@@ -887,8 +887,8 @@
             "tooltipAngle3DStart": "Klicken Sie einmal, um 3 Punkte zu zeichnen, die die Eckpunkte der Winkel darstellen",
             "tooltipSlopeStart": "Klicken Sie einmal, um 3 Punkte zu zeichnen, die eine Dreiecksfläche darstellen.\nDer Neigungswert wird basierend auf der gezeichneten Dreiecksfläche berechnet",
             "altitude": "Höhe",
-            "latitude": "Breitengrad",
-            "longitude": "Längengrad"
+            "latitude": "Lat",
+            "longitude": "Lon"
         },
         "search":{
             "layerMustBeVisible": "Die Zielebene ist inaktiv",
@@ -1336,8 +1336,8 @@
                 "valid": "Geometrie ist gültig",
                 "radius": "Radius",
                 "text": "Text",
-                "lat": "Breitengrad",
-                "lon": "Längengrad",
+                "lat": "Lat",
+                "lon": "Lon",
                 "notValidMarker": "Fügen Sie eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
                 "notValidPolyline": "Alle Koordinaten müssen gültig sein (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Fügen Sie einen Textwert und eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
@@ -1543,11 +1543,11 @@
             },
             "add": "Hinzufügen",
             "cancel": "Abbrechen",
-            "merge": "Mit der vorhandenen Annotationsebene zusammenführen",
-            "replace": "Ersetzen Sie die vorhandene Anmerkungsebene",
-            "success": " erfolgreich importiert",
-            "next": "Nächster",
-            "skip": "springen",
+            "merge": "Mit den vorhandenen Anmerkungen zusammenführen",
+            "replace": "Die vorhandenen Anmerkungen ersetzen",
+            "success": "Erfolgreich importiert",
+            "next": "Weiter",
+            "skip": "Überspringen",
             "finish": "Fertig",
             "layerOf": "Ebene {count} von {total}:",
             "styleCustomizationDisabled":"Diese Ebene hat bereits einen Stil definiert und kann nicht angepasst werden."
@@ -1558,7 +1558,7 @@
                 "dropZone": {
                     "heading": "<p> <h4> Legen Sie hier Ihre Kartenkonfigurations- oder Vektordateien ab </h4> <small> oder nutzen Sie </small> </p>",
                     "selectFiles": "Dateien auswählen...",
-                    "infoSupported": "<p> <small> Unterstützte Dateien zur Kartenkonfiguration: MapStore Legacy-Format, WMC.<br />Unterstützte Vektor-Layer-Dateien: Shapefiles (müssen in einem Zip-Archiv enthalten sein), KML / KMZ, GPX, GeoJSON oder Annotations </small> </p>",
+                    "infoSupported": "<p> <small> Unterstützte Dateien zur Kartenkonfiguration: MapStore Legacy-Format, WMC.<br />Unterstützte Vektor-Layer-Dateien: Shapefiles (müssen in einem Zip-Archiv enthalten sein), KML / KMZ, GPX, GeoJSON oder Anmerkungen </small> </p>",
                     "note": "<p> <small> <i> <strong> Hinweis </strong>: Die aktuelle Karte wird bei der Verwendung von Kartenkonfigurationsdateien überschrieben </i> </small> </p>"
                 },
                 "errors": {
@@ -1700,12 +1700,12 @@
           "allowUnsecureLayers": {
               "label": "Nicht sichere Ebenen zulassen",
               "tooltip": "Das Hinzufügen einer Ebene zur Karte mit aktivierter Option zwingt die Anwendung, Proxy anzuwenden"
-          },
-          "sortBy": {
-            "label": "Sortiere nach",
-            "tooltip": "Namespace-Präfix zur Namenseigenschaft hinzufügen. d.h. ${namespace}:${name}",
-            "placeholder": "Name eingeben"
-          }
+            },
+            "sortBy": {
+              "label": "Sortiere nach",
+              "tooltip": "Namespace-Präfix zur Namenseigenschaft hinzufügen. d.h. ${namespace}:${name}",
+              "placeholder": "Name eingeben"
+            }
         },
         "uploader": {
             "filename": "Dateiname",
@@ -2416,8 +2416,8 @@
             }
         },
         "wizard": {
-            "next": "Nächster",
-            "prev": "Vorheriger",
+            "next": "Weiter",
+            "prev": "Zurück",
             "finish": "Fertig"
         },
         "vectorstyler": {
@@ -2714,13 +2714,13 @@
             "msExtrudedHeight": "Extrudierte Höhe",
             "msExtrusionColor": "Extrusionsfarbe",
             "msExtrusionType": "Extrusionstyp",
-            "wall": "Wand",
+            "wall": "Wand",  
             "enableBanding": "Band styling",
             "selectChannel": "Wählen Sie eine Band aus",
             "minLabel": "Min",
             "maxLabel": "Max",
             "minSourceValue": "Mindestwert der Quelldaten",
-            "maxSourceValue": "Maximaler Quelldatenwert",
+            "maxSourceValue": "Maximaler Quelldatenwert",          
             "customParams": "Benutzerdefinierte Parameter",
             "wrongFormatMsg": "Die eingegebene Konfiguration ist in falschem Format !!"
         },
@@ -2871,8 +2871,8 @@
             "newButton": "Erstellen",
             "editButton": "Speichern",
             "close": "Schließen",
-            "previous": "vorheriger",
-            "next": "nächster",
+            "previous": "zurück",
+            "next": "weiter",
             "cacheCleaned": "Der Cache wurde erfolgreich bereinigt",
             "errorTitle": "Geofence",
             "errorCQL": "Geometrie nicht gültig!",
@@ -3108,7 +3108,7 @@
             "saveSuccessMessage": "Erfolgreich gespeichert",
             "saveTooltip": "Speichern",
             "saveAsTooltip": "Speichern als",
-            "unadvertised": "Nicht geworben",
+            "unadvertised": "Nicht beworben",
             "creator": "Erstellt von",
             "editor": "Zuletzt geändert von"
         },
@@ -3655,8 +3655,8 @@
             "globeTranslucency": "Globustransluzenz",
             "layersOptions": "Ebenenoptionen",
             "cameraPosition": "Kameraposition",
-            "longitude": "Längengrad",
-            "latitude": "Breitengrad",
+            "longitude": "Lon",
+            "latitude": "Lat",
             "height": "Höhe (m)",
             "centerPosition": "Mittelstellung",
             "captureThisViewPositions": "Positionen dieser Ansicht erfassen",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**

- The terms "Breitengrad" and Längengrad" for Lat and Lon cause input fields for Aeronautical Coordinates in Annotations editor to be too small. First intention was to use "Länge" and "Breite" as german terms, but it's still too long. Therefore it's suggested to use Lat and Lon in german as well as in english throughout all functions in MapStore.
![Lat_Lon](https://github.com/geosolutions-it/MapStore2/assets/57953447/aa566d38-1feb-4e05-b070-a841fefedf50)

- some minor grammatical errors have been corrected.

**What is the new behavior?**
- All input field of aeronautical coordinates are wide enough to read all digits.

- german terms are corrected.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
