### PR TITLE
Add localized aria-labels to glyph buttons

### DIFF
--- a/web/client/components/buttons/FullScreenButton.jsx
+++ b/web/client/components/buttons/FullScreenButton.jsx
@@ -11,7 +11,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import ToggleButton from './ToggleButton';
-import { Tooltip } from 'react-bootstrap';
 import Message from '../I18N/Message';
 
 /**
@@ -86,7 +85,7 @@ class FullScreenButton extends React.Component {
     };
 
     render() {
-        return (<ToggleButton {...this.getButtonProperties()} pressed={this.props.active} tooltip={<Tooltip id="full-screen-button-tip"><Message msgId={this.props.active ? this.props.activeTooltip : this.props.notActiveTooltip}/></Tooltip>} />);
+        return (<ToggleButton {...this.getButtonProperties()} pressed={this.props.active} tooltip={<Message msgId={this.props.active ? this.props.activeTooltip : this.props.notActiveTooltip}/>} />);
     }
 }
 

--- a/web/client/components/buttons/GlobeViewSwitcherButton.jsx
+++ b/web/client/components/buttons/GlobeViewSwitcherButton.jsx
@@ -10,7 +10,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import ToggleButton from './ToggleButton';
-import { Tooltip } from 'react-bootstrap';
 import Message from '../I18N/Message';
 
 /**
@@ -85,7 +84,7 @@ class GlobeViewSwitcherButton extends React.Component {
     };
 
     render() {
-        return <ToggleButton {...this.getButtonProperties()} pressed={this.props.active} tooltip={<Tooltip id="globeViewSwitcher-tooltip"><Message msgId={this.props.active ? this.props.activeTooltip : this.props.notActiveTooltip}/></Tooltip>} />;
+        return <ToggleButton {...this.getButtonProperties()} pressed={this.props.active} tooltip={<Message msgId={this.props.active ? this.props.activeTooltip : this.props.notActiveTooltip}/>} />;
     }
 }
 

--- a/web/client/components/buttons/ToggleButton.jsx
+++ b/web/client/components/buttons/ToggleButton.jsx
@@ -11,8 +11,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Glyphicon } from 'react-bootstrap';
 import OverlayTrigger from '../misc/OverlayTrigger';
-import Button from '../misc/Button';
+import {ButtonWithTooltip} from '../misc/Button';
 import ImageButton from './ImageButton';
+import tooltip from "../misc/enhancers/tooltip";
 /**
  * Toggle button with tooltip and icons or image support.
  * @memberof components.buttons
@@ -70,18 +71,36 @@ class ToggleButton extends React.Component {
 
     renderNormalButton = () => {
         return (
-            <Button id={this.props.id} {...this.props.btnConfig} onClick={this.onClick} bsStyle={this.props.pressed ? this.props.pressedStyle : this.props.defaultStyle} style={this.props.style}>
+            <ButtonWithTooltip
+                id={this.props.id}
+                {...this.props.btnConfig}
+                onClick={this.onClick}
+                bsStyle={this.props.pressed ? this.props.pressedStyle : this.props.defaultStyle}
+                style={this.props.style}
+                tooltip={this.props.tooltip}
+                tooltipPosition={this.props.tooltipPlace}
+                keyProp={"overlay-trigger." + this.props.id}
+            >
                 {this.props.glyphicon ? <Glyphicon glyph={this.props.glyphicon}/> : null}
                 {this.props.glyphicon && this.props.text && !React.isValidElement(this.props.text) ? "\u00A0" : null}
                 {this.props.text}
                 {this.props.help}
-            </Button>
+            </ButtonWithTooltip>
         );
     };
 
     renderImageButton = () => {
+        const ImageButtonT = tooltip(ImageButton);
         return (
-            <ImageButton id={this.props.id} image={this.props.image} onClick={this.onClick} style={this.props.style}/>
+            <ImageButtonT
+                id={this.props.id}
+                image={this.props.image}
+                onClick={this.onClick}
+                style={this.props.style}
+                tooltip={this.props.tooltip}
+                tooltipPosition={this.props.tooltipPlace}
+                keyProp={"overlay-trigger." + this.props.id}
+            />
         );
     };
 
@@ -94,15 +113,7 @@ class ToggleButton extends React.Component {
     };
 
     render() {
-        var retval;
-        var btn = this.props.btnType === 'normal' ? this.renderNormalButton() : this.renderImageButton();
-        if (this.props.tooltip) {
-            retval = this.addTooltip(btn);
-        } else {
-            retval = btn;
-        }
-        return retval;
-
+        return this.props.btnType === 'normal' ? this.renderNormalButton() : this.renderImageButton();
     }
 }
 

--- a/web/client/components/buttons/ZoomButton.jsx
+++ b/web/client/components/buttons/ZoomButton.jsx
@@ -10,9 +10,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Button from '../misc/Button';
-import { Glyphicon, Tooltip } from 'react-bootstrap';
-import OverlayTrigger from '../misc/OverlayTrigger';
+import { ButtonWithTooltip } from '../misc/Button';
+import { Glyphicon } from 'react-bootstrap';
 
 class ZoomButton extends React.Component {
     static propTypes = {
@@ -49,34 +48,23 @@ class ZoomButton extends React.Component {
     };
 
     render() {
-        return this.addTooltip(
-            <Button
-                id={this.props.id}
-                style={this.props.style}
-                onClick={() => this.props.onZoom(this.props.currentZoom + this.props.step)}
-                className={this.props.className}
-                disabled={this.props.currentZoom + this.props.step > this.props.maxZoom || this.props.currentZoom + this.props.step < this.props.minZoom}
-                bsStyle={this.props.bsStyle}
-            >
-                {this.props.glyphicon ? <Glyphicon glyph={this.props.glyphicon}/> : null}
-                {this.props.glyphicon && this.props.text ? "\u00A0" : null}
-                {this.props.text}
-                {this.props.help}
-            </Button>
-        );
+        return (<ButtonWithTooltip
+            id={this.props.id}
+            style={this.props.style}
+            onClick={() => this.props.onZoom(this.props.currentZoom + this.props.step)}
+            className={this.props.className}
+            disabled={this.props.currentZoom + this.props.step > this.props.maxZoom || this.props.currentZoom + this.props.step < this.props.minZoom}
+            bsStyle={this.props.bsStyle}
+            tooltip={this.props.tooltip}
+            tooltipPosition={this.props.tooltipPlace}
+            keyProp={"overlay-trigger." + this.props.id}
+        >
+            {this.props.glyphicon ? <Glyphicon glyph={this.props.glyphicon}/> : null}
+            {this.props.glyphicon && this.props.text ? "\u00A0" : null}
+            {this.props.text}
+            {this.props.help}
+        </ButtonWithTooltip>);
     }
-
-    addTooltip = (btn) => {
-        if (!this.props.tooltip) {
-            return btn;
-        }
-        let tooltip = <Tooltip id="locate-tooltip">{this.props.tooltip}</Tooltip>;
-        return (
-            <OverlayTrigger placement={this.props.tooltipPlace} key={"overlay-trigger." + this.props.id} overlay={tooltip}>
-                {btn}
-            </OverlayTrigger>
-        );
-    };
 }
 
 export default ZoomButton;

--- a/web/client/components/home/Home.jsx
+++ b/web/client/components/home/Home.jsx
@@ -49,16 +49,19 @@ class Home extends React.Component {
         let tooltip = <Tooltip id="toolbar-home-button">{<Message msgId="gohome"/>}</Tooltip>;
         return hidden ? false : (
             <React.Fragment>
-                <OverlayTrigger overlay={tooltip} placement={tooltipPosition}>
-                    <Button
-                        id="home-button"
-                        className="square-button"
-                        bsStyle={this.props.bsStyle}
-                        onClick={this.checkUnsavedChanges}
-                        tooltip={tooltip}
-                        {...pick(restProps, ['disabled', 'active', 'block', 'componentClass', 'href', 'children', 'icon', 'bsStyle', 'className'])}
-                    ><Glyphicon glyph={this.props.icon}/></Button>
-                </OverlayTrigger>
+                <Message msgId="gohome">
+                    {(label) => <OverlayTrigger overlay={tooltip} placement={tooltipPosition}>
+                        <Button
+                            id="home-button"
+                            className="square-button"
+                            bsStyle={this.props.bsStyle}
+                            onClick={this.checkUnsavedChanges}
+                            tooltip={tooltip}
+                            aria-label={label}
+                            {...pick(restProps, ['disabled', 'active', 'block', 'componentClass', 'href', 'children', 'icon', 'bsStyle', 'className'])}
+                        ><Glyphicon glyph={this.props.icon}/></Button>
+                    </OverlayTrigger>}
+                </Message>
                 <ConfirmModal
                     ref="unsavedMapModal"
                     show={this.props.displayUnsavedDialog || false}

--- a/web/client/components/mapcontrols/locate/LocateBtn.jsx
+++ b/web/client/components/mapcontrols/locate/LocateBtn.jsx
@@ -8,12 +8,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Glyphicon, Tooltip} from 'react-bootstrap';
+import {Glyphicon} from 'react-bootstrap';
 
-import Message from '../../I18N/Message';
-import OverlayTrigger from '../../misc/OverlayTrigger';
 import defaultIcon from '../../misc/spinners/InlineSpinner/img/spinner.gif';
-import Button from '../../misc/Button';
+import {ButtonWithTooltip} from '../../misc/Button';
 import('./css/locate.css');
 
 let checkingGeoLocation = false;
@@ -74,9 +72,19 @@ class LocateBtn extends React.Component {
     renderButton = () => {
         const geoLocationDisabled = this.props.locate === "PERMISSION_DENIED";
         return (
-            <Button id={this.props.id} disabled={geoLocationDisabled} {...this.props.btnConfig} onClick={this.onClick} bsStyle={this.getBtnStyle()} style={this.props.style}>
+            <ButtonWithTooltip
+                id={this.props.id}
+                disabled={geoLocationDisabled}
+                {...this.props.btnConfig}
+                onClick={this.onClick}
+                bsStyle={this.getBtnStyle()}
+                style={this.props.style}
+                tooltipId={this.props.tooltip}
+                tooltipPosition={this.props.tooltipPlace}
+                keyProp={"overlay-trigger." + this.props.id}
+            >
                 <Glyphicon glyph={this.props.glyph}/>{this.props.text}{this.props.help}
-            </Button>
+            </ButtonWithTooltip>
         );
     };
 
@@ -91,18 +99,18 @@ class LocateBtn extends React.Component {
             }} alt="..." />)
         ;
         return (
-            <Button id={this.props.id} onClick={this.onClick} {...this.props.btnConfig} bsStyle={this.getBtnStyle()} style={this.props.style}>
+            <ButtonWithTooltip
+                id={this.props.id}
+                onClick={this.onClick}
+                {...this.props.btnConfig}
+                bsStyle={this.getBtnStyle()}
+                style={this.props.style}
+                tooltipId={this.props.tooltip}
+                tooltipPosition={this.props.tooltipPlace}
+                keyProp={"overlay-trigger." + this.props.id}
+            >
                 {img}
-            </Button>
-        );
-    };
-
-    addTooltip = (btn) => {
-        const tooltip = <Tooltip id="locate-tooltip"><Message msgId={this.props.tooltip} /></Tooltip>;
-        return (
-            <OverlayTrigger placement={this.props.tooltipPlace} key={`{overlay-trigger.${this.props.id}-${this.props.tooltip}}`} overlay={tooltip}>
-                {btn}
-            </OverlayTrigger>
+            </ButtonWithTooltip>
         );
     };
 
@@ -130,15 +138,7 @@ class LocateBtn extends React.Component {
     }
 
     render() {
-        var retval;
-        var btn = this.props.locate === "LOCATING" ? this.renderLoadingButton() : this.renderButton();
-        if (this.props.tooltip) {
-            retval = this.addTooltip(btn);
-        } else {
-            retval = btn;
-        }
-        return retval;
-
+        return this.props.locate === "LOCATING" ? this.renderLoadingButton() : this.renderButton();
     }
 
     getBtnStyle = () => {

--- a/web/client/components/mapcontrols/navigationhistory/RedoButton.jsx
+++ b/web/client/components/mapcontrols/navigationhistory/RedoButton.jsx
@@ -9,10 +9,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Glyphicon, Tooltip } from 'react-bootstrap';
-
-import OverlayTrigger from '../../misc/OverlayTrigger';
-import Button from '../../misc/Button';
+import { Glyphicon } from 'react-bootstrap';
+import {ButtonWithTooltip} from '../../misc/Button';
 
 class RedoBtn extends React.Component {
     static propTypes = {
@@ -40,44 +38,28 @@ class RedoBtn extends React.Component {
         }
     };
 
-    onClick = () => {
-        this.props.onClick();
-    };
-
     shouldComponentUpdate(nextProps) {
         return this.props.disabled !== nextProps.disabled;
     }
 
-    renderButton = () => {
-        return (
-            <Button id={this.props.id} disabled={this.props.disabled} {...this.props.btnConfig} onClick={this.onClick} bsStyle={this.props.buttonStyle} style={this.props.style}>
-                <Glyphicon glyph={this.props.glyph}/>{this.props.text}{this.props.help}
-            </Button>
-        );
+    onClick = () => {
+        this.props.onClick();
     };
-
-    addTooltip = (btn) => {
-        let tooltip = <Tooltip id="redo-btn-tooltip">{this.props.tooltip}</Tooltip>;
-        return (
-            <OverlayTrigger placement={this.props.tooltipPlace} key={"overlay-trigger." + this.props.id} overlay={tooltip}>
-                {btn}
-            </OverlayTrigger>
-        );
-    };
-
-    UNSAFE_componentWillMount() {
-        // none
-    }
 
     render() {
-        var retval;
-        var btn = this.renderButton();
-        if (this.props.tooltip) {
-            retval = this.addTooltip(btn);
-        } else {
-            retval = btn;
-        }
-        return retval;
+        return (<ButtonWithTooltip
+            id={this.props.id}
+            disabled={this.props.disabled}
+            {...this.props.btnConfig}
+            onClick={this.onClick}
+            bsStyle={this.props.buttonStyle}
+            style={this.props.style}
+            tooltip={this.props.tooltip}
+            tooltipPosition={this.props.tooltipPlace}
+            keyProp={"overlay-trigger." + this.props.id}
+        >
+            <Glyphicon glyph={this.props.glyph}/>{this.props.text}{this.props.help}
+        </ButtonWithTooltip>);
 
     }
 }

--- a/web/client/components/mapcontrols/navigationhistory/UndoButton.jsx
+++ b/web/client/components/mapcontrols/navigationhistory/UndoButton.jsx
@@ -10,9 +10,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Glyphicon, Tooltip } from 'react-bootstrap';
-import OverlayTrigger from '../../misc/OverlayTrigger';
-import Button from '../../misc/Button';
+import { Glyphicon } from 'react-bootstrap';
+import {ButtonWithTooltip} from '../../misc/Button';
 
 class UndoBtn extends React.Component {
     static propTypes = {
@@ -40,44 +39,30 @@ class UndoBtn extends React.Component {
         }
     };
 
-    onClick = () => {
-        this.props.onClick();
-    };
-
     shouldComponentUpdate(nextProps) {
         return this.props.disabled !== nextProps.disabled;
     }
 
-    renderButton = () => {
-        return (
-            <Button id={this.props.id} disabled={this.props.disabled} {...this.props.btnConfig} onClick={this.onClick} bsStyle={this.props.buttonStyle} style={this.props.style}>
-                <Glyphicon glyph={this.props.glyph}/>{this.props.text}{this.props.help}
-            </Button>
-        );
+    onClick = () => {
+        this.props.onClick();
     };
-
-    addTooltip = (btn) => {
-        let tooltip = <Tooltip id="undo-btn-tooltip">{this.props.tooltip}</Tooltip>;
-        return (
-            <OverlayTrigger placement={this.props.tooltipPlace} key={"overlay-trigger." + this.props.id} overlay={tooltip}>
-                {btn}
-            </OverlayTrigger>
-        );
-    };
-
-    UNSAFE_componentWillMount() {
-        // none
-    }
 
     render() {
-        var retval;
-        var btn = this.renderButton();
-        if (this.props.tooltip) {
-            retval = this.addTooltip(btn);
-        } else {
-            retval = btn;
-        }
-        return retval;
+        return (
+            <ButtonWithTooltip
+                id={this.props.id}
+                disabled={this.props.disabled}
+                {...this.props.btnConfig}
+                onClick={this.onClick}
+                bsStyle={this.props.buttonStyle}
+                style={this.props.style}
+                tooltip={this.props.tooltip}
+                tooltipPosition={this.props.tooltipPlace}
+                keyProp={"overlay-trigger." + this.props.id}
+            >
+                <Glyphicon glyph={this.props.glyph}/>{this.props.text}{this.props.help}
+            </ButtonWithTooltip>
+        );
 
     }
 }

--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -230,59 +230,62 @@ export default ({
                     activeTool === "bookmarkSearch" && showBookMarkSearchOption &&
                         <BookmarkSelect mapInitial={props.mapInitial}/>
                 }
-                <SearchBarToolbar
-                    splitTools={false}
-                    toolbarButtons={[
-                        ...(getConfigButtons() ? [{...getConfigButtons()}] : []),
-                        ...items
-                            .filter(({ target }) => target === 'button')
-                            .map(({ component: Element }) => ({
-                                visible: !!showOptions,
-                                Element
-                            })),
-                        {
-                            glyph: removeIcon,
-                            className: "square-button-md no-border",
-                            bsStyle: "default",
-                            pullRight: true,
-                            loading: !isUndefined(loading) && loading,
-                            visible: activeTool === "addressSearch" &&
-                            (searchText !== "" || selectedItems && selectedItems.length > 0),
-                            onClick: () => {
-                                if (activeTool === "addressSearch") {
-                                    clearSearch();
-                                }
-                            },
-                            ...(activeTool === "coordinatesSearch" &&
-                                CoordinateOptions.removeIcon(activeTool, coordinate, onClearCoordinatesSearch, onChangeCoord))
-                        }, {
-                            glyph: searchIcon,
-                            className: "square-button-md no-border " +
-                            (isSearchClickable || activeTool !== "addressSearch" ? "magnifying-glass clickable" : "magnifying-glass"),
-                            bsStyle: "default",
-                            pullRight: true,
-                            tooltipPosition: "bottom",
-                            visible: activeTool === "addressSearch" &&
-                            (!(searchText !== "" || selectedItems && selectedItems.length > 0) || !splitTools),
-                            onClick: () => isSearchClickable && search(),
-                            ...(activeTool === "coordinatesSearch" &&
-                                CoordinateOptions.searchIcon(activeTool, coordinate, onZoomToPoint, defaultZoomLevel)),
-                            ...(activeTool === "bookmarkSearch" &&
+                <Message msgId="catalog.search">
+                    {(searchButtonText) => <SearchBarToolbar
+                        splitTools={false}
+                        toolbarButtons={[
+                            ...(getConfigButtons() ? [{...getConfigButtons()}] : []),
+                            ...items
+                                .filter(({ target }) => target === 'button')
+                                .map(({ component: Element }) => ({
+                                    visible: !!showOptions,
+                                    Element
+                                })),
+                            {
+                                glyph: removeIcon,
+                                className: "square-button-md no-border",
+                                bsStyle: "default",
+                                pullRight: true,
+                                loading: !isUndefined(loading) && loading,
+                                visible: activeTool === "addressSearch" &&
+                                    (searchText !== "" || selectedItems && selectedItems.length > 0),
+                                onClick: () => {
+                                    if (activeTool === "addressSearch") {
+                                        clearSearch();
+                                    }
+                                },
+                                ...(activeTool === "coordinatesSearch" &&
+                                    CoordinateOptions.removeIcon(activeTool, coordinate, onClearCoordinatesSearch, onChangeCoord))
+                            }, {
+                                glyph: searchIcon,
+                                className: "square-button-md no-border " +
+                                    (isSearchClickable || activeTool !== "addressSearch" ? "magnifying-glass clickable" : "magnifying-glass"),
+                                bsStyle: "default",
+                                pullRight: true,
+                                tooltipPosition: "bottom",
+                                'aria-label': searchButtonText,
+                                visible: activeTool === "addressSearch" &&
+                                    (!(searchText !== "" || selectedItems && selectedItems.length > 0) || !splitTools),
+                                onClick: () => isSearchClickable && search(),
+                                ...(activeTool === "coordinatesSearch" &&
+                                    CoordinateOptions.searchIcon(activeTool, coordinate, onZoomToPoint, defaultZoomLevel)),
+                                ...(activeTool === "bookmarkSearch" &&
                                     BookmarkOptions.searchIcon(activeTool, props))
-                        }, {
-                            tooltip: getError(error),
-                            tooltipPosition: "bottom",
-                            className: "square-button-md no-border",
-                            glyph: "warning-sign",
-                            bsStyle: "danger",
-                            glyphClassName: "searcherror",
-                            visible: !!error,
-                            onClick: clearSearch
-                        }, {
-                            visible: showOptions,
-                            renderButton: <SearchBarMenu disabled={showOptions} menuItems={searchMenuOptions} />
-                        }]}
-                />
+                            }, {
+                                tooltip: getError(error),
+                                tooltipPosition: "bottom",
+                                className: "square-button-md no-border",
+                                glyph: "warning-sign",
+                                bsStyle: "danger",
+                                glyphClassName: "searcherror",
+                                visible: !!error,
+                                onClick: clearSearch
+                            }, {
+                                visible: showOptions,
+                                renderButton: <SearchBarMenu disabled={showOptions} menuItems={searchMenuOptions} />
+                            }]}
+                    />}
+                </Message>
             </div>
         </FormGroup>
     </SearchBarBase>);

--- a/web/client/components/maps/search/SearchBar.jsx
+++ b/web/client/components/maps/search/SearchBar.jsx
@@ -43,62 +43,66 @@ export default ({
     const search = defaultSearchWrapper({searchText, searchOptions, maxResults, onSearch, onSearchReset});
     const isSearchFilterEmpty = !searchFilter || (searchFilter.contexts || []).length === 0;
 
-    return (<SearchBarBase className="maps-search">
-        <FormGroup>
-            <div className="input-group">
-                <SearchBarInput
-                    show
-                    hideOnBlur={false}
-                    typeAhead={false}
-                    placeholderMsgId="maps.search"
-                    searchText={searchText}
-                    onSearch={search}
-                    onSearchTextChange={onSearchTextChange}/>
-                <SearchBarToolbar
-                    splitTools={false}
-                    toolbarButtons={[{
-                        glyph: removeIcon,
-                        className: "square-button-md no-border",
-                        bsStyle: "default",
-                        pullRight: true,
-                        visible: searchText !== "",
-                        onClick: () => onSearchReset()
-                    }, {
-                        glyph: searchIcon,
-                        className: "square-button-md no-border magnifying-glass clickable",
-                        bsStyle: "default",
-                        pullRight: true,
-                        visible: true,
-                        onClick: () => search()
-                    }, {
-                        glyph: advancedSearchIcon,
-                        tooltip: <Message
-                            msgId={`search.advancedSearchPanel.${showAdvancedSearchPanel ? 'hide' : 'show'}Tooltip` +
+    return (
+        <Message msgId="maps.searchButton">{(searchButtonText) => (<Message msgId="queryform.reset">{(resetSearchText) => (
+            <SearchBarBase className="maps-search">
+                <FormGroup>
+                    <div className="input-group">
+                        <SearchBarInput
+                            show
+                            hideOnBlur={false}
+                            typeAhead={false}
+                            placeholderMsgId="maps.search"
+                            searchText={searchText}
+                            onSearch={search}
+                            onSearchTextChange={onSearchTextChange}/>
+                        <SearchBarToolbar
+                            splitTools={false}
+                            toolbarButtons={[{
+                                glyph: removeIcon,
+                                className: "square-button-md no-border",
+                                bsStyle: "default",
+                                pullRight: true,
+                                visible: searchText !== "",
+                                onClick: () => onSearchReset(),
+                                'aria-label': resetSearchText
+                            }, {
+                                glyph: searchIcon,
+                                className: "square-button-md no-border magnifying-glass clickable",
+                                bsStyle: "default",
+                                pullRight: true,
+                                visible: true,
+                                onClick: () => search(),
+                                'aria-label': searchButtonText
+                            }, {
+                                glyph: advancedSearchIcon,
+                                tooltip: <Message
+                                    msgId={`search.advancedSearchPanel.${showAdvancedSearchPanel ? 'hide' : 'show'}Tooltip` +
                             (isSearchFilterEmpty ? '' : 'Active')}/>,
-                        className: "square-button-md no-border " +
+                                className: "square-button-md no-border " +
                             (showAdvancedSearchPanel && showContextSearchOption ? "active" : ""),
-                        bsStyle: isSearchFilterEmpty ? "default" : "success",
-                        pullRight: true,
-                        visible: showContextSearchOption,
-                        onClick: () => {
-                            onToggleControl("advancedsearchpanel");
-                            onLoadContexts('*', {params: {start: 0, limit: 12}});
-                        }
-                    }]}/>
-            </div>
-        </FormGroup>
-        <AdvancedSearch
-            loading={loadingFilter || loadingContexts}
-            loadFlags={{
-                loadingFilter,
-                loadingContexts
-            }}
-            show={showAdvancedSearchPanel}
-            showContextSearchOption={showContextSearchOption}
-            searchFilter={searchFilter}
-            contexts={contexts}
-            onClearAll={onSearchFilterClearAll}
-            onSearchFilterChange={onSearchFilterChange}
-            onLoadContexts={onLoadContexts}/>
-    </SearchBarBase>);
+                                bsStyle: isSearchFilterEmpty ? "default" : "success",
+                                pullRight: true,
+                                visible: showContextSearchOption,
+                                onClick: () => {
+                                    onToggleControl("advancedsearchpanel");
+                                    onLoadContexts('*', {params: {start: 0, limit: 12}});
+                                }
+                            }]}/>
+                    </div>
+                </FormGroup>
+                <AdvancedSearch
+                    loading={loadingFilter || loadingContexts}
+                    loadFlags={{
+                        loadingFilter,
+                        loadingContexts
+                    }}
+                    show={showAdvancedSearchPanel}
+                    showContextSearchOption={showContextSearchOption}
+                    searchFilter={searchFilter}
+                    contexts={contexts}
+                    onClearAll={onSearchFilterClearAll}
+                    onSearchFilterChange={onSearchFilterChange}
+                    onLoadContexts={onLoadContexts}/>
+            </SearchBarBase>)}</Message>)}</Message>);
 };

--- a/web/client/components/misc/Button.jsx
+++ b/web/client/components/misc/Button.jsx
@@ -13,4 +13,4 @@ import tooltip from './enhancers/tooltip';
 
 export default buttonWithDisabled(Button);
 
-export const ButtonWithTooltip = tooltip(Button);
+export const ButtonWithTooltip = tooltip(buttonWithDisabled(Button));

--- a/web/client/components/misc/enhancers/__tests__/tooltip-test.jsx
+++ b/web/client/components/misc/enhancers/__tests__/tooltip-test.jsx
@@ -12,6 +12,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import tooltip from '../tooltip';
 import { Button } from 'react-bootstrap';
+import Message from "../../../I18N/HTML";
+import Localized from "../../../I18N/Localized";
+
+const messages = {
+    "testMsg": "my message"
+};
+
 describe("tooltip enhancer", () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -37,6 +44,17 @@ describe("tooltip enhancer", () => {
         expect(el).toExist();
         el.click();
         expect(el.getAttribute('aria-describedby')).toExist();
+    });
+    it('adds an aria-label property with localized content', () => {
+        const CMP = tooltip(Button);
+        const tip = <Message msgId="testMsg"/>;
+        ReactDOM.render(
+            <Localized locale="it-IT" messages={messages}>
+                <CMP tooltip={tip} tooltipTrigger={['click', 'focus', 'hover']} id="text-cmp">TEXT</CMP>
+            </Localized>, document.getElementById("container"));
+        const el = document.getElementById("text-cmp");
+        expect(el).toExist();
+        expect(el.getAttribute('aria-label')).toBe('my message');
     });
 
 });

--- a/web/client/plugins/MousePosition.jsx
+++ b/web/client/plugins/MousePosition.jsx
@@ -10,7 +10,6 @@ import { get } from 'lodash';
 import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Tooltip } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
@@ -58,7 +57,7 @@ const selector = createSelector([
 const MousePositionButton = connect((state) => ({
     pressed: isMouseMoveCoordinatesActiveSelector(state),
     active: isMouseMoveCoordinatesActiveSelector(state),
-    tooltip: <Tooltip id="showMousePositionCoordinates"><Message msgId="showMousePositionCoordinates"/></Tooltip>,
+    tooltip: <Message msgId="showMousePositionCoordinates"/>,
     tooltipPlace: 'left',
     pressedStyle: "success active",
     defaultStyle: "primary",

--- a/web/client/product/components/viewer/Home.jsx
+++ b/web/client/product/components/viewer/Home.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
  */
 import React from 'react';
 
