### PR TITLE
Fix #10508 fix tileprovider crash when using {-y}

### DIFF
--- a/web/client/components/map/cesium/plugins/TileProviderLayer.js
+++ b/web/client/components/map/cesium/plugins/TileProviderLayer.js
@@ -55,6 +55,13 @@ export function template(str, data) {
         if (['x', 'y', 'z', 's'].includes(key)) {
             return textMatched;
         }
+        if (key === '-x') {
+            return "{reverseX}";
+        }
+        if (key === '-y') {
+            return "{reverseY}";
+        }
+
         let value = data[key];
 
         if (value === undefined) {

--- a/web/client/utils/TileProviderUtils.js
+++ b/web/client/utils/TileProviderUtils.js
@@ -11,7 +11,7 @@ export function template(str = "", data = {}) {
     return str.replace(/(\{(.*?)\})/g, function() {
         let st = arguments[0];
         let key = arguments[2] ? arguments[2] : arguments[1];
-        if (["x", "y", "-y", "z"].includes(key)) {
+        if (["x", "-x", "y", "-y", "z"].includes(key)) {
             return arguments[0];
         }
         let value = data[key];

--- a/web/client/utils/TileProviderUtils.js
+++ b/web/client/utils/TileProviderUtils.js
@@ -11,7 +11,7 @@ export function template(str = "", data = {}) {
     return str.replace(/(\{(.*?)\})/g, function() {
         let st = arguments[0];
         let key = arguments[2] ? arguments[2] : arguments[1];
-        if (["x", "y", "z"].includes(key)) {
+        if (["x", "y", "-y", "z"].includes(key)) {
             return arguments[0];
         }
         let value = data[key];

--- a/web/client/utils/__tests__/TileProviderUtils-test.js
+++ b/web/client/utils/__tests__/TileProviderUtils-test.js
@@ -57,8 +57,13 @@ describe('Test the TileProviderUtils', () => {
         expect(
             template("https://test.com/6510a8722129af6954196fbb26dfadc/1.0.0/topowebb/default/3857/{z}/{y}/{x}.png", optArray))
             .toEqual("https://test.com/6510a8722129af6954196fbb26dfadc/1.0.0/topowebb/default/3857/{z}/{y}/{x}.png");
-        // expect().toBe();
+        // test negative y (-y in template)
+        expect(
+            template("https://test.com/default/3857/{z}/{-y}/{x}.png", optArray))
+            .toEqual("https://test.com/default/3857/{z}/{-y}/{x}.png");
+        expect(
+            template("https://test.com/default/3857/{z}/{-y}/{-x}.png", optArray))
+            .toEqual("https://test.com/default/3857/{z}/{-y}/{-x}.png");
     });
-
 
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10508

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
