### PR TITLE
Update release_steps.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_steps.md
+++ b/.github/ISSUE_TEMPLATE/release_steps.md
@@ -99,7 +99,7 @@ This steps have to be followed always when preparing a new release.
   - Version to release **YYYY.XX.mm** (the effective number of the release)
 - [ ] Launch [MapStore2-Stable-Releaser](http://build.geosolutionsgroup.com/view/MapStore/job/MapStore/view/MapStore%20Stable/job/MapStore2-Stable-Releaser/) Jenkins job with
    - **YYYY.XX.mm** for the version
-   - **YYYY.XX.xx** for the branch to build
+   - **vYYYY.XX.mm** for the branch to build (the version tag name, e.g. v2024.01.01)
 - [ ] Wait the end of the 2 process
 
 When the processes are finished, the release is ready to be published on github in draft mode.


### PR DESCRIPTION
## Description

Improved release steps to use the version instead of the tag on jenkins.

Using the tag, created by mapstore action "prepare-release" instead of the branch, guarantees to be able to move on with the tasks independently, without need to wait.

It has been tested (the branch parameter accepts committish values, so they can be commit hash, branch names or tags). 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Update release procedure

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
 #10385 



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

This PR do not require a backport (ISSUES templates makes sense only on the main branch)