### PR TITLE
Fix #10175 : fix 2 services search test nondeterminism

### DIFF
--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -532,7 +532,8 @@ describe('search Epics', () => {
                     typeName: 'topp:states',
                     queriableAttributes: [STATE_NAME],
                     returnFullData: false
-                }
+                },
+                priority: 2
             },
             {
                 type: 'wfs',
@@ -541,7 +542,8 @@ describe('search Epics', () => {
                     typeName: 'topp:states',
                     queriableAttributes: [STATE_NAME],
                     returnFullData: false
-                }
+                },
+                priority: 1
             }],
             maxResults
         };
@@ -556,12 +558,12 @@ describe('search Epics', () => {
                 expect(actions[1].type).toBe(TEXT_SEARCH_LOADING);
                 expect(actions[2].type).toBe(TEXT_SEARCH_RESULTS_LOADED);
                 expect(actions[2].results.length).toBe(maxResults);
-                expect(head(actions[2].results).id).toBe("states.1");
-                expect(last(actions[2].results).id).toBe("states.5");
+                expect(head(actions[2].results).id).toMatch(/^(states|states-ari).1$/);
+                expect(last(actions[2].results).id).toMatch(/^(states|states-ari).5$/);
                 expect(actions[3].type).toBe(TEXT_SEARCH_RESULTS_LOADED);
                 expect(actions[3].results.length).toBe(maxResults);
-                expect(head(actions[3].results).id).toBe("states.1");
-                expect(last(actions[3].results).id).toBe("states.5");
+                expect(head(actions[3].results).id).toBe("states-ari.1");
+                expect(last(actions[3].results).id).toBe("states-ari.5");
                 expect(actions[4].type).toBe(TEXT_SEARCH_LOADING);
                 done();
             }, {});


### PR DESCRIPTION
## Description

Apparently, which search service observable emits results first does not depend on the order in which they are passed into the search. The test however assumed there to be an order, causing it to break on MacOS. 

New version:
- sets a different priority for the services
- accepts results from either file in the first emitted result action
- only accepts results from the file with higher priority in the second result action

Relevant source lines in the search epic:
```js
// merge all results from the streams
.mergeAll()
.scan((oldRes, newRes) => sortBy([...oldRes, ...newRes], ["__PRIORITY__"]))
```

**What kind of change does this PR introduce?**
 - [x] Bugfix

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10175 

**What is the new behavior?**

Tests run through regardless of OS.

## Breaking change
**Does this PR introduce a breaking change?**
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
