### PR TITLE
[Backport 2024.01.xx] #10264: Layer visibility limits may prevent the Info panel of search results from opening (#10302, #10325)

### DIFF
--- a/web/client/actions/__tests__/mapInfo-test.js
+++ b/web/client/actions/__tests__/mapInfo-test.js
@@ -108,6 +108,24 @@ describe('Test correctness of the map actions', () => {
         expect(action.overrideParams).toBe(overrideParams);
         expect(action.itemId).toBe(itemId);
     });
+    it('test featureInfoClick with filterNameList, overrideParams and ignoreVisibilityLimits flag [search service case]', () => {
+        const point = {latlng: {lat: 1, lng: 3}};
+        const layer = {id: "layer.1"};
+        const filterNameList = [];
+        const itemId = "itemId";
+        const overrideParams = {cql_filter: "ID_ORIG=1234"};
+        const ignoreVisibilityLimits = true;
+
+        const action = featureInfoClick(point, layer, filterNameList, overrideParams, itemId, ignoreVisibilityLimits);
+        expect(action).toExist();
+        expect(action.type).toBe(FEATURE_INFO_CLICK);
+        expect(action.point).toBe(point);
+        expect(action.layer).toBe(layer);
+        expect(action.filterNameList).toBe(filterNameList);
+        expect(action.overrideParams).toBe(overrideParams);
+        expect(action.itemId).toBe(itemId);
+        expect(action.ignoreVisibilityLimits).toBe(ignoreVisibilityLimits);
+    });
     it('reset reverse geocode data', () => {
         const e = hideMapinfoRevGeocode();
         expect(e).toExist();

--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -194,15 +194,17 @@ export function updateCenterToMarker(status) {
  * @param {object[]} [filterNameList=[]] list of layers to perform the GFI request
  * @param {object} [overrideParams={}] a map based on name as key and objec as value for overriding request params
  * @param {string} [itemId=null] id of the item needed for filtering results
+ * @param {string} [ignoreVisibilityLimits=false] a boolean flag for ignoring layer visibility limits restrictions to apply GFI
  */
-export function featureInfoClick(point, layer, filterNameList = [], overrideParams = {}, itemId = null) {
+export function featureInfoClick(point, layer, filterNameList = [], overrideParams = {}, itemId = null, ignoreVisibilityLimits = false) {
     return {
         type: FEATURE_INFO_CLICK,
         point,
         layer,
         filterNameList,
         overrideParams,
-        itemId
+        itemId,
+        ignoreVisibilityLimits
     };
 }
 

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -600,6 +600,227 @@ describe('identify Epics', () => {
             }
         }, state);
     });
+    it('getFeatureInfoOnFeatureInfoClick WMS ignoring the layer that has visibility limits', (done) => {
+        // remove previous hook
+        registerHook('RESOLUTION_HOOK', undefined);
+        const state = {
+            map: {present: {...TEST_MAP_STATE.present, resolution: 100000}},
+            mapInfo: {
+                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } }
+            },
+            layers: {
+                flat: [{
+                    id: "TEST1",
+                    name: "TEST",
+                    "title": "TITLE",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json',
+                    minResolution: 500,
+                    maxResolution: 50000
+                },
+                {
+                    id: "TEST_NEW",
+                    name: "TEST",
+                    "title": "TITLE New",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json'
+                },
+                {
+                    id: "TEST2",
+                    name: "TEST2",
+                    "title": "TITLE2",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json'
+                }]
+            }
+        };
+        const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } }, "TEST", ["TEST"], {"TEST": {cql_filter: "id>1"}}, "province_view.5")];
+        testEpic(getFeatureInfoOnFeatureInfoClick, 3, sentActions, ([a0, a1, a2]) => {
+            try {
+                expect(a0).toExist();
+                expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
+                expect(a1).toExist();
+                expect(a1.type).toBe(NEW_MAPINFO_REQUEST);
+                expect(a1.reqId).toExist();
+                expect(a1.request).toExist();
+                expect(a1.request.cql_filter).toExist();
+                expect(a1.request.cql_filter).toBe("id>1");
+                expect(a2).toExist();
+                expect(a2.type).toBe(LOAD_FEATURE_INFO);
+                expect(a2.data).toExist();
+                expect(a2.requestParams).toExist();
+                expect(a2.reqId).toExist();
+                expect(a2.layerMetadata.title).toBe(state.layers.flat[1].title);        // layer that has no visibility limits
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        }, {...state, mapInfo: {
+            ...state.mapInfo,
+            itemId: "province_view.5"
+        }});
+    });
+    it('getFeatureInfoOnFeatureInfoClick WMS with ignoreVisibilityLimits flag with true and layers includes visibility limits [search service case]', (done) => {
+        // remove previous hook
+        registerHook('RESOLUTION_HOOK', undefined);
+        const state = {
+            map: {present: {...TEST_MAP_STATE.present, resolution: 100000}},
+            mapInfo: {
+                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } }
+            },
+            layers: {
+                flat: [{
+                    id: "TEST1",
+                    name: "TEST",
+                    "title": "TITLE",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json',
+                    minResolution: 500,
+                    maxResolution: 50000
+                },
+                {
+                    id: "TEST NEW 2",
+                    name: "TEST",
+                    "title": "TITLE NEW 2",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json',
+                    minResolution: 500,
+                    maxResolution: 50000
+                },
+                {
+                    id: "TEST_NEW",
+                    name: "TEST",
+                    "title": "TITLE New",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json'
+                },
+                {
+                    id: "TEST2",
+                    name: "TEST2",
+                    "title": "TITLE2",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json'
+                }]
+            }
+        };
+        const ignoreVisibilityLimits = true;
+        const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } }, "TEST", ["TEST"], {"TEST": {cql_filter: "id>1"}}, "province_view.5", ignoreVisibilityLimits)];
+        testEpic(getFeatureInfoOnFeatureInfoClick, 5, sentActions, ([a0, a1, a2, a3]) => {
+            try {
+                expect(a0).toExist();
+                expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
+                expect(a1).toExist();
+                expect(a1.type).toBe(NEW_MAPINFO_REQUEST);
+                expect(a1.reqId).toExist();
+                expect(a1.request).toExist();
+                expect(a1.request.id).toEqual(state.layers.flat[2].id);
+                expect(a1.request.cql_filter).toExist();
+                expect(a1.request.cql_filter).toBe("id>1");
+                expect(a2).toExist();
+                expect(a2.type).toBe(NEW_MAPINFO_REQUEST);
+                expect(a2.reqId).toExist();
+                expect(a2.request).toExist();
+                expect(a2.request.id).toEqual(state.layers.flat[1].id);
+                expect(a2.request.cql_filter).toExist();
+                expect(a2.request.cql_filter).toBe("id>1");
+                expect(a3).toExist();
+                expect(a3.type).toBe(NEW_MAPINFO_REQUEST);
+                expect(a3.reqId).toExist();
+                expect(a3.request).toExist();
+                expect(a3.request.id).toEqual(state.layers.flat[0].id);
+                expect(a3.request.cql_filter).toExist();
+                expect(a3.request.cql_filter).toBe("id>1");
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        }, {...state, mapInfo: {
+            ...state.mapInfo,
+            itemId: "province_view.5"
+        }});
+    });
+    it('getFeatureInfoOnFeatureInfoClick WMS with ignoreVisibilityLimits flag with true and selected layers [search service case]', (done) => {
+        // remove previous hook
+        registerHook('RESOLUTION_HOOK', undefined);
+        const state = {
+            map: {present: {...TEST_MAP_STATE.present, resolution: 100000}},
+            mapInfo: {
+                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } }
+            },
+            layers: {
+                flat: [{
+                    id: "TEST1",
+                    name: "TEST",
+                    "title": "TITLE",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json',
+                    minResolution: 500,
+                    maxResolution: 50000
+                },
+                {
+                    id: "TEST NEW 2",
+                    name: "TEST",
+                    "title": "TITLE NEW 2",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json',
+                    minResolution: 500,
+                    maxResolution: 50000
+                },
+                {
+                    id: "TEST_NEW",
+                    name: "TEST",
+                    "title": "TITLE New",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json'
+                },
+                {
+                    id: "TEST2",
+                    name: "TEST2",
+                    "title": "TITLE2",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json'
+                }],
+                selected: ['TEST1']
+            }
+        };
+        const ignoreVisibilityLimits = true;
+        const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } }, "TEST", ["TEST"], {"TEST": {cql_filter: "id>1"}}, "province_view.5", ignoreVisibilityLimits)];
+        testEpic(getFeatureInfoOnFeatureInfoClick, 3, sentActions, ([a0, a1, a2]) => {
+            try {
+                expect(a0).toExist();
+                expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
+                expect(a1).toExist();
+                expect(a1.type).toBe(NEW_MAPINFO_REQUEST);
+                expect(a1.reqId).toExist();
+                expect(a1.request).toExist();
+                expect(a1.request.id).toEqual(state.layers.flat[0].id);
+                expect(a1.request.cql_filter).toExist();
+                expect(a1.request.cql_filter).toBe("id>1");
+                expect(a2.type).toBe(LOAD_FEATURE_INFO);
+                expect(a2.data).toExist();
+                expect(a2.requestParams).toExist();
+                expect(a2.reqId).toExist();
+                expect(a2.layerMetadata.title).toBe(state.layers.flat[0].title);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        }, {...state, mapInfo: {
+            ...state.mapInfo,
+            itemId: "province_view.5"
+        }});
+    });
     it('handleMapInfoMarker show', done => {
         testEpic(handleMapInfoMarker, 1, featureInfoClick({}), ([ a ]) => {
             expect(a.type).toBe(SHOW_MAPINFO_MARKER);

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -222,6 +222,7 @@ describe('search Epics', () => {
             expect(getInfoActions[1].type).toBe(FEATURE_INFO_CLICK);
             expect(getInfoActions[1].filterNameList).toEqual([]);
             expect(getInfoActions[1].layer).toEqual("gs:layername");
+            expect(getInfoActions[1].ignoreVisibilityLimits).toEqual(true);
         });
 
     });
@@ -271,6 +272,7 @@ describe('search Epics', () => {
             expect(getInfoActions[1].filterNameList).toEqual(["gs:layername"]);
             expect(getInfoActions[1].overrideParams).toEqual({"gs:layername": {info_format: "text/html", featureid: "Feature_1", CQL_FILTER: undefined}}); // forces CQL FILTER to undefined (server do not support featureid + CQL_FILTER)
             expect(getInfoActions[1].layer).toEqual("gs:layername");
+            expect(getInfoActions[1].ignoreVisibilityLimits).toEqual(true);
             done();
         }, {layers: {flat: [{name: "gs:layername", url: "base/web/client/test-resources/wms/GetFeature.json", visibility: true, featureInfo: {format: "HTML"}, queryable: true, type: "wms"}]}});
     });
