### PR TITLE
Visibility limits - The resolution option is not retained as Limits type

### DIFF
--- a/web/client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx
+++ b/web/client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx
@@ -98,21 +98,20 @@ function VisibilityLimitsForm({
     zoom: zoomProp,
     projection,
     resolutions = getResolutions(),
-    defaultLimitsType,
     limitsTypesOptions,
+    defaultLimitsType = limitsTypesOptions[0].value,
     dpi,
     onChange
 }) {
 
     const zoom = Math.round(zoomProp || 0);
 
-    const [limitsType, setLimitsType] = useState(defaultLimitsType || limitsTypesOptions[0].value);
-
     const {
         maxResolution,
         minResolution,
         disableResolutionLimits
     } = layer;
+    const limitsType = layer.limitsType || defaultLimitsType;
 
     const dpu = dpi2dpu(dpi, projection);
 
@@ -391,7 +390,9 @@ function VisibilityLimitsForm({
                 }))}
                 disabled={disableResolutionLimits || loading}
                 onChange={({ value }) => {
-                    setLimitsType(value);
+                    onChange({
+                        limitsType: value
+                    });
                     clearMessages();
                 }}
             />


### PR DESCRIPTION


## Description
This PR fixes the limitsType persistence in **client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx**. User-set settings for scale / resolution on an individual layer will now be saved across time. 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10355 

**What is the new behavior?**
Resolution / scale settings are persisted on a layer individual basis.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
