### PR TITLE
[Backport 2024.01.xx] #10125 Annotation click-right options in embedded mode (#10164)

### DIFF
--- a/web/client/plugins/__tests__/TOC-test.jsx
+++ b/web/client/plugins/__tests__/TOC-test.jsx
@@ -483,5 +483,58 @@ describe('TOCPlugin Plugin', () => {
             expect(document.querySelector(WIDGET_BUILDER_SELECTOR)).toBeTruthy("widget doesn't exist");
             expect(document.querySelector(REMOVE_SELECTOR)).toBeTruthy("remove doesn't exist");
         });
+        it('should render the zoom to layer button if there is a vector layer with valid features', () => {
+            const { Plugin } = getPluginForTest(TOCPlugin, {
+                layers: {
+                    flat: [
+                        {
+                            id: 'topp:states__6',
+                            name: 'topp:states',
+                            type: 'vector',
+                            visibility: true,
+                            features: [{
+                                type: 'Feature',
+                                properties: {},
+                                geometry: {
+                                    type: 'Point',
+                                    coordinates: [0, 0]
+                                }
+                            }]
+                        }
+                    ],
+                    groups: [
+                        {
+                            id: 'Default',
+                            title: 'Default',
+                            name: 'Default',
+                            nodes: [
+                                'topp:states__6'
+                            ],
+                            expanded: true
+                        }
+                    ],
+                    selected: [
+                        'topp:states__6'
+                    ],
+                    settings: {
+                        expanded: false,
+                        node: null,
+                        nodeType: null,
+                        options: {}
+                    },
+                    layerMetadata: {
+                        expanded: false,
+                        metadataRecord: {},
+                        maskLoading: false
+                    }
+                }
+            });
+            const WrappedPlugin = dndContext(Plugin);
+            ReactDOM.render(<WrappedPlugin />, document.getElementById("container"));
+            // check zoom and remove selector
+            expect(document.querySelectorAll(TOOL_BUTTON_SELECTOR).length).toBe(3);
+            expect(document.querySelector(ZOOM_TO_SELECTOR)).toBeTruthy();
+            expect(document.querySelector(REMOVE_SELECTOR)).toBeTruthy();
+        });
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR improves the zoom to layer button so support vector layer with valid features and without bbox

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10125

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The zoom to button inside TOC is available also for annotation layers

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
