### PR TITLE
#10213: fix  When the TOC opens the navigation toolbar change position

### DIFF
--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -1987,7 +1987,7 @@ describe('featuregrid Epics', () => {
             const epicResult = actions => {
                 expect(actions.length).toBe(2);
                 expect(actions[0].type).toBe(HIDE_MAPINFO_MARKER);
-                expect(actions[1].type).toBe(OPEN_FEATURE_GRID);
+                expect(actions[1].type).toBe(CLOSE_FEATURE_GRID);
                 done();
             };
 

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -1222,7 +1222,7 @@ export const hideFeatureGridOnDrawerOpenMobile = (action$, { getState } = {}) =>
             && getState().browser.mobile
             && drawerEnabledControlSelector(getState())
         )
-        .switchMap(() => Rx.Observable.of(hideMapinfoMarker(), openFeatureGrid()));
+        .switchMap(() => Rx.Observable.of(hideMapinfoMarker(), closeFeatureGrid()));
 export const hideDrawerOnFeatureGridOpenMobile = (action$, { getState } = {}) =>
     action$
         .ofType(FEATURE_INFO_CLICK)


### PR DESCRIPTION
## Description
- fix bug of when TOC opens the navigation toolbar change position
- edit unit test of 'hideFeatureGridOnDrawerOpenMobile' epic

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue
#10213 

**What is the current behavior?**
#10213 


**What is the new behavior?**
The position of toolbar is still vertical if user opens TOC

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No


## Other useful information
