### PR TITLE
Fix #10237 hide filter button from dashboard legend

### DIFF
--- a/web/client/components/widgets/widget/LegendView.jsx
+++ b/web/client/components/widgets/widget/LegendView.jsx
@@ -35,7 +35,8 @@ export default ({
                 scales,
                 zoom: currentZoomLvl,
                 layerOptions: {
-                    legendOptions: legendProps
+                    legendOptions: legendProps,
+                    hideFilter: true
                 }
             }}
             onChangeMap={(newMap) => {

--- a/web/client/plugins/TOC/components/DefaultLayer.jsx
+++ b/web/client/plugins/TOC/components/DefaultLayer.jsx
@@ -129,6 +129,10 @@ const DefaultLayerNode = ({
         itemComponent: NodeTool
     };
 
+    const filterNode = !config?.layerOptions?.hideFilter
+        ? [{ name: 'FilterLayer', Component: FilterNodeTool }]
+        : [];
+
     return (
         <>
             <NodeHeader
@@ -162,7 +166,7 @@ const DefaultLayerNode = ({
                                 ? indicator.glyph && <NodeTool onClick={false} key={indicator.key} glyph={indicator.glyph} {...indicator.props} />
                                 : null)
                             : null}
-                        {[ { name: 'FilterLayer', Component: FilterNodeTool }, ...nodeToolItems ].filter(({ selector = () => true }) => selector(componentProps)).map(({ Component, name }) => {
+                        {[ ...filterNode, ...nodeToolItems ].filter(({ selector = () => true }) => selector(componentProps)).map(({ Component, name }) => {
                             return (<Component key={name} {...componentProps} />);
                         })}
                     </>
@@ -218,6 +222,7 @@ const DefaultLayerNode = ({
  * @prop {object} config.layerOptions.tooltipOptions options for layer title tooltip
  * @prop {boolean} config.layerOptions.hideLegend hide the legend of the layer
  * @prop {object} config.layerOptions.legendOptions additional options for WMS legend
+ * @prop {boolean} config.layerOptions.hideFilter hide the filter button
  */
 const DefaultLayer = ({
     node: nodeProp,

--- a/web/client/plugins/TOC/components/TOC.jsx
+++ b/web/client/plugins/TOC/components/TOC.jsx
@@ -55,6 +55,7 @@ import {
  * @prop {object} config.layerOptions.tooltipOptions options for layer title tooltip
  * @prop {boolean} config.layerOptions.hideLegend hide the legend of the layer
  * @prop {object} config.layerOptions.legendOptions additional options for WMS legend
+ * @prop {boolean} config.layerOptions.hideFilter hide the filter button in the layer nodes
  */
 export function ControlledTOC({
     tree,
@@ -133,6 +134,7 @@ export function ControlledTOC({
  * @prop {object} config.layerOptions.tooltipOptions options for layer title tooltip
  * @prop {boolean} config.layerOptions.hideLegend hide the legend of the layer
  * @prop {object} config.layerOptions.legendOptions additional options for WMS legend
+ * @prop {boolean} config.layerOptions.hideFilter hide the filter button in the layer nodes
  */
 function TOC({
     map = { layers: [], groups: [] },

--- a/web/client/plugins/TOC/components/__tests__/DefaultLayer-test.jsx
+++ b/web/client/plugins/TOC/components/__tests__/DefaultLayer-test.jsx
@@ -394,4 +394,34 @@ describe('test DefaultLayer module component', () => {
         expect(layerNode).toBeFalsy();
         expect(errorTooltip).toBeFalsy();
     });
+
+    it('should display the layer filter button', () => {
+        const layer = {
+            id: 'layer00',
+            name: 'layer00',
+            title: 'Layer',
+            visibility: false,
+            opacity: 0.5,
+            layerFilter: {}
+        };
+
+        ReactDOM.render(<Layer node={layer} />, document.getElementById("container"));
+        const filter = document.querySelector('.glyphicon-filter');
+        expect(filter).toBeTruthy();
+    });
+
+    it('should not display the layer filter button when hideFilter is true', () => {
+        const layer = {
+            id: 'layer00',
+            name: 'layer00',
+            title: 'Layer',
+            visibility: false,
+            opacity: 0.5,
+            layerFilter: {}
+        };
+
+        ReactDOM.render(<Layer node={layer} config={{ layerOptions: { hideFilter: true } }} />, document.getElementById("container"));
+        const filter = document.querySelector('.glyphicon-filter');
+        expect(filter).toBeFalsy();
+    });
 });

--- a/web/client/plugins/TOC/index.js
+++ b/web/client/plugins/TOC/index.js
@@ -145,6 +145,7 @@ registerCustomSaveHandler('toc', (state) => (state?.toc?.config));
  *   }
  * }
  * ```
+ * @prop {boolean} config.layerOptions.hideFilter hide the filter button in the layer nodes
  * @prop {boolean} defaultOpen if true will open the table of content at initialization
  * @prop {object[]} items this property contains the items injected from the other plugins,
  * using the `containers` option in the plugin that want to inject the components.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds the hideFilter option in TOC to hide the filter button for layers

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10237

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The filter button is not visible in the dashboard legend

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
