### PR TITLE
#10136: Search for Map CRS coordinates

### DIFF
--- a/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
+++ b/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
@@ -27,7 +27,7 @@ import { reproject} from '../../../utils/CoordinatesUtils';
 export const CoordinateOptions = ({
     clearCoordinates: (onClearCoordinatesSearch, onChangeCoord) =>{
         onClearCoordinatesSearch({owner: "search"});
-        const clearedFields = ["lat", "lon", "xCoord", "yCoord"];
+        const clearedFields = ["lat", "lon", "xCoord", "yCoord", "currentMapXYCRS"];
         const resetVal = '';
         clearedFields.forEach(field => onChangeCoord(field, resetVal));
     },
@@ -163,6 +163,8 @@ const CoordinatesSearch = ({
 
     const changeCoordinates = (coord, value) => {
         onChangeCoord(coord, parseFloat(value));
+        // set current map crs to coordinate object
+        if (coordinate?.currentMapXYCRS !== currentMapCRS && currentMapCRS !== "EPSG:4326") onChangeCoord('currentMapXYCRS', currentMapCRS);
         if (!areValidCoordinates()) {
             onClearCoordinatesSearch({owner: "search"});
         }
@@ -179,6 +181,7 @@ const CoordinatesSearch = ({
                 const parsedYCoord = parseFloat((reprojectedValue?.y));
                 onChangeCoord('xCoord', parsedXCoord);
                 onChangeCoord('yCoord', parsedYCoord);
+
                 return;
             }
             coordinate.xCoord && onChangeCoord('xCoord', '');

--- a/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
+++ b/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
@@ -17,6 +17,7 @@ import Message from "../../I18N/Message";
 import CoordinateEntry from "../../misc/coordinateeditors/CoordinateEntry";
 import DropdownToolbarOptions from "../../misc/toolbar/DropdownToolbarOptions";
 import { zoomAndAddPoint, changeCoord } from '../../../actions/search';
+import { reproject} from '../../../utils/CoordinatesUtils';
 
 /**
  * CoordinateOptions for Search bar
@@ -138,6 +139,7 @@ const CoordinatesSearch = ({
     onZoomToPoint,
     onChangeCoord,
     defaultZoomLevel,
+    currentMapCRS,
     aeronauticalOptions = {
         seconds: {
             decimals: 4,
@@ -163,6 +165,24 @@ const CoordinatesSearch = ({
         onChangeCoord(coord, parseFloat(value));
         if (!areValidCoordinates()) {
             onClearCoordinatesSearch({owner: "search"});
+        }
+        // if there is mapCRS available --> calculate X/Y values by reproject to display in case switch to MapCRS
+        if (currentMapCRS !== 'EPSG:4326') {
+            // if there are lat, lon values --> reproject the point and get xCoord and yCoord for map CRS
+            const latNumVal = coord === 'lat' ? parseFloat(value) : coordinate.lat;
+            const lonNumVal = coord === 'lon' ? parseFloat(value) : coordinate.lon;
+            const isLatNumberVal = isNumber(latNumVal) && !isNaN(latNumVal);
+            const isLonNumberVal = isNumber(lonNumVal) && !isNaN(lonNumVal);
+            if (isLatNumberVal && isLonNumberVal) {
+                const reprojectedValue = reproject([lonNumVal, latNumVal], 'EPSG:4326', currentMapCRS, true);
+                const parsedXCoord = parseFloat((reprojectedValue?.x));
+                const parsedYCoord = parseFloat((reprojectedValue?.y));
+                onChangeCoord('xCoord', parsedXCoord);
+                onChangeCoord('yCoord', parsedYCoord);
+                return;
+            }
+            coordinate.xCoord && onChangeCoord('xCoord', '');
+            coordinate.yCoord && onChangeCoord('yCoord', '');
         }
     };
 
@@ -226,7 +246,8 @@ CoordinatesSearch.propTypes = {
     onClearCoordinatesSearch: PropTypes.func,
     onZoomToPoint: PropTypes.func,
     onChangeCoord: PropTypes.func,
-    defaultZoomLevel: PropTypes.number
+    defaultZoomLevel: PropTypes.number,
+    currentMapCRS: PropTypes.string
 };
 
 export default connect((state)=>{

--- a/web/client/components/mapcontrols/searchcoordinates/CurrentMapCRSCoordSearch.js
+++ b/web/client/components/mapcontrols/searchcoordinates/CurrentMapCRSCoordSearch.js
@@ -69,21 +69,8 @@ const CurrentMapCRSCoordinatesSearch = ({
     };
     React.useEffect(() => {
         if (!currentMapCRS || currentMapCRS === 'EPSG:4326') return;
-        // if there are lat, lon values --> reproject the point and get xCoord and yCoord for map CRS
-        const isLatNumberVal = isNumber(coordinate.lat) && !isNaN(coordinate.lat);
-        const isLonNumberVal = isNumber(coordinate.lon) && !isNaN(coordinate.lon);
-        if (isLatNumberVal && isLonNumberVal) {
-            const reprojectedValue = reproject([coordinate.lon, coordinate.lat], 'EPSG:4326', currentMapCRS, true);
-            const parsedXCoord = parseFloat((reprojectedValue?.x));
-            const parsedYCoord = parseFloat((reprojectedValue?.y));
-            onChangeCoord('xCoord', parsedXCoord);
-            onChangeCoord('yCoord', parsedYCoord);
-            // if coords are out of crs extent --> clear the marker
-            if (!isCoordWithinCrs(parsedXCoord, 'xCoord') || !isCoordWithinCrs(parsedYCoord, 'yCoord')) onClearCoordinatesSearch({owner: "search"});
-            return;
-        }
-        coordinate.xCoord && onChangeCoord('xCoord', '');
-        coordinate.yCoord && onChangeCoord('yCoord', '');
+        if (!isCoordWithinCrs(coordinate?.xCoord, 'xCoord') || !isCoordWithinCrs(coordinate?.yCoord, 'yCoord')) onClearCoordinatesSearch({owner: "search"});
+
     }, [currentMapCRS]);
 
     const changeCoordinates = (coord, value) => {
@@ -95,24 +82,15 @@ const CurrentMapCRSCoordinatesSearch = ({
         const numValue = parseFloat(value);
         onChangeCoord(coord, numValue);
         // reproject the new point and set lat/lon
-        if (coord === 'yCoord') {
-            const yCoordValidNum = isNumber(numValue) && !isNaN(numValue) && isCoordWithinCrs(numValue, 'yCoord');
-            const xCoordValidNum = isNumber(coordinate.xCoord) && !isNaN(coordinate.xCoord) && isCoordWithinCrs(coordinate.xCoord, 'xCoord');
-            if (yCoordValidNum && xCoordValidNum) {
-                const projectedPt = reproject([coordinate.xCoord, numValue], currentMapCRS, 'EPSG:4326', true);
-                onChangeCoord('lat', (projectedPt.y));
-                onChangeCoord('lon', (projectedPt.x));
-                return;
-            }
-        } else {
-            const xCoordValidNum = isNumber(numValue) && !isNaN(numValue) && isCoordWithinCrs(numValue, 'xCoord');
-            const yCoordValidNum = isNumber(coordinate.yCoord) && !isNaN(coordinate.yCoord)  && isCoordWithinCrs(coordinate.yCoord, 'yCoord');
-            if (yCoordValidNum && xCoordValidNum) {
-                const projectedPt = reproject([numValue, coordinate.yCoord], currentMapCRS, 'EPSG:4326', true);
-                onChangeCoord('lat', (projectedPt.y));
-                onChangeCoord('lon', (projectedPt.x));
-                return;
-            }
+        const yCoodNumVal = coord === 'yCoord' ? numValue : coordinate.yCoord;
+        const xCoodNumVal = coord === 'xCoord' ? numValue : coordinate.xCoord;
+        const yCoordValidNum = isNumber(yCoodNumVal) && !isNaN(yCoodNumVal) && isCoordWithinCrs(yCoodNumVal, 'yCoord');
+        const xCoordValidNum = isNumber(xCoodNumVal) && !isNaN(xCoodNumVal) && isCoordWithinCrs(xCoodNumVal, 'xCoord');
+        if (yCoordValidNum && xCoordValidNum) {
+            const projectedPt = reproject([xCoodNumVal, yCoodNumVal], currentMapCRS, 'EPSG:4326', true);
+            onChangeCoord('lat', (projectedPt.y));
+            onChangeCoord('lon', (projectedPt.x));
+            return;
         }
         const resetValue = '';
         onChangeCoord('lat', resetValue);


### PR DESCRIPTION
## Description
In this PR: keeping user CRS coordinates X/Y as user enters in case entering them in CRS coordinate search then switches to normal coord search [lat/lon] then back again to CRS coordinates search without making change. 
They are keeping as entered without a threshold.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe: enhancement

## Issue
#10136 

**What is the current behavior?**
It is mentioned at the 1st point in this comment: https://github.com/geosolutions-it/MapStore2/pull/10220#issuecomment-2102181118

**What is the new behavior?**
X/Y coordinates are kept as entered by the user without a threshold.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
