### PR TITLE
Fix #10473 support of autoDetectCORS for 3D tiles

### DIFF
--- a/web/client/utils/ProxyUtils.js
+++ b/web/client/utils/ProxyUtils.js
@@ -44,6 +44,9 @@ export const needProxy = function(uri, config = {}) {
     }
     return needed;
 };
+export const isAutoDetectCORS = function() {
+    return ConfigUtils.getConfigProp('proxyUrl')?.autoDetectCORS;
+};
 
 export const getProxyUrl = function(config = {}) {
     let proxyUrl = ConfigUtils.getProxyUrl(config);


### PR DESCRIPTION
## Description

This draft PR (missing tests and maybe need more options to discuss) is a work in progress and a proof of concept that tries to solve #10473. 
In this PR I was able to check performances on 3D tiles now (that use CORS by default, when not specified in `useCORS`) and the implementation with `autoDetectCORS`. 
Because of the results in terms of performances, I think we need to consider this or alternative solutions that use cors on 3D stuff (See other informations).

Things to do:
- [ ] check if other cesium layers need the same changes
- [ ] add unit tests
- [ ] Update doc to notify `autoDetectCORS` is now supported, if #10472 is merged

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

I tested this map

https://dev-mapstore.geosolutionsgroup.com/mapstore/#/viewer/42750

applying locally this fix compared, noticed a double speed in loading 3D tiles in same conditions.
Locally we have 2 proxies that loads slowly, but it took:
- 1.2 minutes without this fix
- 30 seconds with this fix.

To load all the 3D meshes. In production it already takes, with the proxy, something like 30 seconds, so we may encounter some greater improvements.

I wasn't able to replicate the same effect including the URL in useCORS, for some reason setting it, it fails, but with this fix, it looks to correctly load the tiles.

I think this is a performance improvement we need to take into account. We may change this bahavior to allow an autoDetectCORS in layers too.


