### PR TITLE
[Backport C040-2024.01.xx] #10197: fix Skipping 'Configure Map' step breaks context configuration (#10207)

### DIFF
--- a/web/client/selectors/__tests__/contextcreator-test.js
+++ b/web/client/selectors/__tests__/contextcreator-test.js
@@ -97,7 +97,18 @@ describe('contextcreator selectors', () => {
         const source = {
             map: {
                 present: {
-                    zoom: 10
+                    center: [20, 21],
+                    maxExtent: [0, 0, 0, 0],
+                    projection: 'EPSG:4326',
+                    units: 'meters',
+                    mapInfoControl: {},
+                    zoom: 10,
+                    mapOptions: {},
+                    layers: [],
+                    groups: [],
+                    backgrounds: [],
+                    text_search_config: undefined,
+                    bookmark_search_config: undefined
                 }
             },
             contextcreator: {
@@ -121,11 +132,11 @@ describe('contextcreator selectors', () => {
                 mapConfig: {
                     version: 2,
                     map: {
-                        center: undefined,
-                        maxExtent: undefined,
-                        projection: undefined,
-                        units: undefined,
-                        mapInfoControl: undefined,
+                        center: [20, 21],
+                        maxExtent: [0, 0, 0, 0],
+                        projection: 'EPSG:4326',
+                        units: 'meters',
+                        mapInfoControl: {},
                         zoom: 10,
                         mapOptions: {},
                         layers: [],
@@ -176,6 +187,9 @@ describe('contextcreator selectors', () => {
             metadata: { name: undefined }
         };
         const generatedSource = generateContextResource(source);
-        expect(generatedSource).toEqual(expected);
+        expect(generatedSource.data.mapConfig.map).toEqual(expected.data.mapConfig.map);
+        expect(generatedSource.data.plugins).toEqual(expected.data.plugins);
+        expect(generatedSource.data.plugins).toEqual(expected.data.plugins);
+        expect(generatedSource.data.theme).toEqual(expected.data.theme);
     });
 });

--- a/web/client/selectors/contextcreator.js
+++ b/web/client/selectors/contextcreator.js
@@ -50,7 +50,15 @@ export const prefetchedDataSelector = state => get(state, 'contextcreator.prefet
 export const disableImportSelector = state => creationStepSelector(state) !== "general-settings";
 
 export const generateContextResource = (state) => {
-    const mapConfig = mapSelector(state) ? mapSaveSelector(state) : {};
+    // in some cases, 'mapSelector' doesn't include map configuration, so check and add the map config if missing
+    const map = mapSelector(state);
+    const isMapConfigPresent = !map?.center;
+    let mapConfig = {};
+    if (isMapConfigPresent) {
+        mapConfig = mapConfigSelector(state) || {};
+    } else {
+        mapConfig = map ? mapSaveSelector(state) : {};
+    }
     const plugins = pluginsSelector(state);
     const context = newContextSelector(state);
     const resource = resourceSelector(state);


### PR DESCRIPTION
Backport C040-2024.01.xx - https://github.com/geosolutions-it/MapStore2/issues/10197: fix Skipping 'Configure Map' step breaks context configuration  https://github.com/geosolutions-it/MapStore2/pull/10207

fixing the issue of beak context due to missing map config in case of edit an existing context by skip map configure tab