### PR TITLE
#10250: Fix - Axios 0.28.0 missing paramsSerializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "ag-grid-community": "20.2.0",
     "ag-grid-react": "20.2.0",
     "assert": "2.0.0",
-    "axios": "0.28.0",
+    "axios": "0.28.1",
     "b64-to-blob": "1.2.19",
     "babel-polyfill": "6.8.0",
     "babel-standalone": "6.7.7",


### PR DESCRIPTION
## Description
This PR updates axios version to 0.28.1 to include paramSerializer feature missing in 0.28.

This update doesn't affect other existing features that MS relies on, it adds only missing feature back

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #10250 

**What is the new behavior?**
Param serializer works 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
