### PR TITLE
#10385: Misleading persistence of CSW advanced settings edits in dashboards

### DIFF
--- a/web/client/plugins/widgetbuilder/CatalogServiceEditor.jsx
+++ b/web/client/plugins/widgetbuilder/CatalogServiceEditor.jsx
@@ -20,11 +20,16 @@ const emptyService = {
 export default ({service: defaultService, catalogServices,
     error = () => {}, onAddService = () => {}, isNew, dashboardServices, defaultServices, defaultSelectedService,
     dashboardSelectedService, ...props}) => {
-    const [service, setService] = useState(isNew ? emptyService :
-        isEmpty(dashboardSelectedService) ? {...defaultServices[defaultSelectedService],
-            old: defaultServices[defaultSelectedService], key: defaultSelectedService, excludeShowTemplate: true} :
-            {...dashboardServices[dashboardSelectedService], old: dashboardServices[dashboardSelectedService],
-                key: dashboardSelectedService, excludeShowTemplate: true} );
+    const [service, setService] = useState(() => {
+        // [dashboardHasEmptyServices] if true => show the default sevices, else show the dashobaord services with its stored configurations
+        // adding (!dashboardServices) in the condition shows the expceted behaviour
+        const dashboardHasEmptyServices = isEmpty(dashboardSelectedService) && !dashboardServices;
+        return isNew ? emptyService :
+            dashboardHasEmptyServices ?
+                {...defaultServices[defaultSelectedService], old: defaultServices[defaultSelectedService], key: defaultSelectedService, excludeShowTemplate: true} :
+                {...dashboardServices[dashboardSelectedService || defaultSelectedService], old: dashboardServices[dashboardSelectedService || defaultSelectedService],
+                    key: dashboardSelectedService || defaultSelectedService, excludeShowTemplate: true};
+    });
 
     const existingServices = isEmpty(dashboardServices) ? defaultServices : dashboardServices;
 


### PR DESCRIPTION
## Description
In this PR, fixing the issue of misleading persistence of CSW advanced settings edits in dashboards instead of showing the default CSW with its default advanced settings.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#10358 

**What is the current behavior?**
#10358 

**What is the new behavior?**
Now if the user creates a dashboard with a map then adding layers from CSW without switching to another service, makes some edits to the advanced settings of CSW then save the dashboard. If the user make refresh the page and open the catalog on the existing map, the service with the edited advanced settings will be shows as expected.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
