### PR TITLE
#10342: Fix issue of markers are not printed correctly

### DIFF
--- a/web/client/utils/styleparser/StyleParserUtils.js
+++ b/web/client/utils/styleparser/StyleParserUtils.js
@@ -613,14 +613,14 @@ export const drawWellKnownNameImageFromSymbolizer = (symbolizer) => {
         && !(symbolizer.wellKnownName || '').includes('shape://');
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
-    const radius = symbolizer.radius;
+    const radius = (symbolizer.radius || symbolizer?.size / 2);
     const strokePadding = hasStroke ? symbolizer.strokeWidth / 2 : 4;
     const x = strokePadding;
     const y = strokePadding;
     const cx = radius + strokePadding;
     const cy = radius + strokePadding;
-    const width = symbolizer.radius * 2;
-    const height = symbolizer.radius * 2;
+    const width = radius * 2;
+    const height = radius * 2;
     canvas.setAttribute('width', width + strokePadding * 2);
     canvas.setAttribute('height', height + strokePadding * 2);
 

--- a/web/client/utils/styleparser/StyleParserUtils.js
+++ b/web/client/utils/styleparser/StyleParserUtils.js
@@ -613,14 +613,14 @@ export const drawWellKnownNameImageFromSymbolizer = (symbolizer) => {
         && !(symbolizer.wellKnownName || '').includes('shape://');
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
-    const radius = (symbolizer.radius || symbolizer?.size / 2);
+    const radius = symbolizer.radius;
     const strokePadding = hasStroke ? symbolizer.strokeWidth / 2 : 4;
     const x = strokePadding;
     const y = strokePadding;
     const cx = radius + strokePadding;
     const cy = radius + strokePadding;
-    const width = radius * 2;
-    const height = radius * 2;
+    const width = symbolizer.radius * 2;
+    const height = symbolizer.radius * 2;
     canvas.setAttribute('width', width + strokePadding * 2);
     canvas.setAttribute('height', height + strokePadding * 2);
 
@@ -932,4 +932,8 @@ export const drawIcons = (geoStylerStyle, options) => {
                 }
             })
         );
+};
+export const getCachedImageById = (symbolizer) => {
+    const id = getImageIdFromSymbolizer(symbolizer);
+    return imagesCache[id] || {};
 };

--- a/web/client/utils/styleparser/__tests__/StyleParserUtils-test.js
+++ b/web/client/utils/styleparser/__tests__/StyleParserUtils-test.js
@@ -12,7 +12,8 @@ import {
     drawIcons,
     geoStylerStyleFilter,
     getWellKnownNameImageFromSymbolizer,
-    parseSymbolizerExpressions
+    parseSymbolizerExpressions,
+    drawWellKnownNameImageFromSymbolizer
 } from '../StyleParserUtils';
 
 describe("StyleParserUtils ", () => {
@@ -236,5 +237,20 @@ describe("StyleParserUtils ", () => {
                 outlineDasharray: [ 10, 10 ]
             });
     });
-
+    it('test drawWellKnownNameImageFromSymbolizer method for Icon symbolizer to return width, height = size /2 in case radius not included within symbolizer', () => {
+        const symbolizer1 = {
+            "symbolizerId": "1",
+            "kind": "Icon",
+            "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAqCAYAAACk2+",
+            "opacity": 1,
+            "size": 46,
+            "rotate": 0,
+            "msBringToFront": false,
+            "anchor": "bottom",
+            "msHeightReference": "none"
+        };
+        const {width, height} = drawWellKnownNameImageFromSymbolizer(symbolizer1);
+        expect(width).toBe(symbolizer1.size / 2);
+        expect(height).toBe(symbolizer1.size / 2);
+    });
 });

--- a/web/client/utils/styleparser/__tests__/StyleParserUtils-test.js
+++ b/web/client/utils/styleparser/__tests__/StyleParserUtils-test.js
@@ -250,7 +250,7 @@ describe("StyleParserUtils ", () => {
             "msHeightReference": "none"
         };
         const {width, height} = drawWellKnownNameImageFromSymbolizer(symbolizer1);
-        expect(width).toBe(symbolizer1.size / 2);
-        expect(height).toBe(symbolizer1.size / 2);
+        expect(width).toBe(symbolizer1.size);
+        expect(height).toBe(symbolizer1.size);
     });
 });

--- a/web/client/utils/styleparser/__tests__/StyleParserUtils-test.js
+++ b/web/client/utils/styleparser/__tests__/StyleParserUtils-test.js
@@ -13,7 +13,7 @@ import {
     geoStylerStyleFilter,
     getWellKnownNameImageFromSymbolizer,
     parseSymbolizerExpressions,
-    drawWellKnownNameImageFromSymbolizer
+    getCachedImageById
 } from '../StyleParserUtils';
 
 describe("StyleParserUtils ", () => {
@@ -237,11 +237,20 @@ describe("StyleParserUtils ", () => {
                 outlineDasharray: [ 10, 10 ]
             });
     });
-    it('test drawWellKnownNameImageFromSymbolizer method for Icon symbolizer to return width, height = size /2 in case radius not included within symbolizer', () => {
-        const symbolizer1 = {
-            "symbolizerId": "1",
+    it('test getCachedImageById method for Icon annotationSymbolizer to return width, height = size in case of returning undefined from getCachedImageById', () => {
+        const annotationSymbolizer = {
+            "symbolizerId": "5ba7eae188a0",
             "kind": "Icon",
-            "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAqCAYAAACk2+",
+            "image": {
+                "name": "msMarkerIcon",
+                "args": [
+                    {
+                        "color": "blue",
+                        "shape": "circle",
+                        "glyph": "comment"
+                    }
+                ]
+            },
             "opacity": 1,
             "size": 46,
             "rotate": 0,
@@ -249,8 +258,8 @@ describe("StyleParserUtils ", () => {
             "anchor": "bottom",
             "msHeightReference": "none"
         };
-        const {width, height} = drawWellKnownNameImageFromSymbolizer(symbolizer1);
-        expect(width).toBe(symbolizer1.size);
-        expect(height).toBe(symbolizer1.size);
+        const { width = annotationSymbolizer.size, height = annotationSymbolizer.size } = getCachedImageById(annotationSymbolizer);
+        expect(width).toBe(annotationSymbolizer.size);
+        expect(height).toBe(annotationSymbolizer.size);
     });
 });


### PR DESCRIPTION
## Description
In this PR, the issue of not showing markers properly in print is resolved.  

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10342 

**What is the current behavior?**
#10342

**What is the new behavior?**
Now in print, the markers display in it normally.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
The issue was in **symbolizerToPrintMSStyle** where if the passed symbolizer object to '**drawWellKnownNameImageFromSymbolizer**'  has no radius -> it returns NaN and here: https://github.com/geosolutions-it/MapStore2/blob/909d495947e6dadcd07927c6c2f0924418a511a4/web/client/utils/styleparser/PrintStyleParser.js#L88 
you see the initiate values of width and height should be equal size  which won't be as the returned width and height = NaN which override the symbolizer.size value

So the preproduced issue was as the icon height = NaN. not symbolizer.size