### PR TITLE
#10196 fix context wizard error

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -151,14 +151,20 @@ class CesiumMap extends React.Component {
         this.subscribeClickEvent(map);
 
         this.hand.setInputAction(throttle(this.onMouseMove.bind(this), 500), Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        map.camera.setView({
-            destination: Cesium.Cartesian3.fromDegrees(
-                this.props.viewerOptions?.cameraPosition?.longitude ?? this.props.center.x,
-                this.props.viewerOptions?.cameraPosition?.latitude ?? this.props.center.y,
-                this.props.viewerOptions?.cameraPosition?.height ?? this.getHeightFromZoom(this.props.zoom)
-            ),
-            orientation: this.props.viewerOptions?.orientation
-        });
+
+        const destination = [
+            this.props.viewerOptions?.cameraPosition?.longitude ?? this.props.center?.x,
+            this.props.viewerOptions?.cameraPosition?.latitude ?? this.props.center?.y,
+            this.props.viewerOptions?.cameraPosition?.height ?? this.getHeightFromZoom(this.props.zoom)
+        ];
+        // sometimes the center is undefined on browser history navigation
+        // we should not perform setView in these cases
+        if (destination[0] !== undefined && destination[1] !== undefined) {
+            map.camera.setView({
+                destination: Cesium.Cartesian3.fromDegrees(...destination),
+                orientation: this.props.viewerOptions?.orientation
+            });
+        }
 
         this.setMousePointer(this.props.mousePointer);
 
@@ -485,7 +491,7 @@ class CesiumMap extends React.Component {
                 destination: Cesium.Cartesian3.fromDegrees(
                     newProps.viewerOptions?.cameraPosition?.longitude ?? newProps.center.x,
                     newProps.viewerOptions?.cameraPosition?.latitude ?? newProps.center.y,
-                    newProps.viewerOptions?.cameraPosition?.height ?? this.getHeightFromZoom(newProps.zoom)
+                    newProps.viewerOptions?.cameraPosition?.height ?? this.getHeightFromZoom(newProps.zoom ?? 0)
                 ),
                 orientation: newProps.viewerOptions?.orientation
             };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes the problem reported here https://github.com/geosolutions-it/MapStore2/pull/10198#issuecomment-2056960816

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10196

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

This fix removes the error about the browser navigation inside context wizard with 3D maps

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
