### PR TITLE
[Backport 2024.01.xx]: #10281: Use Cache Options functionality extended to be applied on all the layers from a service (#10349, #10361)

### DIFF
--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web/client/components/catalog/editor/AdvancedSettings/__tests__', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web/client/components/catalog/editor/AdvancedSettings/__tests__', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
+++ b/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
@@ -198,7 +198,10 @@ function WMSCacheOptions({
 }) {
 
     const [tileGridLoading, setTileGridLoading] = useState(false);
-    const [tileGridsResponseMsgId, setTileGridsResponseMsgId] = useState('');
+    const [tileGridsResponseMsgId, setTileGridsResponseMsgId] = useState(() => {
+        const noTileGrids = layer?.tileGridStrategy === 'custom' && layer?.tiled && layer?.tileGrids?.length === 0;
+        return noTileGrids ? "layerProperties.noConfiguredGridSets" : "";
+    });
     const [tileGridsResponseMsgStyle, setTileGridsResponseMsgStyle] = useState('');
     const [standardTileGridInfo, setStandardTileGridInfo] = useState({});
 

--- a/web/client/components/TOC/fragments/settings/__tests__/WMSCacheOptions-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/WMSCacheOptions-test.jsx
@@ -1045,5 +1045,30 @@ describe('WMSCacheOptions', () => {
             .catch(done);
 
     });
+    it('should display noConfiguredGridSets warning message if layer is configured from catalog to `Use Cache Options`, with no grid sets available', () => {
+        ReactDOM.render(<WMSCacheOptions layer={{
+            url: '/geoserver/wms',
+            name: 'topp:states',
+            tileGridStrategy: 'custom',
+            format: 'image/jpeg',
+            tileGridCacheSupport: {
+                formats: ['image/png']
+            },
+            tiled: true,
+            tileGrids: []
+        }} projection="EPSG:3857" />, document.getElementById('container'));
+        expect(document.querySelector('.ms-wms-cache-options')).toBeTruthy();
+        const inputs = document.querySelectorAll('input[type="checkbox"]');
+        expect(inputs.length).toBe(1);
+        const buttons = document.querySelectorAll('button');
+        expect(buttons.length).toBe(2);
+        expect([...buttons].map(button => button.querySelector('.glyphicon').getAttribute('class'))).toEqual([
+            'glyphicon glyphicon-refresh',
+            'glyphicon glyphicon-grid-custom'
+        ]);
+
+        const alert = document.querySelector('.alert');
+        expect(alert.innerText).toBe('layerProperties.noConfiguredGridSets');
+    });
 });
 

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -163,6 +163,14 @@ export default ({
                     onChange={event => onChangeServiceProperty("layerOptions", { ...service.layerOptions, serverType: event?.value })} />
             </InputGroup>
         </FormGroup>
+        {![ServerTypes.NO_VENDOR].includes(service.layerOptions?.serverType) && service.type === "wms" &&  <FormGroup controlId="useCacheOption" key="useCacheOption">
+            <Checkbox data-qa="display-interactive-legend-option"
+                onChange={(e) => onChangeServiceProperty("layerOptions", { ...service.layerOptions, remoteTileGrids: e.target.checked})}
+                checked={!isNil(service.layerOptions?.remoteTileGrids) ? service.layerOptions?.remoteTileGrids : false}>
+                <Message msgId="layerProperties.useCacheOptionInfo.label" />
+                &nbsp;<InfoPopover text={<Message msgId="layerProperties.useCacheOptionInfo.info" />} />
+            </Checkbox>
+        </FormGroup>}
         <hr style={{margin: "8px 0"}}/>
         <FormGroup style={advancedRasterSettingsStyles} className="form-group-flex">
             <ControlLabel className="strong"><Message msgId="layerProperties.format.title" /></ControlLabel>

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -33,7 +33,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
-        expect(fields.length).toBe(13);
+        expect(fields.length).toBe(15);
     });
     it('test csw advanced options', () => {
         ReactDOM.render(<RasterAdvancedSettings service={{type: "csw", autoload: false}}/>, document.getElementById("container"));
@@ -208,6 +208,25 @@ describe('Test Raster advanced settings', () => {
         TestUtils.Simulate.change(allowUnsecureLayers, { "target": { "checked": false }});
         expect(spyOn).toHaveBeenCalled();
         expect(spyOn.calls[1].arguments).toEqual([ 'allowUnsecureLayers', false ]);
+    });
+    it('test component onChangeServiceProperty useCacheOption for remote tile grids', () => {
+        const action = {
+            onChangeServiceProperty: () => {}
+        };
+        const spyOn = expect.spyOn(action, 'onChangeServiceProperty');
+        ReactDOM.render(<RasterAdvancedSettings
+            onChangeServiceProperty={action.onChangeServiceProperty}
+            service={{ type: "wms" }}
+        />, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const formGroup = document.querySelectorAll('.form-group')[7];
+        expect(formGroup.textContent.trim()).toBe('layerProperties.useCacheOptionInfo.label');
+        const useCacheOption = formGroup.querySelector('input[type="checkbox"]');
+        expect(useCacheOption).toBeTruthy();
+        TestUtils.Simulate.change(useCacheOption, { "target": { "checked": true }});
+        expect(spyOn).toHaveBeenCalled();
+        expect(spyOn.calls[0].arguments).toEqual([ 'layerOptions', { remoteTileGrids: true } ]);
     });
     it('test component onChangeServiceProperty singleTile', () => {
         const action = {

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -33,7 +33,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
-        expect(fields.length).toBe(15);
+        expect(fields.length).toBe(14);
     });
     it('test csw advanced options', () => {
         ReactDOM.render(<RasterAdvancedSettings service={{type: "csw", autoload: false}}/>, document.getElementById("container"));
@@ -220,7 +220,7 @@ describe('Test Raster advanced settings', () => {
         />, document.getElementById("container"));
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
-        const formGroup = document.querySelectorAll('.form-group')[7];
+        const formGroup = document.querySelectorAll('.form-group')[6];
         expect(formGroup.textContent.trim()).toBe('layerProperties.useCacheOptionInfo.label');
         const useCacheOption = formGroup.querySelector('input[type="checkbox"]');
         expect(useCacheOption).toBeTruthy();

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -286,6 +286,7 @@ export default (API) => ({
                             if (tileGridData) {
                                 const filteredTileGrids = tileGridData.tileGrids.filter(({ crs }) => isProjectionAvailable(CoordinatesUtils.normalizeSRS(crs)));
                                 tileGridProperties = tileGridData !== undefined ? {
+                                    tiled: true,
                                     tileGrids: tileGridData.tileGrids,
                                     tileGridStrategy: 'custom',
                                     tileGridCacheSupport: filteredTileGrids?.length > 0 ?

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -62,6 +62,7 @@ import {
     updateServiceData
 } from '../utils/CatalogUtils';
 import { getCapabilities, describeLayers, flatLayers } from '../api/WMS';
+import {generateGeoServerWMTSUrl} from '../utils/WMTSUtils';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
 import ConfigUtils from '../utils/ConfigUtils';
 import {getCapabilitiesUrl, getLayerId, getLayerUrl, removeWorkspace, DEFAULT_GROUP_ID} from '../utils/LayersUtils';
@@ -75,6 +76,8 @@ import { extractGeometryType } from '../utils/WFSLayerUtils';
 import { createDefaultStyle } from '../utils/StyleUtils';
 import { removeDuplicateLines } from '../utils/StringUtils';
 import { logError } from '../utils/DebugUtils';
+import { isProjectionAvailable } from '../utils/ProjectionUtils';
+import {getLayerTileMatrixSetsInfo} from '../api/WMTS';
 
 const onErrorRecordSearch = (isNewService, errObj) => {
     logError({message: errObj});
@@ -270,8 +273,27 @@ export default (API) => ({
                     actions.push(zoomToExtent(layer.bbox.bounds, layer.bbox.crs));
                 }
                 if (layer.type === 'wms') {
-                    return Rx.Observable.defer(() => describeLayers(getLayerUrl(layer), layer.name))
-                        .switchMap(results => {
+                    // * fetch the api of cashe option if layer has 'remoteTileGrids' property with true value
+                    return Rx.Observable.forkJoin(
+                        Rx.Observable.defer(() => describeLayers(getLayerUrl(layer), layer.name)),
+                        (!layer?.remoteTileGrids) ?
+                            Rx.Observable.of(null) :
+                            Rx.Observable.defer(() => getLayerTileMatrixSetsInfo(generateGeoServerWMTSUrl(layer), layer.name, layer))
+                                .catch(() => Rx.Observable.of(null))
+                    )
+                        .switchMap(([results, tileGridData]) => {
+                            let tileGridProperties = {};
+                            if (tileGridData) {
+                                const filteredTileGrids = tileGridData.tileGrids.filter(({ crs }) => isProjectionAvailable(CoordinatesUtils.normalizeSRS(crs)));
+                                tileGridProperties = tileGridData !== undefined ? {
+                                    tileGrids: tileGridData.tileGrids,
+                                    tileGridStrategy: 'custom',
+                                    tileGridCacheSupport: filteredTileGrids?.length > 0 ?
+                                        tileGridData.formats ? {formats: tileGridData.formats} : {}
+                                        : undefined
+                                } : {};
+
+                            }
                             if (results) {
                                 let description = find(results, (desc) => desc.name === layer.name );
                                 if (description && description.owsType === 'WFS') {
@@ -280,9 +302,12 @@ export default (API) => ({
                                         search: {
                                             url: filteredUrl,
                                             type: 'wfs'
-                                        }
+                                        }, ...tileGridProperties
                                     }));
                                 }
+                                return Rx.Observable.of(changeLayerProperties(id, {
+                                    ...tileGridProperties
+                                }));
                             }
                             return Rx.Observable.empty();
                         })

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -207,6 +207,10 @@
                 "label": "Lokalisierten Stil aktivieren",
                 "tooltip": "Hinweis: Diese Einstellung benötigt spezifische Konfigurationen im GeoServer"
             },
+            "useCacheOptionInfo": {
+                "label": "Verwenden Sie entfernte benutzerdefinierte Kachelraster",
+                "info": "Stellen Sie sicher, dass WMTS aktiviert ist, um benutzerdefinierte Kachelraster verwenden zu können"
+            },
             "format": {
                 "title": "Format",
                 "tile": "Fliese",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -207,6 +207,10 @@
                 "label": "Enable localized style",
                 "tooltip": "Note: This parameter requires specific configurations on GeoServer"
             },
+            "useCacheOptionInfo": {
+                "label": "Use remote custom tile grids",
+                "info": "Make sure to have WMTS enabled in order to use custom tile grids"
+            },
             "format": {
                 "title": "Format",
                 "tile": "Tile",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -207,6 +207,10 @@
                 "label": "Habilitar estilo localizado",
                 "tooltip": "Nota: este parámetro requiere configuraciones específicas en GeoServer"
             },
+            "useCacheOptionInfo": {
+                "label": "Utilice cuadrículas de mosaicos personalizadas remotas",
+                "info": "Asegúrese de que WMTS esté habilitado para poder usar cuadrículas de mosaicos personalizadas"
+            },
             "format": {
                 "title": "Formato",
                 "tile": "Teja",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -207,6 +207,10 @@
                 "label": "Activer le style localisé",
                 "tooltip": "Remarque: ce paramètre nécessite des configurations spécifiques sur GeoServer"
             },
+            "useCacheOptionInfo": {
+                "label": "Utiliser des grilles de carreaux personnalisées à distance",
+                "info": "Assurez-vous que WMTS est activé afin d'utiliser des grilles de tuiles personnalisées"
+            },
             "format": {
                 "title": "Format",
                 "tile": "Tile",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -207,6 +207,10 @@
                 "label": "Abilita stile localizzato",
                 "tooltip": "Nota: questo parametro richiede configurazioni specifiche su GeoServer"
             },
+            "useCacheOptionInfo": {
+                "label": "Utilizza griglie di riquadri personalizzate remote",
+                "info": "Assicurati che WMTS sia abilitato per utilizzare griglie di riquadri personalizzate"
+            },
             "format": {
                 "title": "Formato",
                 "tile": "Tile",


### PR DESCRIPTION
Backport 2024.01.xx -  #10281: Use Cache Options functionality extended to be applied on all the layers from a service (#10349, #10361)