### PR TITLE
Fix #10368 fix positioning of groups generated from GPT tool

### DIFF
--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -60,7 +60,7 @@ const insertNode = (nodes, node, parent, asFirst = false) => {
     }
     return nodes.map(n => isString(n) ? n : (n.id === parent ? {
         ...n,
-        nodes: [...n.nodes, node]
+        nodes: asFirst ? [node, ...n.nodes] : [...n.nodes, node]
     } : {
         ...n,
         nodes: insertNode(n.nodes, node, parent, asFirst)


### PR DESCRIPTION
* adjusted behaviour of add group action

Now groups as Buffered layers and Intersected layers are added on top of everything, if there is a default group defined then this one will be used

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10368 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
see description
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
