### PR TITLE
#10281: Use Cache Options functionality extended to be applied on all the layers from a service

### DIFF
--- a/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
+++ b/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
@@ -198,7 +198,10 @@ function WMSCacheOptions({
 }) {
 
     const [tileGridLoading, setTileGridLoading] = useState(false);
-    const [tileGridsResponseMsgId, setTileGridsResponseMsgId] = useState('');
+    const [tileGridsResponseMsgId, setTileGridsResponseMsgId] = useState(() => {
+        if (layer?.tileGridStrategy === 'custom' && layer?.tiled && layer?.tileGrids?.length === 0) return "layerProperties.noConfiguredGridSets";
+        return "";
+    });
     const [tileGridsResponseMsgStyle, setTileGridsResponseMsgStyle] = useState('');
     const [standardTileGridInfo, setStandardTileGridInfo] = useState({});
 
@@ -282,7 +285,7 @@ function WMSCacheOptions({
                         bsStyle={(!supportFormatCache || !selectedTileGridId)
                             ? 'danger'
                             : 'success'}
-                        title={<Message msgId="layerProperties.tileGridInfoChecksTitle" />}
+                        title={<Message msgId="layerProperties.notSupportedSelectedFormatCache" />}
                         popoverStyle={{ maxWidth: 'none' }}
                         text={<InfoText
                             layer={layer}

--- a/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
+++ b/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
@@ -199,8 +199,8 @@ function WMSCacheOptions({
 
     const [tileGridLoading, setTileGridLoading] = useState(false);
     const [tileGridsResponseMsgId, setTileGridsResponseMsgId] = useState(() => {
-        if (layer?.tileGridStrategy === 'custom' && layer?.tiled && layer?.tileGrids?.length === 0) return "layerProperties.noConfiguredGridSets";
-        return "";
+        const noTileGrids = layer?.tileGridStrategy === 'custom' && layer?.tiled && layer?.tileGrids?.length === 0;
+        return noTileGrids ? "layerProperties.noConfiguredGridSets" :"";
     });
     const [tileGridsResponseMsgStyle, setTileGridsResponseMsgStyle] = useState('');
     const [standardTileGridInfo, setStandardTileGridInfo] = useState({});

--- a/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
+++ b/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
@@ -285,7 +285,7 @@ function WMSCacheOptions({
                         bsStyle={(!supportFormatCache || !selectedTileGridId)
                             ? 'danger'
                             : 'success'}
-                        title={<Message msgId="layerProperties.notSupportedSelectedFormatCache" />}
+                        title={<Message msgId="layerProperties.tileGridInfoChecksTitle" />}
                         popoverStyle={{ maxWidth: 'none' }}
                         text={<InfoText
                             layer={layer}

--- a/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
+++ b/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
@@ -200,7 +200,7 @@ function WMSCacheOptions({
     const [tileGridLoading, setTileGridLoading] = useState(false);
     const [tileGridsResponseMsgId, setTileGridsResponseMsgId] = useState(() => {
         const noTileGrids = layer?.tileGridStrategy === 'custom' && layer?.tiled && layer?.tileGrids?.length === 0;
-        return noTileGrids ? "layerProperties.noConfiguredGridSets" :"";
+        return noTileGrids ? "layerProperties.noConfiguredGridSets" : "";
     });
     const [tileGridsResponseMsgStyle, setTileGridsResponseMsgStyle] = useState('');
     const [standardTileGridInfo, setStandardTileGridInfo] = useState({});

--- a/web/client/components/TOC/fragments/settings/__tests__/WMSCacheOptions-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/WMSCacheOptions-test.jsx
@@ -1045,7 +1045,7 @@ describe('WMSCacheOptions', () => {
             .catch(done);
 
     });
-    it('should display noConfiguredGridSets warning message if layer is confugred from catalog to `Use Cache Options` but with no fetched configured grid sets', () => {
+    it('should display noConfiguredGridSets warning message if layer is configured from catalog to `Use Cache Options`, with no grid sets available', () => {
         ReactDOM.render(<WMSCacheOptions layer={{
             url: '/geoserver/wms',
             name: 'topp:states',

--- a/web/client/components/TOC/fragments/settings/__tests__/WMSCacheOptions-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/WMSCacheOptions-test.jsx
@@ -1045,5 +1045,30 @@ describe('WMSCacheOptions', () => {
             .catch(done);
 
     });
+    it('should display noConfiguredGridSets warning message if layer is confugred from catalog to `Use Cache Options` but with no fetched configured grid sets', () => {
+        ReactDOM.render(<WMSCacheOptions layer={{
+            url: '/geoserver/wms',
+            name: 'topp:states',
+            tileGridStrategy: 'custom',
+            format: 'image/jpeg',
+            tileGridCacheSupport: {
+                formats: ['image/png']
+            },
+            tiled: true,
+            tileGrids: []
+        }} projection="EPSG:3857" />, document.getElementById('container'));
+        expect(document.querySelector('.ms-wms-cache-options')).toBeTruthy();
+        const inputs = document.querySelectorAll('input[type="checkbox"]');
+        expect(inputs.length).toBe(1);
+        const buttons = document.querySelectorAll('button');
+        expect(buttons.length).toBe(2);
+        expect([...buttons].map(button => button.querySelector('.glyphicon').getAttribute('class'))).toEqual([
+            'glyphicon glyphicon-refresh',
+            'glyphicon glyphicon-grid-custom'
+        ]);
+
+        const alert = document.querySelector('.alert');
+        expect(alert.innerText).toBe('layerProperties.noConfiguredGridSets');
+    });
 });
 

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -287,6 +287,7 @@ export default (API) => ({
                             if (tileGridData) {
                                 const filteredTileGrids = tileGridData.tileGrids.filter(({ crs }) => isProjectionAvailable(CoordinatesUtils.normalizeSRS(crs)));
                                 tileGridProperties = tileGridData !== undefined ? {
+                                    tiled: true,
                                     tileGrids: tileGridData.tileGrids,
                                     tileGridStrategy: 'custom',
                                     tileGridCacheSupport: filteredTileGrids?.length > 0 ?


### PR DESCRIPTION
## Description
In this PR includes handling a missing case of showing a warning message in case of not having the grid sets

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
https://github.com/geosolutions-it/MapStore2/pull/10349#issuecomment-2127038924

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/pull/10349#issuecomment-2127038924

**What is the new behavior?**
If user configure Use Cache Option flag in WMS catalog then add a layer from the catalog and this layer has no configured grid sets, a warning message will display on layer settings without clicking on refresh button.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
