### PR TITLE
#10264: Layer visibility limits may prevent the Info panel of search results from opening

### DIFF
--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -175,9 +175,7 @@ export const searchItemSelected = (action$) =>
         });
 
 /**
- * Gets every `TEXT_SEARCH_ADD_MARKER` event.
- * It is the extentsion of `TEXT_SEARCH_ITEM_SELECTED` event
- * it resposible for retrieving feature info of the selected search results that zoom to and added a merker for by `TEXT_SEARCH_ITEM_SELECTED` event
+ * Handles performing a GFI on the selected search results after zooming in, and adds a marker
  * @param {external:Observable} action$ manages [`FEATURE_INFO_CLICK` and `SHOW_MAPINFO_MARKER`] for showing identify feature info
  * @memberof epics.search
  * @return {external:Observable}

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -43,7 +43,8 @@ import {
     searchOnStartEpic,
     textSearchShowGFIEpic,
     zoomAndAddPointEpic,
-    delayedSearchEpic
+    delayedSearchEpic,
+    getFeatureInfoOfSelectedItem
 } from '../epics/search';
 import mapInfoReducers from '../reducers/mapInfo';
 import searchReducers from '../reducers/search';
@@ -420,7 +421,7 @@ export default {
                 priority: 1
             }
         }),
-    epics: {searchEpic, searchOnStartEpic, searchItemSelected, zoomAndAddPointEpic, textSearchShowGFIEpic, delayedSearchEpic},
+    epics: {searchEpic, searchOnStartEpic, searchItemSelected, zoomAndAddPointEpic, textSearchShowGFIEpic, delayedSearchEpic, getFeatureInfoOfSelectedItem},
     reducers: {
         search: searchReducers,
         mapInfo: mapInfoReducers,


### PR DESCRIPTION
## Description
In this PR, getting the selected search item info is implemented and showing the results into the info [identify] panel even if the layer visibility limit. 
the getFeature [identify] action is isolated from epic 'searchItemSelected' into a new epic called 'getFeatureInfoOfSelectedItem' to be applied after zoom and addMarker events  just to make sure implementing zoom action first.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement


## Issue
#10264 

**What is the current behavior?**
#10264 

**What is the new behavior?**
If the layer has a limited visibility like showing features from a specific scale level, and user searches for an existing feature into the searched layer while the hidden scale level ---> if the feature is existing, it will zoom to this feature and opening the info panel showing the feature info data

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
