### PR TITLE
#10242: Fix - Viewer widgets state not aligned

### DIFF
--- a/web/client/epics/widgets.js
+++ b/web/client/epics/widgets.js
@@ -43,7 +43,7 @@ import {
     getFloatingWidgets,
     getWidgetLayer
 } from '../selectors/widgets';
-import { CHANGE_LAYER_PROPERTIES, LAYER_LOAD, LAYER_ERROR } from '../actions/layers';
+import { CHANGE_LAYER_PROPERTIES, LAYER_LOAD, LAYER_ERROR, UPDATE_NODE } from '../actions/layers';
 
 import { getLayerFromId } from '../selectors/layers';
 import { pathnameSelector } from '../selectors/router';
@@ -261,11 +261,14 @@ export const exportWidgetImage = action$ =>
  * @return {external:Observable}
  */
 export const updateLayerOnLayerPropertiesChange = (action$, store) =>
-    action$.ofType(CHANGE_LAYER_PROPERTIES)
-        .switchMap(({layer, newProperties}) => {
+    action$.ofType(CHANGE_LAYER_PROPERTIES, UPDATE_NODE)
+        .filter(({layer, newProperties, nodeType, options}) => {
+            return (layer && newProperties) || (nodeType === "layers" && has(options, "layerFilter"));
+        })
+        .switchMap(({layer, newProperties, node, options}) => {
             const state = store.getState();
-            const flatLayer = getLayerFromId(state, layer);
-            const shouldUpdate = flatLayer && (has(newProperties, "layerFilter") || has(newProperties, "fields"));
+            const flatLayer = getLayerFromId(state, layer ?? node);
+            const shouldUpdate = flatLayer && (has(newProperties ?? options, "layerFilter") || has(newProperties, "fields"));
             if (shouldUpdate) {
                 return Rx.Observable.of(updateWidgetLayer(flatLayer));
             }


### PR DESCRIPTION
## Description
This PR fixes viewer widgets not updated when layer filters are toggled

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10242

**What is the new behavior?**

https://github.com/geosolutions-it/MapStore2/assets/26929983/7eb1eafc-5016-479c-a48c-4842a4853991



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
