### PR TITLE
#10406: remove the 'Change Password' functionality if the logged in user account is managed via LDAP

### DIFF
--- a/web/client/plugins/__tests__/Login-test.js
+++ b/web/client/plugins/__tests__/Login-test.js
@@ -128,6 +128,30 @@ describe('Login Plugin', () => {
             // click on confirm button
             TestUtils.Simulate.click(buttons[1]);
         });
+        it('test hide change password in case LDAP user [not admin] ', () => {
+            const storeState = stateMocker(toggleControl('LoginForm', 'enabled'), loginSuccess({  User: { name: "Test", access_token: "some-token", role: 'USER' }}) );
+            const { Plugin } = getPluginForTest(Login, storeState);
+            ReactDOM.render(<Plugin isUsingLDAP />, document.getElementById("container"));
+            expect(document.querySelector('#mapstore-login-menu .glyphicon-user')).toBeTruthy();
+            const entries = document.querySelectorAll("#mapstore-login-menu ul li[role=\"presentation\"]");
+            expect(entries.length).toEqual(2); // user.info, user.logout
+        });
+        it('test show change password in case LDAP user [admin] ', () => {
+            const storeState = stateMocker(toggleControl('LoginForm', 'enabled'), loginSuccess({  User: { name: "Test", access_token: "some-token", role: 'ADMIN' }}) );
+            const { Plugin } = getPluginForTest(Login, storeState);
+            ReactDOM.render(<Plugin isUsingLDAP />, document.getElementById("container"));
+            expect(document.querySelector('#mapstore-login-menu .glyphicon-user')).toBeTruthy();
+            const entries = document.querySelectorAll("#mapstore-login-menu ul li[role=\"presentation\"]");
+            expect(entries.length).toEqual(3); // user.info, user.changePwd ,user.logout
+        });
+        it('test show change password in case ms user ', () => {
+            const storeState = stateMocker(toggleControl('LoginForm', 'enabled'), loginSuccess({  User: { name: "Test", access_token: "some-token", role: 'USER' }}) );
+            const { Plugin } = getPluginForTest(Login, storeState);
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            expect(document.querySelector('#mapstore-login-menu .glyphicon-user')).toBeTruthy();
+            const entries = document.querySelectorAll("#mapstore-login-menu ul li[role=\"presentation\"]");
+            expect(entries.length).toEqual(3); // user.info, user.changePwd ,user.logout
+        });
     });
     describe('OmniBar menu entries', () => {
         afterEach(() => {

--- a/web/client/plugins/login/index.js
+++ b/web/client/plugins/login/index.js
@@ -95,12 +95,13 @@ export const LoginNav = connect((state) => ({
     const {currentProvider, providers = []} = stateProps;
     const {type, showAccountInfo = false, showPasswordChange = false} = (providers ?? []).filter(({provider: provider}) => provider === currentProvider)?.[0] ?? {};
     const isOpenID = type === "openID";
+    const isNormalLDAPUser = ownProps.isUsingLDAP && !ownProps.isAdmin;
     return {
         ...ownProps,
         ...stateProps,
         ...dispatchProps,
         showAccountInfo: isOpenID ? showAccountInfo : ownProps.showAccountInfo,
-        showPasswordChange: isOpenID ? showPasswordChange : ownProps.showPasswordChange
+        showPasswordChange: isOpenID ? showPasswordChange : isNormalLDAPUser ? false : ownProps.showPasswordChange
     };
 })(UserMenuComp);
 


### PR DESCRIPTION
## Description
In this PR, a cfg 'isUsingLDAP' is configured for Login plugin in localConfig.json file for handling remove 'Change Password' if the logged in user account and not admin user.

To enable this, the Login plugin in localConfig.json should be like: 
`{
  "name": "Login",
  "cfg": {
    "isUsingLDAP": true
  }
}`
And for the contexts, in pluginsConfig.json file:
`{
      "name": "Login",
      "glyph": "user",
      "title": "plugins.Login.title",
      "description": "plugins.Login.description",
      "defaultConfig": {
        "isUsingLDAP": true
      }
}`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#10406 

**What is the current behavior?**
#10406

**What is the new behavior?**
If 'isUsingLDAP' is configured into localConfig, the change password will be hide if = true and user is not admin else it will be shown.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No


## Other useful information
