### PR TITLE
Fix #10170 Allow to configure backend dev enviroment

### DIFF
--- a/docs/developer-guide/developing.md
+++ b/docs/developer-guide/developing.md
@@ -197,22 +197,10 @@ To run or debug the server side part of MapStore we suggest to run the backend i
 
 ### Enable Remote Debugging
 
-for embedded tomcat you can configure the following:
+for embedded tomcat you can run the following:
 
 ```bash
-# Linux
-
-```
-
-```bash
-# Windows
-set MAVEN_OPTS=-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=4000,server=y,suspend=n
-```
-
-then start tomcat
-
-```bash
-npm start # or npm run start:app, or npm run be:start (this last only for the backend)
+npm run be:start -- backend.debug.args"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000"
 ```
 
 For your local tomcat, you can follow the standard procedure to debug with tomcat.
@@ -222,7 +210,7 @@ For your local tomcat, you can follow the standard procedure to debug with tomca
 * Run eclipse plugin
 
 ```bash
-mvn eclipse:eclipse
+mvn eclipse:eclipse 
 ```
 
 * Import the project in eclipse from **File --> Import**

--- a/docs/developer-guide/developing.md
+++ b/docs/developer-guide/developing.md
@@ -122,9 +122,10 @@ In order to have a full running MapStore in development environment, you need to
 This runs automatically with `npm start`. If you want to run only the backend, you can use `npm run be:start`.
 
 The back end will run on port 8080 and will look for the front-end at port 8081. If you want to change the back-end port, you can set the environment variable `MAPSTORE_BACKEND_PORT` to the desired port.
+Optionally you can set the data dir location by setting the environment variable `MAPSTORE_DATA_DIR`.
 
 ```sh
-export MAPSTORE_BACKEND_PORT=8082
+export MAPSTORE_BACKEND_PORT=8082 # set a different backend port
 export MAPSTORE_DATA_DIR=/usr/datadir # set the datadir location
 npm start # or npm run be:start
 ```

--- a/docs/developer-guide/developing.md
+++ b/docs/developer-guide/developing.md
@@ -125,6 +125,7 @@ The back end will run on port 8080 and will look for the front-end at port 8081.
 
 ```sh
 export MAPSTORE_BACKEND_PORT=8082
+export MAPSTORE_DATA_DIR=/usr/datadir # set the datadir location
 npm start # or npm run be:start
 ```
 
@@ -154,6 +155,29 @@ Now you are good to go, and you can start the frontend
 Your local backend will now start at [http://localhost:8080/mapstore/](http://localhost:8080/mapstore/).
 If you want to change the port you can edit the dedicated entry in `product/pom.xml`, just remember to change also the dev-server proxy configuration on the frontend in the same way.
 
+##### Embedded tomcat properties
+
+The command `npm run be:start` internally runs the maven command `mvn cargo:run` with some properties set.
+You can customize the properties by passing them as arguments to the command.
+
+```bash
+npm run be:start -- <java-properties>
+```
+
+The java properties are passed to the maven command as `-D<property-name>=<property-value>`.
+
+For example:
+
+```bash
+npm run be:start -- -Dsecurity.integration=ldap-direct -Ddatadir.location=/usr/datadir -Dbackend.debug.args="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000"
+```
+
+Here the list of the properties that you can set:
+
+* `datadir.location` : the location of the data directory. This can be set also as environment variable `MAPSTORE_DATA_DIR`.
+* `backend.debug.args` : the arguments to pass to the JVM for debugging. If you want to enable remote debugging, you can set this property to `-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000`
+* `security.integration` : the security integration to use. Possible values are `default`, `keycloak-direct`
+
 #### Local tomcat instance
 
 If you prefer, or if you have some problems with `mvn cargo:run`, you can run MapStore backend in a tomcat instance instead of using the embedded one.
@@ -168,7 +192,7 @@ Even in this case you can connect your frontend to point to this instance of Map
 
 ### Debug
 
-To run or debug the server side part of MapStore we suggest to run the backend in tomcat (embedded or installed) and connect in remote debugging to it. This guide explains how to do it with Eclipse. This procedure has been tested with Eclipse Luna.
+To run or debug the server side part of MapStore we suggest to run the backend in tomcat (embedded or installed) and connect in remote debugging to it.
 
 ### Enable Remote Debugging
 
@@ -176,7 +200,7 @@ for embedded tomcat you can configure the following:
 
 ```bash
 # Linux
-export MAVEN_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=4000,server=y,suspend=n"
+
 ```
 
 ```bash

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -6,10 +6,19 @@
         <artifactId>mapstore-root</artifactId>
         <version>1.8-SNAPSHOT</version>
     </parent>
-
     <groupId>it.geosolutions.mapstore</groupId>
     <artifactId>mapstore-product</artifactId>
     <packaging>war</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.version>8.5.69</tomcat.version>
+        <tomcat.port>8080</tomcat.port>
+        <datadir.location>${env.MAPSTORE_DATA_DIR}</datadir.location>
+        <security.integration>default</security.integration>
+        <!-- <backend.debug.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000</backend.debug.args> -->
+        <backend.debug.args></backend.debug.args>
+
+    </properties>
 
     <name>MapStore Product Web Application</name>
 
@@ -25,7 +34,7 @@
     </dependencies>
 
     <build>
-        <finalName>mapstore</finalName>
+    <finalName>mapstore</finalName>
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -263,6 +272,10 @@
                 <configuration>
                     <container>
                         <containerId>tomcat8x</containerId>
+                        <systemProperties>
+                            <datadir.location>${datadir.location}</datadir.location>
+                            <security.integration>${security.integration}</security.integration>
+                        </systemProperties>
                         <zipUrlInstaller>
                             <url>
                                 https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/8.5.69/tomcat-8.5.69.zip
@@ -278,9 +291,7 @@
                             <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
                             <cargo.logging>low</cargo.logging>
                             <!-- setting javax.xml.parsers.SAXParserFactory is a workaround for issue https://github.com/geosolutions-it/geostore/issues/311 and can be removed when solved -->
-                            <cargo.jvmargs>
-                                -Djavax.xml.parsers.SAXParserFactory="com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl"
-                            </cargo.jvmargs>
+                            <cargo.jvmargs>${backend.debug.args} -Djavax.xml.parsers.SAXParserFactory="com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl"</cargo.jvmargs>
                         </properties>
                     </configuration>
                     <deployables>


### PR DESCRIPTION
## Description

This PR provides the support quick setting in local dev environment of the backend the options for :
- data dir
- remote debugging
- security.integration

Now: 
- running `npm start` you can set the data dir path using the environment variable `MAPSTORE_DATA_DIR`
- running `npm run be:start` you can pass more agruments to the backend, for remote debugging, keycloak integration etc...-

See the documentation changes for more information.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Hard managament of local environment for front-end developers. Not well documented. 

**What is the new behavior?**

Fix #10170 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