-import { Glyphicon, Tooltip } from 'react-bootstrap';
+import { Glyphicon } from 'react-bootstrap';
 import ToggleButton from '../../../components/buttons/ToggleButton';
 import Message from '../../../components/I18N/Message';
 

--- a/web/client/product/components/viewer/Home.jsx
+++ b/web/client/product/components/viewer/Home.jsx
@@ -32,7 +32,6 @@ class Home extends React.Component {
     };
 
     render() {
-        let tooltip = <Tooltip id="toolbar-home-button">{this.props.buttonTooltip}</Tooltip>;
         return (
             <ToggleButton
                 id="home-button"
@@ -42,7 +41,7 @@ class Home extends React.Component {
                 glyphicon="home"
                 helpText={<Message msgId="helptexts.gohome"/>}
                 onClick={this.goHome}
-                tooltip={tooltip}
+                tooltip={this.props.buttonTooltip}
                 tooltipPlace="left"
             />
         );

--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -387,7 +387,8 @@
         "errorSizeExceeded": "Please, reduce the size or the quality of the images",
         "errorLoadingContexts": "An error occurred during contexts loading"
       },
-      "search": "search..."
+      "search": "search...",
+      "searchButton": "Search in Maps"
     },
     "resources": {
       "successSaved": "This resource has been saved correctly",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -458,7 +458,8 @@
                 "errorSizeExceeded": "Bitte verkleinern Sie die Größe der Details oder die Qualität der Bilder",
                 "errorLoadingContexts": "Beim Laden des Karten-Kontexts ist ein Fehler aufgetreten"
             },
