### PR TITLE
[Backport 2024.01.xx] selected layers should not be considered when "enableInfoForSelectedLayers" is off (#10377)

### DIFF
--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -86,7 +86,7 @@ export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { }
 
             const selectedLayers = selectedNodesSelector(getState());
 
-            if (queryableLayers.length === 0 || queryableSelectedLayers.length === 0 && selectedLayers.length !== 0) {
+            if (queryableLayers.length === 0 || enableInfoForSelectedLayers && queryableSelectedLayers.length === 0 && selectedLayers.length !== 0) {
                 return Rx.Observable.of(purgeMapInfoResults(), noQueryableLayers());
             }
 


### PR DESCRIPTION
- #10377 