### PR TITLE
#10158 painless accessibility improvements

### DIFF
--- a/web/client/components/I18N/Localized.jsx
+++ b/web/client/components/I18N/Localized.jsx
@@ -37,6 +37,7 @@ class Localized extends React.Component {
             if (typeof children === 'function') {
                 children = children();
             }
+            document.documentElement.setAttribute("lang", this.props.locale);
 
             return (<IntlProvider key={this.props.locale} locale={this.props.locale}
                 messages={this.flattenMessages(this.props.messages)}

--- a/web/client/components/I18N/Localized.jsx
+++ b/web/client/components/I18N/Localized.jsx
@@ -30,6 +30,16 @@ class Localized extends React.Component {
         };
     }
 
+    componentDidMount() {
+        this.updateDocumentLangAttribute();
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.locale !== prevProps.locale) {
+            this.updateDocumentLangAttribute();
+        }
+    }
+
     render() {
         let { children } = this.props;
 
@@ -37,7 +47,6 @@ class Localized extends React.Component {
             if (typeof children === 'function') {
                 children = children();
             }
-            document.documentElement.setAttribute("lang", this.props.locale);
 
             return (<IntlProvider key={this.props.locale} locale={this.props.locale}
                 messages={this.flattenMessages(this.props.messages)}
@@ -62,6 +71,12 @@ class Localized extends React.Component {
             };
         }, {});
     };
+
+    updateDocumentLangAttribute() {
+        if (document?.documentElement) {
+            document.documentElement.setAttribute("lang", this.props.locale);
+        }
+    }
 }
 
 export default Localized;

--- a/web/client/components/I18N/__tests__/Localized-test.jsx
+++ b/web/client/components/I18N/__tests__/Localized-test.jsx
@@ -40,6 +40,21 @@ describe('Test the localization support HOC', () => {
         expect(dom.innerHTML).toBe("my message");
     });
 
+    it('correctly sets the document language', () => {
+        ReactDOM.render(
+            <Localized locale="it-IT" messages={messages}>
+                {() => <Message msgId="testMsg"/> }
+            </Localized>
+            , document.getElementById("container"));
+        expect(document.documentElement.lang).toBe("it-IT");
+        ReactDOM.render(
+            <Localized locale="de-DE" messages={messages}>
+                {() => <Message msgId="testMsg"/> }
+            </Localized>
+            , document.getElementById("container"));
+        expect(document.documentElement.lang).toBe("de-DE");
+    });
+
     it('localizes wrapped HTML component', () => {
         var localized = ReactDOM.render(
             <Localized locale="it-IT" messages={messages}>

--- a/web/client/components/mapcontrols/scale/ScaleBox.jsx
+++ b/web/client/components/mapcontrols/scale/ScaleBox.jsx
@@ -73,8 +73,8 @@ class ScaleBox extends React.Component {
         } else {
             control =
                 (<Form inline><FormGroup bsSize="small">
-                    <ControlLabel>{this.props.label}</ControlLabel>
-                    <FormControl componentClass="select" onChange={this.onComboChange} value={currentZoomLvl || ""}>
+                    <ControlLabel htmlFor="scaleBox">{this.props.label}</ControlLabel>
+                    <FormControl id="scaleBox" componentClass="select" onChange={this.onComboChange} value={currentZoomLvl || ""}>
                         {this.getOptions()}
                     </FormControl>
                 </FormGroup></Form>)

--- a/web/client/components/misc/PaginationToolbar.jsx
+++ b/web/client/components/misc/PaginationToolbar.jsx
@@ -65,7 +65,7 @@ class PaginationToolbar extends React.Component {
                         onSelect={this.onSelect} />
                 </Col>
                 <Col xs={12}>
-                    <h5>{this.props.loading ? <Message msgId="loading"/> : msg}</h5>
+                    <div>{this.props.loading ? <Message msgId="loading"/> : msg}</div>
                 </Col>
             </Row>
         );

--- a/web/client/index.html
+++ b/web/client/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>MapStore HomePage</title>
         <style>
         body {

--- a/web/client/indexTemplate.html
+++ b/web/client/indexTemplate.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>MapStore HomePage</title>
     <style>
     body {

--- a/web/client/product/plugins/Attribution.jsx
+++ b/web/client/product/plugins/Attribution.jsx
@@ -48,7 +48,7 @@ export default {
                 position: 0,
                 label: props.label || 'GeoSolutions',
                 href: props.href || 'https://www.geosolutionsgroup.com/',
-                img: props.src && <img className="customer-logo" src={props.src} height="30" /> || <img className="customer-logo" src={src} height="30" />,
+                img: props.src && <img className="customer-logo" src={props.src} height="30" alt={props.label || 'GeoSolutions'} /> || <img className="customer-logo" src={src} height="30" alt={props.label || 'GeoSolutions'} />,
                 logo: true
             })
         }


### PR DESCRIPTION
## Description

Tiny changes that improve accessibility. Should hopefully not take longer than a minute to review.


**What kind of change does this PR introduce?**
 - [x] Bugfix

## Issue

**What is the current behavior?**

#10158 

Bad Lighthouse Accessibility Score

**What is the new behavior?**

Better Lighthouse Accessibility Score through:
- Setting Document language
- Fixing a heading that should be a div
- providing a logo with an alt tag
- linking scale label with its form element
- enabling browser zoom

## Breaking change
**Does this PR introduce a breaking change?**
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

Too much Zoom does seem to break the layout, but handing that responsibility to the end user is more accessible for people who need larger controls than
disabling it. Map zoom is unaffected, and since using browser zoom enlarges map controls, users who tried zooming
into the map using browser zoom should be able to notice the actual controls and recover from their mistake.