### PR TITLE
Fix #10243 removing toggle mode of non active longitudinal profile tool

### DIFF
--- a/web/client/epics/longitudinalProfile.js
+++ b/web/client/epics/longitudinalProfile.js
@@ -385,7 +385,7 @@ export const LPresetLongitudinalToolOnDrawToolActiveEpic = (action$, store) => s
     () => {
         return Rx.Observable.of(toggleMode());
     },
-    () => dataSourceModeSelector(store.getState())
+    () => !!dataSourceModeSelector(store.getState()) && dataSourceModeSelector(store.getState()) !== "idle"
 );
 
 /**

--- a/web/client/epics/longitudinalProfile.js
+++ b/web/client/epics/longitudinalProfile.js
@@ -135,7 +135,7 @@ export const LPonDrawActivatedEpic = (action$, store) =>
                             );
                     })
                     .startWith(
-                        unRegisterEventListener('click', CONTROL_NAME),
+                        registerEventListener('click', CONTROL_NAME),
                         changeMapInfoState(false),
                         purgeMapInfoResults(),
                         hideMapinfoMarker(),
@@ -156,7 +156,7 @@ export const LPonDrawActivatedEpic = (action$, store) =>
                 return Rx.Observable.from([
                     purgeMapInfoResults(),
                     hideMapinfoMarker(),
-                    toggleMapInfoState(),
+                    changeMapInfoState(mode !== undefined),
                     ...(get(store.getState(), 'draw.drawOwner', '') === CONTROL_NAME ? DEACTIVATE_ACTIONS : []),
                     unRegisterEventListener('click', CONTROL_NAME)
                 ]);
@@ -385,7 +385,7 @@ export const LPresetLongitudinalToolOnDrawToolActiveEpic = (action$, store) => s
     () => {
         return Rx.Observable.of(toggleMode());
     },
-    () => !!dataSourceModeSelector(store.getState()) && dataSourceModeSelector(store.getState()) !== "idle"
+    () => dataSourceModeSelector(store.getState()) === "draw"
 );
 
 /**

--- a/web/client/plugins/StreetView/epics/streetView.js
+++ b/web/client/plugins/StreetView/epics/streetView.js
@@ -13,7 +13,7 @@ import { updateAdditionalLayer, removeAdditionalLayer } from '../../../actions/a
 import { CLICK_ON_MAP, registerEventListener, unRegisterEventListener } from '../../../actions/map';
 
 
-import {hideMapinfoMarker, toggleMapInfoState} from '../../../actions/mapInfo';
+import {hideMapinfoMarker, changeMapInfoState} from '../../../actions/mapInfo';
 import { mapInfoEnabledSelector } from "../../../selectors/mapInfo";
 
 import { CONTROL_NAME, STREET_VIEW_OWNER, STREET_VIEW_DATA_LAYER_ID } from "../constants";
@@ -42,11 +42,10 @@ export const disableGFIForStreetViewEpic = (action$, { getState = () => { } }) =
         .filter(({control}) => control === CONTROL_NAME)
         // if the enable event happens when the mapInfo is active
         .filter(() => enabledSelector(getState()))
-        .filter(() => mapInfoEnabledSelector(getState()))
         .switchMap(() => {
             // deactivate feature info
             return Rx.Observable.of(hideMapinfoMarker(),
-                toggleMapInfoState()
+                changeMapInfoState(false) // always disable feature info
             ).merge(
                 // restore feature info on close
                 action$.ofType(TOGGLE_CONTROL, SET_CONTROL_PROPERTY, SET_CONTROL_PROPERTIES)
@@ -54,7 +53,7 @@ export const disableGFIForStreetViewEpic = (action$, { getState = () => { } }) =
                     .take(1)
                     .filter(() => !enabledSelector(getState()))
                     .filter(() => !mapInfoEnabledSelector(getState()))
-                    .mapTo(toggleMapInfoState())
+                    .mapTo(changeMapInfoState(true))
                     .takeUntil(action$.ofType(RESET_CONTROLS))
             );
         });


### PR DESCRIPTION
* this was causing the identify to toggle state twice instead of one

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10243

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

the identify tool remains disabled

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
