### PR TITLE
#10488: 'ilike' as default operator for text field in attribute table quick filter

### DIFF
--- a/web/client/components/data/featuregrid/filterRenderers/AttributeFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/AttributeFilter.jsx
@@ -23,7 +23,7 @@ class AttributeFilter extends React.PureComponent {
         column: PropTypes.object,
         placeholderMsgId: PropTypes.string,
         tooltipMsgId: PropTypes.string,
-        operator: PropTypes.string,
+        defaultOperator: PropTypes.string,
         type: PropTypes.string,
         isWithinAttrTbl: PropTypes.bool
     };
@@ -38,7 +38,7 @@ class AttributeFilter extends React.PureComponent {
         onChange: () => {},
         column: {},
         placeholderMsgId: "featuregrid.filter.placeholders.default",
-        operator: "=",
+        defaultOperator: "=",
         isWithinAttrTbl: false
     };
     constructor(props) {
@@ -50,7 +50,7 @@ class AttributeFilter extends React.PureComponent {
             booleanOperators: ["="],
             defaultOperators: ["=", ">", "<", ">=", "<=", "<>", "isNull"],
             timeDateOperators: ["=", ">", "<", ">=", "<=", "<>", "><", "isNull"],
-            operator: this.props.isWithinAttrTbl ? (this.props.operator || '=') : "",
+            operator: this.props.isWithinAttrTbl ? (this.props.defaultOperator) : "",
             isInputValid: true
         };
     }

--- a/web/client/components/data/featuregrid/filterRenderers/AttributeFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/AttributeFilter.jsx
@@ -50,7 +50,7 @@ class AttributeFilter extends React.PureComponent {
             booleanOperators: ["="],
             defaultOperators: ["=", ">", "<", ">=", "<=", "<>", "isNull"],
             timeDateOperators: ["=", ">", "<", ">=", "<=", "<>", "><", "isNull"],
-            operator: this.props.isWithinAttrTbl ? "=" : "",
+            operator: this.props.isWithinAttrTbl ? (this.props.operator || '=') : "",
             isInputValid: true
         };
     }

--- a/web/client/components/data/featuregrid/filterRenderers/BaseDateTimeFilter.js
+++ b/web/client/components/data/featuregrid/filterRenderers/BaseDateTimeFilter.js
@@ -104,7 +104,7 @@ export class DateFilter extends AttributeFilter {
         />);
     }
     handleChange = (value, stringValue) => {
-        this.props.onChange({ value, stringValue, attribute: this.props.column && this.props.column.name, inputOperator: this.state.operator || this.props.operator });
+        this.props.onChange({ value, stringValue, attribute: this.props.column && this.props.column.name, inputOperator: this.state.operator });
     }
     handleChangeRangeFilter = (value, stringValue, order = 'start') => {
         let reqVal = {};
@@ -119,7 +119,7 @@ export class DateFilter extends AttributeFilter {
                 endDate: this.props.value?.endDate
             };
         }
-        this.props.onChange({ value: reqVal, stringValue, attribute: this.props.column && this.props.column.name, inputOperator: this.state.operator || this.props.operator });
+        this.props.onChange({ value: reqVal, stringValue, attribute: this.props.column && this.props.column.name, inputOperator: this.state.operator });
     }
 }
 

--- a/web/client/components/data/featuregrid/filterRenderers/StringFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/StringFilter.jsx
@@ -6,7 +6,7 @@ export default compose(
     defaultProps({
         onValueChange: () => {},
         placeholderMsgId: "featuregrid.filter.placeholders.string",
-        operator: 'ilike'
+        defaultOperator: 'ilike'
     }),
     withHandlers({
         onChange: props => ({value, attribute, inputOperator} = {}) => {

--- a/web/client/components/data/featuregrid/filterRenderers/StringFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/StringFilter.jsx
@@ -5,7 +5,8 @@ import { trim } from 'lodash';
 export default compose(
     defaultProps({
         onValueChange: () => {},
-        placeholderMsgId: "featuregrid.filter.placeholders.string"
+        placeholderMsgId: "featuregrid.filter.placeholders.string",
+        operator: 'ilike'
     }),
     withHandlers({
         onChange: props => ({value, attribute, inputOperator} = {}) => {

--- a/web/client/components/data/featuregrid/filterRenderers/__tests__/StringFilter-test.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/__tests__/StringFilter-test.jsx
@@ -35,6 +35,15 @@ describe('Test for StringFilter component', () => {
         expect(el).toExist();
         expect(el.value).toBe("TEST");
     });
+    it('test the text field with the ilike default operator in attribute table', () => {
+        ReactDOM.render(<StringFilter value={"TEST"} type="string" isWithinAttrTbl />, document.getElementById("container"));
+        const el = document.getElementsByClassName("form-control input-sm")[0];
+        expect(el).toExist();
+        expect(el.value).toBe("TEST");
+        const operatorEl = document.querySelector('.rw-input');
+        expect(operatorEl).toExist();
+        expect(operatorEl.innerHTML).toEqual("ilike");
+    });
     it('Test StringFilter onChange', () => {
         const actions = {
             onChange: () => {}


### PR DESCRIPTION
## Description
In this PR, handling specifying 'ilike' as the default operator in DD operators in attribute table for the text fields is implemented and adding a unit test for that.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10488 

**What is the current behavior?**
#10488 

**What is the new behavior?**
Now the attribute table shows 'ilike' operator for the text fields as a default operator for quick filter.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No


## Other useful information
