### PR TITLE
[Backport 2024.01.xx] #8871 Improve getLegendGraphic compatibility for print (#10041)

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -576,7 +576,6 @@ export const specCreators = {
                                 SERVICE: "WMS",
                                 REQUEST: "GetLegendGraphic",
                                 LAYER: layer.name,
-                                LANGUAGE: spec.language || '',
                                 STYLE: layer.style || '',
                                 SCALE: spec.scale,
                                 ...getLegendIconsSize(spec, layer),

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -582,7 +582,8 @@ export const specCreators = {
                                 ...getLegendIconsSize(spec, layer),
                                 LEGEND_OPTIONS: "forceLabels:" + (spec.forceLabels ? "on" : "") + ";fontAntialiasing:" + spec.antiAliasing + ";dpi:" + spec.legendDpi + ";fontStyle:" + (spec.bold && "bold" || (spec.italic && "italic") || '') + ";fontName:" + spec.fontFamily + ";fontSize:" + spec.fontSize,
                                 format: "image/png",
-                                ...assign({}, layer.params)
+                                ...(spec.language ? {LANGUAGE: spec.language} : {}),
+                                ...layer?.params
                             })
                         })
                     ]

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -395,6 +395,17 @@ describe('PrintUtils', () => {
         const specs = getMapfishLayersSpecification([layer], { projection: "EPSG:3857" }, {}, 'legend');
         expect(specs).toExist();
         expect(specs.length).toBe(1);
+		expect(specs[0].classes.length).toBe(1);
+        // legendURL is a GetLegendGraphic request
+        expect(specs[0].classes[0].icons[0].indexOf('GetLegendGraphic') !== -1).toBe(true);
+        // LANGUAGE, if not included, should not be a parameter of the legend URL
+        expect(specs[0].classes[0].icons[0].indexOf('LANGUAGE')).toBe(-1);
+        const specs2 = getMapfishLayersSpecification([layer], { projection: "EPSG:3857", language: 'de' }, {}, 'legend');
+        expect(specs2).toExist();
+        expect(specs2.length).toBe(1);
+        expect(specs2[0].classes.length).toBe(1);
+        // LANGUAGE, if included, should be a parameter of the legend URL
+        expect(specs2[0].classes[0].icons[0].indexOf('LANGUAGE=de')).toBeGreaterThan(0);
     });
     it('toOpenLayers2Style for vector layer wich contains a FeatureCollection using the default style', () => {
         const style = toOpenLayers2Style(vectorWithFtCollInside, null, "FeatureCollection");


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
[Backport 2024.01.xx] #8871 Improve getLegendGraphic compatibility for print (#10041)
fix  #8871 

Due to a mistake the previous one was targeting master branch instead of the stable one:
https://github.com/geosolutions-it/MapStore2/pull/10043

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#8871

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
