### PR TITLE
#10262: Map (created with context) crashes if the export plugin is set up to be hidden to certain groups and the user is not logged in

### DIFF
--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -164,7 +164,12 @@ const parseExpression = (state = {}, context = {}, value) => {
     };
     const request = url.parse(location.href, true);
     if (expression !== null) {
-        return eval(expression[1]);
+        let modifiedExpression = expression[1];
+        // adding optional operator to the expression
+        if (modifiedExpression.includes(").")) {
+            modifiedExpression = modifiedExpression.replaceAll(").", ")?.");
+        }
+        return eval(modifiedExpression);
     }
     return value;
 };


### PR DESCRIPTION
## Description
In this PR, I made an edit for parseExpression method in PluginUtils.js file to handle verifying the chaining if exists within cfg expressions

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10262 

**What is the current behavior?**
#10262 

**What is the new behavior?**
The map context works well without crashing in the case of #10262 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