-            "search": "Suche..."
+            "search": "Suche...",
+            "searchButton": "Suche in Karten"
         },
         "resources": {
             "successSaved": "Diese Ressource wurde korrekt gespeichert",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -420,7 +420,8 @@
                 "errorSizeExceeded": "Please, reduce the size or the quality of the images",
                 "errorLoadingContexts": "An error occurred during contexts loading"
             },
-			"search": "search..."
+			"search": "search...",
+      "searchButton": "Search in Maps"
 		},
         "resources": {
             "successSaved": "This resource has been saved correctly",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -420,7 +420,8 @@
                 "errorSizeExceeded": "Por favor, reduzca el tamaño de los detalles o la calidad de las imágenes",
                 "errorLoadingContexts": "Se produjo un error durante la carga de contextos"
             },
-            "search": "buscar..."
+            "search": "buscar...",
+            "searchButton": "Buscar mapas"
         },
         "resources": {
             "successSaved": "Este recurso se ha guardado correctamente",

--- a/web/client/translations/data.fi-FI.json
+++ b/web/client/translations/data.fi-FI.json
@@ -278,7 +278,8 @@
         "errorWhenDeleting": "Virhe poiston aikana",
         "errorSizeExceeded": "Pienennä yksityiskohtien kokoa tai kuvien laatua"
       },
