### PR TITLE
#10197: fix Skipping 'Configure Map' step breaks context configuration

### DIFF
--- a/web/client/selectors/__tests__/contextcreator-test.js
+++ b/web/client/selectors/__tests__/contextcreator-test.js
@@ -97,7 +97,18 @@ describe('contextcreator selectors', () => {
         const source = {
             map: {
                 present: {
-                    zoom: 10
+                    center: [20, 21],
+                    maxExtent: [0, 0, 0, 0],
+                    projection: 'EPSG:4326',
+                    units: 'meters',
+                    mapInfoControl: {},
+                    zoom: 10,
+                    mapOptions: {},
+                    layers: [],
+                    groups: [],
+                    backgrounds: [],
+                    text_search_config: undefined,
+                    bookmark_search_config: undefined
                 }
             },
             contextcreator: {
@@ -121,11 +132,11 @@ describe('contextcreator selectors', () => {
                 mapConfig: {
                     version: 2,
                     map: {
-                        center: undefined,
-                        maxExtent: undefined,
-                        projection: undefined,
-                        units: undefined,
-                        mapInfoControl: undefined,
+                        center: [20, 21],
+                        maxExtent: [0, 0, 0, 0],
+                        projection: 'EPSG:4326',
+                        units: 'meters',
+                        mapInfoControl: {},
                         zoom: 10,
                         mapOptions: {},
                         layers: [],
@@ -176,6 +187,9 @@ describe('contextcreator selectors', () => {
             metadata: { name: undefined }
         };
         const generatedSource = generateContextResource(source);
-        expect(generatedSource).toEqual(expected);
+        expect(generatedSource.data.mapConfig.map).toEqual(expected.data.mapConfig.map);
+        expect(generatedSource.data.plugins).toEqual(expected.data.plugins);
+        expect(generatedSource.data.plugins).toEqual(expected.data.plugins);
+        expect(generatedSource.data.theme).toEqual(expected.data.theme);
     });
 });

--- a/web/client/selectors/contextcreator.js
+++ b/web/client/selectors/contextcreator.js
@@ -50,7 +50,14 @@ export const prefetchedDataSelector = state => get(state, 'contextcreator.prefet
 export const disableImportSelector = state => creationStepSelector(state) !== "general-settings";
 
 export const generateContextResource = (state) => {
-    const mapConfig = mapSelector(state) ? mapSaveSelector(state) : {};
+    // in some cases: mapSelector(state) includes only eventListeners so check if mapSelector includes center prop
+    const isMapConfigNotChanged = !mapSelector(state)?.center;
+    let mapConfig = {};
+    if (isMapConfigNotChanged) {
+        mapConfig = mapConfigSelector(state) || {};
+    } else {
+        mapConfig = mapSelector(state) ? mapSaveSelector(state) : {};
+    }
     const plugins = pluginsSelector(state);
     const context = newContextSelector(state);
     const resource = resourceSelector(state);

--- a/web/client/selectors/contextcreator.js
+++ b/web/client/selectors/contextcreator.js
@@ -50,13 +50,14 @@ export const prefetchedDataSelector = state => get(state, 'contextcreator.prefet
 export const disableImportSelector = state => creationStepSelector(state) !== "general-settings";
 
 export const generateContextResource = (state) => {
-    // in some cases: mapSelector(state) includes only eventListeners so check if mapSelector includes center prop
-    const isMapConfigNotChanged = !mapSelector(state)?.center;
+    // in some cases, 'mapSelector' doesn't include map configuration, so check and add the map config if missing
+    const map = mapSelector(state);
+    const isMapConfigPresent = !map?.center;
     let mapConfig = {};
-    if (isMapConfigNotChanged) {
+    if (isMapConfigPresent) {
         mapConfig = mapConfigSelector(state) || {};
     } else {
-        mapConfig = mapSelector(state) ? mapSaveSelector(state) : {};
+        mapConfig = map ? mapSaveSelector(state) : {};
     }
     const plugins = pluginsSelector(state);
     const context = newContextSelector(state);


### PR DESCRIPTION
## Description
In this PR: fixing the issue of beak context due to missing map config in case of edit an existing context by skip map configure tab

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue
#10197 

**What is the current behavior?**
#10197 

**What is the new behavior?**
 Editing an existing context by skip map configure tab is working without break context 


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
