### PR TITLE
Fix release github actions files

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check branch
-      if: ${{ github.repository != 'geosolutions-it/MapStore2' || github.ref == 'master' }}
+      if: ${{ github.ref == 'master' }}
       uses: actions/github-script@v3
       with:
         script: |
@@ -44,5 +44,11 @@ jobs:
         find . -name 'pom.xml' | xargs git add
         git add package.json
         git commit -m "Restore java packages to $SNAPSHOT_VERSION and update package.json"
-        git push origin ${{ github.ref_name }}
-        echo "Snapshots version restored"
+    - name: "Push to protected branch"
+      uses: CasperWA/push-protected@v2
+      with:
+        # This requires a special token to be able to trigger checks on new branch creation
+        # admin permissions are required to temporarily disable branch protection for reviews
+        token: ${{ secrets.PUSH_PROTECTED }}
+        ref: ${{ github.ref }}
+        unprotect_reviews: true

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check branch
-      if: ${{ github.repository != 'geosolutions-it/geostore' || github.ref == 'master' }}
+      if: ${{ github.repository != 'geosolutions-it/MapStore2' || github.ref == 'master' }}
       uses: actions/github-script@v3
       with:
         script: |

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -31,7 +31,7 @@ jobs:
     # Protect master branch
     ################
     - name: Check branch
-      if: ${{ github.repository != 'geosolutions-it/MapStore2' || github.ref == 'master' }}
+      if: ${{ github.ref == 'master' }}
       uses: actions/github-script@v3
       with:
         script: |
@@ -43,7 +43,7 @@ jobs:
         java-version: '11.x'
         distribution: 'adopt'
         cache: maven
-    - name: 'Fix versions, commit and push new tag'
+    - name: 'Fix versions, commit and tag'
       env:
           LAST_MS_VERSION: ${{ github.event.inputs.previous-ms-version }}
           NEW_MS_VERSION: ${{ github.event.inputs.version }}
@@ -92,7 +92,16 @@ jobs:
         git add CHANGELOG.md
         git commit -m "Version Release ${NEW_MS_VERSION}"
         git tag v${NEW_MS_VERSION} # create tag
-        git push origin ${{ github.ref_name }} --tags # push tag
+        # git push origin ${{ github.ref_name }} --tags # push tags
+    - name: "Push to protected branch"
+      uses: CasperWA/push-protected@v2
+      with:
+        # This requires a special token to be able to trigger checks on new branch creation
+        # admin permissions are required to temporarily disable branch protection for reviews
+        token: ${{ secrets.PUSH_PROTECTED }}
+        ref: ${{ github.ref }}
+        tags: true
+        unprotect_reviews: true
   update-main-changelog:
     runs-on: ubuntu-latest
     needs: fix-version
@@ -105,7 +114,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
             node-version: '16.x'
-      - name: 'Updte changelog on master'
+      - name: 'Update changelog on master'
         env:
             LAST_MS_VERSION: ${{ github.event.inputs.previous-ms-version }}
             NEW_MS_VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
draft because still a work in progress. 

## Description

This PR updates github actions . Here the fixes: 

- The post release action had the wrong check checking geostore. In fact this actions do not do any deploy, so execution on main repo is not necessary. The protection on both post release and pre release actions has been simplified to prevent to be executed on master (e.g. forgetting to select the relase branch when sending the request
- Because of branch protection, some changes has been required for the direct commits in the pre and post relase scripts. In particular push on protected branch is not allowed, with the current settings, because of PR review required and because of status checks. Afther inspecting the various solutions suggested in [this](https://github.com/orgs/community/discussions/25305) discussion, I found that a good and working solution is the usage of the specific action https://github.com/CasperWA/push-protected 

**Please check if the PR fulfills these requirements**



**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Fix  #10179

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
