### PR TITLE
geosolutions-it#6913: grid cards keyboard navigation

### DIFF
--- a/web/client/components/misc/GridCard.jsx
+++ b/web/client/components/misc/GridCard.jsx
@@ -47,7 +47,11 @@ class GridCard extends React.Component {
         return (<div
             style={this.props.style}
             className={"gridcard" + (this.props.className ? " " + this.props.className : "")}
-            onClick={this.props.onClick}>
+            onClick={this.props.onClick}
+            role={this.props.onClick ? "link" : ""}
+            tabIndex={0}
+            onKeyDown={(e) => e.key === 'Enter' ? this.props.onClick(e) : null}
+        >
             {!isNil(this.props.header) ? <div style={this.props.titleStyle} className="gridcard-title bg-primary">{this.props.header}</div> : null}
             {this.props.children}
             {this.renderActions()}

--- a/web/client/components/misc/__tests__/GridCard-test.jsx
+++ b/web/client/components/misc/__tests__/GridCard-test.jsx
@@ -61,4 +61,13 @@ describe('This test for GridCard', () => {
         );
         expect(button).toExist();
     });
+
+    it('enter triggers onClick event', (done) => {
+        const container = document.getElementById('container');
+        const testName = "test";
+        const testDescription = "testDescription";
+        ReactDOM.render(
+            <GridCard header={testName} onClick={() => {done();}}>{testDescription}</GridCard>, container);
+        TestUtils.Simulate.keyDown(container.firstElementChild, {key: 'Enter'});
+    });
 });

--- a/web/client/components/misc/style/gridcard.css
+++ b/web/client/components/misc/style/gridcard.css
@@ -3,7 +3,7 @@
     transition: box-shadow 250ms;
 }
 
-.gridcard:hover {
+.gridcard:hover, .gridcard:focus {
     box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
 }
 

--- a/web/client/themes/default/less/maps-properties.less
+++ b/web/client/themes/default/less/maps-properties.less
@@ -338,7 +338,7 @@
         .gridcard {
             height: @square-btn-size * 4.5;
             transition: all 0.3s;
-            &:hover {
+            &:hover, &:focus {
                 .shadow-far;
                 cursor: pointer;
                 z-index: 10;


### PR DESCRIPTION
## Description

Makes grid cards keyboard navigable and accessible again (with tab + enter,
you can reach a map now). 

Does not change how anything looks for non-keyboard users.


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**

#6913 Reaching a map only using the keyboard is impossible. 
Power users and people with motoric impairments often prefer
to navigate a website using the keyboard rather than the mouse.

**What is the new behavior?**

The grid cards, which represent buttons to maps, now can be focused
via keyboard and pressed via Enter button.

## Breaking change

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

Tests only include the "clicking with the Enter button" behaviour, since the testing framework does not seem to
support side effects like focusing elements with the tab button. 