### PR TITLE
#10308: Disable the marker when the search for map type is changed

### DIFF
--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -8,7 +8,7 @@
 
 import React, { useEffect, useState } from 'react';
 import {FormGroup, Glyphicon, MenuItem} from 'react-bootstrap';
-import { isEmpty, isEqual, isUndefined, get } from 'lodash';
+import { isEmpty, isEqual, isUndefined, get, isNumber } from 'lodash';
 
 import Message from '../../I18N/Message';
 import SearchBarMenu from './SearchBarMenu';
@@ -113,7 +113,17 @@ export default ({
             setSearchServiceSelected(-1);
         }
     }, [searchOptions?.services]);
-
+    useEffect(()=>{
+        // clear coord search/ crs search marker
+        if (!['mapCRSCoordinatesSearch', 'coordinatesSearch'].includes(activeTool)) {
+            onClearCoordinatesSearch({owner: "search"});
+            if (isNumber(coordinate?.lon) && isNumber(coordinate?.lat)) {
+                const clearedFields = ["lat", "lon", "xCoord", "yCoord", "currentMapXYCRS"];
+                const resetVal = '';
+                clearedFields.forEach(field => onChangeCoord(field, resetVal));
+            }
+        }
+    }, [activeTool]);
     useEffect(() => {
         // Switch back to coordinate search when map CRS is EPSG:4326 and active tool is Map CRS coordinate search
         if (currentMapCRS === 'EPSG:4326' && activeTool === 'mapCRSCoordinatesSearch') {


### PR DESCRIPTION
## Description
In this PR, clearing marker of coords search if switching from coord search to bookmark search is implemented.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#10308 

**What is the current behavior?**
#10308 

**What is the new behavior?**
If user makes a coord search [lat/lon] or [X/Y] and shows a marker of his/her search, then he/she switches to bookmark search, the marker will be removed from map.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
