### PR TITLE
#10272: Choice of OGC service type for single layer in CSW catalog

### DIFF
--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -110,12 +110,27 @@ const extractWMSParamsFromURL = wms => {
     return false;
 };
 
+const extractWFSParamsFromURL = wfs => {
+    const lowerCaseParams = new Map(Array.from(new URLSearchParams(wfs.value)).map(([key, value]) => [key.toLowerCase(), value]));
+    const layerName = lowerCaseParams.get('typename');
+    if (layerName) {
+        return {
+            ...wfs,
+            protocol: 'OGC:WFS',
+            name: layerName,
+            value: `${wfs.value.match(/[^\?]+[\?]+/g)}service=WFS`
+        };
+    }
+    return false;
+};
+
 const toReference = (layerType, data, options) => {
     if (!data.name) {
         return null;
     }
     switch (layerType) {
     case 'wms':
+    case 'wfs':
         const urlValue = !(data.value.indexOf("http") === 0)
             ? (options && options.catalogURL || "") + "/" + data.value
             : data.value;
@@ -142,38 +157,68 @@ const toReference = (layerType, data, options) => {
 };
 
 const REGEX_WMS_EXPLICIT = [/^OGC:WMS-(.*)-http-get-map/g, /^OGC:WMS/g];
+const REGEX_WFS_EXPLICIT = [/^OGC:WFS-(.*)-http-get-(capabilities|feature)/g, /^OGC:WFS/g];
 const REGEX_WMS_EXTRACT = /serviceType\/ogc\/wms/g;
+const REGEX_WFS_EXTRACT = /serviceType\/ogc\/wfs/g;
 const REGEX_WMS_ALL = REGEX_WMS_EXPLICIT.concat(REGEX_WMS_EXTRACT);
 
 export const getLayerReferenceFromDc = (dc, options, checkEsri = true) => {
     const URI = dc?.URI && castArray(dc.URI);
+    const isWMS = isNil(options?.type) || options?.type === "wms";
+    const isWFS = options?.type === "wfs";
     // look in URI objects for wms and thumbnail
     if (URI) {
-        const wms = head(URI.map(uri => {
-            if (uri.protocol) {
-                if (REGEX_WMS_EXPLICIT.some(regex => uri.protocol.match(regex))) {
+        if (isWMS) {
+            const wms = head(URI.map(uri => {
+                if (uri.protocol) {
+                    if (REGEX_WMS_EXPLICIT.some(regex => uri.protocol.match(regex))) {
                     /** wms protocol params are explicitly defined as attributes (INSPIRE)*/
-                    return uri;
-                }
-                if (uri.protocol.match(REGEX_WMS_EXTRACT)) {
+                        return uri;
+                    }
+                    if (uri.protocol.match(REGEX_WMS_EXTRACT)) {
                     /** wms protocol params must be extracted from the element text (RNDT / INSPIRE) */
-                    return extractWMSParamsFromURL(uri);
+                        return extractWMSParamsFromURL(uri);
+                    }
                 }
+                return false;
+            }).filter(item => item));
+            if (wms) {
+                return toReference('wms', wms, options);
             }
-            return false;
-        }).filter(item => item));
-        if (wms) {
-            return toReference('wms', wms, options);
+        }
+        if (isWFS) {
+            const wfs = head(URI.map(uri => {
+                if (uri.protocol) {
+                    if (REGEX_WFS_EXPLICIT.some(regex => uri.protocol.match(regex))) {
+                    /** wfs protocol params are explicitly defined as attributes (INSPIRE)*/
+                        return uri;
+                    }
+                    if (uri.protocol.match(REGEX_WFS_EXTRACT)) {
+                    /** wfs protocol params must be extracted from the element text (RNDT / INSPIRE) */
+                        return extractWFSParamsFromURL(uri);
+                    }
+                }
+                return false;
+            }).filter(item => item));
+            if (wfs) {
+                return toReference('wfs', wfs, options);
+            }
         }
     }
     // look in references objects
     if (dc?.references?.length) {
         const refs = castArray(dc.references);
         const wms = head(refs.filter((ref) => { return ref.scheme && REGEX_WMS_EXPLICIT.some(regex => ref.scheme.match(regex)); }));
-        if (wms) {
+        const wfs = head(refs.filter((ref) => { return ref.scheme && REGEX_WFS_EXPLICIT.some(regex => ref.scheme.match(regex)); }));
+        if (isWMS && wms) {
             let urlObj = urlUtil.parse(getDefaultUrl(wms.value), true);
             let layerName = urlObj.query && urlObj.query.layers || dc.alternative;
             return toReference('wms', { ...wms, value: urlUtil.format(urlObj), name: layerName }, options);
+        }
+        if (isWFS && wfs) {
+            let urlObj = urlUtil.parse(getDefaultUrl(wfs.value), true);
+            let layerName = urlObj.query && urlObj.query.layers || dc.alternative;
+            return toReference('wfs', { ...wfs, value: urlUtil.format(urlObj), name: layerName }, options);
         }
         if (checkEsri) {
             // checks for esri arcgis in geonode csw

--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -110,6 +110,7 @@ const extractWMSParamsFromURL = wms => {
     return false;
 };
 
+// Extract the relevant information from the wfs URL for (RNDT / INSPIRE)
 const extractWFSParamsFromURL = wfs => {
     const lowerCaseParams = new Map(Array.from(new URLSearchParams(wfs.value)).map(([key, value]) => [key.toLowerCase(), value]));
     const layerName = lowerCaseParams.get('typename');

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -440,6 +440,34 @@ describe("getLayerReferenceFromDc", () => {
         expect(layerRef.type).toBe('OGC:WMS');
         expect(layerRef.url).toBe('catalog_url/wmsurl?SERVICE=WMS&VERSION=1.3.0');
     });
+    it("test layer reference with dc.references of scheme OGC:WFS", () => {
+        const dc = {references: [{value: "http://wmsurl", scheme: 'OGC:WMS'}, {value: "http://wfsurl", scheme: 'OGC:WFS'}], alternative: "some_layer"};
+        const layerRef = getLayerReferenceFromDc(dc, {type: "wfs"});
+        expect(layerRef.params.name).toBe('some_layer');
+        expect(layerRef.type).toBe('OGC:WFS');
+        expect(layerRef.url).toBe('http://wfsurl/');
+    });
+    it("test layer reference with dc.references of scheme OGC:WMS-http-get-capabilities", () => {
+        const dc = {references: [{value: "http://wmsurl", scheme: 'OGC:WMS-http-get-map'}, {value: "http://wfsurl", scheme: 'OGC:WFS-http-get-capabilities'}], alternative: "some_layer"};
+        const layerRef = getLayerReferenceFromDc(dc, {type: "wfs"});
+        expect(layerRef.params.name).toBe('some_layer');
+        expect(layerRef.type).toBe('OGC:WFS-http-get-capabilities');
+        expect(layerRef.url).toBe('http://wfsurl/');
+    });
+    it("test layer reference with dc.references of scheme OGC:WMS-http-get-feature", () => {
+        const dc = {references: [{value: "http://wmsurl", scheme: 'OGC:WMS-http-get-map'}, {value: "http://wfsurl", scheme: 'OGC:WFS-http-get-feature'}], alternative: "some_layer"};
+        const layerRef = getLayerReferenceFromDc(dc, {type: "wfs"});
+        expect(layerRef.params.name).toBe('some_layer');
+        expect(layerRef.type).toBe('OGC:WFS-http-get-feature');
+        expect(layerRef.url).toBe('http://wfsurl/');
+    });
+    it("test layer reference with dc.URI of scheme serviceType/ogc/wfs and options", () => {
+        const dc = {URI: [{value: "wfsurl?service=wfs&typename=some_layer&version=1.3.0", protocol: 'serviceType/ogc/wfs'}, {value: "wmsurl", protocol: 'OGC:WMS'}]};
+        const layerRef = getLayerReferenceFromDc(dc, {type: "wfs", catalogURL: "catalog_url"});
+        expect(layerRef.params.name).toBe('some_layer');
+        expect(layerRef.type).toBe('OGC:WFS');
+        expect(layerRef.url).toBe('catalog_url/wfsurl?service=WFS');
+    });
     it("test layer reference with multiple dc.URI of scheme OGC:WMS", () => {
         const dc = {URI: [{value: "http://wmsurl", protocol: 'OGC:WMS', name: 'some_layer'}, {value: "wfsurl", protocol: 'OGC:WFS'}]};
         const layerRef = getLayerReferenceFromDc(dc);
@@ -479,6 +507,15 @@ describe("getLayerReferenceFromDc", () => {
         const dc = {references: [{value: _url, scheme: 'OGC:WMS'}, {value: "wfsurl", scheme: 'OGC:WFS'}], alternative: "some_layer"};
 
         expect(getLayerReferenceFromDc(dc).url).toBe(_url[0]);
+    });
+    it('getLayerReferenceFromDc for service type WFS', () => {
+        const _url = [
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver1',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver2',
+            'http://gs-stable.geosolutionsgroup.com:443/geoserver3'
+        ];
+        const dc = {references: [{value: 'wmsurl', scheme: 'OGC:WMS'}, {value: _url, scheme: 'OGC:WFS'}], alternative: "some_layer"};
+        expect(getLayerReferenceFromDc(dc, {type: "wfs"}).url).toBe(_url[0]);
     });
 });
 

--- a/web/client/api/catalog/CSW.js
+++ b/web/client/api/catalog/CSW.js
@@ -104,6 +104,11 @@ function getThumbnailFromDc(dc, options) {
     }
     return thumbURL;
 }
+
+/**
+ * Extract bounding box object from the record
+ * @param {Object} record from OGC service
+ */
 function getBoundingBox(record) {
     if (isEmpty(record.boundingBox?.crs) || isEmpty(record.boundingBox?.extent)) {
         return null;

--- a/web/client/api/catalog/WFS.js
+++ b/web/client/api/catalog/WFS.js
@@ -15,7 +15,7 @@ import {
     testService as commonTestService,
     preprocess as commonPreprocess
 } from './common';
-import { get, castArray } from 'lodash';
+import { get, castArray, isEmpty } from 'lodash';
 
 const searchAndPaginate = (json = {}, startPosition, maxRecords, text) => {
 
@@ -123,7 +123,18 @@ export const getCatalogRecords = ({records} = {}) => {
     return null;
 };
 
+const getLayerData = (record, options) => {
+    const layer = recordToLayer(record, options);
+    return getRecords(record.url, 1, 1, record.name).then((result)=> {
+        const [newRecord] = result?.records ?? [];
+        return isEmpty(newRecord) ? layer : recordToLayer(newRecord, options);
+    }).catch(() => layer);
+};
+
 export const getLayerFromRecord = (record, options, asPromise) => {
+    if (options.fetchCapabilities && asPromise) {
+        return getLayerData(record, options);
+    }
     const layer = recordToLayer(record, options);
     return asPromise ? Promise.resolve(layer) : layer;
 };

--- a/web/client/api/catalog/WFS.js
+++ b/web/client/api/catalog/WFS.js
@@ -123,6 +123,13 @@ export const getCatalogRecords = ({records} = {}) => {
     return null;
 };
 
+/**
+ * Formulate WFS layer data from record
+ * and fetch capabilities if needed to add capibilities specific data
+ * @param {Object} record data obtained from catalog service
+ * @param {Object} options props specific to wfs
+ * @returns {Promise} promise that resolves to formulated layer data
+ */
 const getLayerData = (record, options) => {
     const layer = recordToLayer(record, options);
     return getRecords(record.url, 1, 1, record.name).then((result)=> {

--- a/web/client/api/catalog/__tests__/CSW-test.js
+++ b/web/client/api/catalog/__tests__/CSW-test.js
@@ -172,6 +172,128 @@ describe('Test correctness of the CSW catalog APIs', () => {
         expect(records[0].metadata.uri).toEqual(['<ul><li><a target="_blank" href="https://geobretagne.fr/geoserver/audiar/wms?SERVICE=WMS&REQUEST=GetCapabilities">synthese_pos_plu_rennes_metropole</a></li></ul>']);
     });
 
+    it('csw with additional OGC services', () => {
+        const records = getCatalogRecords({
+            records: [{
+                boundingBox: {
+                    extent: [43.718, 11.348, 43.84, 11.145],
+                    crs: 'EPSG:3003'
+                },
+                dc: {
+                    references: [],
+                    identifier: 'c_d612:sha-identifier',
+                    title: 'title',
+                    type: 'dataset',
+                    subject: [
+                        'web',
+                        'world',
+                        'sport',
+                        'transportation'
+                    ],
+                    format: [
+                        'ESRI Shapefile',
+                        'KML'
+                    ],
+                    contributor: 'contributor',
+                    rights: [
+                        'otherRestrictions',
+                        'otherRestrictions'
+                    ],
+                    source: 'source',
+                    relation: {
+                        TYPE_NAME: 'DC_1_1.SimpleLiteral'
+                    },
+                    URI: [{
+                        TYPE_NAME: "DC_1_1.URI",
+                        description: "layer1 description",
+                        name: "layer1",
+                        protocol: "OGC:WMS",
+                        value: "https://geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities"
+                    },
+                    {
+                        TYPE_NAME: "DC_1_1.URI",
+                        description: "layer2 description",
+                        name: "layer2",
+                        protocol: "OGC:WFS",
+                        value: "https://geoserver/wfs?SERVICE=WFS&REQUEST=GetCapabilities"
+                    }]
+                }
+            }]
+        }, {});
+        expect(records.length).toEqual(1);
+        expect(records[0].boundingBox).toEqual({ extent: [43.718, 11.348, 43.84, 11.145], crs: 'EPSG:3003' });
+        expect(records[0].description).toEqual("");
+        expect(records[0].identifier).toEqual("c_d612:sha-identifier");
+        expect(records[0].thumbnail).toEqual(null);
+        expect(records[0].title).toEqual('title');
+        expect(records[0].tags).toEqual('');
+        expect(records[0].metadata.boundingBox).toEqual(['43.718,11.348,43.84,11.145']);
+        expect(records[0].metadata.contributor).toEqual(['contributor']);
+        expect(records[0].metadata.format).toEqual(['ESRI Shapefile', 'KML']);
+        expect(records[0].metadata.identifier).toEqual(['c_d612:sha-identifier']);
+        expect(records[0].metadata.relation).toEqual([{ TYPE_NAME: 'DC_1_1.SimpleLiteral' }]);
+        expect(records[0].metadata.rights).toEqual(['otherRestrictions']);
+        expect(records[0].metadata.references).toEqual(['<ul><li><a target="_blank" href="https://geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities">layer1</a></li><li><a target="_blank" href="https://geoserver/wfs?SERVICE=WFS&REQUEST=GetCapabilities">layer2</a></li></ul>']);
+        expect(records[0].metadata.source).toEqual(['source']);
+        expect(records[0].metadata.subject).toEqual(["<ul><li>web</li><li>world</li><li>sport</li><li>transportation</li></ul>"]);
+        expect(records[0].metadata.title).toEqual(['title']);
+        expect(records[0].metadata.type).toEqual(['dataset']);
+        expect(records[0].metadata.uri).toEqual(['<ul><li><a target="_blank" href="https://geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities">layer1</a></li><li><a target="_blank" href="https://geoserver/wfs?SERVICE=WFS&REQUEST=GetCapabilities">layer2</a></li></ul>']);
+
+        expect(records[0].references).toEqual([{
+            type: 'OGC:WMS',
+            url: 'https://geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities',
+            SRS: [],
+            params: {
+                name: 'layer1'
+            }
+        }, {
+            type: 'OGC:WFS',
+            url: 'https://geoserver/wfs?SERVICE=WFS&REQUEST=GetCapabilities',
+            SRS: [],
+            params: {
+                name: 'layer2'
+            }
+        }]);
+        expect(records[0].ogcReferences).toEqual({
+            type: 'OGC:WMS',
+            url: 'https://geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities',
+            SRS: [],
+            params: {
+                name: 'layer1'
+            }
+        });
+        expect(records[0].additionalOGCServices).toEqual(
+            {
+                wfs: {
+                    url: 'https://geoserver/wfs?SERVICE=WFS&REQUEST=GetCapabilities',
+                    name: 'layer2',
+                    references: [
+                        {
+                            type: 'OGC:WMS',
+                            url: 'https://geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities',
+                            SRS: [],
+                            params: { name: 'layer1'}
+                        },
+                        {
+                            type: 'OGC:WFS',
+                            url: 'https://geoserver/wfs?SERVICE=WFS&REQUEST=GetCapabilities',
+                            SRS: [],
+                            params: {name: 'layer2'}
+                        }
+                    ],
+                    ogcReferences: {
+                        type: 'OGC:WFS',
+                        url: 'https://geoserver/wfs?SERVICE=WFS&REQUEST=GetCapabilities',
+                        SRS: [],
+                        params: {name: 'layer2'}
+                    },
+                    fetchCapabilities: true
+                }
+            }
+        );
+    });
+
     it('csw dct:temporal metadata YYYY-MM-DD', () => {
         let records = getCatalogRecords({
             records: [{

--- a/web/client/api/catalog/__tests__/CSW-test.js
+++ b/web/client/api/catalog/__tests__/CSW-test.js
@@ -288,7 +288,16 @@ describe('Test correctness of the CSW catalog APIs', () => {
                         SRS: [],
                         params: {name: 'layer2'}
                     },
-                    fetchCapabilities: true
+                    fetchCapabilities: true,
+                    boundingBox: {
+                        crs: 'EPSG:3003',
+                        bounds: {
+                            minx: 43.718,
+                            miny: 11.348,
+                            maxx: 43.84,
+                            maxy: 11.145
+                        }
+                    }
                 }
             }
         );

--- a/web/client/components/catalog/__tests__/RecordItem-test.jsx
+++ b/web/client/components/catalog/__tests__/RecordItem-test.jsx
@@ -502,6 +502,84 @@ describe('This test for RecordItem', () => {
         expect(button).toBeTruthy();
         button.click();
     });
+    it('check additional OGC service', (done) => {
+        const record = {
+            serviceType: 'csw',
+            layerType: "wms",
+            isValid: true,
+            identifier: "test-identifier",
+            title: "sample title",
+            tags: ["subject1", "subject2"],
+            description: "sample abstract",
+            thumbnail: SAMPLE_IMAGE,
+            boundingBox: {
+                extent: [10.686,
+                    44.931,
+                    46.693,
+                    12.54],
+                crs: "EPSG:4326"
+            },
+            references: [{
+                type: "OGC:WMS",
+                url: "http://wms.sample.service:80/geoserver/wms?SERVICE=WMS&ms2-authkey=TEST&requiredParam=REQUIRED",
+                SRS: [],
+                params: { name: "workspace:layername1" }
+            }],
+            ogcReferences: {
+                type: "OGC:WMS",
+                url: "http://wms.sample.service:80/geoserver/wms?SERVICE=WMS&ms2-authkey=TEST&requiredParam=REQUIRED",
+                SRS: [],
+                params: { name: "workspace:layername2" }
+            },
+            additionalOGCServices: {
+                "wfs": {
+                    url: "http://wfs.sample.service:80/geoserver/wfs?SERVICE=WFS",
+                    name: "workspace:layername2",
+                    fetchCapabilities: true,
+                    references: [{
+                        type: "OGC:WMS",
+                        url: "http://wms.sample.service:80/geoserver/wms?SERVICE=WMS&ms2-authkey=TEST&requiredParam=REQUIRED",
+                        SRS: [],
+                        params: { name: "workspace:layername1" }
+                    }, {
+                        type: "OGC:WFS",
+                        url: "http://wfs.sample.service:80/geoserver/wfs?SERVICE=WFS",
+                        SRS: [],
+                        params: { name: "workspace:layername2" }
+                    }]
+                }
+            }
+        };
+        let actions = {
+            onLayerAdd: (layer, options) => {
+                const url = "http://wfs.sample.service:80/geoserver/wfs?SERVICE=WFS";
+                expect(layer.type).toBe("wfs");
+                expect(layer.search).toBeTruthy();
+                expect(layer.search).toEqual({url, type: "wfs"});
+                expect(layer.url).toBe(url);
+                expect(layer.name).toBe("workspace:layername2");
+                expect(options.zoomToLayer).toBeTruthy();
+                done();
+            }
+        };
+        const item = ReactDOM.render(<RecordItem
+            authkeyParamNames={["ms2-authkey"]}
+            record={record}
+            onLayerAdd={actions.onLayerAdd}
+            catalogURL="fakeURL"
+            catalogType="csw"
+        />, document.getElementById("container"));
+        expect(item).toBeTruthy();
+
+        const itemDom = ReactDOM.findDOMNode(item);
+        expect(itemDom).toBeTruthy();
+        const splitButton = document.querySelector('#add-layer-button');
+        expect(splitButton).toBeTruthy();
+        TestUtils.Simulate.click(splitButton);
+        const menuWFS = document.querySelector('#ogc-wfs');
+        expect(menuWFS).toBeTruthy();
+        TestUtils.Simulate.click(menuWFS);
+    });
 
     it('check event handlers with layerBaseConfig and csw service', (done) => {
         let actions = {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1616,6 +1616,10 @@
             "noRecordsMatched": "Kein passender Eintrag",
             "wmsGetCapLink": "WMS",
             "wfsGetCapLink": "WFS",
+            "additionalOGCServices": {
+                "wfs": "AUS WFS",
+                "wms": "AUS WMS"
+            },
             "share": "Teilen",
             "copyToClipboard": "In die Zwischenablage kopieren",
             "copied": "Kopiert!",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1577,6 +1577,10 @@
             "noRecordsMatched": "No record matched",
             "wmsGetCapLink": "WMS",
             "wfsGetCapLink": "WFS",
+            "additionalOGCServices": {
+                "wfs": "FROM WFS",
+                "wms": "FROM WMS"
+            },
             "share": "Share",
             "copyToClipboard": "Copy to clipboard",
             "copied": "Copied!",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1578,6 +1578,10 @@
             "noRecordsMatched": "Ningún resultado encontrado",
             "wmsGetCapLink": "WMS",
             "wfsGetCapLink": "WFS",
+            "additionalOGCServices": {
+                "wfs": "DE WFS",
+                "wms": "DE WMS"
+            },
             "share": "Compartir",
             "copyToClipboard": "Copiar en el portapapeles",
             "copied": "¡Copiado!",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1578,6 +1578,10 @@
             "noRecordsMatched": "Aucun enregistrement correspondant",
             "wmsGetCapLink": "WMS",
             "wfsGetCapLink": "WFS",
+            "additionalOGCServices": {
+                "wfs": "DEPUIS WFS",
+                "wms": "DEPUIS WMS"
+            },
             "share": "Partager",
             "copyToClipboard": "Copier vers le presse-papier",
             "copied": "Copié !",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1577,6 +1577,10 @@
             "noRecordsMatched": "Nessun risultato trovato",
             "wmsGetCapLink": "WMS",
             "wfsGetCapLink": "WFS",
+            "additionalOGCServices": {
+                "wfs": "DA WFS",
+                "wms": "DA WMS"
+            },
             "share": "Condividi",
             "copyToClipboard": "Copia negli appunti",
             "copied": "Copiato!",


### PR DESCRIPTION
## Description
This PR gives the ability for the user to choose which service type, when the records has support for multi OGC service in the dc references, to be used when adding a layer to map via catalog of service type 'csw'

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #10272 

**What is the new behavior?**
User can choose the service from which the layer to be added to Map.
>[!NOTE]
Currently support only WFS as the additional OGC service

<img width="553" alt="image" src="https://github.com/geosolutions-it/MapStore2/assets/26929983/b74f6dc2-e2bf-4e5d-a07d-4169eef28afb">


https://github.com/geosolutions-it/MapStore2/assets/26929983/1d836b1d-fa18-4a81-9b27-d02bdc5cf51b


>[!NOTE]
**TEST DATA**
 https://gn3-rndt.geo-solutions.it/geonetwork/srv/eng/csw (Layer name - unesco)
 https://geobretagne.fr/geonetwork/srv/fre/csw (many records has multiple ogc service)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
