### PR TITLE
#10026: Interactive legend for TOC layers [Vector layer part]

### DIFF
--- a/web/client/actions/__tests__/layerFilter-test.js
+++ b/web/client/actions/__tests__/layerFilter-test.js
@@ -20,7 +20,11 @@ import {
     DISCARD_CURRENT_FILTER,
     discardCurrentFilter,
     applyFilter,
-    APPLY_FILTER
+    APPLY_FILTER,
+    LAYER_FILTER_BY_LEGEND,
+    layerFilterByLegend,
+    RESET_LAYER_FILTER_BY_LEGEND,
+    resetLegendFilter
 } from '../layerFilter';
 
 
@@ -62,6 +66,18 @@ describe('Test correctness of the layerFilter actions', () => {
         var retval = applyFilter();
         expect(retval).toExist();
         expect(retval.type).toBe(APPLY_FILTER);
+    });
+
+    it('layerFilterByLegend', () => {
+        var retval = layerFilterByLegend();
+        expect(retval).toBeTruthy();
+        expect(retval.type).toBe(LAYER_FILTER_BY_LEGEND);
+    });
+
+    it('resetLegendFilter', () => {
+        var retval = resetLegendFilter();
+        expect(retval).toBeTruthy();
+        expect(retval.type).toBe(RESET_LAYER_FILTER_BY_LEGEND);
     });
 
 });

--- a/web/client/actions/layerFilter.js
+++ b/web/client/actions/layerFilter.js
@@ -26,6 +26,9 @@ export const APPLY_FILTER = 'LAYER_FILTER:APPLY_FILTER';
  */
 export const OPEN_QUERY_BUILDER = 'LAYER_FILTER:OPEN_QUERY_BUILDER';
 
+export const LAYER_FILTER_BY_LEGEND = 'LAYER_FILTER:LAYER_FILTER_BY_LEGEND';
+
+export const RESET_LAYER_FILTER_BY_LEGEND = 'LAYER_FILTER:RESET_LAYER_FILTER_BY_LEGEND';
 
 export function storeCurrentFilter() {
     return {
@@ -62,3 +65,20 @@ export function initLayerFilter(filter) {
     };
 }
 
+export function layerFilterByLegend(layerId, nodeType, legendCQLFilter, filterArr) {
+    return {
+        type: LAYER_FILTER_BY_LEGEND,
+        legendCQLFilter,
+        nodeType,
+        layerId,
+        filterArr
+    };
+}
+
+export function resetLegendFilter(reason, value) {
+    return {
+        type: RESET_LAYER_FILTER_BY_LEGEND,
+        reason,     // here the reason for reset is change 'style' or change the enable/disable interactive legend config 'disableEnableInteractiveLegend'
+        value
+    };
+}

--- a/web/client/api/catalog/WFS.js
+++ b/web/client/api/catalog/WFS.js
@@ -75,7 +75,13 @@ const searchAndPaginate = (json = {}, startPosition, maxRecords, text) => {
     };
 };
 
