### PR TITLE
10294 fix arcgis layer grouping bug

### DIFF
--- a/web/client/api/catalog/ArcGIS.js
+++ b/web/client/api/catalog/ArcGIS.js
@@ -17,7 +17,7 @@ function validateUrl(serviceUrl) {
     return false;
 }
 
-const recordToLayer = (record) => {
+const recordToLayer = (record, { layerBaseConfig }) => {
     if (!record) {
         return null;
     }
@@ -38,7 +38,8 @@ const recordToLayer = (record) => {
             options: {
                 layers: record.layers
             }
-        })
+        }),
+        ...layerBaseConfig
     };
 };
 

--- a/web/client/api/catalog/__tests__/ArcGIS-test.js
+++ b/web/client/api/catalog/__tests__/ArcGIS-test.js
@@ -57,8 +57,8 @@ describe('Test ArcGIS Catalog API', () => {
             url: "base/web/client/test-resources/arcgis/arcgis-test-data.json"
         };
         try {
-            const layer = getLayerFromRecord( testRecord );
-            const { type, url, name, title, visibility } = layer;
+            const layer = getLayerFromRecord( testRecord, { layerBaseConfig: { group: undefined } } );
+            const { type, url, name, title, visibility, group } = layer;
 
             expect(type).toBeTruthy();
             expect(type).toBe('arcgis');
@@ -73,6 +73,39 @@ describe('Test ArcGIS Catalog API', () => {
             expect(title).toBe(testRecord.title);
 
             expect(visibility).toBeTruthy();
+
+            expect(group).toBe(undefined);
+        } catch (e) {
+            done(e);
+        }
+        done();
+    });
+    it('should get layer from record while a group is selected', (done) => {
+        const testRecord = {
+            name: 1,
+            title: "Outreach",
+            url: "base/web/client/test-resources/arcgis/arcgis-test-data.json"
+        };
+        const _selectedGroup = 'test_group';
+        try {
+            const layer = getLayerFromRecord( testRecord, { layerBaseConfig: { group: _selectedGroup } } );
+            const { type, url, name, title, visibility, group } = layer;
+
+            expect(type).toBeTruthy();
+            expect(type).toBe('arcgis');
+
+            expect(url).toBeTruthy();
+            expect(url).toBe(testRecord.url);
+
+            expect(name).toBeTruthy();
+            expect(name).toBe(`${testRecord.name}`);
+
+            expect(title).toBeTruthy();
+            expect(title).toBe(testRecord.title);
+
+            expect(visibility).toBeTruthy();
+
+            expect(group).toBe(_selectedGroup);
         } catch (e) {
             done(e);
         }


### PR DESCRIPTION
## Description
This PR fixes #10294 , namely, adding an arcgis type layer to a selected group does not add the layer to the group.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#10294

**What is the new behavior?**
Layer is correctly added to the selected group on initialization,

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
