### PR TITLE
[Backport 2024.01.xx] #10262: Map (created with context) crashes if the export plugin is set up to be hidden to certain groups and the user is not logged in (#10270)

### DIFF
--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -164,7 +164,12 @@ const parseExpression = (state = {}, context = {}, value) => {
     };
     const request = url.parse(location.href, true);
     if (expression !== null) {
-        return eval(expression[1]);
+        let modifiedExpression = expression[1];
+        // adding optional operator to the expression
+        if (modifiedExpression.includes(").")) {
+            modifiedExpression = modifiedExpression.replaceAll(").", ")?.");
+        }
+        return eval(modifiedExpression);
     }
     return value;
 };

--- a/web/client/utils/__tests__/PluginsUtils-test.js
+++ b/web/client/utils/__tests__/PluginsUtils-test.js
@@ -118,7 +118,18 @@ describe('PluginsUtils', () => {
     it('handleExpression', () => {
         expect(PluginsUtils.handleExpression({state1: "test1"}, {context1: "test2"}, "{state.state1 + ' ' + context.context1}")).toBe("test1 test2");
     });
-
+    it('handleExpression in case there is a chaining within the expression that needs to access available state', () => {
+        const state = {groups: ["ADMIN", "NORMAL_USER"]};
+        const getState = (path) => state[path];
+        expect(PluginsUtils.handleExpression(getState, {context1: "test2"}, "{state('groups').filter(gr => ['ADMIN'].includes(gr)).length}")).toBe(1);
+        expect(PluginsUtils.handleExpression(getState, {context1: "test2"}, "{state('groups').filter(gr => ['NORMAL_USER'].includes(gr)).length}")).toBe(1);
+        expect(PluginsUtils.handleExpression(getState, {context1: "test2"}, "{state('groups').filter(gr => ['NOT_ADMIN'].includes(gr)).length}")).toBe(0);
+    });
+    it('handleExpression in case there is a chaining within the expression that needs to access unavailable state', () => {
+        const state = {groups: undefined};
+        const getState = (path) => state[path];
+        expect(PluginsUtils.handleExpression(getState, {context1: "test2"}, "{state('groups').filter(gr => ['ADMIN'].includes(gr))}")).toBe(undefined);
+    });
     it('getPluginItems', () => {
         const plugins = {
             Test1Plugin: {


### PR DESCRIPTION
Backport 2024.01.xx -  #10262: Map (created with context) crashes if the export plugin is set up to be hidden to certain groups and the user is not logged in (#10270)