### PR TITLE
Fix #10233 Add support for HTML response for WFS layer

### DIFF
--- a/web/client/api/__tests__/WFS-test.js
+++ b/web/client/api/__tests__/WFS-test.js
@@ -7,7 +7,8 @@ import {
     getFeatureLayer,
     toDescribeURL,
     getCapabilitiesURL,
-    getFeatureURL
+    getFeatureURL,
+    getSupportedFormat
 } from '../WFS';
 
 let mockAxios;
@@ -22,106 +23,180 @@ describe('Test WFS ogc API functions', () => {
         mockAxios.restore();
         setTimeout(done);
     });
-    describe('getFeatureLayer', () => {
-        const schemaString = 'xmlns:gml="http://www.opengis.net/gml" '
-                    + 'xmlns:wfs="http://www.opengis.net/wfs" '
-                    + 'xmlns:ogc="http://www.opengis.net/ogc" '
-                    + 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
-                    + 'xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd" ';
-        it('getFeatureLayer', (done) => {
-            mockAxios.onPost().reply(({url, data, headers}) => {
-                expect(url).toContain('test');
-                expect(data).toEqual(
-                    `<wfs:GetFeature service="WFS" version="1.1.0" `
-                    + schemaString
-                    + `resultType="results" outputFormat="application/json">`
-                    + `<wfs:Query typeName="layer1" srsName="EPSG:4326"></wfs:Query></wfs:GetFeature>`);
-                // check headers passed
-                expect(headers.Authentication).toBe('Basic token');
-                return [200, {
-                    featureTypes: [{
-                        name: 'layer1'
-                    }]
-                }];
-            });
-            getFeatureLayer({
-                type: 'wfs',
-                url: 'test',
-                name: 'layer1'
-            }, {}, {
-                headers: {
-                    'Authentication': 'Basic token'
-                }
-            }).then((data) => {
-                expect(data).toExist();
-                done();
-            });
-        });
-        it('getFeatureLayer with layerFilter', (done) => {
-            mockAxios.onPost().reply(({url, data}) => {
-                expect(url).toContain('test');
-                // some checks on the filter presence
-                expect(data).toContain('<ogc:Filter>');
-                expect(data).toContain('<ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo>');
-                return [200, {
-                    featureTypes: [{
-                        name: 'layer1'
-                    }]
-                }];
-            });
-            getFeatureLayer({
-                type: 'wfs',
-                url: 'test',
-                name: 'layer1',
-                layerFilter: {
-                    filters: [{
-                        format: 'cql',
-                        body: "prop = 'value'"
-                    }]
-                }
-            }).then((data) => {
-                expect(data).toExist();
-                done();
-            });
-        });
-        it('getFeatureLayer with layer filter and filter passed', (done) => {
-            mockAxios.onPost().reply(({url, data}) => {
-                expect(url).toContain('test');
-                // some checks on the filter presence
-                expect(data).toContain('<ogc:Filter><ogc:And>');
-                expect(data).toContain('<ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo>');
-                expect(data).toContain('<ogc:PropertyIsEqualTo><ogc:PropertyName>prop2</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo>');
 
-                return [200, {
-                    featureTypes: [{
-                        name: 'layer1'
-                    }]
-                }];
-            });
-            getFeatureLayer({
-                type: 'wfs',
-                url: 'test',
-                name: 'layer1',
-                layerFilter: {
-                    filters: [{
-                        format: 'cql',
-                        body: "prop = 'value'"
-                    }]
-                }
-            }, {
-                filters: [{
-                    // a mapstore filter
-                    filters: [{
-                        format: 'cql',
-                        body: "prop2 = 'value'"
-                    }]
+    const schemaString = 'xmlns:gml="http://www.opengis.net/gml" '
+        + 'xmlns:wfs="http://www.opengis.net/wfs" '
+        + 'xmlns:ogc="http://www.opengis.net/ogc" '
+        + 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+        + 'xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd" ';
+    it('getFeatureLayer', (done) => {
+        mockAxios.onPost().reply(({ url, data, headers }) => {
+            expect(url).toContain('test');
+            expect(data).toEqual(
+                `<wfs:GetFeature service="WFS" version="1.1.0" `
+                + schemaString
+                + `resultType="results" outputFormat="application/json">`
+                + `<wfs:Query typeName="layer1" srsName="EPSG:4326"></wfs:Query></wfs:GetFeature>`);
+            // check headers passed
+            expect(headers.Authentication).toBe('Basic token');
+            return [200, {
+                featureTypes: [{
+                    name: 'layer1'
                 }]
-            }).then((data) => {
-                expect(data).toExist();
-                done();
-            });
+            }];
+        });
+        getFeatureLayer({
+            type: 'wfs',
+            url: 'test',
+            name: 'layer1'
+        }, {}, {
+            headers: {
+                'Authentication': 'Basic token'
+            }
+        }).then((data) => {
+            expect(data).toExist();
+            done();
         });
     });
+    it('getFeatureLayer with layerFilter', (done) => {
+        mockAxios.onPost().reply(({ url, data }) => {
+            expect(url).toContain('test');
+            // some checks on the filter presence
+            expect(data).toContain('<ogc:Filter>');
+            expect(data).toContain('<ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo>');
+            return [200, {
+                featureTypes: [{
+                    name: 'layer1'
+                }]
+            }];
+        });
+        getFeatureLayer({
+            type: 'wfs',
+            url: 'test',
+            name: 'layer1',
+            layerFilter: {
+                filters: [{
+                    format: 'cql',
+                    body: "prop = 'value'"
+                }]
+            }
+        }).then((data) => {
+            expect(data).toExist();
+            done();
+        });
+    });
+    it('getFeatureLayer with layer filter and filter passed', (done) => {
+        mockAxios.onPost().reply(({ url, data }) => {
+            expect(url).toContain('test');
+            // some checks on the filter presence
+            expect(data).toContain('<ogc:Filter><ogc:And>');
+            expect(data).toContain('<ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo>');
+            expect(data).toContain('<ogc:PropertyIsEqualTo><ogc:PropertyName>prop2</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo>');
+
+            return [200, {
+                featureTypes: [{
+                    name: 'layer1'
+                }]
+            }];
+        });
+        getFeatureLayer({
+            type: 'wfs',
+            url: 'test',
+            name: 'layer1',
+            layerFilter: {
+                filters: [{
+                    format: 'cql',
+                    body: "prop = 'value'"
+                }]
+            }
+        }, {
+            filters: [{
+                // a mapstore filter
+                filters: [{
+                    format: 'cql',
+                    body: "prop2 = 'value'"
+                }]
+            }]
+        }).then((data) => {
+            expect(data).toExist();
+            done();
+        });
+    });
+
+    it('getSupportedFormat without text/html format', (done) => {
+        mockAxios.onGet().reply(200, `
+            <wfs:WFS_Capabilities>
+            <ows:OperationsMetadata>
+            <ows:Operation name="GetFeature">
+                <ows:Parameter name="outputFormat">
+                    <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+                    <ows:Value>GML2</ows:Value>
+                    <ows:Value>KML</ows:Value>
+                    <ows:Value>SHAPE-ZIP</ows:Value>
+                    <ows:Value>application/geopackage+sqlite3</ows:Value>
+                    <ows:Value>application/gml+xml; version=3.2</ows:Value>
+                    <ows:Value>application/json</ows:Value>
+                    <ows:Value>application/vnd.google-earth.kml xml</ows:Value>
+                    <ows:Value>application/vnd.google-earth.kml+xml</ows:Value>
+                    <ows:Value>application/x-gpkg</ows:Value>
+                    <ows:Value>csv</ows:Value>
+                    <ows:Value>geopackage</ows:Value>
+                    <ows:Value>geopkg</ows:Value>
+                    <ows:Value>gml3</ows:Value>
+                    <ows:Value>gml32</ows:Value>
+                    <ows:Value>gpkg</ows:Value>
+                    <ows:Value>json</ows:Value>
+                    <ows:Value>text/csv</ows:Value>
+                    <ows:Value>text/xml; subtype=gml/2.1.2</ows:Value>
+                    <ows:Value>text/xml; subtype=gml/3.2</ows:Value>
+                </ows:Parameter>
+            </ows:Operation>
+            </ows:OperationsMetadata>
+            </wfs:WFS_Capabilities>
+            `);
+        getSupportedFormat('/geoserver-without-text-html/wfs').then((data) => {
+            expect(data).toEqual({ infoFormats: ['application/json'] });
+            done();
+        }).catch(done);
+    });
+    it('getSupportedFormat with text/html format', (done) => {
+        mockAxios.onGet().reply(200, `
+            <wfs:WFS_Capabilities>
+            <ows:OperationsMetadata>
+            <ows:Operation name="GetFeature">
+                <ows:Parameter name="outputFormat">
+                    <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+                    <ows:Value>GML2</ows:Value>
+                    <ows:Value>KML</ows:Value>
+                    <ows:Value>SHAPE-ZIP</ows:Value>
+                    <ows:Value>application/geopackage+sqlite3</ows:Value>
+                    <ows:Value>application/gml+xml; version=3.2</ows:Value>
+                    <ows:Value>application/json</ows:Value>
+                    <ows:Value>application/vnd.google-earth.kml xml</ows:Value>
+                    <ows:Value>application/vnd.google-earth.kml+xml</ows:Value>
+                    <ows:Value>application/x-gpkg</ows:Value>
+                    <ows:Value>csv</ows:Value>
+                    <ows:Value>geopackage</ows:Value>
+                    <ows:Value>geopkg</ows:Value>
+                    <ows:Value>gml3</ows:Value>
+                    <ows:Value>gml32</ows:Value>
+                    <ows:Value>gpkg</ows:Value>
+                    <ows:Value>json</ows:Value>
+                    <ows:Value>text/csv</ows:Value>
+                    <ows:Value>text/html</ows:Value>
+                    <ows:Value>text/xml; subtype=gml/2.1.2</ows:Value>
+                    <ows:Value>text/xml; subtype=gml/3.2</ows:Value>
+                </ows:Parameter>
+            </ows:Operation>
+            </ows:OperationsMetadata>
+            </wfs:WFS_Capabilities>
+            `);
+        getSupportedFormat('/geoserver-with-text-html/wfs').then((data) => {
+            expect(data).toEqual({ infoFormats: ['application/json', 'text/html'] });
+            done();
+        }).catch(done);
+    });
+
     it('toDescribeURL with URL array', () => {
         const _url = [
             'http://gs-stable.geosolutionsgroup.com:443/geoserver1',

--- a/web/client/api/catalog/WFS.js
+++ b/web/client/api/catalog/WFS.js
@@ -7,20 +7,15 @@
  */
 
 import { cleanAuthParamsFromURL } from '../../utils/SecurityUtils';
-import ConfigUtils from '../../utils/ConfigUtils';
 import { getRecordLinks, extractOGCServicesReferences } from '../../utils/CatalogUtils';
 
 import { getCapabilities, getCapabilitiesURL } from '../WFS';
-import xml2js from 'xml2js';
 import {
     validate as commonValidate,
     testService as commonTestService,
     preprocess as commonPreprocess
 } from './common';
 import { get, castArray } from 'lodash';
-
-const capabilitiesCache = {};
-
 
 const searchAndPaginate = (json = {}, startPosition, maxRecords, text) => {
 
@@ -95,22 +90,8 @@ const recordToLayer = (record) => {
 };
 
 export const getRecords = (url, startPosition, maxRecords, text, info) => {
-    const cached = capabilitiesCache[url];
-    if (cached && new Date().getTime() < cached.timestamp + (ConfigUtils.getConfigProp('cacheExpire') || 60) * 1000) {
-        return new Promise((resolve) => {
-            resolve(searchAndPaginate(cached.data, startPosition, maxRecords, text, info));
-        });
-    }
-    return getCapabilities(url).then((response) => {
-        let json;
-        xml2js.parseString(response.data, { explicitArray: false, stripPrefix: true }, (ignore, result) => {
-            json = { ...result, url };
-        });
-        capabilitiesCache[url] = {
-            timestamp: new Date().getTime(),
-            data: json
-        };
-        return searchAndPaginate(json, startPosition, maxRecords, text, info);
+    return getCapabilities(url).then((data) => {
+        return searchAndPaginate(data, startPosition, maxRecords, text, info);
     });
 };
 

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -386,6 +386,7 @@ class CesiumMap extends React.Component {
                 let msId;
                 let properties;
                 let geometry = null;
+                let id;
                 if (feature instanceof Cesium.Cesium3DTileFeature && feature?.tileset?.msId) {
                     msId = feature.tileset.msId;
                     // 3d tile feature does not contain a geometry in the Cesium3DTileFeature class
@@ -397,16 +398,18 @@ class CesiumMap extends React.Component {
                     const value = getFeatureById(feature.id);
                     properties = value.feature.properties;
                     geometry = value.feature.geometry;
+                    id = value.feature.id;
                     msId = value.msId;
                 }
                 if (!properties || !msId) {
                     return acc;
                 }
+                const newFeature = { type: 'Feature', properties, geometry, ...(id && { id }) };
                 return {
                     ...acc,
                     [msId]: acc[msId]
-                        ? [...acc[msId], { type: 'Feature', properties, geometry }]
-                        : [{ type: 'Feature', properties, geometry }]
+                        ? [...acc[msId], newFeature]
+                        : [newFeature]
                 };
             }, []);
             return Object.keys(groupIntersectedFeatures).map(id => ({ id, features: groupIntersectedFeatures[id] }));

--- a/web/client/plugins/tocitemssettings/tabs/FeatureInfo/index.jsx
+++ b/web/client/plugins/tocitemssettings/tabs/FeatureInfo/index.jsx
@@ -92,7 +92,7 @@ const formatCards = {
 };
 const FeatureInfo = defaultProps({
     formatCards,
-    defaultInfoFormat: Object.assign({ "HIDDEN": "text/html"}, getAvailableInfoFormat())
+    defaultInfoFormat: getAvailableInfoFormat()
 })(FeatureInfoCmp);
 
 export default FeatureInfo;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR includes the possibility to use HTML get feature info for WFS when available as output format

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10233

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
