### PR TITLE
#10225: Enhance UX for simple 3D navigation in touch devices [Implementation via Config-level]

### DIFF
--- a/web/client/components/buttons/ZoomToMaxExtentButton.jsx
+++ b/web/client/components/buttons/ZoomToMaxExtentButton.jsx
@@ -119,7 +119,7 @@ class ZoomToMaxExtentButton extends React.Component {
         // zooming to the initial extent based on initial map configuration
         var mapConfig = this.props.mapInitialConfig;
         let bbox = getBbox(mapConfig.center, mapConfig.zoom, this.props.mapConfig.size);
-        this.props.changeMapView(mapConfig.center, mapConfig.zoom, bbox, this.props.mapConfig.size, null, this.props.mapConfig.projection);
+        this.props.changeMapView(mapConfig.center, mapConfig.zoom, bbox, this.props.mapConfig.size, null, this.props.mapConfig.projection, mapConfig?.viewerOptions);
     };
 }
 

--- a/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
+++ b/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
@@ -204,7 +204,7 @@ describe('This test for ZoomToMaxExtentButton', () => {
             componentSpy.restore();
 
             expect(actionsSpy.calls.length).toBe(1);
-            expect(actionsSpy.calls[0].arguments.length).toBe(6);
+            expect(actionsSpy.calls[0].arguments.length).toBe(7);
             expect(actionsSpy.calls[0].arguments[0]).toExist();
             expect(actionsSpy.calls[0].arguments[1]).toExist();
             // the bbox is null since no hook was registered

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -52,8 +52,7 @@ class CesiumMap extends React.Component {
         errorPanel: PropTypes.func,
         onReload: PropTypes.func,
         style: PropTypes.object,
-        interactive: PropTypes.bool,
-        mapInitialConfig: PropTypes.object
+        interactive: PropTypes.bool
     };
 
     static defaultProps = {
@@ -136,7 +135,7 @@ class CesiumMap extends React.Component {
         if (this.props.registerHooks) {
             this.registerHooks();
         }
-        if (this.props.mapOptions?.navigationTools !== false && !this.props.mapOptions?.hideCompass) {
+        if (this.props.mapOptions?.navigationTools !== false) {
             map.extend(viewerCesiumNavigationMixin, {
                 enableCompass: this.props.mapOptions?.navigationTools,
                 // the default zoom controls inside CesiumNavigation are not working
@@ -152,23 +151,7 @@ class CesiumMap extends React.Component {
         this.subscribeClickEvent(map);
 
         this.hand.setInputAction(throttle(this.onMouseMove.bind(this), 500), Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        if (this.props.mapOptions?.enableQuickResetTo3DView) {
-            if (this.props?.mapInitialConfig?.viewerOptions) {
-                const initDestination = [
-                    this.props?.mapInitialConfig?.viewerOptions?.cameraPosition?.longitude ?? this.props.center?.x,
-                    this.props?.mapInitialConfig?.viewerOptions?.cameraPosition?.latitude ?? this.props.center?.y,
-                    this.props?.mapInitialConfig?.viewerOptions?.cameraPosition?.height ?? this.getHeightFromZoom(this.props.zoom)
-                ];
-                // sometimes the center is undefined on browser history navigation
-                // we should not perform setView in these cases
-                if (initDestination[0] !== undefined && initDestination[1] !== undefined) {
-                    map.camera.setView({
-                        destination: Cesium.Cartesian3.fromDegrees(...initDestination),
-                        orientation: this.props?.mapInitialConfig?.viewerOptions?.orientation
-                    });
-                }
-            }
-        }
+
         const destination = [
             this.props.viewerOptions?.cameraPosition?.longitude ?? this.props.center?.x,
             this.props.viewerOptions?.cameraPosition?.latitude ?? this.props.center?.y,
@@ -176,7 +159,7 @@ class CesiumMap extends React.Component {
         ];
         // sometimes the center is undefined on browser history navigation
         // we should not perform setView in these cases
-        if (destination[0] !== undefined && destination[1] !== undefined && !this.props.mapOptions?.enableQuickResetTo3DView) {
+        if (destination[0] !== undefined && destination[1] !== undefined) {
             map.camera.setView({
                 destination: Cesium.Cartesian3.fromDegrees(...destination),
                 orientation: this.props.viewerOptions?.orientation
@@ -197,38 +180,16 @@ class CesiumMap extends React.Component {
 
         // this is needed to display correctly intersection between terrain and primitives
         scene.globe.depthTestAgainstTerrain = this.props.mapOptions?.depthTestAgainstTerrain ?? false;
-        // handle disable tilt or hide compass ui widget from map
-        if (this.props.mapOptions?.hideCompass || this.props.mapOptions?.disableTilt) {
-            // disable tilt effect if disableTilt into mapOptions = true
-            map.scene.screenSpaceCameraController.enableTilt = false;
-        }
         // set zoom limits if found
-        if (this.props.mapOptions?.zoomLimits) {
-            const minZoomLevel = this.props.mapOptions?.zoomLimits.min;
-            const maxZoomLevel = this.props.mapOptions?.zoomLimits.max;
+        if (this.props.mapOptions?.minimumZoomDistance || this.props.mapOptions?.maximumZoomDistance) {
+            const minZoomLevel = this.props.mapOptions?.minimumZoomDistance;
+            const maxZoomLevel = this.props.mapOptions?.maximumZoomDistance;
             if (minZoomLevel) {
                 map.scene.screenSpaceCameraController.minimumZoomDistance = minZoomLevel;
             }
             if (maxZoomLevel) {
                 map.scene.screenSpaceCameraController.maximumZoomDistance = maxZoomLevel;
             }
-        }
-        // set fixed orientation for the current map center
-        if (this.props.mapOptions?.enableFixedOrientation) {
-            const camera = map.camera;
-            const cameraCenter = camera.position;
-            const cartographicCenterPoint = Cesium.Cartographic.fromCartesian(cameraCenter);
-            const longitude = Cesium.Math.toDegrees(cartographicCenterPoint.longitude);
-            const latitude = Cesium.Math.toDegrees(cartographicCenterPoint.latitude);
-            const center = Cesium.Cartesian3.fromDegrees(longitude, latitude);
-            const transform = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-
-            // View in east-north-up frame
-            camera.constrainedAxis = Cesium.Cartesian3.UNIT_Z;
-            camera.lookAtTransform(
-                transform,
-                cameraCenter
-            );
         }
 
         this.forceUpdate();
@@ -698,7 +659,7 @@ class CesiumMap extends React.Component {
         this.map.scene.screenSpaceCameraController.enableZoom = !(interactionsOptions.mouseWheelZoom === false);
         this.map.scene.screenSpaceCameraController.enableRotate = !(interactionsOptions.dragPan === false);
         this.map.scene.screenSpaceCameraController.enableTranslate = !(interactionsOptions.dragPan === false);
-        this.map.scene.screenSpaceCameraController.enableTilt = !(interactionsOptions.dragPan === false);          // block zoom into background
+        this.map.scene.screenSpaceCameraController.enableTilt = !(interactionsOptions.dragPan === false);
     }
 }
 

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -160,6 +160,15 @@ import {getHighlightLayerOptions} from "../utils/HighlightUtils";
  * @prop {boolean} mapOptions.cesium.showGroundAtmosphere enable ground atmosphere of the globe (default false)
  * @prop {boolean} mapOptions.cesium.enableFog enable fog in the view (default false)
  * @prop {boolean} mapOptions.cesium.depthTestAgainstTerrain if true all primitive 3d features will be tested against the terrain while if false they will be drawn on top of the terrain even if hidden by it (default true)
+ * @prop {boolean} mapOptions.cesium.disableTilt disable tilt effect in the view (default false)
+ * @prop {boolean} mapOptions.cesium.hideCompass hide compass from UI and disable its functionality on map which is disabling tilt/rotate effect (default false)
+ * @prop {boolean} mapOptions.cesium.enableQuickResetTo3DView enable quick reset in 3d mode to the camera scene that stored in map state (default false)
+ * @prop {boolean} mapOptions.cesium.disableTilt disable tilt effect  to prevent the user from going underground (default false)
+ * @prop {boolean} mapOptions.cesium.hideCompass hide the compass UI widget from cesium map and its operations [rotate, reset to North, tilt] (default false)
+ * @prop {boolean} mapOptions.cesium.enableFixedOrientation enable fix the orientation around the current map center making it the origin of the camera scene (default false)
+ * @prop {object} mapOptions.cesium.zoomLimits zoom limits for the camera map scene
+ * @prop {number} mapOptions.cesium.zoomLimits.max max zoom limit to restrict the zoom out operation based on it
+ * @prop {number} mapOptions.cesium.zoomLimits.min min zoom limit to restrict the zoom in operation based on it
  * @static
  * @example
  * // Adding a layer to be used as a source for the elevation (shown in the MousePosition plugin configured with showElevation = true)
@@ -209,7 +218,8 @@ class MapPlugin extends React.Component {
         items: PropTypes.array,
         onLoadingMapPlugins: PropTypes.func,
         onMapTypeLoaded: PropTypes.func,
-        pluginsCreator: PropTypes.func
+        pluginsCreator: PropTypes.func,
+        mapInitialConfig: PropTypes.object
     };
 
     static defaultProps = {
@@ -247,7 +257,8 @@ class MapPlugin extends React.Component {
         items: [],
         onLoadingMapPlugins: () => {},
         onMapTypeLoaded: () => {},
-        pluginsCreator
+        pluginsCreator,
+        mapInitialConfig: {}
     };
     state = {
         canRender: true
@@ -388,6 +399,7 @@ class MapPlugin extends React.Component {
                     zoomControl={this.props.zoomControl}
                     onResolutionsChange={this.props.onResolutionsChange}
                     errorPanel={ErrorPanel}
+                    mapInitialConfig={this.props.mapInitialConfig}
                 >
                     {this.renderLayers()}
                     {this.renderSupportTools()}

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -160,15 +160,8 @@ import {getHighlightLayerOptions} from "../utils/HighlightUtils";
  * @prop {boolean} mapOptions.cesium.showGroundAtmosphere enable ground atmosphere of the globe (default false)
  * @prop {boolean} mapOptions.cesium.enableFog enable fog in the view (default false)
  * @prop {boolean} mapOptions.cesium.depthTestAgainstTerrain if true all primitive 3d features will be tested against the terrain while if false they will be drawn on top of the terrain even if hidden by it (default true)
- * @prop {boolean} mapOptions.cesium.disableTilt disable tilt effect in the view (default false)
- * @prop {boolean} mapOptions.cesium.hideCompass hide compass from UI and disable its functionality on map which is disabling tilt/rotate effect (default false)
- * @prop {boolean} mapOptions.cesium.enableQuickResetTo3DView enable quick reset in 3d mode to the camera scene that stored in map state (default false)
- * @prop {boolean} mapOptions.cesium.disableTilt disable tilt effect  to prevent the user from going underground (default false)
- * @prop {boolean} mapOptions.cesium.hideCompass hide the compass UI widget from cesium map and its operations [rotate, reset to North, tilt] (default false)
- * @prop {boolean} mapOptions.cesium.enableFixedOrientation enable fix the orientation around the current map center making it the origin of the camera scene (default false)
- * @prop {object} mapOptions.cesium.zoomLimits zoom limits for the camera map scene
- * @prop {number} mapOptions.cesium.zoomLimits.max max zoom limit to restrict the zoom out operation based on it
- * @prop {number} mapOptions.cesium.zoomLimits.min min zoom limit to restrict the zoom in operation based on it
+ * @prop {number} mapOptions.cesium.maximumZoomDistance max zoom limit (in meter unit) to restrict the zoom out operation based on it
+ * @prop {number} mapOptions.cesium.minimumZoomDistance  min zoom limit (in meter unit) to restrict the zoom in operation based on it
  * @static
  * @example
  * // Adding a layer to be used as a source for the elevation (shown in the MousePosition plugin configured with showElevation = true)
@@ -218,8 +211,7 @@ class MapPlugin extends React.Component {
         items: PropTypes.array,
         onLoadingMapPlugins: PropTypes.func,
         onMapTypeLoaded: PropTypes.func,
-        pluginsCreator: PropTypes.func,
-        mapInitialConfig: PropTypes.object
+        pluginsCreator: PropTypes.func
     };
 
     static defaultProps = {
@@ -257,8 +249,7 @@ class MapPlugin extends React.Component {
         items: [],
         onLoadingMapPlugins: () => {},
         onMapTypeLoaded: () => {},
-        pluginsCreator,
-        mapInitialConfig: {}
+        pluginsCreator
     };
     state = {
         canRender: true
@@ -399,7 +390,6 @@ class MapPlugin extends React.Component {
                     zoomControl={this.props.zoomControl}
                     onResolutionsChange={this.props.onResolutionsChange}
                     errorPanel={ErrorPanel}
-                    mapInitialConfig={this.props.mapInitialConfig}
                 >
                     {this.renderLayers()}
                     {this.renderSupportTools()}

--- a/web/client/plugins/map/selector.js
+++ b/web/client/plugins/map/selector.js
@@ -24,8 +24,7 @@ export default createShallowSelectorCreator(isEqual)(
     isLocalizedLayerStylesEnabledSelector,
     localizedLayerStylesNameSelector,
     currentLocaleLanguageSelector,
-    state => state.mapInitialConfig,
-    (projectionDefs, map, mapType, layers, features, loadingError, securityToken, elevationEnabled, isLocalizedLayerStylesEnabled, localizedLayerStylesName, currentLocaleLanguage, mapInitialConfig) => ({
+    (projectionDefs, map, mapType, layers, features, loadingError, securityToken, elevationEnabled, isLocalizedLayerStylesEnabled, localizedLayerStylesName, currentLocaleLanguage) => ({
         projectionDefs,
         map,
         mapType,
@@ -36,7 +35,6 @@ export default createShallowSelectorCreator(isEqual)(
         elevationEnabled,
         isLocalizedLayerStylesEnabled,
         localizedLayerStylesName,
-        currentLocaleLanguage,
-        mapInitialConfig
+        currentLocaleLanguage
     })
 );

--- a/web/client/plugins/map/selector.js
+++ b/web/client/plugins/map/selector.js
@@ -24,7 +24,8 @@ export default createShallowSelectorCreator(isEqual)(
     isLocalizedLayerStylesEnabledSelector,
     localizedLayerStylesNameSelector,
     currentLocaleLanguageSelector,
-    (projectionDefs, map, mapType, layers, features, loadingError, securityToken, elevationEnabled, isLocalizedLayerStylesEnabled, localizedLayerStylesName, currentLocaleLanguage) => ({
+    state => state.mapInitialConfig,
+    (projectionDefs, map, mapType, layers, features, loadingError, securityToken, elevationEnabled, isLocalizedLayerStylesEnabled, localizedLayerStylesName, currentLocaleLanguage, mapInitialConfig) => ({
         projectionDefs,
         map,
         mapType,
@@ -35,6 +36,7 @@ export default createShallowSelectorCreator(isEqual)(
         elevationEnabled,
         isLocalizedLayerStylesEnabled,
         localizedLayerStylesName,
-        currentLocaleLanguage
+        currentLocaleLanguage,
+        mapInitialConfig
     })
 );

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1109,7 +1109,7 @@
         "zoombuttons": {
             "zoomInTooltip": "Zoom vergrößern",
             "zoomOutTooltip": "Zoom verringern",
-            "zoomAllTooltip": "Zoom auf maximale Ausdehnung"
+            "zoomAllTooltip": "Zoom auf zur Anfangsansicht"
         },
         "fullscreen": {
             "tooltipActivate": "Umschalten auf Vollbild",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1070,7 +1070,7 @@
         "zoombuttons": {
             "zoomInTooltip": "Increase zoom",
             "zoomOutTooltip": "Decrease zoom",
-            "zoomAllTooltip": "Zoom to max extent"
+            "zoomAllTooltip": "Zoom to intial ciew"
         },
         "fullscreen": {
             "tooltipActivate": "Switch to full screen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1070,7 +1070,7 @@
         "zoombuttons": {
             "zoomInTooltip": "Increase zoom",
             "zoomOutTooltip": "Decrease zoom",
-            "zoomAllTooltip": "Zoom to intial ciew"
+            "zoomAllTooltip": "Zoom to initial view"
         },
         "fullscreen": {
             "tooltipActivate": "Switch to full screen",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1070,7 +1070,7 @@
         "zoombuttons": {
             "zoomInTooltip": "Acercar",
             "zoomOutTooltip": "Alejar",
-            "zoomAllTooltip": "Ajustar a la máxima extensión"
+            "zoomAllTooltip": "Ajustar a la vista inicial"
         },
         "fullscreen": {
             "tooltipActivate": "Cambiar a pantalla completa",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1070,7 +1070,7 @@
         "zoombuttons": {
             "zoomInTooltip": "Zoomer vers l'avant",
             "zoomOutTooltip": "Zoomer vers l'arrière",
-            "zoomAllTooltip": "Agrandir à l'extension maximale"
+            "zoomAllTooltip": "Agrandir à la vue initiale"
         },
         "fullscreen": {
             "tooltipActivate": "Passer en plein écran",

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -1015,7 +1015,7 @@
     "zoombuttons": {
       "zoomInTooltip": "Increase zoom",
       "zoomOutTooltip": "Decrease zoom",
-      "zoomAllTooltip": "Zoom to max extent"
+      "zoomAllTooltip": "Zoom to initial view"
     },
     "fullscreen": {
       "tooltipActivate": "Switch to full screen",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1070,7 +1070,7 @@
         "zoombuttons": {
             "zoomInTooltip": "Aumenta Zoom",
             "zoomOutTooltip": "Diminuisci Zoom",
-            "zoomAllTooltip": "Zoom Alla Massima Estensione"
+            "zoomAllTooltip": "Zoom Alla vista iniziale"
         },
         "fullscreen": {
             "tooltipActivate":  "Passa a schermo intero",


### PR DESCRIPTION
## Description
In this PR, the required enhancements are implemented but within the config-level by adding some cfg for cesium mapOptions to enhance UX of navigation.
In includes: 
- Handle disable tilt effect
- Handle enabling zoom limits max, min or both
- Handle enabling fixing orientation of the map scene
- Handle enabling hiding the compass UI widget [will disable tilt effect as well]
- Handling quick reset to the initial camera scene stored into map object

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue
#10225 
**What is the current behavior?**
#10225 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
There are 2 notes need to highlighted: 
1- For the point `Quick reset of the 3D map view (the camera view) to restore the initial state`, I have checked the implementation of zoomToExtent button and I found out as an enhancement for 3D mode only, we can pass the viewerOptions object - that includes orientation and destination objects - to the zoomTo action which will do the same required functionality.

But If the required logic is keeping zoomTo extent implementation as it is currently and extending the functionality by adding the new functionality in a separate place, it is Ok. 

2- For the point of `fix camera orientation limits and/or fixed camera orientation`, When I enable fix camera orientation ` enableFixedOrientation: true` and `disableTilt = true`, the tilt doesn't disable.
It enables the tilt effect by default. so there will be conflict between disabling tilt and fix camera orientation.