-      "search": "Haku..."
+      "search": "Haku...",
+      "searchButton": "Hae karttoja"
     },
     "resources": {
       "successSaved": "Tämä resurssi on tallennettu oikein",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -420,7 +420,8 @@
                 "errorSizeExceeded": "S'il vous plaît, réduisez la taille ou la qualité des images",
                 "errorLoadingContexts": "Une erreur s'est produite lors du chargement des contextes"
             },
-            "search": "rechercher ..."
+            "search": "rechercher ...",
+          "searchButton": "Rechercher des cartes"
         },
         "resources": {
             "successSaved": "Cette ressource a été enregistrée correctement",

--- a/web/client/translations/data.hr-HR.json
+++ b/web/client/translations/data.hr-HR.json
@@ -277,7 +277,8 @@
                 "errorWhenDeleting": "Došlo je do greške prilikom postupka brisanja",
                 "errorSizeExceeded": "Molimo, smanjite veličinu detalja ili kvalitetu slika"
             },
-			"search": "pretraži karte..."
+			"search": "pretraži karte...",
+        "searchButton": "Pretraži karte"
 		},
         "resources": {
             "deleteConfirmTitle": "Jeste li sigurni",

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -391,7 +391,8 @@
         "errorSizeExceeded": "Please, reduce the size or the quality of the images",
         "errorLoadingContexts": "An error occurred during contexts loading"
       },