-const recordToLayer = (record) => {
+const recordToLayer = (record, {
+    service
+}) => {
+    // this is for getting the configration of interactive legend
+    const {
+        layerOptions
+    } = service || {};
     return {
         type: record.type || "wfs",
         search: {
@@ -90,7 +96,8 @@ const recordToLayer = (record) => {
         description: record.description || "",
         bbox: record.boundingBox,
         links: getRecordLinks(record),
-        ...record.layerOptions
+        ...record.layerOptions,
+        ...layerOptions
     };
 };
 

--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -23,6 +23,7 @@ import { getSupportedFormat } from '../../../../api/WMS';
 import WMSCacheOptions from './WMSCacheOptions';
 import ThreeDTilesSettings from './ThreeDTilesSettings';
 import ModelTransformation from './ModelTransformation';
+
 export default class extends React.Component {
     static propTypes = {
         opacityText: PropTypes.node,
@@ -36,12 +37,14 @@ export default class extends React.Component {
         isCesiumActive: PropTypes.bool,
         projection: PropTypes.string,
         resolutions: PropTypes.array,
-        zoom: PropTypes.number
+        zoom: PropTypes.number,
+        resetLegendFilter: PropTypes.func
     };
 
     static defaultProps = {
         onChange: () => {},
-        opacityText: <Message msgId="opacity"/>
+        opacityText: <Message msgId="opacity"/>,
+        resetLegendFilter: () => {}
     };
 
     constructor(props) {
@@ -216,7 +219,29 @@ export default class extends React.Component {
                     layer={this.props.element}
                     onChange={this.props.onChange}
                 />
-
+                {['wfs', 'vector'].includes(this.props.element.type) &&
+                    <Row>
+                        <div className={"legend-options"}>
+                            <Col xs={12} className={"legend-label"}>
+                                <label key="legend-options-title" className="control-label"><Message msgId="layerProperties.legendOptions.title" /></label>
+                            </Col>
+                            <Col xs={12}>
+                                <Checkbox
+                                    data-qa="display-interactive-legend-option"
+                                    value="enableInteractiveLegend"
+                                    key="enableInteractiveLegend"
+                                    onChange={(e) => {
+                                        if (!e.target.checked) this.props.resetLegendFilter('disableEnableInteractiveLegend');
+                                        this.props.onChange("enableInteractiveLegend", e.target.checked);
+                                    }}
+                                    checked={this.props.element.enableInteractiveLegend} >
+                                    <Message msgId="layerProperties.enableInteractiveLegendInfo.label"/>
+                                    &nbsp;{this.props.element.type === 'wfs' && <InfoPopover text={<Message msgId="layerProperties.enableInteractiveLegendInfo.tooltip" />} />}
+                                </Checkbox>
+                            </Col>
+                        </div>
+                    </Row>
+                }
                 {this.props.element.type === "wms" &&
                 <Row>
                     <Col xs={12}>

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -45,9 +45,9 @@ describe('test Layer Properties Display module component', () => {
         // wrap in a stateful component, stateless components render return null
         // see: https://facebook.github.io/react/docs/top-level-api.html#reactdom.render
         const comp = ReactDOM.render(<Display element={l} settings={settings} />, document.getElementById("container"));
-        expect(comp).toExist();
+        expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
-        expect(inputs).toExist();
+        expect(inputs).toBeTruthy();
         expect(inputs.length).toBe(5);
         ReactTestUtils.Simulate.focus(inputs[0]);
         expect(inputs[0].value).toBe('100');
@@ -71,9 +71,9 @@ describe('test Layer Properties Display module component', () => {
         // wrap in a stateful component, stateless components render return null
         // see: https://facebook.github.io/react/docs/top-level-api.html#reactdom.render
         const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
-        expect(comp).toExist();
+        expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
-        expect(inputs).toExist();
+        expect(inputs).toBeTruthy();
         expect(inputs.length).toBe(13);
         ReactTestUtils.Simulate.focus(inputs[2]);
         expect(inputs[2].value).toBe('70');
@@ -109,7 +109,7 @@ describe('test Layer Properties Display module component', () => {
         };
 
         const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
-        expect(comp).toExist();
+        expect(comp).toBeTruthy();
         const formatRefresh = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "format-refresh" );
         ReactTestUtils.Simulate.click(formatRefresh[0]);
     });
@@ -165,7 +165,7 @@ describe('test Layer Properties Display module component', () => {
         };
         ReactDOM.render(<Display isLocalizedLayerStylesEnabled element={l} settings={settings}/>, document.getElementById("container"));
         const isLocalizedLayerStylesOption = document.querySelector('[data-qa="display-lacalized-layer-styles-option"]');
-        expect(isLocalizedLayerStylesOption).toExist();
+        expect(isLocalizedLayerStylesOption).toBeTruthy();
     });
 
     it('tests Display component for wms with force proxy option displayed', () => {
@@ -243,7 +243,7 @@ describe('test Layer Properties Display module component', () => {
             onChange() {}
         };
         const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
-        expect(comp).toExist();
+        expect(comp).toBeTruthy();
         const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "control-label" );
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         const legendWidth = inputs[11];
@@ -281,11 +281,11 @@ describe('test Layer Properties Display module component', () => {
         };
         let spy = expect.spyOn(handlers, "onChange");
         const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
-        expect(comp).toExist();
+        expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         const legendPreview = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "legend-preview" );
-        expect(legendPreview).toExist();
-        expect(inputs).toExist();
+        expect(legendPreview).toBeTruthy();
+        expect(inputs).toBeTruthy();
         expect(inputs.length).toBe(13);
         let legendWidth = inputs[11];
         let legendHeight = inputs[12];
@@ -350,9 +350,9 @@ describe('test Layer Properties Display module component', () => {
             }
         };
         const comp = ReactDOM.render(<Display element={l} settings={settings}/>, document.getElementById("container"));
-        expect(comp).toExist();
+        expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
-        expect(inputs).toExist();
+        expect(inputs).toBeTruthy();
         expect(inputs.length).toBe(13);
         expect(inputs[11].value).toBe("20");
         expect(inputs[12].value).toBe("40");

--- a/web/client/epics/__tests__/layerfilter-test.js
+++ b/web/client/epics/__tests__/layerfilter-test.js
@@ -8,10 +8,10 @@
 
 import expect from 'expect';
 
-import { openQueryBuilder, discardCurrentFilter, applyFilter } from '../../actions/layerFilter';
+import { openQueryBuilder, discardCurrentFilter, applyFilter, layerFilterByLegend, resetLegendFilter } from '../../actions/layerFilter';
 import { QUERY_FORM_SEARCH } from '../../actions/queryform';
 import { testEpic } from './epicTestUtils';
-import { handleLayerFilterPanel, restoreSavedFilter, onApplyFilter } from '../layerfilter';
+import { handleLayerFilterPanel, restoreSavedFilter, onApplyFilter, applyCQLFilterBasedOnLegendFilter, applyResetLegendFilter } from '../layerfilter';
 
 describe('layerFilter Epics', () => {
     it("handleLayerFilterPanel is correctly initiated and react to QUERY_FORM_SEARCH", (done) => {
@@ -82,5 +82,150 @@ describe('layerFilter Epics', () => {
             done();
 
         });
+    });
+
+    it("applyCQLFilterBasedOnLegendFilter to apply legend filter", (done) => {
+        let action = [layerFilterByLegend('topp:states__5', 'layers', "[FIELD_01 >= '5' AND FIELD_01 < '1']")];
+
+        // State need a selected layers
+        const state = {layers: {
+            flat: [{id: "topp:states__5", name: "topp:states", search: {url: "searchUrl"}, url: "url"}],
+            selected: ["topp:states__5"]}
+        };
+        testEpic(applyCQLFilterBasedOnLegendFilter, 3, action, (actions) => {
+            expect(actions[0].type).toBe("QUERY_FORM_SEARCH");
+            expect(actions[0].searchUrl).toBe("searchUrl");
+            expect(actions[0].filterObj.filters[0].id).toBe("interactiveLegend");
+            expect(actions[1].type).toBe("CHANGE_LAYER_PROPERTIES");
+            expect(actions[2].type).toBe("LAYER_FILTER:APPLIED_FILTER");
+            done();
+
+        }, state);
+    });
+
+    it("applyCQLFilterBasedOnLegendFilter to reset legend filter", (done) => {
+        let action = [layerFilterByLegend('topp:states__5', 'layers', "")];
+
+        // State need a selected layers
+        const state = {
+            layers: {
+                flat: [{id: "topp:states__5", name: "topp:states", search: {url: "searchUrl"}, url: "url",
+                    enableInteractiveLegend: true,
+                    layerFilter: {
+                        filters: [
+                            {
+                                "id": "interactiveLegend",
+                                "format": "logic",
+                                "version": "1.0.0",
+                                "logic": "AND",
+                                "filters": [
+                                    {
+                                        "format": "cql",
+                                        "version": "1.0.0",
+                                        "body": "FIELD_01 >= '5' AND FIELD_01 < '1'",
+                                        "id": "[FIELD_01 >= '5' AND FIELD_01 < '1']"
+                                    }
+                                ]
+                            }
+                        ]
+                    }}],
+                selected: ["topp:states__5"]
+            }
+        };
+        testEpic(applyCQLFilterBasedOnLegendFilter, 3, action, (actions) => {
+            expect(actions[0].type).toBe("QUERY_FORM_SEARCH");
+            expect(actions[0].searchUrl).toBe("searchUrl");
+            expect(actions[0].filterObj).toBe(undefined);
+            expect(actions[1].type).toBe("CHANGE_LAYER_PROPERTIES");
+            expect(actions[2].type).toBe("LAYER_FILTER:APPLIED_FILTER");
+            done();
+
+        }, state);
+    });
+
+    it("applyResetLegendFilter to reset legend filter in case change 'style' for wms", (done) => {
+        let action = [resetLegendFilter('style', 'style_02')];
+
+        // State need a selected layers
+        const state = {
+            layers: {
+                flat: [{id: "topp:states__5", name: "topp:states", search: {url: "searchUrl"}, url: "url", type: 'wms',
+                    enableInteractiveLegend: true,
+                    style: 'style_01',
+                    layerFilter: {
+                        filters: [
+                            {
+                                "id": "interactiveLegend",
+                                "format": "logic",
+                                "version": "1.0.0",
+                                "logic": "AND",
+                                "filters": [
+                                    {
+                                        "format": "cql",
+                                        "version": "1.0.0",
+                                        "body": "FIELD_01 >= '5' AND FIELD_01 < '1'",
+                                        "id": "[FIELD_01 >= '5' AND FIELD_01 < '1']"
+                                    }
+                                ]
+                            }
+                        ]
+                    }}],
+                selected: ["topp:states__5"]
+            }
+        };
+        testEpic(applyResetLegendFilter, 3, action, (actions) => {
+            expect(actions[0].type).toBe("QUERY_FORM_SEARCH");
+            expect(actions[0].searchUrl).toBe("searchUrl");
+            expect(actions[0].filterObj).toBe(undefined);
+            expect(actions[1].type).toBe("CHANGE_LAYER_PROPERTIES");
+            expect(actions[2].type).toBe("LAYER_FILTER:APPLIED_FILTER");
+            done();
+
+        }, state);
+    });
+    it("applyResetLegendFilter to reset legend filter in case change 'style' for wfs", (done) => {
+        let action = [resetLegendFilter('style', '{"rules":[{"name":"Style 01 wfs","ruleId2":"ruleId","symbolizers":[{"kind":"Fill","color":"#0920ff","fillOpacity":1,"outlineColor":"#3075e9","outlineOpacity":1,"outlineWidth":2,"symbolizerId":"symbolizerId1"}]}]}')];
+
+        // State need a selected layers
+        const state = {
+            layers: {
+                flat: [{id: "topp:states__5", name: "topp:states", search: {url: "searchUrl"}, url: "url", type: 'wfs',
+                    enableInteractiveLegend: true,
+                    style: {
+                        body: {}, format: 'geostyler', metadate: {
+                            editorType: 'visual',
+                            styleJSON: `{"rules": [{"name": "Style 02 wfs","ruleId":"ruleId2","symbolizers":[{"kind":"Fill","color":"#0920ff","fillOpacity":1,"outlineColor":"#3075e9","outlineOpacity":1,"outlineWidth":2,"symbolizerId":"symbolizerId2"}]}]}`
+                        }
+                    },
+                    layerFilter: {
+                        filters: [
+                            {
+                                "id": "interactiveLegend",
+                                "format": "logic",
+                                "version": "1.0.0",
+                                "logic": "AND",
+                                "filters": [
+                                    {
+                                        "format": "cql",
+                                        "version": "1.0.0",
+                                        "body": "FIELD_01 >= '5' AND FIELD_01 < '1'",
+                                        "id": "[FIELD_01 >= '5' AND FIELD_01 < '1']"
+                                    }
+                                ]
+                            }
+                        ]
+                    }}],
+                selected: ["topp:states__5"]
+            }
+        };
+        testEpic(applyResetLegendFilter, 3, action, (actions) => {
+            expect(actions[0].type).toBe("QUERY_FORM_SEARCH");
+            expect(actions[0].searchUrl).toBe("searchUrl");
+            expect(actions[0].filterObj).toBe(undefined);
+            expect(actions[1].type).toBe("CHANGE_LAYER_PROPERTIES");
+            expect(actions[2].type).toBe("LAYER_FILTER:APPLIED_FILTER");
+            done();
+
+        }, state);
     });
 });

--- a/web/client/epics/layerfilter.js
+++ b/web/client/epics/layerfilter.js
@@ -14,16 +14,17 @@ import { get, head } from 'lodash';
 import { LOCATION_CHANGE } from 'connected-react-router';
 import { TOGGLE_CONTROL, setControlProperty } from '../actions/controls';
 import { QUERY_FORM_SEARCH, loadFilter, reset, search } from '../actions/queryform';
-import { changeLayerProperties } from '../actions/layers';
+import { changeLayerProperties, updateNode } from '../actions/layers';
 
 import {
     OPEN_QUERY_BUILDER,
     initLayerFilter,
     DISCARD_CURRENT_FILTER,
     APPLY_FILTER,
-    storeAppliedFilter
+    storeAppliedFilter,
+    LAYER_FILTER_BY_LEGEND,
+    RESET_LAYER_FILTER_BY_LEGEND
 } from '../actions/layerFilter';
-
 import { featureTypeSelected, toggleLayerFilter, initQueryPanel } from '../actions/wfsquery';
 import { getSelectedLayer } from '../selectors/layers';
 import { changeDrawingStatus } from '../actions/draw';
@@ -114,8 +115,127 @@ export const onApplyFilter = (action$, {getState}) =>
 
         });
 
+/**
+ * It applies the legend filter for wms/wms/vector layer
+ * @memberof epics.layerFilter
+ * @param {external:Observable} action$ manages `LAYER_FILTER_BY_LEGEND`
+ * @return {external:Observable} `APPLIED_FILTER`
+ */
+export const applyCQLFilterBasedOnLegendFilter = (action$, {getState}) => {
+    return  action$.ofType(LAYER_FILTER_BY_LEGEND)
+        .switchMap((action) => {
+            const state = getState();
+            const layer = head(state.layers.flat.filter(l => l.id === action.layerId));
+            const queryFormFilterObj = {...get(getState(), "queryform", {})};
+            let filterObj = layer.layerFilter ? layer.layerFilter : queryFormFilterObj;
+            let searchUrl = layer?.search?.url;
+            let actions = [];
+            // reset thte filter if legendCQLFilter is empty
+            if (!action.legendCQLFilter) {
+                // clear legend filter with id = 'interactiveLegend'
+                const isLegendFilterExist = filterObj?.filters?.find(f => f.id === 'interactiveLegend');
+                if (isLegendFilterExist) {
+                    filterObj = {
+                        ...filterObj, filters: filterObj?.filters?.filter(f => f.id !== 'interactiveLegend')
+                    };
+                }
+                let newFilter = isNotEmptyFilter(filterObj) ? filterObj : undefined;
+                if (layer.type === 'vector') {
+                    actions.push(
+                        updateNode(layer.id, 'layer', {geoStylerFilter: undefined})
+                    );
+                }
+                actions.push(...[search(searchUrl, newFilter), addFilterToLayer(layer.id, newFilter), storeAppliedFilter(newFilter)]);
+                return Rx.Observable.from(actions);
+            }
+            let legendCQLFilter = action.legendCQLFilter;
+            let filter = {...(filterObj || {})};
+            if (legendCQLFilter) {
+                // remove the unnecessaru brackets --> in some cases wms getLegendGraphic provides filter with brackets
+                // "[FIELD_01 >= '1' AND FIELD_01 < '0']" ---> to be "FIELD_01 >= '1' AND FIELD_01 < '0'"
+                const cqlStatement = legendCQLFilter.includes("[") ? legendCQLFilter.slice(1, legendCQLFilter.length - 1) : legendCQLFilter;
+                // add legend filter with id = 'interactiveLegend' in cql format
+                filter.filters =  [
+                    ...(filterObj?.filters?.filter(f => f.id !== 'interactiveLegend') || []), ...[
+                        {
+                            "id": "interactiveLegend",
+                            "format": "logic",
+                            "version": "1.0.0",
+                            "logic": "AND",
+                            "filters": [{
+                                "format": "cql",
+                                "version": "1.0.0",
+                                "body": cqlStatement,
+                                "id": `[${cqlStatement}]`
+                            }]
+                        }
+                    ]
+                ];
+                if (layer.type === 'vector') {
+                    actions.push(
+                        updateNode(layer.id, 'layer', {geoStylerFilter: action.filterArr})
+                    );
+                }
+                actions.push(...[search(searchUrl, filter), addFilterToLayer(layer.id, filter), storeAppliedFilter(filter)]);
+            }
+            return Rx.Observable.from(actions);
+        });
+};
+/**
+ * It applies a reset for legend filter for wms/wms/vector layer
+ * @memberof epics.layerFilter
+ * @param {external:Observable} action$ manages `RESET_LAYER_FILTER_BY_LEGEND`
+ * @return {external:Observable} `APPLIED_FILTER`
+ */
+export const applyResetLegendFilter = (action$, {getState}) => {
+    return  action$.ofType(RESET_LAYER_FILTER_BY_LEGEND)
+        .switchMap((action) => {
+            const state = getState();
+            const layer = getSelectedLayer(state);
+            let actions = [];
+            const layerType = layer.type;
+            const isWFSOrVectorLayer = layerType === 'wfs' || layerType === 'vector';
+            const isWMSLayer = layerType === 'wms';
+            const isResetForStyle = action.reason === 'style';      // here the reason for reset is change 'style' or change the enable/disable interactive legend config 'disableEnableInteractiveLegend'
+            let needReset;
+            // check if the selected style is different than the current layer's one, if not cancel the epic
+            if (isWFSOrVectorLayer && isResetForStyle) {
+                needReset = action.reason === 'style' && layer.style?.metadata?.styleJSON !== action?.value;
+            } else if (isWMSLayer && isResetForStyle) {
+                needReset = action.reason === 'style' && layer.style !== action?.value;
+            } else if (!isResetForStyle) {
+                // in case of reason === 'disableEnableInteractiveLegend'
+                needReset = true;
+            }
+            // check if the layer has interactive legend or not, if not cancel the epic
+            const isLayerWithJSONLegend = layer?.enableInteractiveLegend;
+            if (!needReset || !isLayerWithJSONLegend) return Rx.Observable.empty();
+            const queryFormFilterObj = {...get(getState(), "queryform", {})};
+            let filterObj = layer.layerFilter ? layer.layerFilter : queryFormFilterObj;
+            let searchUrl = layer?.search?.url;
+            // reset thte filter if legendCQLFilter is empty
+            const isLegendFilterExist = filterObj?.filters?.find(f => f.id === 'interactiveLegend');
+            if (isLegendFilterExist) {
+                filterObj = {
+                    ...filterObj, filters: filterObj?.filters?.filter(f => f.id !== 'interactiveLegend')
+                };
+                let newFilter = isNotEmptyFilter(filterObj) ? filterObj : undefined;
+                if (layer.type === 'vector') {
+                    actions.push(
+                        updateNode(layer.id, 'layer', {geoStylerFilter: undefined})
+                    );
+                }
+                actions.push(...[search(searchUrl, newFilter), addFilterToLayer(layer.id, newFilter), storeAppliedFilter(newFilter)]);
+                return Rx.Observable.from(actions);
+            }
+            return Rx.Observable.empty();
+        });
+};
+
 export default {
     handleLayerFilterPanel,
     restoreSavedFilter,
-    onApplyFilter
+    onApplyFilter,
+    applyCQLFilterBasedOnLegendFilter,
+    applyResetLegendFilter
 };

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -342,7 +342,8 @@ class MapPlugin extends React.Component {
     renderLayerContent = (layer, projection) => {
         const plugins = this.state.plugins;
         if (layer.features) {
-            return layer.features.filter(createFeatureFilter(layer.filterObj)).map( (feature) => {
+            const layerHasLegendFilter = layer?.geoStylerFilter;        // it is for filtering vector layer, it is used for filtering features based on legend filter [geostyler array]
+            return layer.features.filter(createFeatureFilter(layer.filterObj, layerHasLegendFilter)).map((feature) => {
                 return (
                     <plugins.Feature
                         key={feature.id}

--- a/web/client/plugins/TOC/components/DefaultLayer.jsx
+++ b/web/client/plugins/TOC/components/DefaultLayer.jsx
@@ -71,7 +71,8 @@ const DefaultLayerNode = ({
     error,
     visibilityWarningMessageId,
     visibilityCheck,
-    nodeIcon
+    nodeIcon,
+    onLayerFilterByLegend = () => {}
 }) => {
 
     const getContent = () => {
@@ -91,6 +92,8 @@ const DefaultLayerNode = ({
                         <li>
                             <VectorLegend
                                 style={node?.style}
+                                onLayerFilterByLegend={onLayerFilterByLegend}
+                                layer={node}
                             />
                         </li>
                     </>
@@ -107,6 +110,7 @@ const DefaultLayerNode = ({
                             scales={config?.scales}
                             language={config?.language}
                             {...config?.layerOptions?.legendOptions}
+                            onLayerFilterByLegend={onLayerFilterByLegend}
                         />
                     </li>
                 </>
@@ -239,7 +243,8 @@ const DefaultLayer = ({
     nodeToolItems = [],
     nodeItems = [],
     nodeTypes,
-    theme
+    theme,
+    onLayerFilterByLegend = () => {}
 }) => {
 
     const replacedNode = replaceNodeOptions(nodeProp, nodeType);
@@ -300,7 +305,8 @@ const DefaultLayer = ({
                 handleOnChange({ visibility });
             }}
         />),
-        nodeIcon: <Glyphicon className="ms-node-icon" glyph={icon} />
+        nodeIcon: <Glyphicon className="ms-node-icon" glyph={icon} />,
+        onLayerFilterByLegend: onLayerFilterByLegend
     };
     const style = getNodeStyle(node, nodeType);
     const className = getNodeClassName(node, nodeType);

--- a/web/client/plugins/TOC/components/LayersTree.jsx
+++ b/web/client/plugins/TOC/components/LayersTree.jsx
@@ -77,6 +77,7 @@ const LayersTree = ({
     layerNodeComponent = DefaultLayer,
     onContextMenu = () => {},
     onSelect = () => {},
+    onLayerFilterByLegend = () => {},
     contextMenu,
     selectedNodes = [],
     rootGroupId = ROOT_GROUP_ID,
@@ -204,6 +205,7 @@ const LayersTree = ({
                             onSelect={onSelect}
                             nodeItems={nodeItems}
                             nodeToolItems={nodeToolItems}
+                            onLayerFilterByLegend={onLayerFilterByLegend}
                         />
                     );
                 })}

--- a/web/client/plugins/TOC/components/TOC.jsx
+++ b/web/client/plugins/TOC/components/TOC.jsx
@@ -63,6 +63,7 @@ export function ControlledTOC({
     onChange = () => {},
     onSelectNode = () => {},
     onContextMenu = () => {},
+    onLayerFilterByLegend = () => {},
     groupNodeComponent,
     layerNodeComponent,
     filterText,
@@ -87,6 +88,7 @@ export function ControlledTOC({
                 onChange(currentNode.id, nodeType, options)
             }
             groupNodeComponent={groupNodeComponent}
+            onLayerFilterByLegend={onLayerFilterByLegend}
             layerNodeComponent={layerNodeComponent}
             contextMenu={contextMenu}
             onContextMenu={onContextMenu}

--- a/web/client/plugins/TOC/components/VectorLegend.jsx
+++ b/web/client/plugins/TOC/components/VectorLegend.jsx
@@ -8,15 +8,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import RuleLegendIcon from '../../../components/styleeditor/RuleLegendIcon';
+import { parseGeoStylerFilterToCql } from '../../../utils/StyleEditorUtils';
+
 /**
  * VectorLegend renders the legend given a valid vector style
  * @prop {object} style a layer style object in geostyler format
+ * @prop {object} layer a layer
+ * @prop {object} onLayerFilterByLegend a handler of legend filter
  */
-function VectorLegend({ style }) {
-
+function VectorLegend({ style, layer, onLayerFilterByLegend }) {
+    const handleLegendFilter = (filter) => {
+        if (!layer?.enableInteractiveLegend || !layer?.visibility) return;
+        const cql = filter ? parseGeoStylerFilterToCql(filter) : filter;
+        const isLegendFilterIncluded = layer?.layerFilter?.filters?.find(f=>f.id === 'interactiveLegend');
+        const prevFilter = isLegendFilterIncluded ? isLegendFilterIncluded?.filters?.[0]?.body : '';
+        onLayerFilterByLegend(layer.id, 'layers', cql === prevFilter ? '' : cql, filter);
+    };
     const renderRules = (rules) => {
         return (rules || []).map((rule) => {
-            return (<div className="ms-vector-legend-rule" key={rule.ruleId}>
+            const isLegendFilterIncluded = layer?.layerFilter?.filters?.find(f=>f.id === 'interactiveLegend');
+            const prevFilter = isLegendFilterIncluded ? isLegendFilterIncluded?.filters?.[0]?.body : '';
+            // if isLegendFilterIncluded && rule.filter ---> get cql to compare current with prev filter
+            const ruleFilter = rule.filter && isLegendFilterIncluded ? parseGeoStylerFilterToCql(rule.filter) : '';
+
+            return (<div className={`wfs-legend-rule ${layer?.enableInteractiveLegend && layer?.visibility ? 'json-legend-rule' : ''} ${ruleFilter && prevFilter === ruleFilter ? 'active' : ''}`} key={rule.ruleId || rule.name} onClick={()=>handleLegendFilter(rule?.filter)}>
                 <RuleLegendIcon rule={rule} />
                 <span>{rule.name || ''}</span>
             </div>);
@@ -33,7 +48,9 @@ function VectorLegend({ style }) {
 }
 
 VectorLegend.propTypes = {
-    style: PropTypes.object
+    style: PropTypes.object,
+    layer: PropTypes.object,
+    onLayerFilterByLegend: PropTypes.func
 };
 
 export default VectorLegend;

--- a/web/client/plugins/TOC/components/__tests__/VectorLegend-test.jsx
+++ b/web/client/plugins/TOC/components/__tests__/VectorLegend-test.jsx
@@ -47,7 +47,7 @@ describe('VectorLegend module component', () => {
             }
         };
         ReactDOM.render(<VectorLegend style={style} />, document.getElementById('container'));
-        const ruleElements = document.querySelectorAll('.ms-vector-legend-rule');
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule');
         expect(ruleElements.length).toBe(1);
         const textElement = ruleElements[0].getElementsByTagName('span');
         expect(textElement[0].innerHTML).toBe('Some Line');
@@ -80,7 +80,7 @@ describe('VectorLegend module component', () => {
             }
         };
         ReactDOM.render(<VectorLegend style={style} />, document.getElementById('container'));
-        const ruleElements = document.querySelectorAll('.ms-vector-legend-rule');
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule');
         expect(ruleElements.length).toBe(1);
         const textElement = ruleElements[0].getElementsByTagName('span');
         expect(textElement[0].innerHTML).toBe('Some Line');
@@ -113,7 +113,7 @@ describe('VectorLegend module component', () => {
             }
         };
         ReactDOM.render(<VectorLegend style={style} />, document.getElementById('container'));
-        const ruleElements = document.querySelectorAll('.ms-vector-legend-rule');
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule');
         expect(ruleElements.length).toBe(1);
         const textElement = ruleElements[0].getElementsByTagName('span');
         expect(textElement[0].innerHTML).toBe('Some Line');
@@ -148,7 +148,7 @@ describe('VectorLegend module component', () => {
             }
         };
         ReactDOM.render(<VectorLegend style={style} />, document.getElementById('container'));
-        const ruleElements = document.querySelectorAll('.ms-vector-legend-rule');
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule');
         expect(ruleElements.length).toBe(1);
         const textElement = ruleElements[0].getElementsByTagName('span');
         expect(textElement[0].innerHTML).toBe('Some polygon');
@@ -186,7 +186,7 @@ describe('VectorLegend module component', () => {
             }
         };
         ReactDOM.render(<VectorLegend style={style} />, document.getElementById('container'));
-        const ruleElements = document.querySelectorAll('.ms-vector-legend-rule');
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule');
         expect(ruleElements.length).toBe(1);
         const textElement = ruleElements[0].getElementsByTagName('span');
         expect(textElement[0].innerHTML).toBe('Some mark');
@@ -220,7 +220,7 @@ describe('VectorLegend module component', () => {
             }
         };
         ReactDOM.render(<VectorLegend style={style} />, document.getElementById('container'));
-        const ruleElements = document.querySelectorAll('.ms-vector-legend-rule');
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule');
         expect(ruleElements.length).toBe(1);
         const textElement = ruleElements[0].getElementsByTagName('span');
         expect(textElement[0].getAttribute('class')).toBe('glyphicon glyphicon-point');
@@ -283,7 +283,7 @@ describe('VectorLegend module component', () => {
             }
         };
         ReactDOM.render(<VectorLegend style={style} />, document.getElementById('container'));
-        const ruleElements = document.querySelectorAll('.ms-vector-legend-rule');
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule');
         expect(ruleElements.length).toBe(3);
     });
 
@@ -310,8 +310,259 @@ describe('VectorLegend module component', () => {
             }
         };
         ReactDOM.render(<VectorLegend style={style} />, document.getElementById('container'));
-        const ruleElements = document.querySelectorAll('.ms-vector-legend-rule');
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule');
         const textElement = ruleElements[0].getElementsByTagName('span');
         expect(textElement[0].innerHTML).toBe('');
+    });
+
+    it('Should render interactive item for "Polygon" symbolizer', () => {
+        const style = {
+            format: 'geostyler',
+            body: {
+                rules: [
+                    {
+                        "name": ">= 159.055 and < 137771.05799999996",
+                        "filter": [
+                            "&&",
+                            [
+                                ">=",
+                                "LAND_KM",
+                                159.055
+                            ],
+                            [
+                                "<",
+                                "LAND_KM",
+                                137771.05799999996
+                            ]
+                        ],
+                        "symbolizers": [
+                            {
+                                "kind": "Fill",
+                                "color": "#fff7ec",
+                                "fillOpacity": 1,
+                                "outlineColor": "#777777",
+                                "outlineWidth": 1,
+                                "msClassificationType": "both",
+                                "msClampToGround": true
+                            }
+                        ]
+                    },
+                    {
+                        "name": ">= 137771.05799999996 and < 275383.0609999999",
+                        "filter": [
+                            "&&",
+                            [
+                                ">=",
+                                "LAND_KM",
+                                137771.05799999996
+                            ],
+                            [
+                                "<",
+                                "LAND_KM",
+                                275383.0609999999
+                            ]
+                        ],
+                        "symbolizers": [
+                            {
+                                "kind": "Fill",
+                                "color": "#fdd49e",
+                                "fillOpacity": 1,
+                                "outlineColor": "#777777",
+                                "outlineWidth": 1,
+                                "msClassificationType": "both",
+                                "msClampToGround": true
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wfs',
+            url: 'http://localhost:8080/geoserver/wfs',
+            enableInteractiveLegend: true
+        };
+        ReactDOM.render(<VectorLegend layer={l} style={style} />, document.getElementById('container'));
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule.json-legend-rule');
+        expect(ruleElements.length).toBe(2);
+        const textElement = ruleElements[0].getElementsByTagName('span');
+        expect(textElement[0].innerText).toBe('>= 159.055 and < 137771.05799999996');
+        const iconContainerElement = ruleElements[0].querySelectorAll('.ms-rule-legend-icon');
+        expect(iconContainerElement.length).toBe(1);
+        expect(iconContainerElement[0].innerHTML).toBeTruthy();
+    });
+
+    it('Should render interactive item for "Line" symbolizer', () => {
+        const style = {
+            format: 'geostyler',
+            body: {
+                rules: [
+                    {
+                        "name": ">= 0.000145169491362 and < 4.969539144872505",
+                        "filter": [
+                            "&&",
+                            [
+                                ">=",
+                                "l_mile",
+                                0.000145169491362
+                            ],
+                            [
+                                "<",
+                                "l_mile",
+                                4.969539144872505
+                            ]
+                        ],
+                        "symbolizers": [
+                            {
+                                "kind": "Line",
+                                "color": "#7f0000",
+                                "width": 1,
+                                "opacity": 1,
+                                "cap": "round",
+                                "join": "round",
+                                "msClampToGround": true
+                            }
+                        ]
+                    },
+                    {
+                        "name": ">= 4.969539144872505 and < 9.938933120253648",
+                        "filter": [
+                            "&&",
+                            [
+                                ">=",
+                                "l_mile",
+                                4.969539144872505
+                            ],
+                            [
+                                "<",
+                                "l_mile",
+                                9.938933120253648
+                            ]
+                        ],
+                        "symbolizers": [
+                            {
+                                "kind": "Line",
+                                "color": "#d7301f",
+                                "width": 1,
+                                "opacity": 1,
+                                "cap": "round",
+                                "join": "round",
+                                "msClampToGround": true
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wfs',
+            url: 'http://localhost:8080/geoserver/wfs',
+            enableInteractiveLegend: true
+        };
+        ReactDOM.render(<VectorLegend layer={l} style={style} />, document.getElementById('container'));
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule.json-legend-rule');
+        expect(ruleElements.length).toBe(2);
+        const textElement = ruleElements[0].getElementsByTagName('span');
+        expect(textElement[0].innerText).toBe('>= 0.000145169491362 and < 4.969539144872505');
+        const iconContainerElement = ruleElements[0].querySelectorAll('.ms-rule-legend-icon');
+        expect(iconContainerElement.length).toBe(1);
+        expect(iconContainerElement[0].innerHTML).toBeTruthy();
+    });
+
+    it('Should render interactive item for "Point" symbolizer', () => {
+        const style = {
+            format: 'geostyler',
+            body: {
+                rules: [
+                    {
+                        "name": ">= 487 and < 790.2",
+                        "filter": [
+                            "&&",
+                            [
+                                ">=",
+                                "gid",
+                                487
+                            ],
+                            [
+                                "<",
+                                "gid",
+                                790.2
+                            ]
+                        ],
+                        "symbolizers": [
+                            {
+                                "kind": "Mark",
+                                "wellKnownName": "Circle",
+                                "color": "#fff7ec",
+                                "fillOpacity": 1,
+                                "strokeColor": "#777777",
+                                "strokeOpacity": 1,
+                                "strokeWidth": 1,
+                                "radius": 16,
+                                "rotate": 0,
+                                "msBringToFront": false,
+                                "msHeightReference": "none"
+                            }
+                        ]
+                    },
+                    {
+                        "name": ">= 790.2 and < 1093.4",
+                        "filter": [
+                            "&&",
+                            [
+                                ">=",
+                                "gid",
+                                790.2
+                            ],
+                            [
+                                "<",
+                                "gid",
+                                1093.4
+                            ]
+                        ],
+                        "symbolizers": [
+                            {
+                                "kind": "Mark",
+                                "wellKnownName": "Circle",
+                                "color": "#fdd49e",
+                                "fillOpacity": 1,
+                                "strokeColor": "#777777",
+                                "strokeOpacity": 1,
+                                "strokeWidth": 1,
+                                "radius": 16,
+                                "rotate": 0,
+                                "msBringToFront": false,
+                                "msHeightReference": "none"
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wfs',
+            url: 'http://localhost:8080/geoserver/wfs',
+            enableInteractiveLegend: true
+        };
+        ReactDOM.render(<VectorLegend layer={l} style={style} />, document.getElementById('container'));
+        const ruleElements = document.querySelectorAll('.wfs-legend-rule.json-legend-rule');
+        expect(ruleElements.length).toBe(2);
+        const textElement = ruleElements[0].getElementsByTagName('span');
+        expect(textElement[0].innerText).toBe('>= 487 and < 790.2');
+        const iconContainerElement = ruleElements[0].querySelectorAll('.ms-rule-legend-icon');
+        expect(iconContainerElement.length).toBe(1);
+        expect(iconContainerElement[0].innerHTML).toBeTruthy();
     });
 });

--- a/web/client/plugins/TOC/index.js
+++ b/web/client/plugins/TOC/index.js
@@ -19,6 +19,7 @@ import {
     groupsSelector,
     selectedNodesSelector
 } from '../../selectors/layers';
+import { layerFilterByLegend } from '../../actions/layerFilter';
 import { userSelector } from '../../selectors/security';
 import { currentLocaleSelector, currentLocaleLanguageSelector } from '../../selectors/locale';
 import { mapSelector, mapNameSelector } from '../../selectors/map';
@@ -364,7 +365,8 @@ function TOC({
     toolbarButtonProps,
     init,
     onOpen,
-    onResetInit
+    onResetInit,
+    onLayerFilterByLegend = () => {}
 }, context) {
     const activateParameter = (allow, activate) => {
         const isUserAdmin = user && user.role === 'ADMIN' || false;
@@ -525,6 +527,7 @@ function TOC({
                 nodeToolItems={nodeToolItems}
                 nodeItems={nodeItems}
                 singleDefaultGroup={singleDefaultGroup}
+                onLayerFilterByLegend={onLayerFilterByLegend}
             />
             {activateToolsContainer ? <ContextMenu
                 value={contextMenu}
@@ -621,7 +624,8 @@ const ConnectedTOC = connect(tocSelector, {
     onChange: updateNode,
     onSelectNode: selectNode,
     onOpen: setControlProperty.bind(null, 'drawer', 'enabled', true),
-    onResetInit: updateTOCConfig.bind(null, { init: false })
+    onResetInit: updateTOCConfig.bind(null, { init: false }),
+    onLayerFilterByLegend: layerFilterByLegend
 })(TOC);
 
 export default createPlugin('TOC', {

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -15,6 +15,7 @@ import {createSelector} from 'reselect';
 import {setControlProperty} from '../actions/controls';
 import {getLayerCapabilities} from '../actions/layerCapabilities';
 import {hideSettings, updateNode, updateSettings, updateSettingsParams, showSettings} from '../actions/layers';
+import { resetLegendFilter } from '../actions/layerFilter';
 import {toggleStyleEditor} from '../actions/styleeditor';
 import {updateSettingsLifecycle} from "../components/TOC/enhancers/tocItemsSettings";
 import TOCItemsSettings from '../components/TOC/TOCItemsSettings';
@@ -139,7 +140,8 @@ const TOCItemsSettingsPlugin = compose(
         onRetrieveLayerData: getLayerCapabilities,
         onSetTab: setControlProperty.bind(null, 'layersettings', 'activeTab'),
         onUpdateParams: updateSettingsParams,
-        onToggleStyleEditor: toggleStyleEditor
+        onToggleStyleEditor: toggleStyleEditor,
+        resetLegendFilter: resetLegendFilter
     }),
     updateSettingsLifecycle,
     defaultProps({
@@ -166,5 +168,4 @@ export default createPlugin('TOCItemsSettings', {
         }
     }
 });
-
 

--- a/web/client/plugins/styleeditor/VectorStyleEditor.jsx
+++ b/web/client/plugins/styleeditor/VectorStyleEditor.jsx
@@ -8,6 +8,7 @@
 
 import React, { useEffect, useRef, useState }  from 'react';
 import uniq from 'lodash/uniq';
+import isEqual from 'lodash/isEqual';
 import { StyleEditor } from './StyleCodeEditor';
 import TextareaEditor from '../../components/styleeditor/Editor';
 import VisualStyleEditor from '../../components/styleeditor/VisualStyleEditor';
@@ -77,7 +78,8 @@ function VectorStyleEditor({
         'Courier New',
         'Brush Script MT'
     ],
-    onUpdateNode = () => {}
+    onUpdateNode = () => {},
+    resetLegendFilter = () => {}
 }) {
 
     const request = capabilitiesRequest[layer?.type];
@@ -90,9 +92,14 @@ function VectorStyleEditor({
     function handleClearStyle() {
         setError(null);
         onUpdateNode(layer.id, 'layers', { style: getVectorDefaultStyle(layer) });
+        // apply reset legend filter in case of change style
+        if (['wfs', 'vector'].includes(layer.type)) {
+            resetLegendFilter('style');
+        }
     }
 
     function handleUpdateMetadata(metadata) {
+        const isStyleChanged = !isEqual(style.current?.metadata?.styleJSON, metadata?.styleJSON);
         style.current = {
             ...style.current,
             metadata: {
@@ -100,6 +107,11 @@ function VectorStyleEditor({
                 ...metadata
             }
         };
+        // apply reset legend filter in case of change style
+        if (isStyleChanged && ['wfs', 'vector'].includes(layer.type) && layer?.enableInteractiveLegend) {
+            resetLegendFilter('style', style.current?.metadata?.styleJSON);
+        }
+
         onUpdateNode(layer?.id, 'layers', {
             style: { ...style.current }
         });

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -14,6 +14,7 @@ import { createSelector } from 'reselect';
 import { updateOptionsByOwner } from '../../actions/additionallayers';
 import { getLayerCapabilities } from '../../actions/layerCapabilities';
 import { updateSettingsParams } from '../../actions/layers';
+import { resetLegendFilter } from '../../actions/layerFilter';
 import {
     addStyle,
     createStyle,
@@ -121,7 +122,8 @@ export const StyleList = compose(
             })
         ),
         {
-            onSelect: updateSettingsParams
+            onSelect: updateSettingsParams,
+            onResetLegendFilterStyle: resetLegendFilter
         }
     ),
     withState('filterText', 'onFilter', ''),

--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -633,6 +633,50 @@ describe('Test the queryform reducer', () => {
         expect(state.spatialField.attribute).toEqual("GEOMETRY");
     });
 
+    it('Query Form Reset and keeping legend filter is exist', () => {
+        let testAction = {
+            type: "QUERY_FORM_RESET"
+        };
+
+        const initialState = {
+            test: true,
+            spatialField: {
+                attribute: "GEOMETRY"
+            },
+            filters: [
+                {
+                    format: "logic",
+                    logic: "AND",
+                    filters: [{
+                        format: 'cql',
+                        body: 'ATTRIBUTE1 = \'VALUE1\''
+                    }]
+                },
+                {
+                    "id": "interactiveLegend",
+                    "format": "logic",
+                    "version": "1.0.0",
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "format": "cql",
+                            "version": "1.0.0",
+                            "body": "FIELD_01 >= '5' AND FIELD_01 < '1'",
+                            "id": "[FIELD_01 >= '5' AND FIELD_01 < '1']"
+                        }
+                    ]
+                }
+            ]
+        };
+
+        let state = queryform(initialState, testAction);
+        expect(state).toBeTruthy();
+
+        expect(state.test).toEqual(true);
+        expect(state.spatialField.attribute).toEqual("GEOMETRY");
+        expect(state.filters.length).toEqual(1);
+    });
+
     it('Show Generated Filter', () => {
         let testAction = {
             type: "SHOW_GENERATED_FILTER",

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -380,10 +380,11 @@ function queryform(state = initialState, action) {
     case QUERY_FORM_RESET: {
         let spatialField = assign({}, initialState.spatialField, { attribute: state.spatialField.attribute, value: undefined });
         let crossLayerFilter = { attribute: state.crossLayerFilter && state.crossLayerFilter.attribute };
+        const isLegendFilterExist = state.filters?.find(i => i.id === 'interactiveLegend');
         return assign({}, state, initialState, {
             spatialField,
             crossLayerFilter,
-            filters: [],
+            filters: isLegendFilterExist ? [isLegendFilterExist] : [],
             map: state.map
         });
     }

--- a/web/client/themes/default/less/toc.less
+++ b/web/client/themes/default/less/toc.less
@@ -88,6 +88,13 @@
             .background-color-var(@theme-vars[selected-bg]);
             .outline-color-var(@theme-vars[focus-color]);
         }
+        .wms-json-legend-rule:hover, .wfs-legend-rule.json-legend-rule:hover {
+            .color-var(@theme-vars[primary]);
+        }
+        .wms-json-legend-rule.active, .wfs-legend-rule.json-legend-rule.active {
+            .background-color-var(@theme-vars[primary]);
+            .color-var(@theme-vars[primary-contrast]);
+        }
     }
 }
 
@@ -388,15 +395,29 @@
     }
 }
 
+// style for wms json legend
+.wms-legend {
+    .wms-json-legend-rule {
+        display: flex;
+        margin-bottom: @padding-left-square-md;
+        .ms-rule-legend-icon {
+            margin-right: 8px;
+        }
+    }
+}
+
 // legend for vector wfs styles
 .ms-vector-legend {
     display: flex;
     flex-direction: column;
     gap: 2px;
-    .ms-vector-legend-rule {
+    .ms-vector-legend-rule, .wfs-legend-rule {
         display: flex;
     }
     .ms-rule-legend-icon {
         margin-right: 4px;
     }
+}
+.wms-json-legend-rule:hover, .wfs-legend-rule.json-legend-rule:hover{
+    cursor: pointer;
 }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -203,6 +203,10 @@
               "legendHeight": "Höhe",
               "legendPreview": "Vorschau"
             },
+            "enableInteractiveLegendInfo": {
+                "label": "Aktivieren Sie die interaktive Legende",
+                "tooltip": "Hinweis: Diese Einstellung benötigt spezifische Konfigurationen im GeoServer"
+            },
             "enableLocalizedLayerStyles": {
                 "label": "Lokalisierten Stil aktivieren",
                 "tooltip": "Hinweis: Diese Einstellung benötigt spezifische Konfigurationen im GeoServer"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -207,6 +207,10 @@
                 "label": "Enable localized style",
                 "tooltip": "Note: This parameter requires specific configurations on GeoServer"
             },
+            "enableInteractiveLegendInfo": {
+                "label": "Enable interactive legend",
+                "tooltip": "Note: This parameter requires specific configurations on GeoServer"
+            },
             "format": {
                 "title": "Format",
                 "tile": "Tile",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -200,6 +200,10 @@
               "legendHeight": "Altura",
               "legendPreview": "Avance"
             },
+            "enableInteractiveLegendInfo": {
+                "label": "Habilitar una leyenda interactiva",
+                "tooltip": "Nota: este parámetro requiere configuraciones específicas en GeoServer"
+            },
             "templateFormatInfoAlertExample": "La identificación de la característica es <span style='white-space:nowrap'>${ properties.datos }</span> ora <span style='white-space:nowrap'>${ properties['datos-valor'] }</span>",
             "templateError": "Hubo un error al aplicar la plantilla a la información devuelta por el servidor, verifique la plantilla",
             "templatePreview": "Vista previa de la plantilla",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -203,6 +203,10 @@
               "legendHeight": "Hauteur",
               "legendPreview": "Aperçu"
             },
+            "enableInteractiveLegendInfo": {
+                "label": "Activer la légende interactive",
+                "tooltip": "Remarque: ce paramètre nécessite des configurations spécifiques sur GeoServer"
+            },
             "enableLocalizedLayerStyles": {
                 "label": "Activer le style localisé",
                 "tooltip": "Remarque: ce paramètre nécessite des configurations spécifiques sur GeoServer"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1,4 +1,4 @@
-    {
+{
     "locale": "it-IT",
     "messages": {
         "Language": "Lingua",
@@ -202,6 +202,10 @@
               "legendWidth": "Larghezza",
               "legendHeight": "Altezza",
               "legendPreview": "Anteprima"
+            },
+            "enableInteractiveLegendInfo": {
+                "label": "Abilita leggenda interattiva",
+                "tooltip": "Nota: questo parametro richiede configurazioni specifiche su GeoServer"
             },
             "enableLocalizedLayerStyles": {
                 "label": "Abilita stile localizzato",

--- a/web/client/utils/__tests__/StyleEditorUtils-test.js
+++ b/web/client/utils/__tests__/StyleEditorUtils-test.js
@@ -34,7 +34,8 @@ import {
     getVectorLayerGeometryType,
     getVectorDefaultStyle,
     styleValidation,
-    getAttributes
+    getAttributes,
+    parseGeoStylerFilterToCql
 } from '../StyleEditorUtils';
 
 describe('StyleEditorUtils test', () => {
@@ -1274,5 +1275,102 @@ describe('StyleEditorUtils test', () => {
             { attribute: 'name', label: 'alias', type: 'string' },
             { attribute: 'count', label: 'count', type: 'number' }
         ]);
+    });
+    describe('StyleEditorUtils parseGeoStylerFilterToCql', () => {
+        it('test parseGeoStylerFilterToCql with simple geostyler filter', () => {
+            const simpleGeostylerFilter = [
+                "&&",
+                [
+                    "<",
+                    "FIELD_01",
+                    10
+                ],
+                [
+                    ">",
+                    "FIELD_01",
+                    0
+                ]
+            ];
+            expect(parseGeoStylerFilterToCql(simpleGeostylerFilter)).toBe(`("FIELD_01" < \'10\' AND "FIELD_01" > \'0\')`);
+        });
+        it('test parseGeoStylerFilterToCql with a geostyler filter with direct group', () => {
+            const geostylerFilterWithDirectGroup = [
+                "&&",
+                [
+                    "<",
+                    "FIELD_01",
+                    10
+                ],
+                [
+                    ">",
+                    "FIELD_01",
+                    0
+                ],
+                [
+                    "&&",
+                    [
+                        "<",
+                        "FIELD_02",
+                        200000
+                    ],
+                    [
+                        ">",
+                        "FIELD_02",
+                        150000
+                    ]
+                ]
+            ];
+            expect(parseGeoStylerFilterToCql(geostylerFilterWithDirectGroup)).toBe(`("FIELD_01" < \'10\' AND "FIELD_01" > \'0\' AND ("FIELD_02" < \'200000\' AND "FIELD_02" > \'150000\'))`);
+        });
+        it('test parseGeoStylerFilterToCql with complex geostyler filter', () => {
+            const complexGeostylerFilter = [
+                "||",
+                [
+                    ">",
+                    "FIELD_02",
+                    2000
+                ],
+                [
+                    "&&",
+                    [
+                        ">",
+                        "FIELD_01",
+                        0
+                    ],
+                    [
+                        "<",
+                        "FIELD_01",
+                        100000
+                    ],
+                    [
+                        "&&",
+                        [
+                            "<",
+                            "FIELD_01",
+                            210000
+                        ],
+                        [
+                            ">",
+                            "FIELD_01",
+                            152000
+                        ]
+                    ]
+                ],
+                [
+                    "&&",
+                    [
+                        "<",
+                        "FIELD_01",
+                        200000
+                    ],
+                    [
+                        ">",
+                        "FIELD_01",
+                        150000
+                    ]
+                ]
+            ];
+            expect(parseGeoStylerFilterToCql(complexGeostylerFilter)).toBe(`("FIELD_02" > \'2000\' OR ("FIELD_01" > \'0\' AND "FIELD_01" < \'100000\' AND ("FIELD_01" < \'210000\' AND "FIELD_01" > \'152000\')) OR ("FIELD_01" < \'200000\' AND "FIELD_01" > \'150000\'))`);
+        });
     });
 });


### PR DESCRIPTION
## Description
In this PR, interactive legend functionality for WMS/WFS layers is implemented. User can configure enabling the interactive legend for vector layer from display tab in layer settings. Legend filter will be reset if user change the style and user can reset it manually by clicking on the selected filter legend again to remove the legend filter.

This PR includes: 
- Adding interactive legend for vector layers
- Add checkbox for enable the interactive legend for vector into layer settings
- handle the logic of filter by legend for vector layer in case of 2d openlayer map and 3d cesium map
- write unit tests based on code changes

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue
#10026 

**What is the current behavior?**
#10026 

**What is the new behavior?**
User can add vector layer and enable the interactive legend to enable him/her to filter the layer if user change style that includes filter expressions like classification style for example.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
