### PR TITLE
[Backport 2024.01.xx]: #10406: remove the 'Change Password' functionality if the logged in user account is managed via LDAP (#10407)

### DIFF
--- a/web/client/plugins/__tests__/Login-test.js
+++ b/web/client/plugins/__tests__/Login-test.js
@@ -128,6 +128,30 @@ describe('Login Plugin', () => {
             // click on confirm button
             TestUtils.Simulate.click(buttons[1]);
         });
+        it('test hide change password in case LDAP user [not admin] ', () => {
+            const storeState = stateMocker(toggleControl('LoginForm', 'enabled'), loginSuccess({  User: { name: "Test", access_token: "some-token", role: 'USER' }}) );
+            const { Plugin } = getPluginForTest(Login, storeState);
+            ReactDOM.render(<Plugin isUsingLDAP />, document.getElementById("container"));
+            expect(document.querySelector('#mapstore-login-menu .glyphicon-user')).toBeTruthy();
+            const entries = document.querySelectorAll("#mapstore-login-menu ul li[role=\"presentation\"]");
+            expect(entries.length).toEqual(2); // user.info, user.logout
+        });
+        it('test show change password in case LDAP user [admin] ', () => {
+            const storeState = stateMocker(toggleControl('LoginForm', 'enabled'), loginSuccess({  User: { name: "Test", access_token: "some-token", role: 'ADMIN' }}) );
+            const { Plugin } = getPluginForTest(Login, storeState);
+            ReactDOM.render(<Plugin isUsingLDAP />, document.getElementById("container"));
+            expect(document.querySelector('#mapstore-login-menu .glyphicon-user')).toBeTruthy();
+            const entries = document.querySelectorAll("#mapstore-login-menu ul li[role=\"presentation\"]");
+            expect(entries.length).toEqual(3); // user.info, user.changePwd ,user.logout
+        });
+        it('test show change password in case ms user ', () => {
+            const storeState = stateMocker(toggleControl('LoginForm', 'enabled'), loginSuccess({  User: { name: "Test", access_token: "some-token", role: 'USER' }}) );
+            const { Plugin } = getPluginForTest(Login, storeState);
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            expect(document.querySelector('#mapstore-login-menu .glyphicon-user')).toBeTruthy();
+            const entries = document.querySelectorAll("#mapstore-login-menu ul li[role=\"presentation\"]");
+            expect(entries.length).toEqual(3); // user.info, user.changePwd ,user.logout
+        });
     });
     describe('OmniBar menu entries', () => {
         afterEach(() => {

--- a/web/client/plugins/login/index.js
+++ b/web/client/plugins/login/index.js
@@ -95,12 +95,13 @@ export const LoginNav = connect((state) => ({
     const {currentProvider, providers = []} = stateProps;
     const {type, showAccountInfo = false, showPasswordChange = false} = (providers ?? []).filter(({provider: provider}) => provider === currentProvider)?.[0] ?? {};
     const isOpenID = type === "openID";
+    const isNormalLDAPUser = ownProps.isUsingLDAP && !ownProps.isAdmin;
     return {
         ...ownProps,
         ...stateProps,
         ...dispatchProps,
         showAccountInfo: isOpenID ? showAccountInfo : ownProps.showAccountInfo,
-        showPasswordChange: isOpenID ? showPasswordChange : ownProps.showPasswordChange
+        showPasswordChange: isOpenID ? showPasswordChange : isNormalLDAPUser ? false : ownProps.showPasswordChange
     };
 })(UserMenuComp);
 


### PR DESCRIPTION
Backport 2024.01.xx - #10406: remove the 'Change Password' functionality if the logged in user account is managed via LDAP (#10407)