### PR TITLE
Fix #10506 Adding possibility to fetch legends images using Bearer token

### DIFF
--- a/web/client/components/misc/SecureImage.jsx
+++ b/web/client/components/misc/SecureImage.jsx
@@ -7,26 +7,12 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { connect } from 'react-redux';
 import axios from 'axios';
-import { createSelector } from 'reselect';
 
-import { securityTokenSelector } from '../../../selectors/security';
-import {
-    getAuthenticationMethod,
-    getAuthenticationHeaders
-} from '../../../utils/SecurityUtils';
+import { getAuthenticationMethod } from '../../utils/SecurityUtils';
 
 
-const SecureImage = connect(
-    createSelector(
-        securityTokenSelector,
-        (token) => {
-            return { token };
-        }
-    ),
-    {}
-)(({
+const SecureImage = ({
     alt,
     src,
     token,
@@ -48,8 +34,7 @@ const SecureImage = connect(
 
         if (authMethod === "bearer") {
             axios.get(src, {
-                responseType: 'blob',
-                headers: getAuthenticationHeaders(src, token)
+                responseType: 'blob'
             })
                 .then((response) => {
                     const imageUrl = URL.createObjectURL(response.data);
@@ -80,6 +65,6 @@ const SecureImage = connect(
             {...props}
         />
     );
-});
+};
 
 export default SecureImage;

--- a/web/client/components/misc/SecureImage.jsx
+++ b/web/client/components/misc/SecureImage.jsx
@@ -15,7 +15,6 @@ import { getAuthenticationMethod } from '../../utils/SecurityUtils';
 const SecureImage = ({
     alt,
     src,
-    token,
     ...props
 }) => {
     const [imageSrc, setImageSrc] = useState('');
@@ -53,7 +52,7 @@ const SecureImage = ({
                 URL.revokeObjectURL(imageSrc);
             }
         };
-    }, [src, token]);
+    }, [src]);
 
     return (
         <img

--- a/web/client/plugins/TOC/components/Legend.jsx
+++ b/web/client/plugins/TOC/components/Legend.jsx
@@ -14,7 +14,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {
-    addAuthenticationParameter,
     addAuthenticationToSLD,
     clearNilValuesForParams,
     getAuthenticationMethod

--- a/web/client/plugins/TOC/components/Legend.jsx
+++ b/web/client/plugins/TOC/components/Legend.jsx
@@ -16,9 +16,11 @@ import React from 'react';
 import {
     addAuthenticationParameter,
     addAuthenticationToSLD,
-    clearNilValuesForParams
+    clearNilValuesForParams,
+    getAuthenticationMethod
 } from '../../../utils/SecurityUtils';
 import Message from '../../../components/I18N/Message';
+import SecureImage from './SecureImage';
 import { randomInt } from '../../../utils/RandomUtils';
 
 /**
@@ -85,22 +87,26 @@ class Legend extends React.Component {
 
             const cleanParams = clearNilValuesForParams(layer.params);
             const scale = this.getScale(props);
-            let query = assign({}, {
-                service: "WMS",
-                request: "GetLegendGraphic",
-                format: "image/png",
-                height: props.legendHeight,
-                width: props.legendWidth,
-                layer: layer.name,
-                style: layer.style || null,
-                version: layer.version || "1.3.0",
-                SLD_VERSION: "1.1.0",
-                LEGEND_OPTIONS: props.legendOptions
-            }, layer.legendParams || {},
-            props.language && layer.localizedLayerStyles ? {LANGUAGE: props.language} : {},
-            addAuthenticationToSLD(cleanParams || {}, props.layer),
-            cleanParams && cleanParams.SLD_BODY ? {SLD_BODY: cleanParams.SLD_BODY} : {},
-            scale !== null ? { SCALE: scale } : {});
+            let query = assign(
+                {},
+                {
+                    service: "WMS",
+                    request: "GetLegendGraphic",
+                    format: "image/png",
+                    height: props.legendHeight,
+                    width: props.legendWidth,
+                    layer: layer.name,
+                    style: layer.style || null,
+                    version: layer.version || "1.3.0",
+                    SLD_VERSION: "1.1.0",
+                    LEGEND_OPTIONS: props.legendOptions
+                },
+                layer.legendParams || {},
+                props.language && layer.localizedLayerStyles ? {LANGUAGE: props.language} : {},
+                addAuthenticationToSLD(cleanParams || {}, props.layer),
+                cleanParams && cleanParams.SLD_BODY ? {SLD_BODY: cleanParams.SLD_BODY} : {},
+                scale !== null ? { SCALE: scale } : {}
+            );
             addAuthenticationParameter(url, query);
 
             return urlUtil.format({
@@ -114,7 +120,23 @@ class Legend extends React.Component {
     }
     render() {
         if (!this.state.error && this.props.layer && this.props.layer.type === "wms" && this.props.layer.url) {
-            return <img onError={this.onImgError} onLoad={(e) => this.validateImg(e.target)} src={this.getUrl(this.props)} style={this.props.style}/>;
+            const url = this.getUrl(this.props);
+            const authMethod = getAuthenticationMethod(url);
+            return (
+                authMethod === "bearer" ?
+                    <SecureImage
+                        onError={this.onImgError}
+                        onLoad={(e) => this.validateImg(e.target)}
+                        src={url}
+                        style={this.props.style}
+                    /> :
+                    <img
+                        onError={this.onImgError}
+                        onLoad={(e) => this.validateImg(e.target)}
+                        src={url}
+                        style={this.props.style}
+                    />
+            );
         }
         return <Message msgId="layerProperties.legenderror" />;
     }

--- a/web/client/plugins/TOC/components/Legend.jsx
+++ b/web/client/plugins/TOC/components/Legend.jsx
@@ -121,19 +121,12 @@ class Legend extends React.Component {
             const url = this.getUrl(this.props);
             const authMethod = getAuthenticationMethod(url);
             return (
-                authMethod === "bearer" ?
-                    <SecureImage
-                        onError={this.onImgError}
-                        onLoad={(e) => this.validateImg(e.target)}
-                        src={url}
-                        style={this.props.style}
-                    /> :
-                    <img
-                        onError={this.onImgError}
-                        onLoad={(e) => this.validateImg(e.target)}
-                        src={url}
-                        style={this.props.style}
-                    />
+                <SecureImage
+                    onError={this.onImgError}
+                    onLoad={(e) => this.validateImg(e.target)}
+                    src={url}
+                    style={this.props.style}
+                />
             );
         }
         return <Message msgId="layerProperties.legenderror" />;

--- a/web/client/plugins/TOC/components/Legend.jsx
+++ b/web/client/plugins/TOC/components/Legend.jsx
@@ -18,7 +18,8 @@ import {
     clearNilValuesForParams
 } from '../../../utils/SecurityUtils';
 import Message from '../../../components/I18N/Message';
-import SecureImage from './SecureImage';
+import SecureImage from '../../../components/misc/SecureImage';
+
 import { randomInt } from '../../../utils/RandomUtils';
 
 /**

--- a/web/client/plugins/TOC/components/Legend.jsx
+++ b/web/client/plugins/TOC/components/Legend.jsx
@@ -15,8 +15,7 @@ import React from 'react';
 
 import {
     addAuthenticationToSLD,
-    clearNilValuesForParams,
-    getAuthenticationMethod
+    clearNilValuesForParams
 } from '../../../utils/SecurityUtils';
 import Message from '../../../components/I18N/Message';
 import SecureImage from './SecureImage';
@@ -119,7 +118,6 @@ class Legend extends React.Component {
     render() {
         if (!this.state.error && this.props.layer && this.props.layer.type === "wms" && this.props.layer.url) {
             const url = this.getUrl(this.props);
-            const authMethod = getAuthenticationMethod(url);
             return (
                 <SecureImage
                     onError={this.onImgError}

--- a/web/client/plugins/TOC/components/Legend.jsx
+++ b/web/client/plugins/TOC/components/Legend.jsx
@@ -107,7 +107,6 @@ class Legend extends React.Component {
                 cleanParams && cleanParams.SLD_BODY ? {SLD_BODY: cleanParams.SLD_BODY} : {},
                 scale !== null ? { SCALE: scale } : {}
             );
-            addAuthenticationParameter(url, query);
 
             return urlUtil.format({
                 host: urlObj.host,

--- a/web/client/plugins/TOC/components/SecureImage.jsx
+++ b/web/client/plugins/TOC/components/SecureImage.jsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
+import { securityTokenSelector } from '../../../selectors/security';
+
+const SecureImage = connect(
+    createSelector(
+        securityTokenSelector,
+        (token) => {
+            return { token };
+        }
+    ),
+    {}
+)(({
+    alt,
+    src,
+    token,
+    ...props
+}) => {
+    const [imageSrc, setImageSrc] = useState('');
+
+    useEffect(() => {
+        const fetchImage = async() => {
+            try {
+                const response = await fetch(src, {
+                    headers: {
+                        'Authorization': `Bearer ${token}`
+                    }
+                });
+                if (response.ok) {
+                    const blob = await response.blob();
+                    const imageUrl = URL.createObjectURL(blob);
+                    setImageSrc(imageUrl);
+                } else {
+                    console.error('Failed to fetch image:', response.statusText);
+                }
+            } catch (error) {
+                console.error('Error fetching image:', error);
+            }
+        };
+
+        fetchImage();
+
+        // Clean up the URL object when the component unmounts
+        return () => {
+            if (imageSrc) {
+                URL.revokeObjectURL(imageSrc);
+            }
+        };
+    }, [src, token]);
+
+    return (
+        <img src={imageSrc} alt={alt} {...props} />
+    );
+});
+
+export default SecureImage;

--- a/web/client/plugins/TOC/components/__tests__/Legend-test.jsx
+++ b/web/client/plugins/TOC/components/__tests__/Legend-test.jsx
@@ -15,7 +15,7 @@ import * as TestUtils from 'react-dom/test-utils';
 
 import Legend from '../Legend';
 
-describe.only("test the Layer legend", () => {
+describe("test the Layer legend", () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setTimeout(done);

--- a/web/client/plugins/TOC/components/__tests__/Legend-test.jsx
+++ b/web/client/plugins/TOC/components/__tests__/Legend-test.jsx
@@ -11,12 +11,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Rx from 'rxjs';
 import url from 'url';
+import * as TestUtils from 'react-dom/test-utils';
 
 import Legend from '../Legend';
 
-import * as TestUtils from 'react-dom/test-utils';
-
-describe("test the Layer legend", () => {
+describe.only("test the Layer legend", () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setTimeout(done);
@@ -176,13 +175,15 @@ describe("test the Layer legend", () => {
             "name": "layer3",
             "format": "image/png"
         };
-        ReactDOM.render(
-            <Legend
-                layer={layer}
-                currentZoomLvl={2.3456}
-                scales={[10000, 5000, 2000, 1000]}
-            />,
-            document.getElementById("container"));
+        TestUtils.act(() => {
+            ReactDOM.render(
+                <Legend
+                    layer={layer}
+                    currentZoomLvl={2.3456}
+                    scales={[10000, 5000, 2000, 1000]}
+                />,
+                document.getElementById("container"));
+        });
         const legendImage = document.querySelector("img");
         expect(legendImage).toBeTruthy();
         const { query } = url.parse(legendImage.getAttribute('src'), true);
@@ -197,13 +198,15 @@ describe("test the Layer legend", () => {
             "name": "layer3",
             "format": "image/png"
         };
-        ReactDOM.render(
-            <Legend
-                layer={layer}
-                currentZoomLvl={10}
-                scales={[10000, 5000, 2000, 1000]}
-            />,
-            document.getElementById("container"));
+        TestUtils.act(() => {
+            ReactDOM.render(
+                <Legend
+                    layer={layer}
+                    currentZoomLvl={10}
+                    scales={[10000, 5000, 2000, 1000]}
+                />,
+                document.getElementById("container"));
+        });
         const legendImage = document.querySelector("img");
         expect(legendImage).toBeTruthy();
         const { query } = url.parse(legendImage.getAttribute('src'), true);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

adding possibility to request images legend using bearer token

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10506

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

now if the legend url needs to use a Bearer token it switches to a SecureImage component that fetches the token from state, so this will work only if the user is logged in (because the legends are behind a secured geoserver, and authentication is needed)
otherwise it will show legend not available

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

I also remove the line 
addAuthenticationParameter(url, query);

because it was doing nothing placed there (returning a value not used)
