### PR TITLE
#9932: On Binary dashboard public dashboard have + button

### DIFF
--- a/web/client/selectors/__tests__/dashboard-test.js
+++ b/web/client/selectors/__tests__/dashboard-test.js
@@ -97,6 +97,13 @@ describe('dashboard selectors', () => {
                 }
             }
         })).toBe(false);
+        expect(buttonCanEdit({
+            router: {
+                location: {
+                    pathname: '/dashboard/1'
+                }
+            }
+        })).toBe(false);
     });
 
     it("test dashboardServicesSelector", () => {

--- a/web/client/selectors/dashboard.js
+++ b/web/client/selectors/dashboard.js
@@ -21,7 +21,7 @@ export const isDashboardLoading = state => state && state.dashboard && state.das
 export const getDashboardSaveErrors = state => state && state.dashboard && state.dashboard.saveErrors;
 export const isBrowserMobile = state => state && state.browser && state.browser.mobile;
 export const buttonCanEdit = createSelector(pathnameSelector, dashboardResource, isBrowserMobile,
-    (path, resource, isMobile) => isMobile ? !isMobile : (resource && resource.canEdit || isNaN(path.substr(-4))));
+    (path, resource, isMobile) => isMobile ? !isMobile : (resource && resource.canEdit || isNaN(path.substr(-1))));
 export const originalDataSelector = state => state?.dashboard?.originalData;
 
 export const dashboardServicesSelector =  state => state && state.dashboard && state.dashboard.services;

--- a/web/client/selectors/dashboard.js
+++ b/web/client/selectors/dashboard.js
@@ -21,6 +21,8 @@ export const isDashboardLoading = state => state && state.dashboard && state.das
 export const getDashboardSaveErrors = state => state && state.dashboard && state.dashboard.saveErrors;
 export const isBrowserMobile = state => state && state.browser && state.browser.mobile;
 export const buttonCanEdit = createSelector(pathnameSelector, dashboardResource, isBrowserMobile,
+    // can edit only on desktop, when the resource is saved and editable by the user or when we are editing a new dashboard
+    // in that case the `path` ends with a number. Like `dashboard/1` or `dashboard/1234`.
     (path, resource, isMobile) => isMobile ? !isMobile : (resource && resource.canEdit || isNaN(path.substr(-1))));
 export const originalDataSelector = state => state?.dashboard?.originalData;
 


### PR DESCRIPTION
## Description
This PR fixes the issue of not hiding add dashboard button for guest users if dashboard view only.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#9932 

**What is the current behavior?**
#9932 

**What is the new behavior?**
For guest users, if dashboard has view mode only, it will be hidden

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
