### PR TITLE
[Backport 2024.01.xx] #8953 Ability to expand the TOC at context loading (#10166)

### DIFF
--- a/web/client/plugins/TOC/index.js
+++ b/web/client/plugins/TOC/index.js
@@ -145,6 +145,7 @@ registerCustomSaveHandler('toc', (state) => (state?.toc?.config));
  *   }
  * }
  * ```
+ * @prop {boolean} defaultOpen if true will open the table of content at initialization
  * @prop {object[]} items this property contains the items injected from the other plugins,
  * using the `containers` option in the plugin that want to inject the components.
  * You can select the position where to insert the components adding the `target` property.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds the documentation for the property `defaultOpen` for TOC plugin, this property allows to keep open the TOC at initialization as default behaviour. If the option is changed from the TOC context menu will have priority over the default one.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Documentation

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#8953

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Documented the defaultOpen property of TOC plugin

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
