### PR TITLE
Fix #10470 when CRS is only 1

### DIFF
--- a/web/client/api/WMS.js
+++ b/web/client/api/WMS.js
@@ -106,7 +106,7 @@ export const searchAndPaginate = (json = {}, startPosition, maxRecords, text) =>
     const root = json.Capability;
     const service = json.Service;
     const onlineResource = getOnlineResource(root);
-    const SRSList = root.Layer && (root.Layer.SRS || root.Layer.CRS)?.map((crs) => crs.toUpperCase()) || [];
+    const SRSList = root.Layer && castArray(root.Layer.SRS || root.Layer.CRS)?.map((crs) => crs.toUpperCase()) || [];
     const credits = root.Layer && root.Layer.Attribution && extractCredits(root.Layer.Attribution);
     const getMapFormats = castArray(root?.Request?.GetMap?.Format || []);
     const getFeatureInfoFormats = castArray(root?.Request?.GetFeatureInfo?.Format || []);

--- a/web/client/api/__tests__/WMS-test.js
+++ b/web/client/api/__tests__/WMS-test.js
@@ -108,6 +108,23 @@ describe('Test correctness of the WMS APIs', () => {
                 expect(result.service).toBeTruthy();
                 expect(result.records[0].getMapFormats.length).toBe(20);
                 expect(result.numberOfRecordsMatched).toBe(5);
+                expect(result.records[0].SRS.length).toBe(3);
+                expect(result.layerOptions).toBeTruthy();
+                expect(result.layerOptions.version).toBe('1.3.0');
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+    it('GetRecords', (done) => {
+        API.getRecords('base/web/client/test-resources/wms/GetCapabilities-1.3.0-minimal.xml', 0, 2, '').then((result) => {
+            try {
+                expect(result).toBeTruthy();
+                expect(result.service).toBeTruthy();
+                expect(result.records[0].getMapFormats.length).toBe(1);
+                expect(result.records[0].SRS.length).toBe(1);
+                expect(result.numberOfRecordsMatched).toBe(1);
                 expect(result.layerOptions).toBeTruthy();
                 expect(result.layerOptions.version).toBe('1.3.0');
                 done();

--- a/web/client/test-resources/wms/GetCapabilities-1.3.0-minimal.xml
+++ b/web/client/test-resources/wms/GetCapabilities-1.3.0-minimal.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<WMS_Capabilities xmlns="http://www.opengis.net/wms"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd" version="1.3.0">
+    <Service>
+        <Name>WMS</Name>
+        <Title>Map</Title>
+        <OnlineResource xlink:type="simple" xlink:href="http://10.0.0.191:80/wms" />
+        <MaxWidth>4096</MaxWidth>
+        <MaxHeight>4096</MaxHeight>
+    </Service>
+    <Capability>
+        <Request>
+            <GetCapabilities>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:type="simple" xlink:href="http://10.0.0.191:80/wms?" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetCapabilities>
+            <GetFeatureInfo>
+                <Format>application/json</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:type="simple" xlink:href="http://10.0.0.191:80/wms?" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetFeatureInfo>
+            <GetMap>
+                <Format>image/png</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:type="simple" xlink:href="http://10.0.0.191:80/wms?" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetMap>
+        </Request>
+        <Exception>
+            <Format>XML</Format>
+        </Exception>
+        <Layer queryable="1">
+            <Name>Map</Name>
+            <Title>Map</Title>
+            <CRS>EPSG:3857</CRS>
+            <BoundingBox CRS="EPSG:3857" minx="-8547715.63930251" miny="5199853.840378792" maxx="-8477042.31270172" maxy="5255826.651484046" />
+        </Layer>
+    </Capability>
+</WMS_Capabilities>


### PR DESCRIPTION
## Description

This PR fixes Fix #10470  error by supporting the case when only 1 CRS is present in capabilities. 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10470 

**What is the new behavior?**
Fix #10470 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
