### PR TITLE
Update pom.xml

### DIFF
--- a/binary/pom.xml
+++ b/binary/pom.xml
@@ -116,7 +116,7 @@
                         <configuration>
                             <tasks>
                                 <echo message="Downloading JRE..."/>
-                                <get src="https://www.dropbox.com/s/68r915h7hxaq5ms/jre.tar.gz?dl=1"
+                                <get src="https://www.dropbox.com/scl/fi/2rjaso3cxgab0jdjxwpjr/jre.tar.gz?rlkey=1wrf6mcemn5d2e88t8u0wxbk3&amp;dl=1"
                                      dest="${project.build.directory}/jre.tar.gz"/>
                                 <echo message="Untar JRE..."/>
                                 <gunzip src="${project.build.directory}/jre.tar.gz"


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10200 

The pom.xml contains an outdated link of JDK, causing MapStore to crash when started as binary

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
At pom.xml file. I have just updated the link to download Java JDK to the latest version 11.0.16+8.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information