### PR TITLE
Fix #10429 error message when using vector data with no wpsUrl defined

### DIFF
--- a/web/client/epics/geoProcessing.js
+++ b/web/client/epics/geoProcessing.js
@@ -684,6 +684,19 @@ export const runIntersectProcessGPTEpic = (action$, store) => action$
         const counter = getCounter(layers, GPT_INTERSECTION_GROUP_ID);
         let sourceFC$;
         let intersectionFC$;
+        let misconfiguredLayers = [];
+        if (!layerUrl) {
+            misconfiguredLayers.push(layer.name + " - " + layer.title);
+        }
+        if (misconfiguredLayers.length) {
+            return Rx.Observable.of(showErrorNotification({
+                title: "errorTitleDefault",
+                message: "GeoProcessing.notifications.errorMissingUrl",
+                autoDismiss: 6,
+                position: "tc",
+                values: {layerName: misconfiguredLayers.join(", ")}
+            }));
+        }
         if (isEmpty(sourceFeature)) {
             sourceFC$ = executeProcess(
                 layerUrl,

--- a/web/client/epics/geoProcessing.js
+++ b/web/client/epics/geoProcessing.js
@@ -486,7 +486,7 @@ export const runBufferProcessGPTEpic = (action$, store) => action$
         const counter = getCounter(layers, GPT_BUFFER_GROUP_ID);
         let misconfiguredLayers = [];
         if (!layerUrl) {
-            misconfiguredLayers.push(layer.name + " - " + layer.title);
+            misconfiguredLayers.push(layer.name === layer.title ? layer.name : layer.name + " - " + layer.title);
         }
         if (misconfiguredLayers.length) {
             return Rx.Observable.of(showErrorNotification({
@@ -678,6 +678,11 @@ export const runIntersectProcessGPTEpic = (action$, store) => action$
         const layer = getLayerFromIdSelector(state, layerId);
         const layers = availableLayersSelector(state);
         const layerUrl = wpsUrlSelector(state) || head(castArray(layer.url));
+
+        const intersectionLayerId = intersectionLayerIdSelector(state);
+        const intersectionLayer = getLayerFromIdSelector(state, intersectionLayerId);
+        const intersectionLayerUrl = wpsUrlSelector(state) || head(castArray(intersectionLayer.url));
+
         const sourceFeature = sourceFeatureSelector(state);
         const executeOptions = {};
         const intersectionFeature = intersectionFeatureSelector(state);
@@ -686,7 +691,10 @@ export const runIntersectProcessGPTEpic = (action$, store) => action$
         let intersectionFC$;
         let misconfiguredLayers = [];
         if (!layerUrl) {
-            misconfiguredLayers.push(layer.name + " - " + layer.title);
+            misconfiguredLayers.push(layer.name === layer.title ? layer.name : layer.name + " - " + layer.title);
+        }
+        if (!intersectionLayerUrl) {
+            misconfiguredLayers.push(intersectionLayer.name === intersectionLayer.title ? intersectionLayer.name : intersectionLayer.name + " - " + intersectionLayer.title);
         }
         if (misconfiguredLayers.length) {
             return Rx.Observable.of(showErrorNotification({
@@ -712,9 +720,7 @@ export const runIntersectProcessGPTEpic = (action$, store) => action$
         } else {
             sourceFC$ = Rx.Observable.of(sourceFeature.geometry);
         }
-        const intersectionLayerId = intersectionLayerIdSelector(state);
-        const intersectionLayer = getLayerFromIdSelector(state, intersectionLayerId);
-        const intersectionLayerUrl = wpsUrlSelector(state) || head(castArray(intersectionLayer.url));
+
         if (isEmpty(intersectionFeature)) {
             intersectionFC$ = executeProcess(
                 intersectionLayerUrl,
@@ -862,7 +868,7 @@ export const runIntersectProcessGPTEpic = (action$, store) => action$
                     })
                     .catch((e) => {
                         logError(e);
-                        let misconfiguredLayers = [];
+                        misconfiguredLayers = [];
                         if (!layerUrl) {
                             misconfiguredLayers.push(layer.name + " - " + layer.title);
                         }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

now if wpsUrl is not present it will show this
![image](https://github.com/geosolutions-it/MapStore2/assets/11991428/a177c0f6-e9c4-4c00-990f-9396138925e4)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10429

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
