### PR TITLE
Tomcat leak version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ ENV TERM xterm
 COPY --from=mother "/mapstore/mapstore.war" "${MAPSTORE_WEBAPP_DST}/mapstore.war"
 COPY --from=mother "/mapstore/docker" "${CATALINA_BASE}/docker/"
 
+COPY binary/tomcat/conf/server.xml "${CATALINA_BASE}/conf/"
+RUN sed -i -e 's/8082/8080/g' ${CATALINA_BASE}/conf/server.xml
+
 RUN mkdir -p ${DATA_DIR}
 
 

--- a/binary/tomcat/conf/server.xml
+++ b/binary/tomcat/conf/server.xml
@@ -174,6 +174,10 @@
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 
+        <Valve className="org.apache.catalina.valves.ErrorReportValve"
+               showReport="false" 
+               showServerInfo="false"/> 
+          
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
## Description

Update the default template for tomcat in order to avoid displaying version in error pages.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other : Application server base configuration

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Tomcat shows version deployed in error pages.

**What is the new behavior?**
Just showing 404 error by example.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
