### PR TITLE
#10026: fix functional tests for Interactive legend for TOC layers [WMS Support]

### DIFF
--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -38,12 +38,14 @@ export default class extends React.Component {
         isCesiumActive: PropTypes.bool,
         projection: PropTypes.string,
         resolutions: PropTypes.array,
-        zoom: PropTypes.number
+        zoom: PropTypes.number,
+        isMapOpen: PropTypes.bool
     };
 
     static defaultProps = {
         onChange: () => {},
-        opacityText: <Message msgId="opacity"/>
+        opacityText: <Message msgId="opacity"/>,
+        isMapOpen: false
     };
 
     constructor(props) {
@@ -263,7 +265,7 @@ export default class extends React.Component {
                         <Col xs={12} className={"legend-label"}>
                             <label key="legend-options-title" className="control-label"><Message msgId="layerProperties.legendOptions.title" /></label>
                         </Col>
-                        { this.props.element?.serverType !== ServerTypes.NO_VENDOR &&
+                        { this.props.element?.serverType !== ServerTypes.NO_VENDOR && this.props?.isMapOpen &&
                             <Col xs={12} className="first-selectize">
                                 <Checkbox
                                     data-qa="display-interactive-legend-option"

--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -39,13 +39,13 @@ export default class extends React.Component {
         projection: PropTypes.string,
         resolutions: PropTypes.array,
         zoom: PropTypes.number,
-        isMapOpen: PropTypes.bool
+        hideInteractiveLegendOption: PropTypes.bool
     };
 
     static defaultProps = {
         onChange: () => {},
         opacityText: <Message msgId="opacity"/>,
-        isMapOpen: false
+        hideInteractiveLegendOption: false
     };
 
     constructor(props) {
@@ -265,7 +265,7 @@ export default class extends React.Component {
                         <Col xs={12} className={"legend-label"}>
                             <label key="legend-options-title" className="control-label"><Message msgId="layerProperties.legendOptions.title" /></label>
                         </Col>
-                        { this.props.element?.serverType !== ServerTypes.NO_VENDOR && this.props?.isMapOpen &&
+                        { this.props.element?.serverType !== ServerTypes.NO_VENDOR && !this.props?.hideInteractiveLegendOption &&
                             <Col xs={12} className="first-selectize">
                                 <Checkbox
                                     data-qa="display-interactive-legend-option"

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -52,7 +52,7 @@ describe('test Layer Properties Display module component', () => {
         ReactTestUtils.Simulate.focus(inputs[0]);
         expect(inputs[0].value).toBe('100');
     });
-    it('tests Display component for wms', () => {
+    it('tests Display component for wms for map viewer', () => {
         const l = {
             name: 'layer00',
             title: 'Layer',
@@ -70,11 +70,39 @@ describe('test Layer Properties Display module component', () => {
         let spy = expect.spyOn(handlers, "onChange");
         // wrap in a stateful component, stateless components render return null
         // see: https://facebook.github.io/react/docs/top-level-api.html#reactdom.render
-        const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<Display element={l} isMapOpen settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toBeTruthy();
         expect(inputs.length).toBe(14);
+        ReactTestUtils.Simulate.focus(inputs[2]);
+        expect(inputs[2].value).toBe('70');
+        inputs[8].click();
+        expect(spy.calls.length).toBe(1);
+    });
+    it('tests Display component for wms for dashboard or geostory', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const settings = {
+            options: {opacity: 0.7}
+        };
+        const handlers = {
+            onChange() {}
+        };
+        let spy = expect.spyOn(handlers, "onChange");
+        // wrap in a stateful component, stateless components render return null
+        // see: https://facebook.github.io/react/docs/top-level-api.html#reactdom.render
+        const comp = ReactDOM.render(<Display element={l} isMapOpen={false} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        expect(comp).toBeTruthy();
+        const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
+        expect(inputs).toBeTruthy();
+        expect(inputs.length).toBe(13);
         ReactTestUtils.Simulate.focus(inputs[2]);
         expect(inputs[2].value).toBe('70');
         inputs[8].click();
@@ -227,7 +255,37 @@ describe('test Layer Properties Display module component', () => {
         expect(spyOn.calls[0].arguments).toEqual([ 'forceProxy', true ]);
     });
 
-    it('tests Layer Properties Legend component', () => {
+    it('tests Layer Properties Legend component for map viewer only', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const settings = {
+            options: {opacity: 1}
+        };
+        const handlers = {
+            onChange() {}
+        };
+        const comp = ReactDOM.render(<Display element={l} isMapOpen settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        expect(comp).toBeTruthy();
+        const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "control-label" );
+        const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
+        const legendWidth = inputs[12];
+        const legendHeight = inputs[13];
+        // Default legend values
+        expect(legendWidth.value).toBe('12');
+        expect(legendHeight.value).toBe('12');
+        expect(labels.length).toBe(8);
+        expect(labels[4].innerText).toBe("layerProperties.legendOptions.title");
+        expect(labels[5].innerText).toBe("layerProperties.legendOptions.legendWidth");
+        expect(labels[6].innerText).toBe("layerProperties.legendOptions.legendHeight");
+        expect(labels[7].innerText).toBe("layerProperties.legendOptions.legendPreview");
+    });
+    it('tests Layer Properties Legend component for dashboard or geostory', () => {
         const l = {
             name: 'layer00',
             title: 'Layer',
@@ -246,8 +304,8 @@ describe('test Layer Properties Display module component', () => {
         expect(comp).toBeTruthy();
         const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "control-label" );
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
-        const legendWidth = inputs[12];
-        const legendHeight = inputs[13];
+        const legendWidth = inputs[11];
+        const legendHeight = inputs[12];
         // Default legend values
         expect(legendWidth.value).toBe('12');
         expect(legendHeight.value).toBe('12');
@@ -257,7 +315,6 @@ describe('test Layer Properties Display module component', () => {
         expect(labels[6].innerText).toBe("layerProperties.legendOptions.legendHeight");
         expect(labels[7].innerText).toBe("layerProperties.legendOptions.legendPreview");
     });
-
     it('tests Layer Properties Legend component events', () => {
         const l = {
             name: 'layer00',
@@ -281,7 +338,7 @@ describe('test Layer Properties Display module component', () => {
             onChange() {}
         };
         let spy = expect.spyOn(handlers, "onChange");
-        const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<Display element={l} settings={settings} isMapOpen onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         const legendPreview = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "legend-preview" );
@@ -359,7 +416,7 @@ describe('test Layer Properties Display module component', () => {
                 opacity: 1
             }
         };
-        const comp = ReactDOM.render(<Display element={l} settings={settings}/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<Display element={l} isMapOpen settings={settings}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toBeTruthy();

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -70,7 +70,7 @@ describe('test Layer Properties Display module component', () => {
         let spy = expect.spyOn(handlers, "onChange");
         // wrap in a stateful component, stateless components render return null
         // see: https://facebook.github.io/react/docs/top-level-api.html#reactdom.render
-        const comp = ReactDOM.render(<Display element={l} isMapOpen settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toBeTruthy();
@@ -98,7 +98,7 @@ describe('test Layer Properties Display module component', () => {
         let spy = expect.spyOn(handlers, "onChange");
         // wrap in a stateful component, stateless components render return null
         // see: https://facebook.github.io/react/docs/top-level-api.html#reactdom.render
-        const comp = ReactDOM.render(<Display element={l} isMapOpen={false} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<Display element={l} hideInteractiveLegendOption settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toBeTruthy();
@@ -270,7 +270,7 @@ describe('test Layer Properties Display module component', () => {
         const handlers = {
             onChange() {}
         };
-        const comp = ReactDOM.render(<Display element={l} isMapOpen settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "control-label" );
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
@@ -300,7 +300,7 @@ describe('test Layer Properties Display module component', () => {
         const handlers = {
             onChange() {}
         };
-        const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<Display element={l} hideInteractiveLegendOption settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "control-label" );
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
@@ -338,7 +338,7 @@ describe('test Layer Properties Display module component', () => {
             onChange() {}
         };
         let spy = expect.spyOn(handlers, "onChange");
-        const comp = ReactDOM.render(<Display element={l} settings={settings} isMapOpen onChange={handlers.onChange}/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         const legendPreview = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "legend-preview" );
@@ -416,7 +416,7 @@ describe('test Layer Properties Display module component', () => {
                 opacity: 1
             }
         };
-        const comp = ReactDOM.render(<Display element={l} isMapOpen settings={settings}/>, document.getElementById("container"));
+        const comp = ReactDOM.render(<Display element={l} settings={settings}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toBeTruthy();

--- a/web/client/components/widgets/builder/wizard/map/NodeEditor.jsx
+++ b/web/client/components/widgets/builder/wizard/map/NodeEditor.jsx
@@ -41,6 +41,7 @@ export default ({
             {tabs.filter(tab => tab.id && tab.id === activeTab).filter(tab => tab.Component).map(tab => (
                 <tab.Component
                     {...props}
+                    hideInteractiveLegendOption
                     key={'ms-tab-settings-body-' + tab.id}
                     containerWidth={width}
                     element={element}

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -30,7 +30,7 @@ import {
 import { createPlugin } from '../utils/PluginsUtils';
 import defaultSettingsTabs from './tocitemssettings/defaultSettingsTabs';
 import { isCesium } from '../selectors/maptype';
-import { showEditableFeatureCheckboxSelector, isMapOnlyOpenedSelector } from "../seleectors/map";
+import { showEditableFeatureCheckboxSelector, isMapOnlyOpenedSelector } from "../selectors/map";
 import { isAnnotationLayer } from './Annotations/utils/AnnotationsUtils';
 
 const tocItemsSettingsSelector = createSelector([

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -30,7 +30,7 @@ import {
 import { createPlugin } from '../utils/PluginsUtils';
 import defaultSettingsTabs from './tocitemssettings/defaultSettingsTabs';
 import { isCesium } from '../selectors/maptype';
-import { showEditableFeatureCheckboxSelector, isMapOnlyOpenedSelector } from "../selectors/map";
+import { showEditableFeatureCheckboxSelector } from "../selectors/map";
 import { isAnnotationLayer } from './Annotations/utils/AnnotationsUtils';
 
 const tocItemsSettingsSelector = createSelector([
@@ -44,9 +44,8 @@ const tocItemsSettingsSelector = createSelector([
     elementSelector,
     isLocalizedLayerStylesEnabledSelector,
     isCesium,
-    showEditableFeatureCheckboxSelector,
-    isMapOnlyOpenedSelector
-], (settings, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, activeTab, element, isLocalizedLayerStylesEnabled, isCesiumActive, showFeatureEditOption, isMapOpen) => ({
+    showEditableFeatureCheckboxSelector
+], (settings, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, activeTab, element, isLocalizedLayerStylesEnabled, isCesiumActive, showFeatureEditOption) => ({
     settings,
     element,
     groups,
@@ -57,8 +56,7 @@ const tocItemsSettingsSelector = createSelector([
     activeTab,
     isLocalizedLayerStylesEnabled,
     isCesiumActive,
-    showFeatureEditOption,
-    isMapOpen
+    showFeatureEditOption
 }));
 
 const SettingsButton = connect(() => ({}), {
@@ -123,6 +121,7 @@ const SettingsButton = connect(() => ({}), {
  * @prop cfg.hideTitleTranslations {bool} if true hide the title translations tool
  * @prop cfg.showTooltipOptions {bool} if true, it shows tooltip section
  * @prop cfg.initialActiveTab {string} tab that will be enabled initially when the settings are opened. Possible values:
+ * @prop cfg.hideInteractiveLegendOption {bool} if true, it hide the checkbox of enable interactive legend in display tab
  * 'general' (General tab), 'display' (Display tab), 'style' (Style tab), 'feature' (Feature info tab).
  * @example
  * {

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -30,7 +30,7 @@ import {
 import { createPlugin } from '../utils/PluginsUtils';
 import defaultSettingsTabs from './tocitemssettings/defaultSettingsTabs';
 import { isCesium } from '../selectors/maptype';
-import { showEditableFeatureCheckboxSelector } from "../selectors/map";
+import { showEditableFeatureCheckboxSelector, isMapOnlyOpenedSelector } from "../seleectors/map";
 import { isAnnotationLayer } from './Annotations/utils/AnnotationsUtils';
 
 const tocItemsSettingsSelector = createSelector([
@@ -44,8 +44,9 @@ const tocItemsSettingsSelector = createSelector([
     elementSelector,
     isLocalizedLayerStylesEnabledSelector,
     isCesium,
-    showEditableFeatureCheckboxSelector
-], (settings, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, activeTab, element, isLocalizedLayerStylesEnabled, isCesiumActive, showFeatureEditOption) => ({
+    showEditableFeatureCheckboxSelector,
+    isMapOnlyOpenedSelector
+], (settings, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, activeTab, element, isLocalizedLayerStylesEnabled, isCesiumActive, showFeatureEditOption, isMapOpen) => ({
     settings,
     element,
     groups,
@@ -56,7 +57,8 @@ const tocItemsSettingsSelector = createSelector([
     activeTab,
     isLocalizedLayerStylesEnabled,
     isCesiumActive,
-    showFeatureEditOption
+    showFeatureEditOption,
+    isMapOpen
 }));
 
 const SettingsButton = connect(() => ({}), {

--- a/web/client/plugins/mapEditor/DefaultConfiguration.js
+++ b/web/client/plugins/mapEditor/DefaultConfiguration.js
@@ -64,7 +64,12 @@ export default {
             }
         },
         "AddGroup", "MapFooter",
-        "TOCItemsSettings",
+        {
+            "name": "TOCItemsSettings",
+            "cfg": {
+                "hideInteractiveLegendOption": true
+            }
+        },
         "MapImport",
         "MapExport",
         {

--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -155,8 +155,3 @@ export const isMouseMoveIdentifyActiveSelector = (state) => {
 export const identifyFloatingToolSelector = (state) => {
     return mouseMoveListenerSelector(state).includes('identifyFloatingTool') || state.mode === "embedded" || (state.mapPopups?.popups && detectIdentifyInMapPopUp(state));
 };
-
-export const isMapOnlyOpenedSelector = (state) => {
-    // state?.mapEditor?.onwer --> to exclude geostory
-    return projectionSelector(state) && !state?.mapEditor?.owner;
-};

--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -156,3 +156,7 @@ export const identifyFloatingToolSelector = (state) => {
     return mouseMoveListenerSelector(state).includes('identifyFloatingTool') || state.mode === "embedded" || (state.mapPopups?.popups && detectIdentifyInMapPopUp(state));
 };
 
+export const isMapOnlyOpenedSelector = (state) => {
+    // state?.mapEditor?.onwer --> to exclude geostory
+    return projectionSelector(state) && !state?.mapEditor?.owner;
+};

--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -155,3 +155,4 @@ export const isMouseMoveIdentifyActiveSelector = (state) => {
 export const identifyFloatingToolSelector = (state) => {
     return mouseMoveListenerSelector(state).includes('identifyFloatingTool') || state.mode === "embedded" || (state.mapPopups?.popups && detectIdentifyInMapPopUp(state));
 };
+

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -709,6 +709,7 @@ export const saveLayer = (layer) => {
         version: layer.version,
         expanded: layer.expanded || false
     },
+    layer?.enableInteractiveLegend !== undefined ? { enableInteractiveLegend: layer?.enableInteractiveLegend } : {},
     layer.sources ? { sources: layer.sources } : {},
     layer.heightOffset ? { heightOffset: layer.heightOffset } : {},
     layer.params ? { params: layer.params } : {},


### PR DESCRIPTION
## Description
This PR includes fixing functional tests for interactive legend #10026:
- Hide checkbox of enabling interactive legend for WMS layers in dashboard and geostory as they will be implemented in a separate issue.
- fix not saving the flag of enabling interactive legend into wms layers in case save map.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10026


**What is the current behavior?**
Saving map with a layer that has a flag of enabling interactive legend to keep it in each open this map was not working well.
Dashboard and geostory were containing the checkbox of enabling interactive legend in Display tab in layer settings.

**What is the new behavior?**
Save map is handling storing the enable interactive legend flag to keep it stored if user close the map and open it again.
For dashboard and geostory pages, the enable interactive legend checkbox in layer settings in Display tab is hidden now.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
