### PR TITLE
#10374: Changing the layer's opacity in a Map View makes MapStore crash

### DIFF
--- a/web/client/components/mapviews/settings/LayerOverridesNode.jsx
+++ b/web/client/components/mapviews/settings/LayerOverridesNode.jsx
@@ -16,6 +16,7 @@ import {
     Alert
 } from 'react-bootstrap';
 import Select from 'react-select';
+import {clamp} from 'lodash';
 import FormControl from '../../misc/DebouncedFormControl';
 import { formatClippingFeatures } from '../../../utils/MapViewsUtils';
 import Message from '../../I18N/Message';
@@ -104,7 +105,10 @@ function LayerOverridesNode({
                         className="opacity-field"
                         fallbackValue={1}
                         value={layer.opacity}
-                        onChange={(value) => onChange({ opacity: value })}
+                        onChange={(value) => {
+                            const opacity = value && clamp(parseFloat(value), 0, 1);
+                            onChange({ opacity: opacity || 0 });
+                        }}
                     />
                 </FormGroup>}
                 {isClippingSupported && <div className="ms-map-views-layer-clipping">


### PR DESCRIPTION
## Description
In this PR, fixing issue of crash app in change layer's opacity in map view is done.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue
#10374 

**What is the current behavior?**
#10374 

**What is the new behavior?**
App doesn't crash now in case of change opacity in map view.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
