### PR TITLE
[Backport 2024.01.xx]: #10418: Share tool - the 'Add place mark and zoom to sharing link' option is not applied correctly (#10419)

### DIFF
--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -224,7 +224,7 @@ export const getFeatureInfoOfSelectedItem = (action$, store) =>
                 ];
             }
         }
-        return [Rx.Observable.empty()];
+        return Rx.Observable.empty();
     }).delay(50);
 /**
  * Handles show GFI button click action.


### PR DESCRIPTION
## Description
Backport 2024.01.xx - #10418: Share tool - the 'Add place mark and zoom to sharing link' option is not applied correctly (#10419)