### PR TITLE
#10070 - Fix: Scroll bars for legend widgets won't move coherently with displayed data

### DIFF
--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -20,7 +20,7 @@ import {
     enableBarChartStack,
     FONT
 } from '../../utils/WidgetsUtils';
-
+import withLegendScrollHandler from './withLegendScrollHandler';
 const Plot = React.lazy(() => import('./PlotlyChart'));
 
 const processDataProperties = (formula, key, data) => {
@@ -698,4 +698,4 @@ function WidgetChart({
     );
 }
 
-export default withClassifyGeoJSONSync(WidgetChart);
+export default withLegendScrollHandler(withClassifyGeoJSONSync(WidgetChart));

--- a/web/client/components/charts/withLegendScrollHandler.jsx
+++ b/web/client/components/charts/withLegendScrollHandler.jsx
@@ -1,0 +1,61 @@
+
+import React from 'react';
+import isNil from 'lodash/isNil';
+
+/**
+ * Handler to deal with legend mouse wheel sensitivity issue
+ * with chart widget has multiple legend items
+ * NOTE: This is a workaround for issue in plotly.js https://github.com/plotly/plotly.js/issues/6737
+ * until fix on plotly is implemented
+ */
+const withLegendScrollHandler = (WrappedComponent) => {
+    return (props) => {
+        /**
+         * Event listener captures mouse wheel event of legend element
+         * and modifies the deltaY such that the sensitivity is exhibited in a controlled manner
+         */
+        const legendMouseWheelEventHandler = (graphDiv) => {
+            const legend = graphDiv.querySelector('.infolayer .legend');
+            if (legend) {
+                const legendBg = legend.querySelector('.bg');
+
+                // add listener in capture mode
+                legend.addEventListener('wheel', function(event) {
+                    if (!event.isTrusted) return;
+                    event.preventDefault();
+                    event.stopPropagation();
+
+                    const maxScrollDistance = legend.getBBox()?.height;
+                    const scrollHeight = legendBg?.getBBox()?.height;
+
+                    let deltaY = 0.30; // fallback fixed value
+                    if (!isNil(scrollHeight) && !isNil(maxScrollDistance)) {
+                        deltaY = (scrollHeight / maxScrollDistance) * 100;
+                    }
+                    if (Number(event.deltaY) < 0) {
+                        deltaY *= -1; // negate on upward scroll
+                    }
+                    const newEvent = new WheelEvent('wheel', {
+                        clientX: event.clientX,
+                        clientY: event.clientY,
+                        deltaY,
+                        view: window,
+                        bubbles: true,
+                        cancelable: true
+                    });
+                    event.target.dispatchEvent(newEvent);
+                }, true);
+            }
+        };
+        return (
+            <WrappedComponent
+                {...props}
+                onInitialized={(figure, graphDiv) => {
+                    legendMouseWheelEventHandler(graphDiv);
+                    props.onInitialized(figure, graphDiv);
+                }}
+            />);
+    };
+};
+
+export default withLegendScrollHandler;


### PR DESCRIPTION
## Description
This PR adds a handler (easily discardable when fix in plotly.js is implemented) to control mouse wheel sensitivity and normalizes the deltaY so that it seamless across browsers

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10070 

**What is the new behavior?**


https://github.com/geosolutions-it/MapStore2/assets/26929983/f6ad7f32-756f-43a3-b89f-7db4ddf6a88d


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
