### PR TITLE
#10424: The measure tool is not opened properly if Measure plugin has 'showCoordinateEditor' with true into cfg.defaultOptions

### DIFF
--- a/web/client/plugins/Measure.jsx
+++ b/web/client/plugins/Measure.jsx
@@ -175,7 +175,7 @@ const MeasurePlugin = connect(
     }))
 )(({coordsAeronauticalEnabled, ...props}) => {
     return (
-        <div className={props.mapType !== MapLibraries.CESIUM && props?.defaultOptions?.showCoordinateEditor ? "measure-container measure-coords-editor-2d" : "measure-container"} style={{top: coordsAeronauticalEnabled ? 88 : 48}}>
+        <div className={props.mapType !== MapLibraries.CESIUM && props?.defaultOptions?.showCoordinateEditor ? "measure-container measure-coords-editor" : "measure-container"} style={{top: coordsAeronauticalEnabled ? 88 : 48}}>
             {
                 props.mapType === MapLibraries.CESIUM
                     ? <div id="measure-cesium-wrapper"/>

--- a/web/client/plugins/Measure.jsx
+++ b/web/client/plugins/Measure.jsx
@@ -175,7 +175,7 @@ const MeasurePlugin = connect(
     }))
 )(({coordsAeronauticalEnabled, ...props}) => {
     return (
-        <div className={props.mapType !== MapLibraries.CESIUM ? "measure-container" : "measure-container measure-cesium"} style={{top: coordsAeronauticalEnabled ? 88 : 48}}>
+        <div className={props.mapType !== MapLibraries.CESIUM && props?.defaultOptions?.showCoordinateEditor ? "measure-container measure-coords-editor-2d" : "measure-container"} style={{top: coordsAeronauticalEnabled ? 88 : 48}}>
             {
                 props.mapType === MapLibraries.CESIUM
                     ? <div id="measure-cesium-wrapper"/>

--- a/web/client/plugins/Measure.jsx
+++ b/web/client/plugins/Measure.jsx
@@ -175,7 +175,7 @@ const MeasurePlugin = connect(
     }))
 )(({coordsAeronauticalEnabled, ...props}) => {
     return (
-        <div className="measure-container" style={{top: coordsAeronauticalEnabled ? 88 : 48}}>
+        <div className={props.mapType !== MapLibraries.CESIUM ? "measure-container" : "measure-container measure-cesium"} style={{top: coordsAeronauticalEnabled ? 88 : 48}}>
             {
                 props.mapType === MapLibraries.CESIUM
                     ? <div id="measure-cesium-wrapper"/>

--- a/web/client/plugins/__tests__/Measure-test.jsx
+++ b/web/client/plugins/__tests__/Measure-test.jsx
@@ -37,7 +37,7 @@ describe('Measure Plugin', () => {
     it('test measure in case default options showCoordinateEditor = true', () => {
         const { Plugin} = getPluginForTest(Measure, { controls: { measure: { enabled: true } } });
         ReactDOM.render(<Plugin defaultOptions={{showCoordinateEditor: true}} />, document.getElementById("container"));
-        const measureCoordEditor2DNode = document.querySelector('.measure-container.measure-coords-editor-2d');
+        const measureCoordEditor2DNode = document.querySelector('.measure-container.measure-coords-editor');
         expect(measureCoordEditor2DNode).toBeTruthy();
         const measureToolbarNode = document.querySelector('.ms-measure-toolbar');
         expect(measureToolbarNode).toBeTruthy();

--- a/web/client/plugins/__tests__/Measure-test.jsx
+++ b/web/client/plugins/__tests__/Measure-test.jsx
@@ -34,4 +34,12 @@ describe('Measure Plugin', () => {
         Simulate.click(closeNode.parentNode);
         expect(store.getState().controls.measure.enabled).toBe(false);
     });
+    it('test measure in case default options showCoordinateEditor = true', () => {
+        const { Plugin} = getPluginForTest(Measure, { controls: { measure: { enabled: true } } });
+        ReactDOM.render(<Plugin defaultOptions={{showCoordinateEditor: true}} />, document.getElementById("container"));
+        const measureCoordEditor2DNode = document.querySelector('.measure-container.measure-coords-editor-2d');
+        expect(measureCoordEditor2DNode).toBeTruthy();
+        const measureToolbarNode = document.querySelector('.ms-measure-toolbar');
+        expect(measureToolbarNode).toBeTruthy();
+    });
 });

--- a/web/client/themes/default/less/measure.less
+++ b/web/client/themes/default/less/measure.less
@@ -113,7 +113,7 @@
         }
     }
 }
-.measure-container:not(.measure-coords-editor-2d){
+.measure-container:not(.measure-coords-editor){
     position: absolute;
     z-index: 100;
     right: 46px;

--- a/web/client/themes/default/less/measure.less
+++ b/web/client/themes/default/less/measure.less
@@ -113,7 +113,7 @@
         }
     }
 }
-.measure-container.measure-cesium{
+.measure-container:not(.measure-coords-editor-2d){
     position: absolute;
     z-index: 100;
     right: 46px;

--- a/web/client/themes/default/less/measure.less
+++ b/web/client/themes/default/less/measure.less
@@ -113,12 +113,14 @@
         }
     }
 }
-.measure-container {
+.measure-container.measure-cesium{
     position: absolute;
     z-index: 100;
     right: 46px;
     margin: 0;
     top: 48px;
+}
+.measure-container {
     .ms-measure-toolbar {
         position: relative;
         background-color: #ffffff;


### PR DESCRIPTION
## Description
In this PR, fix UI issue for the measure tool is done. Due to this fix, the measure tool is opened properly as expected if Measure plugin has 'showCoordinateEditor' with true into cfg.defaultOptions.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10424 

**What is the current behavior?**
#10424 

**What is the new behavior?**
The measure tool UI is shown as expected when it is open for both 2D and 3D maps.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
