### PR TITLE
#10264: Layer visibility limits may prevent the Info panel of search results from opening [fix missing implementation]

### DIFF
--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -194,15 +194,17 @@ export function updateCenterToMarker(status) {
  * @param {object[]} [filterNameList=[]] list of layers to perform the GFI request
  * @param {object} [overrideParams={}] a map based on name as key and objec as value for overriding request params
  * @param {string} [itemId=null] id of the item needed for filtering results
+ * @param {string} [layerWithIgnoreVisibilityLimits=null] layer object of the layer that needs to ignore its visibility limits restrictions to apply GFI
  */
-export function featureInfoClick(point, layer, filterNameList = [], overrideParams = {}, itemId = null) {
+export function featureInfoClick(point, layer, filterNameList = [], overrideParams = {}, itemId = null, layerWithIgnoreVisibilityLimits = null) {
     return {
         type: FEATURE_INFO_CLICK,
         point,
         layer,
         filterNameList,
         overrideParams,
-        itemId
+        itemId,
+        layerWithIgnoreVisibilityLimits         // [in some cases needs to ignore the restrictions of visibility limits that prevent GFI]
     };
 }
 

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -74,7 +74,7 @@ import {updatePointWithGeometricFilter} from "../utils/IdentifyUtils";
  */
 export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { } }) =>
     action$.ofType(FEATURE_INFO_CLICK)
-        .switchMap(({ point, filterNameList = [], overrideParams = {} }) => {
+        .switchMap(({ point, filterNameList = [], overrideParams = {}, layerWithIgnoreVisibilityLimits }) => {
             // Reverse - To query layer in same order as in TOC
             let queryableLayers = reverse(queryableLayersSelector(getState()));
             const queryableSelectedLayers = queryableSelectedLayersSelector(getState());
@@ -84,8 +84,12 @@ export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { }
             }
 
             const selectedLayers = selectedNodesSelector(getState());
-
-            if (queryableLayers.length === 0 || queryableSelectedLayers.length === 0 && selectedLayers.length !== 0) {
+            const queryableSelectedLayerNotExist = queryableSelectedLayers.length === 0;
+            const queryableLayersHasignoreVisiblimitsLayer = layerWithIgnoreVisibilityLimits && queryableLayers.find(i => i.id === layerWithIgnoreVisibilityLimits.id);
+            if (!queryableLayersHasignoreVisiblimitsLayer && queryableSelectedLayerNotExist && layerWithIgnoreVisibilityLimits) {
+                queryableLayers = [...queryableLayers, layerWithIgnoreVisibilityLimits];
+            }
+            if (!layerWithIgnoreVisibilityLimits && (queryableLayers.length === 0 || queryableSelectedLayers.length === 0 && selectedLayers.length !== 0)) {
                 return Rx.Observable.of(purgeMapInfoResults(), noQueryableLayers());
             }
 

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -217,7 +217,8 @@ export const getFeatureInfoOfSelectedItem = (action$, store) =>
                 }
                 return [
                     ...(forceVisibility && layerObj ? [changeLayerProperties(layerObj.id, {visibility: true})] : []),
-                    ...(!item.__SERVICE__.openFeatureInfoButtonEnabled ? [featureInfoClick({ latlng }, typeName, filterNameList, overrideParams, itemId)] : []),
+                    ...(!item.__SERVICE__.openFeatureInfoButtonEnabled ? [featureInfoClick({ latlng }, typeName, filterNameList, overrideParams, itemId, layerObj)] : []),
+
                     showMapinfoMarker()
                 ];
             }
@@ -254,7 +255,7 @@ export const textSearchShowGFIEpic = (action$, store) =>
                                 }
                                 : {}
                             )
-                        } }, itemId),
+                        } }, itemId, layerObj),
                     showMapinfoMarker(),
                     addMarker(item)
                 ).merge(


### PR DESCRIPTION
## Description
In this PR:
- handle showing feature info in case of search within single layer or all layers options is implemented
- edit featureInfoClick action creator by passing an optional param called 'layerWithIgnoreVisibilityLimits' to enforce it to queryable layers if not exist due to visibility limits

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue
#10264 

**What is the current behavior?**
#10264 

**What is the new behavior?**
If the layer has a limited visibility like showing features from a specific scale level, and user searches for an existing feature into the searched layer while the hidden scale level ---> if the feature is existing, it will open the info panel showing the feature info data

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