-      "search": "search..."
+      "search": "search...",
+      "searchButton": "Search for maps"
     },
     "resources": {
       "successSaved": "This resource has been saved correctly",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -420,7 +420,8 @@
                 "errorSizeExceeded": "Riduci il contenuto o la qualità delle immagini",
                 "errorLoadingContexts": "Si è verificato un errore durante il caricamento dei contesti"
             },
-			"search": "Cerca..."
+			"search": "Cerca...",
+      "searchButton": "Cerca mappe"
 		},
         "resources": {
             "successSaved": "Questa risorsa è stata salvata correttamente",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -408,7 +408,8 @@
                 "errorSizeExceeded": "Gelieve de afbeeldingen te verkleinen of de kwaliteit te verlagen",
                 "errorLoadingContexts": "Er is een fout opgetreden tijdens het laden van app-contexts"
             },
-			"search": "Zoeken..."
+			"search": "Zoeken...",
+      "searchButton": "Zoek kaarten"
 		},
         "resources": {
             "successSaved": "Deze resource is correct opgeslagen",

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -279,7 +279,8 @@
               "errorWhenDeleting": "Ocorreu um erro durante o processo de remoção",
               "errorSizeExceeded": "Por favor, reduza a quantidade dos detalhes ou a qualidade das imagens"
           },