@@ -383,6 +385,7 @@ describe('search Epics', () => {
             expect(getInfoActions[1].filterNameList).toEqual(["gs:layername"]);
             expect(getInfoActions[1].overrideParams).toEqual({"gs:layername": {info_format: "text/html", featureid: "Feature_1", CQL_FILTER: undefined}}); // forces CQL FILTER to undefined (server do not support featureid + CQL_FILTER)
             expect(getInfoActions[1].layer).toEqual("gs:layername");
+            expect(getInfoActions[1].ignoreVisibilityLimits).toEqual(true);
             done();
         }, {layers: {flat: [{name: "gs:layername", url: "base/web/client/test-resources/wms/GetFeature.json", visibility: true, featureInfo: {format: "HTML"}, queryable: true, type: "wms"}]}});
     });
@@ -722,6 +725,7 @@ describe('search Epics', () => {
             expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
             expect(actions[0].overrideParams.layerName.info_format).toBe("text/html");
             expect(actions[0].overrideParams.layerName.featureid).toBe("layer_01");
+            expect(actions[0].ignoreVisibilityLimits).toEqual(true);
             expect(actions[1].type).toBe(SHOW_MAPINFO_MARKER);
             expect(actions[2].type).toBe(TEXT_SEARCH_ADD_MARKER);
             expect(actions[3].type).toBe(ZOOM_TO_EXTENT);
@@ -757,6 +761,7 @@ describe('search Epics', () => {
             expect(actions[1].type).toBe(FEATURE_INFO_CLICK);
             expect(actions[1].overrideParams.layerName.info_format).toBe("text/html");
             expect(actions[1].overrideParams.layerName.featureid).toBe("layer_01");
+            expect(actions[1].ignoreVisibilityLimits).toEqual(true);
             expect(actions[2].type).toBe(SHOW_MAPINFO_MARKER);
             expect(actions[3].type).toBe(TEXT_SEARCH_ADD_MARKER);
             expect(actions[4].type).toBe(ZOOM_TO_EXTENT);

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -41,7 +41,7 @@ import {
     itemIdSelector, overrideParamsSelector, filterNameListSelector,
     currentEditFeatureQuerySelector, mapTriggerSelector, enableInfoForSelectedLayersSelector
 } from '../selectors/mapInfo';
-import { centerToMarkerSelector, queryableLayersSelector, queryableSelectedLayersSelector, selectedNodesSelector } from '../selectors/layers';
+import { centerToMarkerSelector, getSelectedLayers, layersSelector, queryableLayersSelector, queryableSelectedLayersSelector, selectedNodesSelector } from '../selectors/layers';
 import { modeSelector, getAttributeFilters, isFeatureGridOpen } from '../selectors/featuregrid';
 import { spatialFieldSelector } from '../selectors/queryform';
 import { mapSelector, projectionDefsSelector, projectionSelector, isMouseMoveIdentifyActiveSelector } from '../selectors/map';
@@ -52,7 +52,7 @@ import { createControlEnabledSelector, measureSelector } from '../selectors/cont
 import { localizedLayerStylesEnvSelector } from '../selectors/localizedLayerStyles';
 import { mouseOutSelector } from '../selectors/mousePosition';
 import {getBbox, getCurrentResolution, parseLayoutValue} from '../utils/MapUtils';
-import {buildIdentifyRequest, filterRequestParams} from '../utils/MapInfoUtils';
+import {buildIdentifyRequest, defaultQueryableFilter, filterRequestParams} from '../utils/MapInfoUtils';
 import { IDENTIFY_POPUP } from '../components/map/popups';
 
 const gridEditingSelector = state => modeSelector(state) === 'EDIT';
@@ -74,10 +74,11 @@ import {updatePointWithGeometricFilter} from "../utils/IdentifyUtils";
  */
 export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { } }) =>
     action$.ofType(FEATURE_INFO_CLICK)
-        .switchMap(({ point, filterNameList = [], overrideParams = {} }) => {
+        .switchMap(({ point, filterNameList = [], overrideParams = {}, ignoreVisibilityLimits }) => {
+            // ignoreVisibilityLimits is for ignore limits of layers visibility
             // Reverse - To query layer in same order as in TOC
-            let queryableLayers = reverse(queryableLayersSelector(getState()));
-            const queryableSelectedLayers = queryableSelectedLayersSelector(getState());
+            let queryableLayers = ignoreVisibilityLimits ? reverse([...layersSelector(getState())].filter(l=>defaultQueryableFilter(l))) :  reverse(queryableLayersSelector(getState()));
+            const queryableSelectedLayers = ignoreVisibilityLimits ? [...getSelectedLayers(getState())].filter(l => defaultQueryableFilter(l)) : queryableSelectedLayersSelector(getState());
             const enableInfoForSelectedLayers = enableInfoForSelectedLayersSelector(getState());
             if (enableInfoForSelectedLayers && queryableSelectedLayers.length) {
                 queryableLayers = queryableSelectedLayers;

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -37,6 +37,7 @@ import {
     searchTextLoading,
     selectNestedService,
     serverError,
+    TEXT_SEARCH_ADD_MARKER,
     TEXT_SEARCH_ITEM_SELECTED,
     TEXT_SEARCH_RESET,
     TEXT_SEARCH_RESULTS_PURGE,
@@ -122,7 +123,7 @@ export const searchEpic = action$ =>
  * @return {Observable}
  */
 
-export const searchItemSelected = (action$, store) =>
+export const searchItemSelected = (action$) =>
     action$.ofType(TEXT_SEARCH_ITEM_SELECTED)
         .switchMap(action => {
             // itemSelectionStream --> emits actions for zoom and marker add
@@ -145,46 +146,6 @@ export const searchItemSelected = (action$, store) =>
                         zoomToExtent([bbox[0], bbox[1], bbox[2], bbox[3]], "EPSG:4326", item.__SERVICE__ && item.__SERVICE__.options && item.__SERVICE__.options.maxZoomLevel || 21),
                         addMarker(item)
                     ];
-                    if (item.__SERVICE__ && !isNil(item.__SERVICE__.launchInfoPanel) && item.__SERVICE__.options && item.__SERVICE__.options.typeName) {
-                        let coord = pointOnSurface(item).geometry.coordinates;
-                        const latlng = { lng: coord[0], lat: coord[1] };
-                        const typeName = item.__SERVICE__.options.typeName;
-                        if (coord) {
-                            const state = store.getState();
-                            const layerObj = typeName && getLayerFromName(state, typeName);
-                            let itemId = null;
-                            let filterNameList = [];
-                            let overrideParams = {};
-                            let forceVisibility = false;
-                            if (item.__SERVICE__.launchInfoPanel === "single_layer") {
-                                /* take info from the item selected and restrict feature info to this layer
-                                 * and filtering with `featureid` which might be ignored by other servers,
-                                 * but can be used by GeoServer to select the specific feature instead to showing all the results
-                                 * when info_format is other than application/json */
-                                forceVisibility = item.__SERVICE__.forceSearchLayerVisibility;
-                                filterNameList = [typeName];
-                                itemId = item.id;
-                                overrideParams = {
-                                    [item.__SERVICE__.options.typeName]: {
-                                        info_format: getInfoFormat(layerObj, state),
-                                        ...(itemId
-                                            ? {
-                                                featureid: itemId,
-                                                CQL_FILTER: undefined
-                                            }
-                                            : {}
-                                        )
-                                    }
-                                };
-                            }
-                            return [
-                                ...(forceVisibility && layerObj ? [changeLayerProperties(layerObj.id, {visibility: true})] : []),
-                                ...(!item.__SERVICE__.openFeatureInfoButtonEnabled ? [featureInfoClick({ latlng }, typeName, filterNameList, overrideParams, itemId)] : []),
-                                showMapinfoMarker(),
-                                ...actions
-                            ];
-                        }
-                    }
                     return actions;
                 });
 
@@ -213,6 +174,56 @@ export const searchItemSelected = (action$, store) =>
             return Rx.Observable.of(resultsPurge()).concat(itemSelectionStream, nestedServicesStream, searchTextStream);
         });
 
+/**
+ * Handles performing a GFI on the selected search results after zooming in, and adds a marker
+ * @param {external:Observable} action$ manages [`FEATURE_INFO_CLICK` and `SHOW_MAPINFO_MARKER`] for showing identify feature info
+ * @memberof epics.search
+ * @return {external:Observable}
+ */
+export const getFeatureInfoOfSelectedItem = (action$, store) =>
+    action$.ofType(TEXT_SEARCH_ADD_MARKER).switchMap((action) => {
+        const item = action.markerPosition;
+        if (item.__SERVICE__ && !isNil(item.__SERVICE__.launchInfoPanel) && item.__SERVICE__.options && item.__SERVICE__.options.typeName) {
+            let coord = pointOnSurface(item).geometry.coordinates;
+            const latlng = { lng: coord[0], lat: coord[1] };
+            const typeName = item.__SERVICE__.options.typeName;
+            if (coord) {
+                const state = store.getState();
+                const layerObj = typeName && getLayerFromName(state, typeName);
+                let itemId = null;
+                let filterNameList = [];
+                let overrideParams = {};
+                let forceVisibility = false;
+                if (item.__SERVICE__.launchInfoPanel === "single_layer") {
+                    /* take info from the item selected and restrict feature info to this layer
+                    * and filtering with `featureid` which might be ignored by other servers,
+                    * but can be used by GeoServer to select the specific feature instead to showing all the results
+                    * when info_format is other than application/json */
+                    forceVisibility = item.__SERVICE__.forceSearchLayerVisibility;
+                    filterNameList = [typeName];
+                    itemId = item.id;
+                    overrideParams = {
+                        [item.__SERVICE__.options.typeName]: {
+                            info_format: getInfoFormat(layerObj, state),
+                            ...(itemId
+                                ? {
+                                    featureid: itemId,
+                                    CQL_FILTER: undefined
+                                }
+                                : {}
+                            )
+                        }
+                    };
+                }
+                return [
+                    ...(forceVisibility && layerObj ? [changeLayerProperties(layerObj.id, {visibility: true})] : []),
+                    ...(!item.__SERVICE__.openFeatureInfoButtonEnabled ? [featureInfoClick({ latlng }, typeName, filterNameList, overrideParams, itemId)] : []),
+                    showMapinfoMarker()
+                ];
+            }
+        }
+        return [Rx.Observable.empty()];
+    }).delay(50);
 /**
  * Handles show GFI button click action.
  */

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -13,7 +13,7 @@ import assign from 'object-assign';
 import {isNil, sortBy} from 'lodash';
 import uuid from 'uuid';
 
-import {centerToMarkerSelector, getLayerFromName, queryableLayersSelector} from '../selectors/layers';
+import {centerToMarkerSelector, getLayerFromName, layersSelector} from '../selectors/layers';
 
 import {updateAdditionalLayer} from '../actions/additionallayers';
 import {
@@ -52,7 +52,7 @@ import {generateTemplateString} from '../utils/TemplateUtils';
 
 import {API} from '../api/searchText';
 import {getFeatureSimple} from '../api/WFS';
-import {getDefaultInfoFormatValueFromLayer} from '../utils/MapInfoUtils';
+import {defaultQueryableFilter, getDefaultInfoFormatValueFromLayer} from '../utils/MapInfoUtils';
 import {identifyOptionsSelector, isMapPopup} from '../selectors/mapInfo';
 import { addPopup } from '../actions/mapPopups';
 import { IDENTIFY_POPUP } from '../components/map/popups';
@@ -215,9 +215,11 @@ export const getFeatureInfoOfSelectedItem = (action$, store) =>
                         }
                     };
                 }
+                const ignoreVisibilityLimits = true;
                 return [
                     ...(forceVisibility && layerObj ? [changeLayerProperties(layerObj.id, {visibility: true})] : []),
-                    ...(!item.__SERVICE__.openFeatureInfoButtonEnabled ? [featureInfoClick({ latlng }, typeName, filterNameList, overrideParams, itemId)] : []),
+                    ...(!item.__SERVICE__.openFeatureInfoButtonEnabled ? [featureInfoClick({ latlng }, typeName, filterNameList, overrideParams, itemId, ignoreVisibilityLimits)] : []),
+
                     showMapinfoMarker()
                 ];
             }
@@ -238,6 +240,7 @@ export const textSearchShowGFIEpic = (action$, store) =>
             const coord = pointOnSurface(item).geometry.coordinates;
             const latlng = { lng: coord[0], lat: coord[1] };
             const itemId = item.id;
+            const ignoreVisibilityLimits = true;
             return !!coord &&
                 showGFIForService(item?.__SERVICE__) && layerIsVisibleForGFI(layerObj, item?.__SERVICE__) ?
                 Rx.Observable.of(
@@ -254,7 +257,7 @@ export const textSearchShowGFIEpic = (action$, store) =>
                                 }
                                 : {}
                             )
-                        } }, itemId),
+                        } }, itemId, ignoreVisibilityLimits),
                     showMapinfoMarker(),
                     addMarker(item)
                 ).merge(
@@ -315,8 +318,10 @@ export const searchOnStartEpic = (action$, store) =>
     action$.ofType(SEARCH_LAYER_WITH_FILTER)
         .switchMap(({layer: name, "cql_filter": cqlFilter}) => {
             const state = store.getState();
+            let queryableLayers = [...layersSelector(state)].filter(l=>defaultQueryableFilter(l));          // ignore visibility limits
+            const isLayerNotQueryableSelected = queryableLayers.filter(l => l.name === name).length === 0;
             // if layer is NOT queriable and visible then show error notification
-            if (queryableLayersSelector(state).filter(l => l.name === name ).length === 0) {
+            if (isLayerNotQueryableSelected) {
                 return Rx.Observable.of(nonQueriableLayerError());
             }
             const layer = getLayerFromName(state, name);
@@ -358,14 +363,14 @@ export const searchOnStartEpic = (action$, store) =>
                                     showMapinfoMarker()
                                 );
                             }
-
+                            const ignoreVisibilityLimits = true;
                             // trigger get feature info
                             return Rx.Observable.of(
                                 featureInfoClick(
                                     { latlng },
                                     typeName,
                                     [typeName],
-                                    { [typeName]: { cql_filter: cqlFilter } }
+                                    { [typeName]: { cql_filter: cqlFilter } }, null, ignoreVisibilityLimits
                                 )
                             )
                                 .merge(mapActionObservable);

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -43,7 +43,8 @@ import {
     searchOnStartEpic,
     textSearchShowGFIEpic,
     zoomAndAddPointEpic,
-    delayedSearchEpic
+    delayedSearchEpic,
+    getFeatureInfoOfSelectedItem
 } from '../epics/search';
 import mapInfoReducers from '../reducers/mapInfo';
 import searchReducers from '../reducers/search';
@@ -422,7 +423,7 @@ export default {
                 priority: 1
             }
         }),
-    epics: {searchEpic, searchOnStartEpic, searchItemSelected, zoomAndAddPointEpic, textSearchShowGFIEpic, delayedSearchEpic},
+    epics: {searchEpic, searchOnStartEpic, searchItemSelected, zoomAndAddPointEpic, textSearchShowGFIEpic, delayedSearchEpic, getFeatureInfoOfSelectedItem},
     reducers: {
         search: searchReducers,
         mapInfo: mapInfoReducers,


### PR DESCRIPTION
[Backport 2024.01.xx] - https://github.com/geosolutions-it/MapStore2/issues/10264: Layer visibility limits may prevent the Info panel of search results from opening (#10302, #10325)