### PR TITLE
Fix #10489 Problems with GeoStory map configurations merge process 

### DIFF
--- a/web/client/components/geostory/common/enhancers/__tests__/map-test.jsx
+++ b/web/client/components/geostory/common/enhancers/__tests__/map-test.jsx
@@ -35,7 +35,29 @@ describe("geostory media map component enhancers", () => {
         const Sink = withMapEnhancer(createSink( props => {
             expect(props).toBeTruthy();
             expect(props.map).toBeTruthy();
-            expect(props.map).toEqual({id: "2", layers: []});
+            expect(props.map).toEqual({id: "2", layers: [], groups: []});
+            done();
+        }));
+        ReactDOM.render(<Provider store={store}><Sink resourceId={resourceId} map={{}}/></Provider>, document.getElementById("container"));
+    });
+    it('withMapEnhancer generate correct props for legacy geostory', (done) => {
+        const resources = [{id: "1", type: "map", data: {id: "2", layers: [ {
+            "visibility": true
+        }, null], groups: [null, null, {
+            "expanded": false
+        }], context: "1"}}];
+        const store = {
+            subscribe: () => {}, getState: () => ({geostory: {currentStory: {resources}}})
+        };
+        const resourceId = "1";
+        const Sink = withMapEnhancer(createSink( props => {
+            expect(props).toBeTruthy();
+            expect(props.map).toBeTruthy();
+            expect(props.map).toEqual({id: "2", layers: [ {
+                "visibility": true
+            }, undefined], groups: [undefined, undefined, {
+                "expanded": false
+            }]});
             done();
         }));
         ReactDOM.render(<Provider store={store}><Sink resourceId={resourceId} map={{}}/></Provider>, document.getElementById("container"));

--- a/web/client/components/geostory/common/enhancers/map.jsx
+++ b/web/client/components/geostory/common/enhancers/map.jsx
@@ -39,8 +39,9 @@ export default compose(
         ({ resources, resourceId, map = {}}) => {
             const resource = find(resources, { id: resourceId }) || {};
             const baseMap = omit(resource.data, ['context']);
-            const cleanedMap = {...map, layers: (map.layers || baseMap?.layers || []).map(l => l ? l : undefined)};         // for better intiating cleanedMap layers in case 'map.layers = undefined' -> baseMap.layers check is added in fallBack
-            return { map: createMapObject(baseMap, cleanedMap)};
+            const isLegacyGeostory = (map?.layers || [])?.indexOf(null) !== -1 || (map?.groups || [])?.indexOf(null) !== -1;
+            const cleanedMap = {...map, layers: (map.layers || baseMap?.layers || []).map(lay => lay ? lay : undefined), groups: (map.groups || baseMap?.groups || []).map(gr => gr ? gr : undefined)};         // for better initiating cleanedMap layers in case 'map.layers = undefined' -> baseMap.layers check is added in fallBack
+            return { map: createMapObject(baseMap, cleanedMap, isLegacyGeostory)};
         }
     ));
 /**

--- a/web/client/components/geostory/common/enhancers/map.jsx
+++ b/web/client/components/geostory/common/enhancers/map.jsx
@@ -37,9 +37,10 @@ export default compose(
             }))),
     withProps(
         ({ resources, resourceId, map = {}}) => {
-            const cleanedMap = {...map, layers: (map.layers || []).map(l => l ? l : undefined)};
             const resource = find(resources, { id: resourceId }) || {};
-            return { map: createMapObject(omit(resource.data, ['context']), cleanedMap)};
+            const baseMap = omit(resource.data, ['context']);
+            const cleanedMap = {...map, layers: (map.layers || baseMap?.layers || []).map(l => l ? l : undefined)};         // for better intiating cleanedMap layers in case 'map.layers = undefined' -> baseMap.layers check is added in fallBack
+            return { map: createMapObject(baseMap, cleanedMap)};
         }
     ));
 /**

--- a/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
+++ b/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
@@ -129,9 +129,9 @@ class StyleBasedWMSJsonLegend extends React.Component {
         return '';
     }
     renderRules = (rules) => {
+        const isLegendFilterIncluded = this.props?.layer?.layerFilter?.filters?.find(f=>f.id === 'interactiveLegend');
+        const legendFilters = isLegendFilterIncluded ? isLegendFilterIncluded?.filters : [];
         return (rules || []).map((rule) => {
-            const isLegendFilterIncluded = this.props?.layer?.layerFilter?.filters?.find(f=>f.id === 'interactiveLegend');
-            const legendFilters = isLegendFilterIncluded ? isLegendFilterIncluded?.filters : [];
             const isFilterExistBefore = legendFilters?.find(f => f.id === rule.filter);
             const isFilterDisabled = this.props?.layer?.layerFilter?.disabled;
             const activeFilter = rule.filter && isFilterExistBefore;

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -171,10 +171,18 @@ export const applyDefaults = (options = {}) => merge({}, DEFAULT_MAP_OPTIONS, op
  * create map object
  * @param {object} baseMap initial map object
  * @param {object} overrides object to override with
+ * @param {bool} isLegacyGeostory boolean that indicates if the geostory is legacy one or new
  * @return {object} options merged with defaults
  */
-export const createMapObject = (baseMap = {}, overrides = {}) => {
-    return merge({}, baseMap, overrides);
+export const createMapObject = (baseMap = {}, overrides = {}, isLegacyGeostory = false) => {
+    const mergedMap = merge({}, baseMap, overrides);
+    if (isLegacyGeostory) {
+        return mergedMap;
+    }
+    return {
+        ...mergedMap, layers: overrides?.layers || [], groups: overrides?.groups || []
+    };
+
 };
 /**
  * check if a string matches a regex

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -174,7 +174,13 @@ export const applyDefaults = (options = {}) => merge({}, DEFAULT_MAP_OPTIONS, op
  * @return {object} options merged with defaults
  */
 export const createMapObject = (baseMap = {}, overrides = {}) => {
-    return merge({}, baseMap, overrides);
+    const baseMapCloned = { ...baseMap };
+    // use override [replace] logic instead of merge to get the updated map
+    const updatedMap = Object.keys(overrides).reduce((cumulatedMap, key) => {
+        cumulatedMap[key] = overrides[key];
+        return cumulatedMap;
+    }, baseMapCloned);
+    return updatedMap;
 };
 /**
  * check if a string matches a regex

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -174,13 +174,7 @@ export const applyDefaults = (options = {}) => merge({}, DEFAULT_MAP_OPTIONS, op
  * @return {object} options merged with defaults
  */
 export const createMapObject = (baseMap = {}, overrides = {}) => {
-    const baseMapCloned = { ...baseMap };
-    // use override [replace] logic instead of merge to get the updated map
-    const updatedMap = Object.keys(overrides).reduce((cumulatedMap, key) => {
-        cumulatedMap[key] = overrides[key];
-        return cumulatedMap;
-    }, baseMapCloned);
-    return updatedMap;
+    return merge({}, baseMap, overrides);
 };
 /**
  * check if a string matches a regex

--- a/web/client/utils/__tests__/GeoStoryUtils-test.js
+++ b/web/client/utils/__tests__/GeoStoryUtils-test.js
@@ -351,7 +351,8 @@ describe("GeoStory Utils", () => {
                     mouseClick: false,
                     dragPan: true
                 }
-            }
+            },
+            layers: [], groups: []
         };
         const res = createMapObject(DEFAULT_MAP_OPTIONS, {
             mapOptions: {
@@ -380,7 +381,8 @@ describe("GeoStory Utils", () => {
                 name: "layer01", center: {x: 1, y: 1, crs: 'EPSG:4326'}, zoom: 1
             }, {
                 name: "layer02", center: {x: 2, y: 2, crs: 'EPSG:4326'}, zoom: 2
-            }]
+            }],
+            groups: []
         };
         const res1 = createMapObject({...DEFAULT_MAP_OPTIONS, layers: []}, {
             mapOptions: {
@@ -412,7 +414,8 @@ describe("GeoStory Utils", () => {
                 name: "layer01", center: {x: 1.5, y: 1.5, crs: 'EPSG:4326'}, zoom: 1.5
             }, {
                 name: "layer02", center: {x: 2, y: 2, crs: 'EPSG:4326'}, zoom: 2
-            }]
+            }],
+            groups: []
         };
         const res2 = createMapObject({...DEFAULT_MAP_OPTIONS, layers: [{
             name: "layer01", center: {x: 1, y: 1, crs: 'EPSG:4326'}, zoom: 1
@@ -430,6 +433,56 @@ describe("GeoStory Utils", () => {
             }]
         });
         expect(res2).toEqual(merged2);
+        // legacy geostory
+        const merged3 = {
+            zoomControl: true,
+            mapInfoControl: false,
+            mapOptions: {
+                scrollWheelZoom: false,
+                interactions: {
+                    mouseWheelZoom: false,
+                    mouseClick: false,
+                    dragPan: true
+                }
+            },
+            layers: [{
+                "visibility": false
+            },  {
+                "visibility": true
+            }, undefined],
+            groups: [undefined, {
+                expanded: true
+            }, {
+                expanded: true
+            }]
+        };
+        const res3 = createMapObject({...DEFAULT_MAP_OPTIONS, layers: [{
+            "visibility": true
+        },  {
+            "visibility": false
+        }, undefined], groups: [undefined, {
+            expanded: false
+        }, {
+            expanded: true
+        }]}, {
+            mapOptions: {
+                scrollWheelZoom: false,
+                interactions: {
+                    mouseClick: false
+                }
+            },
+            layers: [{
+                "visibility": false
+            },  {
+                "visibility": true
+            }, undefined],
+            groups: [undefined, {
+                expanded: true
+            }, {
+                expanded: true
+            }]
+        }, true);
+        expect(res3).toEqual(merged3);
     });
     it('test testRegex', () => {
         const title = "title";

--- a/web/client/utils/__tests__/GeoStoryUtils-test.js
+++ b/web/client/utils/__tests__/GeoStoryUtils-test.js
@@ -355,8 +355,11 @@ describe("GeoStory Utils", () => {
         };
         const res = createMapObject(DEFAULT_MAP_OPTIONS, {
             mapOptions: {
+                scrollWheelZoom: false,
                 interactions: {
-                    mouseClick: false
+                    mouseWheelZoom: false,
+                    mouseClick: false,
+                    dragPan: true
                 }
             }
         });

--- a/web/client/utils/__tests__/GeoStoryUtils-test.js
+++ b/web/client/utils/__tests__/GeoStoryUtils-test.js
@@ -357,13 +357,79 @@ describe("GeoStory Utils", () => {
             mapOptions: {
                 scrollWheelZoom: false,
                 interactions: {
-                    mouseWheelZoom: false,
-                    mouseClick: false,
-                    dragPan: true
+                    mouseClick: false
                 }
             }
         });
         expect(res).toEqual(merged);
+    });
+    it('test override layers in  createMapObject', () => {
+        // initial baseMap layer is empty array
+        const merged1 = {
+            zoomControl: true,
+            mapInfoControl: false,
+            mapOptions: {
+                scrollWheelZoom: false,
+                interactions: {
+                    mouseWheelZoom: false,
+                    mouseClick: false,
+                    dragPan: true
+                }
+            },
+            layers: [{
+                name: "layer01", center: {x: 1, y: 1, crs: 'EPSG:4326'}, zoom: 1
+            }, {
+                name: "layer02", center: {x: 2, y: 2, crs: 'EPSG:4326'}, zoom: 2
+            }]
+        };
+        const res1 = createMapObject({...DEFAULT_MAP_OPTIONS, layers: []}, {
+            mapOptions: {
+                scrollWheelZoom: false,
+                interactions: {
+                    mouseClick: false
+                }
+            },
+            layers: [{
+                name: "layer01", center: {x: 1, y: 1, crs: 'EPSG:4326'}, zoom: 1
+            }, {
+                name: "layer02", center: {x: 2, y: 2, crs: 'EPSG:4326'}, zoom: 2
+            }]
+        });
+        expect(res1).toEqual(merged1);
+        // initial baseMap layer not empty array
+        const merged2 = {
+            zoomControl: true,
+            mapInfoControl: false,
+            mapOptions: {
+                scrollWheelZoom: false,
+                interactions: {
+                    mouseWheelZoom: false,
+                    mouseClick: false,
+                    dragPan: true
+                }
+            },
+            layers: [{
+                name: "layer01", center: {x: 1.5, y: 1.5, crs: 'EPSG:4326'}, zoom: 1.5
+            }, {
+                name: "layer02", center: {x: 2, y: 2, crs: 'EPSG:4326'}, zoom: 2
+            }]
+        };
+        const res2 = createMapObject({...DEFAULT_MAP_OPTIONS, layers: [{
+            name: "layer01", center: {x: 1, y: 1, crs: 'EPSG:4326'}, zoom: 1
+        }]}, {
+            mapOptions: {
+                scrollWheelZoom: false,
+                interactions: {
+                    mouseClick: false
+                }
+            },
+            layers: [{
+                name: "layer01", center: {x: 1.5, y: 1.5, crs: 'EPSG:4326'}, zoom: 1.5
+            }, {
+                name: "layer02", center: {x: 2, y: 2, crs: 'EPSG:4326'}, zoom: 2
+            }]
+        });
+        expect(res2).toEqual(merged2);
     });
     it('test testRegex', () => {
         const title = "title";


### PR DESCRIPTION
## Description
In this PR, fixing issue of reset legend filter within map configure panel in geostory is implemented. Now in geostories, if the interactive legend is enabled and set on a new map, it is possible to edit it correctly on the map inline panel.
The issue is mentioned here: https://github.com/geosolutions-it/MapStore2/pull/10426#issuecomment-2176031801


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
https://github.com/geosolutions-it/MapStore2/pull/10426#issuecomment-2176031801
Also involved https://github.com/geosolutions-it/MapStore2/issues/10489

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/pull/10426#issuecomment-2176031801

**What is the new behavior?**
In geostories, if the interactive legend is enabled and set on a new map, it is Ok to edit it correctly on the map inline panel without any non expected behavior.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
