### PR TITLE
[Backport 2024.01.xx] Fix #10112 Review class name for symbolizer field (#10286)

### DIFF
--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -647,7 +647,7 @@ function Fields({
                 const Component = isPropertyField ? PropertySelector : FieldComponent;
                 const disabled = isDisabled && isDisabled(properties[key], state.current.properties, fieldsConfig);
                 const visible = isVisible ? isVisible(properties[key], state.current.properties, format) : true;
-                return visible ? (<div className={`ms-symbolizer-field-wrapper ${type || ""}`}>
+                return visible ? (<div className={`ms-symbolizer-field-wrapper ${type ? `ms-symbolizer-type-${type}` : ''}`}>
                     <Component
                         {...fieldsConfig}
                         key={key}

--- a/web/client/themes/default/less/style-editor.less
+++ b/web/client/themes/default/less/style-editor.less
@@ -620,7 +620,7 @@ Ported to CodeMirror by Peter Kroon
 .ms-symbolizer-field-wrapper {
     display: flex;
     align-items: center;
-    &.channel {
+    &.ms-symbolizer-type-channel {
         display: unset;
     }
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR review style class name for symbolizer field to avoid what reported in this comment https://github.com/geosolutions-it/MapStore2/pull/10118#issuecomment-2098817677

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10112

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Mark symbolizer has correct background syule

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
