### PR TITLE
[Backport 2024.01.xx] Fix #10246 Issue adding layer when a group is present on TOC (#10278)

### DIFF
--- a/web/client/plugins/__tests__/AddGroup-test.jsx
+++ b/web/client/plugins/__tests__/AddGroup-test.jsx
@@ -12,6 +12,7 @@ import ReactDOM from 'react-dom';
 import AddGroupPlugin from '../AddGroup';
 import { getPluginForTest } from './pluginsTestUtils';
 import ReactTestUtils from 'react-dom/test-utils';
+import { DEFAULT_GROUP_ID } from '../../utils/LayersUtils';
 
 describe('AddGroup Plugin', () => {
     beforeEach((done) => {
@@ -75,12 +76,12 @@ describe('AddGroup Plugin', () => {
         const btn = document.getElementsByTagName('button')[1];
         ReactTestUtils.Simulate.click(btn);
         expect(store.getState().layers.groups.length).toBe(2);
-        expect(store.getState().layers.groups[1].title).toBe('newgroup');
-        expect(store.getState().layers.groups[1].name).toExist();
-        expect(store.getState().layers.groups[1].name.length).toBe(36);
-        expect(store.getState().layers.groups[1].id).toExist();
-        expect(store.getState().layers.groups[1].id.length).toBe(36);
-        expect(store.getState().layers.groups[1].nodes.length).toBe(0);
+        expect(store.getState().layers.groups[0].nodes[0].title).toBe('newgroup');
+        expect(store.getState().layers.groups[0].nodes[0].name).toExist();
+        expect(store.getState().layers.groups[0].nodes[0].name.length).toBe(36);
+        expect(store.getState().layers.groups[0].nodes[0].id).toExist();
+        expect(store.getState().layers.groups[0].nodes[0].id.length).toBe(36 + DEFAULT_GROUP_ID.length + 1 /* 1 is the dot */);
+        expect(store.getState().layers.groups[0].nodes[0].nodes.length).toBe(0);
     });
 
     it('Add Nested Group on confirm', () => {
@@ -89,11 +90,11 @@ describe('AddGroup Plugin', () => {
             controls: {
                 addgroup: {
                     enabled: true,
-                    parent: 'group1.group2'
+                    parent: DEFAULT_GROUP_ID + '.group2'
                 }
             },
             layers: {
-                groups: [{ id: 'group1', nodes: [{id: 'group1.group2', nodes: []}] }]
+                groups: [{ id: DEFAULT_GROUP_ID, nodes: [{id: DEFAULT_GROUP_ID + '.group2', nodes: []}] }]
             }
         });
         ReactTestUtils.act(() => {
@@ -115,7 +116,7 @@ describe('AddGroup Plugin', () => {
         expect(newgroup.name).toExist();
         expect(newgroup.name.length).toBe(36);
         expect(newgroup.id).toExist();
-        expect(newgroup.id.length).toBe(6 + 6 + 36 + 2);
+        expect(newgroup.id.length).toBe(DEFAULT_GROUP_ID.length + 6 + 36 + 2);
         expect(newgroup.nodes.length).toBe(0);
     });
 });

--- a/web/client/reducers/__tests__/layers-test.js
+++ b/web/client/reducers/__tests__/layers-test.js
@@ -9,6 +9,7 @@ import expect from 'expect';
 
 import layers from '../layers';
 import { changeLayerParams, addLayer, addGroup, moveNode, ADD_GROUP } from '../../actions/layers';
+import { DEFAULT_GROUP_ID } from '../../utils/LayersUtils';
 
 
 describe('Test the layers reducer', () => {
@@ -831,10 +832,11 @@ describe('Test the layers reducer', () => {
             group: 'newgroup'
         };
 
-        const state = layers({groups: [{id: 'group1'}]}, action);
+        const state = layers({groups: [{id: 'group1', nodes: []}]}, action);
         expect(state).toExist();
         expect(state.groups.length).toBe(2);
-        expect(state.groups[1].title).toBe('newgroup');
+        expect(state.groups[0].id).toBe(DEFAULT_GROUP_ID);
+        expect(state.groups[0].nodes[0].title).toBe('newgroup');
     });
 
     it('add nested group', () => {
@@ -846,10 +848,10 @@ describe('Test the layers reducer', () => {
 
         const state = layers({ groups: [{ id: 'group1', nodes: [{ id: 'group1.group2', nodes: [{ id: 'group1.group2.group3', nodes: []}]}] }] }, action);
         expect(state).toExist();
-        expect(state.groups.length).toBe(1);
-        expect(state.groups[0].nodes.length).toBe(1);
-        expect(state.groups[0].nodes[0].nodes.length).toBe(2);
-        const newgroup = state.groups[0].nodes[0].nodes[1];
+        expect(state.groups.length).toBe(2);
+        expect(state.groups[1].nodes.length).toBe(1);
+        expect(state.groups[1].nodes[0].nodes.length).toBe(2);
+        const newgroup = state.groups[1].nodes[0].nodes[1];
         expect(newgroup.id).toBe('group1.group2.' + newgroup.name);
         expect(newgroup.title).toBe('newgroup');
         expect(newgroup.nodes.length).toBe(0);
@@ -869,11 +871,11 @@ describe('Test the layers reducer', () => {
             }
         );
         expect(state).toExist();
-        expect(state.groups.length).toBe(1);
-        expect(state.groups[0].nodes.length).toBe(1);
-        expect(state.groups[0].nodes[0].nodes.length).toBe(3);
-        const newgroup1 = state.groups[0].nodes[0].nodes[1];
-        const newgroup2 = state.groups[0].nodes[0].nodes[2];
+        expect(state.groups.length).toBe(2);
+        expect(state.groups[1].nodes.length).toBe(1);
+        expect(state.groups[1].nodes[0].nodes.length).toBe(3);
+        const newgroup1 = state.groups[1].nodes[0].nodes[1];
+        const newgroup2 = state.groups[1].nodes[0].nodes[2];
         expect(newgroup1.title).toBe('newgroup');
         expect(newgroup1.name).toExist();
         expect(newgroup1.name.length).toBe(36);
@@ -904,12 +906,20 @@ describe('Test the layers reducer', () => {
             addGroup(options.title, 'group1', options)
         );
         expect(state).toExist();
-        expect(state.groups.length).toBe(1);
-        expect(state.groups[0].nodes.length).toBe(1);
-        const newNode = state.groups[0].nodes[0];
+        expect(state.groups.length).toBe(2);
+        expect(state.groups[1].nodes.length).toBe(1);
+        const newNode = state.groups[1].nodes[0];
         expect(newNode.id).toBe(options.id);
         expect(newNode.title).toBe(options.title);
         expect(newNode.name).toBe(options.name);
+    });
+
+    it('should add group to default even if parent is not defined', () => {
+        const state = layers({groups: []}, addGroup('newgroup'));
+        expect(state).toBeTruthy();
+        expect(state.groups.length).toBe(1);
+        expect(state.groups[0].id).toBe(DEFAULT_GROUP_ID);
+        expect(state.groups[0].nodes[0].title).toBe('newgroup');
     });
 
     it('move groups when two are with the same title', () => {

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -258,17 +258,30 @@ function layers(state = { flat: [] }, action) {
     }
     case ADD_GROUP: {
         const id = uuidv1();
+        const defaultGroup = {
+            id: DEFAULT_GROUP_ID,
+            name: DEFAULT_GROUP_ID,
+            title: DEFAULT_GROUP_ID,
+            expanded: true,
+            nodes: []
+        };
+        // ensure new added group are included in the default
+        const parent = action.parent ?? DEFAULT_GROUP_ID;
+        const groups = (state.groups || []).find((group) => group.id === DEFAULT_GROUP_ID)
+            ? state.groups
+            : [defaultGroup, ...state.groups];
+
         const newGroups = insertNode(
-            state.groups,
+            groups,
             {
-                id: action.parent ? (action.parent + '.' + id) : id,
+                id: parent + '.' + id,
                 title: action.group,
                 name: id,
                 nodes: [],
                 expanded: true,
                 ...action.options
             },
-            action.parent,
+            parent,
             action.asFirst
         );
         return assign({}, state, {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds a control to add new groups to the Default one when there are not a target parent group

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10246

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The new group will be added always to the default one if the parent target is not defined

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
