### PR TITLE
#10418: Share tool - the 'Add place mark and zoom to sharing link' option is not applied correctly

### DIFF
--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -224,7 +224,7 @@ export const getFeatureInfoOfSelectedItem = (action$, store) =>
                 ];
             }
         }
-        return [Rx.Observable.empty()];
+        return Rx.Observable.empty();
     }).delay(50);
 /**
  * Handles show GFI button click action.


### PR DESCRIPTION
## Description
In this PR, a fix a bug in search epic 'getFeatureInfoOfSelectedItem' that affects share tool is done. The issue was return in this epic was expecting empty array or empty observable and it wasn't one of them by mistake.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10418 

**What is the current behavior?**
#10418 

**What is the new behavior?**
Now if user makes share with adding a marker on the map for the sharing map, then close the share modal --> the marker will be removed from the current map viewer and if user tries to click on home btn to go to home page, it will work well.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