-    			"search": "pesquisar..."
+    			"search": "pesquisar...",
+          "searchButton": "Pesquisar mapas"
     		},
         "resources": {
             "deleteConfirmTitle": "Tem a certeza",

--- a/web/client/translations/data.sk-SK.json
+++ b/web/client/translations/data.sk-SK.json
@@ -371,7 +371,8 @@
                 "errorSizeExceeded": "Prosím, zníž veľkosť alebo kvalitu obrázkov",
                 "errorLoadingContexts": "An error occurred during contexts loading"
             },
-			"search": "Vyhľadávanie..."
+			"search": "Vyhľadávanie...",
+      "searchButton": "Vyhľadajte mapy"
 		},
         "resources": {
             "successSaved": "Zdroj sa úspešne uložil",

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -341,7 +341,8 @@
                 "errorSizeExceeded": "Prova att minska storleken eller kvaliteten på bilderna",
                 "errorLoadingContexts": "Ett fel uppstod när webbkarta laddades"
             },
-			"search": "Sök..."
+			"search": "Sök...",
+      "searchButton": "Sök kartor"
 		},
         "resources": {
             "successSaved": "Den här resursen har sparats korrekt",

--- a/web/client/translations/data.vi-VN.json
+++ b/web/client/translations/data.vi-VN.json
@@ -833,6 +833,7 @@
             },
             "removeFromFeaturedMaps": "Xóa khỏi bản đồ đặc trưng",
             "search": "Tìm kiếm...",
