### PR TITLE
Fix #10513 Print preview state is not aligned with TOC

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -25,14 +25,14 @@ import Dialog from '../components/misc/Dialog';
 import printReducers from '../reducers/print';
 import printEpics from '../epics/print';
 import { printSpecificationSelector } from "../selectors/print";
-import { layersSelector } from '../selectors/layers';
+import { layersSelector, rawGroupsSelector } from '../selectors/layers';
 import { currentLocaleSelector } from '../selectors/locale';
 import { mapSelector, scalesSelector } from '../selectors/map';
 import { mapTypeSelector } from '../selectors/maptype';
 import { normalizeSRS, convertDegreesToRadian } from '../utils/CoordinatesUtils';
 import { getMessageById } from '../utils/LocaleUtils';
 import { defaultGetZoomForExtent, getResolutions, mapUpdated, dpi2dpu, DEFAULT_SCREEN_DPI, getScales, reprojectZoom } from '../utils/MapUtils';
-import { isInsideResolutionsLimits } from '../utils/LayersUtils';
+import { getDerivedLayersVisibility, isInsideResolutionsLimits } from '../utils/LayersUtils';
 import { has, includes } from 'lodash';
 import {additionalLayersSelector} from "../selectors/additionallayers";
 import { MapLibraries } from '../utils/MapTypeUtils';
@@ -629,8 +629,9 @@ export default {
                     (state) => state.browser && (!state.browser.ie || state.browser.ie11),
                     currentLocaleSelector,
                     mapTypeSelector,
-                    (state) => state.print.map
-                ], (open, capabilities, printSpec, pdfUrl, error, map, layers, additionalLayers, scales, usePreview, currentLocale, mapType, printMap) => ({
+                    (state) => state.print.map,
+                    rawGroupsSelector
+                ], (open, capabilities, printSpec, pdfUrl, error, map, layers, additionalLayers, scales, usePreview, currentLocale, mapType, printMap, groups) => ({
                     open,
                     capabilities,
                     printSpec,
@@ -638,7 +639,7 @@ export default {
                     error,
                     map,
                     layers: [
-                        ...layers.filter(filterLayer),
+                        ...getDerivedLayersVisibility(layers, groups).filter(filterLayer),
                         ...(printSpec?.additionalLayers ? additionalLayers.map(l => l.options).filter(
                             l => {
                                 const isVector = l.type === 'vector';

--- a/web/client/plugins/__tests__/Print-test.jsx
+++ b/web/client/plugins/__tests__/Print-test.jsx
@@ -569,4 +569,92 @@ describe('Print Plugin', () => {
             }
         });
     });
+    it("test removing visible layers with invisible group", (done) => {
+        const actions = {
+            onPrint: () => {}
+        };
+        let spy = expect.spyOn(actions, "onPrint");
+        getPrintPlugin({
+            layers:
+                {
+                    flat: [
+                        {
+                            id: 'test:Linea_costa__38262060-608e-11ef-b6d2-f1ba404475c4',
+                            format: 'image/png',
+                            group: 'Default.34a0a320-608e-11ef-b6d2-f1ba404475c4',
+                            search: {
+                                url: '/geoserver/wfs',
+                                type: 'wfs'
+                            },
+                            name: 'test:Linea_costa',
+                            description: '',
+                            title: 'Linea_costa',
+                            type: 'wms',
+                            url: '/geoserver/wms',
+                            visibility: true
+                        },
+                        {
+                            type: 'wms',
+                            format: 'image/png',
+                            featureInfo: null,
+                            url: '/geoserver/wms',
+                            visibility: true,
+                            dimensions: [],
+                            name: 'test:areeverdiPolygon',
+                            title: 'areeverdiPolygon',
+                            id: 'test:areeverdiPolygon__722d7920-608e-11ef-8123-43293ce7e0e8'
+                        }
+                    ],
+                    groups: [
+                        {
+                            id: 'Default',
+                            title: 'Default',
+                            name: 'Default',
+                            nodes: [
+                                'test:areeverdiPolygon__722d7920-608e-11ef-8123-43293ce7e0e8',
+                                {
+                                    id: 'Default.34a0a320-608e-11ef-b6d2-f1ba404475c4',
+                                    title: 'g1',
+                                    name: '34a0a320-608e-11ef-b6d2-f1ba404475c4',
+                                    nodes: [
+                                        'test:Linea_costa__38262060-608e-11ef-b6d2-f1ba404475c4'
+                                    ],
+                                    visibility: false
+                                }
+                            ],
+                            visibility: true
+                        }
+                    ]
+                },
+            projection: "EPSG:4326",
+            state: {
+                ...initialState,
+                map: {
+                    ...initialState.map,
+                    zoom: 5.1
+                }
+            }
+        }).then(({ Plugin }) => {
+            try {
+                ReactDOM.render(<Plugin
+                    pluginCfg={{
+                        onPrint: actions.onPrint
+                    }}
+                    defaultBackground={["osm", "empty"]}
+                />, document.getElementById("container"));
+                const submit = document.getElementsByClassName("print-submit").item(0);
+                expect(submit).toExist();
+                ReactTestUtils.Simulate.click(submit);
+
+                setTimeout(() => {
+                    expect(spy.calls.length).toBe(1);
+                    expect(spy.calls[0].arguments[1].layers.length).toBe(1);
+                    expect(spy.calls[0].arguments[1].layers[0].layers).toEqual(['test:areeverdiPolygon']);
+                    done();
+                }, 0);
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes the issue #10513. Before layers were only filtered by it's visibility, now layers are also filtered considering it's group visibility.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
[#10513](https://github.com/geosolutions-it/MapStore2/issues/10513)
Layer in the map preview of print plugin is visible even though it's group is invisible. In TOC it is working fine.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Like in TOC now in print preview map also layer will be visible if it's group is visible.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
