### PR TITLE
Embedded geostory URL issue with scroll position

### DIFF
--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -70,6 +70,7 @@ class SharePanel extends React.Component {
         shareUrlReplaceString: PropTypes.string,
         shareApiUrl: PropTypes.string,
         shareConfigUrl: PropTypes.string,
+        currSectionId: PropTypes.string,
         embedPanel: PropTypes.bool,
         embedOptions: PropTypes.object,
         showAPI: PropTypes.bool,
@@ -213,7 +214,7 @@ class SharePanel extends React.Component {
     getShareUrl = () => {
         const { settings, advancedSettings, mapType, viewerOptions } = this.props;
         const shouldRemoveSectionId = !settings.showSectionId && advancedSettings && advancedSettings.sectionId;
-        let shareUrl = getSharedGeostoryUrl(removeQueryFromUrl(this.props.shareUrl), shouldRemoveSectionId);
+        let shareUrl = getSharedGeostoryUrl(removeQueryFromUrl(this.props.shareUrl), shouldRemoveSectionId, this.props.currSectionId);
         if (settings.bboxEnabled && advancedSettings && advancedSettings.bbox && this.state.bbox) shareUrl = `${shareUrl}?bbox=${this.state.bbox}`;
         if (settings.showHome && advancedSettings && advancedSettings.homeButton) shareUrl = `${shareUrl}?showHome=true`;
         if (settings.centerAndZoomEnabled && advancedSettings && advancedSettings.centerAndZoom) {

--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -80,12 +80,14 @@ const Share = connect(createSelector([
             ? [cameraPosition.longitude, cameraPosition.latitude]
             : map?.center;
         return center && ConfigUtils.getCenter(center);
-    }
-], (isVisible, version, map, mapType, context, settings, formatCoords, point, isScrollPosition, viewerOptions, center) => ({
+    },
+    state => state.geostory?.currentPage?.sectionId
+], (isVisible, version, map, mapType, context, settings, formatCoords, point, isScrollPosition, viewerOptions, center, currSectionId) => ({
     isVisible,
     shareUrl: location.href,
     shareApiUrl: getApiUrl(location.href),
     shareConfigUrl: getConfigUrl(location.href, ConfigUtils.getConfigProp('geoStoreUrl')),
+    currSectionId,
     version,
     viewerOptions,
     mapType,

--- a/web/client/utils/ShareUtils.js
+++ b/web/client/utils/ShareUtils.js
@@ -103,7 +103,7 @@ export const removeQueryFromUrl = (url = '') => {
     const formatHash = Url.format({ ...parseHash, query: null, search: null });
     return Url.format({ ...parsedUrl, query: null, search: null, hash: formatHash ? `#${formatHash}` : null });
 };
-export const getSharedGeostoryUrl = (url = '', removeScroll = false) => {
+export const getSharedGeostoryUrl = (url = '', removeScroll = false, currSectionId) => {
     if (url.match(/\#\/(geostory)/)) {
         let geostoryUrl = url.match(/\/(geostory)\/((shared)|(newgeostory))/)
             ? url
@@ -113,6 +113,8 @@ export const getSharedGeostoryUrl = (url = '', removeScroll = false) => {
             const parsedUrl = geostoryUrl.split('#')[1]?.split('/');
             if (parsedUrl.length === 6 && parsedUrl.includes('shared')) geostoryUrl = replace(geostoryUrl, `/section/${parsedUrl[parsedUrl.length - 1]}`, '');
             if (parsedUrl.length === 8 && parsedUrl.includes('shared')) geostoryUrl = replace(geostoryUrl, `/section/${parsedUrl[parsedUrl.length - 3]}/column/${parsedUrl[parsedUrl.length - 1]}`, '');
+        } else if ( !removeScroll && !geostoryUrl.includes('section') ) {
+            geostoryUrl = geostoryUrl + '/section/' + currSectionId;
         }
 
         return geostoryUrl;


### PR DESCRIPTION
## Description
Added section component to url on init of geostory, when scroll position is enabled.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#9047 

**What is the new behavior?**
When user enables `Include scroll position` flag, the `/section/id` component of the url is properly added.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
