### PR TITLE
Fix #10040 print arcgis layer with different projections 

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -531,7 +531,8 @@ export default {
                             "wfs",
                             "vector",
                             "graticule",
-                            "empty"
+                            "empty",
+                            "arcgis"
                         ], layer.type) || layer.type === "wmts" && has(layer.allowedSRS, projection);
                     };
                     isAllowed = (layer, projection) => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes the 2nd problem reported in this comment https://github.com/geosolutions-it/MapStore2/pull/10330#issuecomment-2124672457

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10040

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

It is possible to print arcgis layer with projections different from EPSG:3857

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