+            "searchButton": "Tìm kiếm bản đồ",
             "title": "Bản đồ"
         },
         "markNameSelector": {

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -278,7 +278,8 @@
                 "errorWhenDeleting": "An error occurred during deleting process",
                 "errorSizeExceeded": "Please, reduce the size of the details or the quality of the images"
             },
-			"search": "搜索地图..."
+			"search": "搜索地图...",
+      "searchButton": "搜索地图"
 		},
         "resources": {
             "deleteConfirmTitle": "Are you sure",


### PR DESCRIPTION
## Description

MapStore uses a lot of glyph-only buttons with text tooltips. While these tooltips provide 
text for the buttons via `aria-labeledby` properties, they are only effective when the tooltips
are being rendered (and the id tying them together is often broken). 

This PR proposes a change to the `tooltip` enhancer, which adds the tooltip text as 
`aria-label` to the wrapped buttons. 

It also refactors some buttons to also use the `tooltip` enhancer, and adds localized `aria-label`s
to a few glyph buttons without tooltip.

We would be interested in your opinion whether this is a small enough change to accept, or
whether it introduces unnecessary complexity. However, this is not a high priority issue.

**What kind of change does this PR introduce?**
 - [x] Feature

## Issue

**What is the current behavior?**

#10158 

**What is the new behavior?**
Most glyph buttons now have a reliably present, localized `aria-label`.

## Breaking change
**Does this PR introduce a breaking change?**
 - [x] No

## Other useful information

- The most important change is the one to the tooltip enhancer (first commit). To achieve localization without needing to modify existing usages, the props of a `Message` component passed as `tooltip` prop are read out. Maybe this is a little "hacky".
- Using the tooltip enhancer (and `ButtonWithTooltip` component) wherever possible seems like a sensible refactoring whether you like the `aria-label` change or not. If you do not want to merge this PR, I could do a new one just with this commit.