### PR TITLE
#10196 3D map context throws an error using browser history navigation

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -466,6 +466,13 @@ class CesiumMap extends React.Component {
             // avoid errors like 44.40641479 !== 44.40641478999999
             return a.toFixed(12) - b.toFixed(12) <= 0.000000000001;
         };
+
+        // there are some transition cases where the center is not defined
+        // so we could avoid to compute the setView if the center value is missing
+        if (newProps.center === undefined) {
+            return;
+        }
+
         const centerIsUpdate = !isNearlyEqual(newProps.center.x, currentCenter.longitude) ||
                                !isNearlyEqual(newProps.center.y, currentCenter.latitude);
         const zoomChanged = newProps.zoom !== currentZoom;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes the computation of view in Cesium map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10196

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The application does not break when navigating the browser history on context pages

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
