### PR TITLE
[Backport 2024.01.xx] Fix #10373 Style layer - Property value cause an error on 3D view (#10383)

### DIFF
--- a/web/client/utils/styleparser/CesiumStyleParser.js
+++ b/web/client/utils/styleparser/CesiumStyleParser.js
@@ -7,7 +7,7 @@
  */
 import * as Cesium from 'cesium';
 import chroma from 'chroma-js';
-import { castArray, isNumber, isEqual, range } from 'lodash';
+import { castArray, isNumber, isEqual, range, isNaN } from 'lodash';
 import { needProxy, getProxyUrl } from '../ProxyUtils';
 import {
     resolveAttributeTemplate,
@@ -613,7 +613,7 @@ const symbolizerToPrimitives = {
         const { image, width, height } = images.find(({ id }) => id === getImageIdFromSymbolizer(parsedSymbolizer, symbolizer)) || {};
         const side = width > height ? width : height;
         const scale = (parsedSymbolizer.radius * 2) / side;
-        return image ? [
+        return image && !isNaN(scale) ? [
             {
                 type: 'point',
                 geometryType: 'point',
@@ -652,7 +652,7 @@ const symbolizerToPrimitives = {
         const { image, width, height } = images.find(({ id }) => id === getImageIdFromSymbolizer(parsedSymbolizer, symbolizer)) || {};
         const side = width > height ? width : height;
         const scale = parsedSymbolizer.size / side;
-        return image ? [{
+        return image && !isNaN(scale) ? [{
             type: 'point',
             geometryType: 'point',
             entity: {

--- a/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
+++ b/web/client/utils/styleparser/__tests__/CesiumStyleParser-test.js
@@ -1461,4 +1461,98 @@ describe('CesiumStyleParser', () => {
                 }).catch(done);
         });
     });
+    it('should not draw the marker when using radius property without argument', (done) => {
+        const style = {
+            name: '',
+            rules: [
+                {
+                    filter: undefined,
+                    name: '',
+                    symbolizers: [
+                        {
+                            kind: 'Mark',
+                            wellKnownName: 'Circle',
+                            color: '#ff0000',
+                            fillOpacity: 0.5,
+                            strokeColor: '#00ff00',
+                            strokeOpacity: 0.25,
+                            strokeWidth: 3,
+                            radius: {
+                                name: 'property',
+                                args: []
+                            },
+                            rotate: 90,
+                            msBringToFront: true,
+                            symbolizerId: 'symbolizer-01'
+                        }
+                    ]
+                }
+            ]
+        };
+        const feature = {
+            type: 'Feature',
+            id: 'feature-01',
+            properties: {
+                radius: 2
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [7, 41]
+            }
+        };
+        parser.writeStyle(style)
+            .then((styleFunc) => styleFunc({
+                features: [{ ...feature, positions: GeoJSONStyledFeatures.featureToCartesianPositions(feature) }]
+            }))
+            .then((styledFeatures) => {
+                expect(styledFeatures.length).toBe(0);
+                done();
+            }).catch(done);
+    });
+    it('should not draw the icon when using size property without argument', (done) => {
+        const style = {
+            name: '',
+            rules: [
+                {
+                    filter: undefined,
+                    name: '',
+                    symbolizers: [
+                        {
+                            kind: 'Icon',
+                            /* png 1px x 1px */
+                            image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII=',
+                            opacity: 0.5,
+                            size: {
+                                name: 'property',
+                                args: []
+                            },
+                            rotate: 90,
+                            msBringToFront: true,
+                            anchor: 'bottom-left',
+                            symbolizerId: 'symbolizer-01'
+                        }
+                    ]
+                }
+            ]
+        };
+        const feature = {
+            type: 'Feature',
+            id: 'feature-01',
+            properties: {
+                radius: 2
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [7, 41]
+            }
+        };
+        parser.writeStyle(style)
+            .then((styleFunc) => styleFunc({
+                features: [{ ...feature, positions: GeoJSONStyledFeatures.featureToCartesianPositions(feature) }]
+            }))
+            .then((styledFeatures) => {
+                expect(styledFeatures.length).toBe(0);
+                done();
+            }).catch(done);
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces a fix to render the mark or icon only when the radius or size are numbers

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10373

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The Mark and Icon symbolizer are not breaking the map viewer while selecting the `Property value` option for `radius` and `size` property

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
