### PR TITLE
Fix #10340 Global service support for ArcGIS rest catalog

### DIFF
--- a/web/client/api/ArcGIS.js
+++ b/web/client/api/ArcGIS.js
@@ -36,6 +36,15 @@ const extentToBoundingBox = (extent) => {
     return null;
 };
 
+const getCommonProperties = (data) => {
+    return {
+        version: data?.currentVersion,
+        queryable: (data?.capabilities || '').includes('Data'),
+        format: (data.supportedImageFormatTypes || '')
+            .split(',')
+            .filter(format => /PNG|JPG|GIF/.test(format))[0] || 'PNG32'
+    };
+};
 /**
  * Retrieve layer metadata.
  *
@@ -44,6 +53,21 @@ const extentToBoundingBox = (extent) => {
  * @returns layer metadata
  */
 export const getLayerMetadata = (layerUrl, layerName) => {
+    if (layerName === undefined) {
+        return axios.get(layerUrl, { params: { f: 'json' }})
+            .then(({ data }) => {
+                const bbox = extentToBoundingBox(data?.fullExtent);
+                return {
+                    ...getCommonProperties(data),
+                    ...(bbox && { bbox }),
+                    description: data.description || data.serviceDescription,
+                    options: {
+                        layers: data.layers
+                    },
+                    data
+                };
+            });
+    }
     return axios.get(`${trimEnd(layerUrl, '/')}/${layerName}`, { params: { f: 'json' }})
         .then(({ data }) => {
             const bbox = extentToBoundingBox(data?.extent);
@@ -75,15 +99,23 @@ const getData = (url, params = {}) => {
         });
     return request()
         .then((data) => {
-            const { layers } = data || {};
+            const { layers, services } = data || {};
+            if (services) {
+                return searchAndPaginate(
+                    services.filter(service => ['MapServer', 'ImageServer'].includes(service.type)).map((service) => {
+                        return {
+                            url: `${trimEnd(url, '/')}/${service.name}/${service.type}`,
+                            version: data.currentVersion,
+                            name: service.name,
+                            description: service.type
+                        };
+                    }), params);
+            }
             // Map is similar to WMS GetMap capability for MapServer
             const mapExportSupported = (data?.capabilities || '').includes('Map');
             const commonProperties = {
                 url,
-                version: data?.currentVersion,
-                format: (data.supportedImageFormatTypes || '')
-                    .split(',')
-                    .filter(format => /PNG|JPG|GIF/.test(format))[0] || 'PNG32'
+                ...getCommonProperties(data)
             };
             const bbox = extentToBoundingBox(data?.fullExtent);
             const records = [
@@ -92,7 +124,6 @@ const getData = (url, params = {}) => {
                         name: data?.documentInfo?.Title || data.name || params?.info?.options?.service?.title ||  data.mapName,
                         description: data.description || data.serviceDescription,
                         bbox,
-                        queryable: (data?.capabilities || '').includes('Data'),
                         layers,
                         ...commonProperties
                     }
@@ -100,8 +131,7 @@ const getData = (url, params = {}) => {
                 ...(mapExportSupported && layers ? layers : []).map((layer) => {
                     return {
                         ...layer,
-                        ...commonProperties,
-                        queryable: (data?.capabilities || '').includes('Data')
+                        ...commonProperties
                     };
                 })
             ];

--- a/web/client/api/catalog/ArcGIS.js
+++ b/web/client/api/catalog/ArcGIS.js
@@ -12,7 +12,7 @@ import { getCapabilities } from '../ArcGIS';
 
 function validateUrl(serviceUrl) {
     if (isValidURL(serviceUrl)) {
-        return serviceUrl.includes('MapServer');
+        return serviceUrl.includes('rest/services');
     }
     return false;
 }

--- a/web/client/components/catalog/editor/MainFormUtils.js
+++ b/web/client/components/catalog/editor/MainFormUtils.js
@@ -10,7 +10,7 @@ export const defaultPlaceholder = (service) => {
         "3dtiles": "e.g. https://mydomain.com/tileset.json",
         "cog": "e.g. https://mydomain.com/cog.tif",
         "model": "e.g. https://mydomain.com/filename.ifc",
-        "arcgis": "e.g. https://mydomain.com/arcgis/rest/services/<name>/MapServer"
+        "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
     };
     for ( const [key, value] of Object.entries(urlPlaceholder)) {
         if ( key === service.type) {

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -373,7 +373,7 @@ export default (API) => ({
                         );
                     }
                 }
-                if (layer.type === 'arcgis' && layer.name !== undefined) {
+                if (layer.type === 'arcgis' && (layer.name !== undefined || !layer?.options?.layers)) {
                     return Rx.Observable.defer(() => getLayerMetadata(layer.url, layer.name))
                         .switchMap(({ data, ...layerOptions }) => {
                             const newLayer = {

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -185,7 +185,7 @@ class MetadataExplorerComponent extends React.Component {
 
     static defaultProps = {
         id: "mapstore-metadata-explorer",
-        serviceTypes: [{ name: "csw", label: "CSW" }, { name: "wms", label: "WMS" }, { name: "wmts", label: "WMTS" }, { name: "tms", label: "TMS", allowedProviders: DEFAULT_ALLOWED_PROVIDERS }, { name: "wfs", label: "WFS" }, { name: "3dtiles", label: "3D Tiles" }, {name: "model", label: "IFC Model"}, { name: "arcgis", label: "ArcGIS Rest Service" }],
+        serviceTypes: [{ name: "csw", label: "CSW" }, { name: "wms", label: "WMS" }, { name: "wmts", label: "WMTS" }, { name: "tms", label: "TMS", allowedProviders: DEFAULT_ALLOWED_PROVIDERS }, { name: "wfs", label: "WFS" }, { name: "3dtiles", label: "3D Tiles" }, {name: "model", label: "IFC Model"}, { name: "arcgis", label: "ArcGIS" }],
         active: false,
         wrap: false,
         modal: true,

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -185,7 +185,7 @@ class MetadataExplorerComponent extends React.Component {
 
     static defaultProps = {
         id: "mapstore-metadata-explorer",
-        serviceTypes: [{ name: "csw", label: "CSW" }, { name: "wms", label: "WMS" }, { name: "wmts", label: "WMTS" }, { name: "tms", label: "TMS", allowedProviders: DEFAULT_ALLOWED_PROVIDERS }, { name: "wfs", label: "WFS" }, { name: "3dtiles", label: "3D Tiles" }, {name: "model", label: "IFC Model"}, { name: "arcgis", label: "ArcGIS MapServer" }],
+        serviceTypes: [{ name: "csw", label: "CSW" }, { name: "wms", label: "WMS" }, { name: "wmts", label: "WMTS" }, { name: "tms", label: "TMS", allowedProviders: DEFAULT_ALLOWED_PROVIDERS }, { name: "wfs", label: "WFS" }, { name: "3dtiles", label: "3D Tiles" }, {name: "model", label: "IFC Model"}, { name: "arcgis", label: "ArcGIS Rest Service" }],
         active: false,
         wrap: false,
         modal: true,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces the possibility to request layer from `/arcgis/rest/services/` endpoints inside the ArcGIS catalog

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10340

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

It is possible to use the `/arcgis/rest/services/` endpoint in the catalog

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
