### PR TITLE
Improved documentation for autoDetectCORS, tileSize and singleTiles

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -20,9 +20,14 @@ This is the main structure:
   "printUrl": "/geoserver-test/pdf/info.json",
   // a string or an object for the proxy URL.
   "proxyUrl": {
+    // When autoDetectCORS is not present or false, the application will use the proxy for all the requests except the ones in the useCORS array.
+    // if autoDetectCORS=true, the application will try the CORS request first, than will try to use the proxy if the request fails.
+    // note: this parameter is actually not supported by Cesium, that will always use the proxy or the CORS request when in useCORS array.
+    "autoDetectCORS": false,
     // if it is an object, the url entry holds the url to the proxy
     "url": "/MapStore2/proxy/?url=",
-    // useCORS array contains a list of services that support CORS and so do not need a proxy
+    // useCORS array contains a list of services that support CORS and so do not need a proxy.
+    // if autoDetectCORS is true, this array will be ignored (except for Cesium)
     "useCORS": ["http://nominatim.openstreetmap.org", "https://nominatim.openstreetmap.org"]
   },
   // JSON file where uploaded extensions are configured

--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -247,6 +247,8 @@ Details:
 - `search`: an object to configure the search features service. It is used to link a WFS service, typically with this shape: `{url: 'http://some.wfs.service', type: 'wfs'}`.
 - `fields`: if the layer has a wfs service configured, this can contain the fields (attributes) of the features, with custom configuration (e.g. aliases, types, etc.). See [Fields](#fields) for details.
 - `credits`: includes the information to show in attribution.(`imageUrl`, `link`, `title`).
+- `singleTile`: By default, WMS is invoked using tiled requests. If you want to use a single tile request, you can set this property to `true`.
+- `tileSize`: defines the size of the tiles in pixels for tiled requests. It is a number and it can be `256` or `512`. Default is `256`.
 
 ##### Fields
 


### PR DESCRIPTION
## Description

In this small PR we add documentation for the following properties:
- `autoDetectCors` in `localConfig.json`
- `tileSize` and `singleTile` in WMS layers of map.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: Only doc


## Issue

Documentation was missing

**What is the new behavior?**
Documentation has been added

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

@tdipisa I confirm that `autoDetectCORS` is not supported by Cesium. In general the library, that supports a retry, as for [this example](https://cesium.com/learn/ion-sdk/ref-doc/Resource.html#Resource) do not seems to allow to replace the proxy. In fact even if I tried to replace the proxy, the retry is not performed with the proxy. We may need to investigate if this can be fixed. 