### PR TITLE
Selected layers should not be considered when "enableInfoForSelectedlayers" is off

### DIFF
--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -86,7 +86,7 @@ export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { }
 
             const selectedLayers = selectedNodesSelector(getState());
 
-            if (queryableLayers.length === 0 || queryableSelectedLayers.length === 0 && selectedLayers.length !== 0) {
+            if (queryableLayers.length === 0 || enableInfoForSelectedLayers && queryableSelectedLayers.length === 0 && selectedLayers.length !== 0) {
                 return Rx.Observable.of(purgeMapInfoResults(), noQueryableLayers());
             }
 


### PR DESCRIPTION
## Description
```enableInfoForSelectedLayers: false``` is a config option to disregard selection for [identify ](https://mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins#plugins.Identify). But when there are queryable layers and a switched off layer is selected, the "No active queryable layer" popup is shown. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
When there are queryable layers and a switched off layer is selected, the "No active queryable layer" popup is shown. 

**What is the new behavior?**
When there are queryable layers and a switched off layer is selected, the queryable layers are queried.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
tested with this localConfig item
```json
      {
        "name": "Identify",
        "cfg": {
          "showHighlightFeatureButton": true,
          "showAllResponses": false,
          "enableInfoForSelectedLayers": false,
          "viewerOptions": {
            "container": "{context.ReactSwipe}"
          },
          "showEdit": true
        },
        "override": {
          "Toolbar": {
            "position": 11
          }
        }
      }
```