### PR TITLE
Fix #10497. Fixed logic operators precedence in CQL filter parse

### DIFF
--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -2227,6 +2227,19 @@ describe('FilterUtils', () => {
             xmlnsToAdd: ['xmlns:ogc="http://www.opengis.net/ogc"', 'xmlns:gml="http://www.opengis.net/gml"']
         }, undefined, {...filterObj, ogcVersion});
         expect(filter).toEqual(expectedFilter);
+        const args = [{
+            "ogcVersion": "1.1.0"
+        }, "P1 = 'V1' AND P2 = 'V2' OR P1 = 'V3' AND P2 = 'V4'", undefined, {
+            "featureTypeName": "cgd:GEO_FEATURE",
+            "filterType": "OGC",
+            "ogcVersion": "1.1.0",
+            "pagination": {
+                "startIndex": 0,
+                "maxFeatures": 20
+            }
+        }];
+        expect(mergeFiltersToOGC(...args)).toEqual(`<ogc:Filter><ogc:And><ogc:Or><ogc:And><ogc:PropertyIsEqualTo><ogc:PropertyName>P1</ogc:PropertyName><ogc:Literal>V1</ogc:Literal></ogc:PropertyIsEqualTo><ogc:PropertyIsEqualTo><ogc:PropertyName>P2</ogc:PropertyName><ogc:Literal>V2</ogc:Literal></ogc:PropertyIsEqualTo></ogc:And><ogc:And><ogc:PropertyIsEqualTo><ogc:PropertyName>P1</ogc:PropertyName><ogc:Literal>V3</ogc:Literal></ogc:PropertyIsEqualTo><ogc:PropertyIsEqualTo><ogc:PropertyName>P2</ogc:PropertyName><ogc:Literal>V4</ogc:Literal></ogc:PropertyIsEqualTo></ogc:And></ogc:Or></ogc:And></ogc:Filter>`);
+
     });
     // sub function to convert filters from other formats
     describe('sub function to convert filters from other formats', () => {

--- a/web/client/utils/ogc/Filter/__tests__/fromObject-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/fromObject-test.js
@@ -173,6 +173,33 @@ const FUNCTIONS = [
 const REAL_WORLD = [
     // real world example
     {
+        cql: "P1 = 'V1' AND P2 = 'V3' OR P1 = 'V1' AND P2 = 'V3'",
+        expected:
+            '<ogc:Or>'
+                + '<ogc:And>'
+                    + '<ogc:PropertyIsEqualTo>'
+                        + '<ogc:PropertyName>P1</ogc:PropertyName>'
+                        + '<ogc:Literal>V1</ogc:Literal>'
+                    + '</ogc:PropertyIsEqualTo>'
+                    + '<ogc:PropertyIsEqualTo>'
+                        + '<ogc:PropertyName>P2</ogc:PropertyName>'
+                        + '<ogc:Literal>V3</ogc:Literal>'
+                    + '</ogc:PropertyIsEqualTo>'
+                + '</ogc:And>'
+                + '<ogc:And>'
+                    + '<ogc:PropertyIsEqualTo>'
+                        + '<ogc:PropertyName>P1</ogc:PropertyName>'
+                        + '<ogc:Literal>V1</ogc:Literal>'
+                    + '</ogc:PropertyIsEqualTo>'
+                    + '<ogc:PropertyIsEqualTo>'
+                        + '<ogc:PropertyName>P2</ogc:PropertyName>'
+                        + '<ogc:Literal>V3</ogc:Literal>'
+                    + '</ogc:PropertyIsEqualTo>'
+                + '</ogc:And>'
+            + '</ogc:Or>'
+
+    },
+    {
         cql: "( DTINCID <= '1789-07-13' AND DTINCID >= '1492-10-11' ) AND (DOW='1') AND (TPINCID='1')",
         expected:
             '<ogc:And>'


### PR DESCRIPTION
## Description
This fixes the logic operator precedence.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10497

**What is the new behavior?**
Fix #10497.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
