### PR TITLE
[Backport 2024.01.xx] Fix #10252 Mask property is not applied inside views (#10253)

### DIFF
--- a/web/client/utils/cesium/GeoJSONStyledFeatures.js
+++ b/web/client/utils/cesium/GeoJSONStyledFeatures.js
@@ -112,12 +112,12 @@ class GeoJSONStyledFeatures {
             return {
                 polygon: {
                     ...entity.polygon,
-                    hierarchy: new Cesium.PolygonHierarchy(
+                    hierarchy: new Cesium.ConstantProperty(new Cesium.PolygonHierarchy(
                         geometry[0].map(cartesian => cartesian.clone()),
                         geometry
                             .filter((hole, idx) => idx > 0)
-                            .map(hole => hole.map((cartesian) => cartesian.clone()))
-                    )
+                            .map(hole => new Cesium.PolygonHierarchy(hole.map((cartesian) => cartesian.clone())))
+                    ))
                 }
             };
         }
@@ -248,7 +248,7 @@ class GeoJSONStyledFeatures {
                                 primitive.geometry[0].map(cartesian => cartesian.clone()),
                                 primitive.geometry
                                     .filter((hole, idx) => idx > 0)
-                                    .map(hole => hole.map((cartesian) => cartesian.clone()))
+                                    .map(hole => new Cesium.PolygonHierarchy(hole.map((cartesian) => cartesian.clone())))
                             ),
                             arcType: polygon.arcType,
                             perPositionHeight: polygon.height !== undefined ? false : polygon.perPositionHeight,
@@ -322,7 +322,7 @@ class GeoJSONStyledFeatures {
                                 primitive.geometry[0].map(cartesian => cartesian.clone()),
                                 primitive.geometry
                                     .filter((hole, idx) => idx > 0)
-                                    .map(hole => hole.map((cartesian) => cartesian.clone()))
+                                    .map(hole => new Cesium.PolygonHierarchy(hole.map((cartesian) => cartesian.clone())))
                             ),
                             arcType: polygon.arcType,
                             perPositionHeight: polygon.perPositionHeight


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The mask problem has been solved by wrapping the polygon holes with the `Cesium.PolygonHierarchy` class that is the expected structure for Cesium.
There was also another problem with clipping that was happening randomly so this PR introduces an hardening on the management of 3Dtiles layer clippingPlanes property.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10252 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Mask and clipping works again in map views

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
