### PR TITLE
Allow editing by fields and set fields value from general fields settings

### DIFF
--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -65,6 +65,7 @@ export const LOAD_MORE_FEATURES = "LOAD_MORE_FEATURES";
 export const GRID_QUERY_RESULT = 'FEATUREGRID:QUERY_RESULT';
 export const SET_TIME_SYNC = "FEATUREGRID:SET_TIME_SYNC";
 export const SET_PAGINATION = "FEATUREGRID:SET_PAGINATION";
+export const GRID_ROW_UPDATE = "FEATUREGRID:GRID_ROW_UPDATE";
 
 export function toggleShowAgain() {
     return {
@@ -258,6 +259,13 @@ export function toggleViewMode() {
 export function featureModified(features, updated) {
     return {
         type: FEATURES_MODIFIED,
+        features,
+        updated
+    };
+}
+export function gridRowUpdate(features, updated) {
+    return {
+        type: GRID_ROW_UPDATE,
         features,
         updated
     };

--- a/web/client/components/TOC/fragments/LayerFields/index.jsx
+++ b/web/client/components/TOC/fragments/LayerFields/index.jsx
@@ -59,12 +59,13 @@ const LayerFields = ({ layer, updateFields = () => {}, ...props }) => {
         };
     }, []);
 
-    const onChange = (name, attribute, value) => {
+    const onChange = (name, attribute, value, isGeometryType = false) => {
         const newFields = fields.map((field) => {
             if (field.name === name) {
                 return {
                     ...field,
-                    [attribute]: value
+                    [attribute]: value,
+                    ...(isGeometryType ? {isGeometry: true} : {})
                 };
             }
             return field;

--- a/web/client/components/data/featuregrid/editors/AutocompleteEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/AutocompleteEditor.jsx
@@ -31,7 +31,8 @@ class AutocompleteEditor extends AttributeEditor {
         autocompleteStreamFactory: PropTypes.func,
         url: PropTypes.string,
         typeName: PropTypes.string,
-        value: PropTypes.string
+        value: PropTypes.string,
+        disabled: PropTypes.bool
     };
     static defaultProps = {
         isValid: () => true,

--- a/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DateTimeEditor.jsx
@@ -35,7 +35,8 @@ class DateTimeEditor extends AttributeEditor {
         calendar: PropTypes.bool,
         time: PropTypes.bool,
         onChange: PropTypes.func,
-        onBlur: PropTypes.func
+        onBlur: PropTypes.func,
+        disabled: PropTypes.bool
     };
 
     static contextTypes = {

--- a/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
@@ -40,7 +40,8 @@ class DropDownEditor extends AttributeEditor {
         filter: PropTypes.string,
         values: PropTypes.array,
         labels: PropTypes.array,
-        emptyValue: PropTypes.string
+        emptyValue: PropTypes.string,
+        disabled: PropTypes.bool
     };
     static defaultProps = {
         isValid: () => true,

--- a/web/client/components/data/featuregrid/editors/FormatEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/FormatEditor.jsx
@@ -23,7 +23,8 @@ export default class FormatEditor extends React.Component {
         dataType: PropTypes.string,
         column: PropTypes.object,
         formatRegex: PropTypes.string,
-        onTemporaryChanges: PropTypes.func
+        onTemporaryChanges: PropTypes.func,
+        disabled: PropTypes.bool
     };
 
     static defaultProps = {
@@ -61,6 +62,7 @@ export default class FormatEditor extends React.Component {
     render() {
         return (<input
             {...this.props.inputProps}
+            disabled={this.props?.disabled}
             style={!this.state.validated || this.state.isValid ? {} : {
                 borderColor: 'red'
             }}

--- a/web/client/components/data/featuregrid/editors/NumberEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/NumberEditor.jsx
@@ -34,7 +34,8 @@ export default class NumberEditor extends React.Component {
         minValue: PropTypes.number,
         maxValue: PropTypes.number,
         column: PropTypes.object,
-        onTemporaryChanges: PropTypes.func
+        onTemporaryChanges: PropTypes.func,
+        disabled: PropTypes.bool
     };
 
     static defaultProps = {
@@ -80,6 +81,7 @@ export default class NumberEditor extends React.Component {
     render() {
         return (<IntlNumberFormControl
             {...this.props.inputProps}
+            disabled={this.props?.disabled}
             style={!this.state.validated || this.state.isValid ? {} : {
                 borderColor: 'red'
             }}

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -154,12 +154,13 @@ const featuresToGrid = compose(
                         options: props.options?.propertyName
                     }, {
                         getHeaderRenderer,
-                        getEditor: (desc) => {
+                        getEditor: (desc, field) => {
                             const generalProps = {
                                 onTemporaryChanges: props.gridEvents && props.gridEvents.onTemporaryChanges,
                                 autocompleteEnabled: props.autocompleteEnabled,
                                 url: props.url,
-                                typeName: props.typeName
+                                typeName: props.typeName,
+                                disabled: field && field?.editable === false
                             };
                             const regexProps = {attribute: desc.name, url: props.url, typeName: props.typeName};
                             const rules = props.customEditorsOptions && props.customEditorsOptions.rules || [];
@@ -169,7 +170,8 @@ const featuresToGrid = compose(
                             if (!isNil(editor)) {
                                 return editor;
                             }
-                            return props.editors(desc.localType, generalProps);
+                            const typeEditor = props.editors(desc.localType, generalProps);
+                            return typeEditor;
                         },
                         getFilterRenderer: getFilterRendererFunc,
                         getFormatter: (desc) => getFormatter(desc, (props.fields ?? []).find(f => f.name === desc.name)),

--- a/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
+++ b/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
@@ -28,7 +28,6 @@ class CellRenderer extends React.Component {
         const isValid = isProperty ? this.context.isValid(this.props.rowData.get(this.props.column.key), this.props.column.key) : true;
         const className = (isModified ? ['modified'] : [])
             .concat(isValid ? [] : ['invalid']).join(" ");
-        console.log(this.props);
         return <Cell {...this.props} ref="cell" className={className}/>;
     }
 }

--- a/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
+++ b/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
@@ -28,6 +28,7 @@ class CellRenderer extends React.Component {
         const isValid = isProperty ? this.context.isValid(this.props.rowData.get(this.props.column.key), this.props.column.key) : true;
         const className = (isModified ? ['modified'] : [])
             .concat(isValid ? [] : ['invalid']).join(" ");
+        console.log(this.props);
         return <Cell {...this.props} ref="cell" className={className}/>;
     }
 }

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -61,20 +61,20 @@ const standardButtons = {
         visible={mode === "EDIT" && !hasChanges && !hasNewFeatures}
         onClick={events.switchViewMode}
         glyph="arrow-left"/>),
-    addFeature: ({disabled, mode, hasNewFeatures, hasChanges, hasSupportedGeometry = true, events = {}}) => (<TButton
+    addFeature: ({disabled, mode, hasNewFeatures, hasChanges, canEditGeometry, hasSupportedGeometry = true, events = {}}) => (<TButton
         id="add-feature"
         keyProp="add-feature"
         tooltipId="featuregrid.toolbar.addNewFeatures"
         disabled={disabled}
-        visible={mode === "EDIT" && !hasNewFeatures && !hasChanges && hasSupportedGeometry}
+        visible={mode === "EDIT" && canEditGeometry && !hasNewFeatures && !hasChanges && hasSupportedGeometry}
         onClick={events.createFeature}
         glyph="row-add"/>),
-    drawFeature: ({isDrawing = false, disabled, isSimpleGeom, mode, selectedCount, hasGeometry, hasSupportedGeometry = true, events = {}}) => (<TButton
+    drawFeature: ({isDrawing = false, disabled, isSimpleGeom, mode, selectedCount, canEditGeometry, hasGeometry, hasSupportedGeometry = true, events = {}}) => (<TButton
         id="draw-feature"
         keyProp="draw-feature"
         tooltipId={getDrawFeatureTooltip(isDrawing, isSimpleGeom)}
         disabled={disabled}
-        visible={mode === "EDIT" && selectedCount === 1 && (!hasGeometry || hasGeometry && !isSimpleGeom) && hasSupportedGeometry}
+        visible={mode === "EDIT" && selectedCount === 1 && canEditGeometry && (!hasGeometry || hasGeometry && !isSimpleGeom) && hasSupportedGeometry}
         onClick={events.startDrawingFeature}
         active={isDrawing}
         glyph="pencil-add"/>),
@@ -103,12 +103,12 @@ const standardButtons = {
         visible={mode === "EDIT" && hasChanges || hasNewFeatures}
         onClick={events.clearFeatureEditing}
         glyph="remove-square"/>),
-    deleteGeometry: ({disabled, mode, hasGeometry, selectedCount, hasSupportedGeometry = true, events = {}}) => (<TButton
+    deleteGeometry: ({disabled, mode, hasGeometry, selectedCount, canEditGeometry, hasSupportedGeometry = true, events = {}}) => (<TButton
         id="delete-geometry"
         keyProp="delete-geometry"
         tooltipId="featuregrid.toolbar.deleteGeometry"
         disabled={disabled}
-        visible={mode === "EDIT" && hasGeometry && selectedCount === 1 && hasSupportedGeometry}
+        visible={mode === "EDIT" && hasGeometry && selectedCount === 1 && hasSupportedGeometry && canEditGeometry}
         onClick={events.deleteGeometry}
         glyph="polygon-trash"/>),
     gridSettings: ({disabled, isColumnsOpen, selectedCount, mode, events = {}}) => (<TButton
@@ -170,11 +170,11 @@ const standardButtons = {
         active={timeSync}
         onClick={() => events.setTimeSync && events.setTimeSync(!timeSync)}
         glyph="time" />),
-    snapToFeature: ({snapping, availableSnappingLayers = [], isSnappingLoading, snappingConfig, mode, mapType, editorHeight, pluginCfg, events = {}}) => (<TSplitButton
+    snapToFeature: ({snapping, availableSnappingLayers = [], canEditGeometry, isSnappingLoading, snappingConfig, mode, mapType, editorHeight, pluginCfg, events = {}}) => (<TSplitButton
         id="snap-button"
         keyProp="snap-button"
         tooltipId={snapping ? "featuregrid.toolbar.disableSnapping" : "featuregrid.toolbar.enableSnapping"}
-        visible={mode === "EDIT" && (pluginCfg?.snapTool ?? true) && mapType === MapLibraries.OPENLAYERS}
+        visible={mode === "EDIT" && (pluginCfg?.snapTool ?? true) && mapType === MapLibraries.OPENLAYERS && canEditGeometry}
         onClick={() => {
             events.toggleSnapping && events.toggleSnapping(!snapping);
         }}
@@ -317,6 +317,7 @@ export default React.memo((props = {}) => {
             setShowPopoverSync(getApi().getItem("showPopoverSync") !== null && pluginCfg?.showPopoverSync ? getApi().getItem("showPopoverSync") === "true" : pluginCfg?.showPopoverSync);
         }
     }, [props.mode]);
+    // const canEditGeometry = props.isEditingAllowed &&
     return (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
 
         {sortBy(buttons.concat(toolbarItems), ["position"]).map(({Component}) => <Component {...props} showPopoverSync={showPopover} hideSyncPopover={() => setShowPopoverSync(false)} mode={props?.mode ?? "VIEW"} disabled={props.disableToolbar} />)}

--- a/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
+++ b/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
@@ -149,16 +149,21 @@ describe('Featuregrid toolbar component', () => {
             createFeature: () => {}
         };
         spyOn(events, "createFeature");
-        ReactDOM.render(<Toolbar events={events} mode="VIEW" isEditingAllowed/>, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="VIEW" isEditingAllowed canEditGeometry/>, document.getElementById("container"));
         const el = document.getElementsByClassName("featuregrid-toolbar")[0];
         expect(el).toExist();
         let addButton = document.getElementById("fg-add-feature");
         expect(isVisibleButton(addButton)).toBe(false);
         addButton.click();
         expect(events.createFeature).toHaveBeenCalled();
-        ReactDOM.render(<Toolbar events={events} mode="EDIT" isEditingAllowed/>, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" isEditingAllowed canEditGeometry/>, document.getElementById("container"));
+        addButton = document.getElementById("fg-add-feature");
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" canEditGeometry/>, document.getElementById("container"));
         addButton = document.getElementById("fg-add-feature");
         expect(isVisibleButton(addButton)).toBe(true);
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" isEditingAllowed canEditGeometry={false}/>, document.getElementById("container"));
+        addButton = document.getElementById("fg-add-feature");
+        expect(isVisibleButton(addButton)).toBe(false);
         ReactDOM.render(<Toolbar events={events} mode="EDIT" hasChanges/>, document.getElementById("container"));
         addButton = document.getElementById("fg-add-feature");
         expect(isVisibleButton(addButton)).toBe(false);
@@ -172,26 +177,29 @@ describe('Featuregrid toolbar component', () => {
             startDrawingFeature: () => {}
         };
         spyOn(events, "startDrawingFeature");
-        ReactDOM.render(<Toolbar events={events} mode="VIEW" isEditingAllowed/>, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="VIEW" isEditingAllowed canEditGeometry/>, document.getElementById("container"));
         const el = document.getElementsByClassName("featuregrid-toolbar")[0];
         expect(el).toExist();
         let button = document.getElementById("fg-draw-feature");
         expect(isVisibleButton(button)).toBe(false);
         button.click();
         expect(events.startDrawingFeature).toHaveBeenCalled();
-        ReactDOM.render(<Toolbar events={events} mode="EDIT" selectedCount={1} hasGeometry isSimpleGeom={false} />, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" canEditGeometry selectedCount={1} hasGeometry isSimpleGeom={false} />, document.getElementById("container"));
         button = document.getElementById("fg-draw-feature");
         expect(isVisibleButton(button)).toBe(true);
-        ReactDOM.render(<Toolbar events={events} mode="EDIT" selectedCount={1} hasGeometry isSimpleGeom />, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" isEditingAllowed canEditGeometry={false} selectedCount={1} hasGeometry isSimpleGeom={false} />, document.getElementById("container"));
         button = document.getElementById("fg-draw-feature");
         expect(isVisibleButton(button)).toBe(false);
-        ReactDOM.render(<Toolbar events={events} mode="EDIT" selectedCount={1} hasGeometry={false} />, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" canEditGeometry selectedCount={1} hasGeometry isSimpleGeom />, document.getElementById("container"));
+        button = document.getElementById("fg-draw-feature");
+        expect(isVisibleButton(button)).toBe(false);
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" canEditGeometry selectedCount={1} hasGeometry={false} />, document.getElementById("container"));
         button = document.getElementById("fg-draw-feature");
         expect(isVisibleButton(button)).toBe(true);
-        ReactDOM.render(<Toolbar events={events} mode="EDIT" selectedCount={1} hasGeometry={false} isSimpleGeom={false} isDrawing/>, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" canEditGeometry selectedCount={1} hasGeometry={false} isSimpleGeom={false} isDrawing/>, document.getElementById("container"));
         button = document.getElementById("fg-draw-feature");
         expect(isVisibleButton(button)).toBe(true);
-        ReactDOM.render(<Toolbar events={events} mode="EDIT" selectedCount={2}/>, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" canEditGeometry selectedCount={2}/>, document.getElementById("container"));
         button = document.getElementById("fg-draw-feature");
         expect(isVisibleButton(button)).toBe(false);
     });
@@ -257,16 +265,19 @@ describe('Featuregrid toolbar component', () => {
         expect(isVisibleButton(button)).toBe(false);
         button.click();
         expect(events.deleteGeometry).toHaveBeenCalled();
-        ReactDOM.render(<Toolbar events={events} mode="EDIT" selectedCount={1} />, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" canEditGeometry selectedCount={1} />, document.getElementById("container"));
         button = document.getElementById("fg-delete-geometry");
         expect(isVisibleButton(button)).toBe(false);
-        ReactDOM.render(<Toolbar events={events} mode="EDIT" selectedCount={1} hasGeometry />, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" canEditGeometry={false} selectedCount={1} hasGeometry />, document.getElementById("container"));
+        button = document.getElementById("fg-delete-geometry");
+        expect(isVisibleButton(button)).toBe(false);
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" canEditGeometry selectedCount={1} hasGeometry />, document.getElementById("container"));
         button = document.getElementById("fg-delete-geometry");
         expect(isVisibleButton(button)).toBe(true);
-        ReactDOM.render(<Toolbar events={events} mode="VIEW" selectedCount={1} hasGeometry />, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="VIEW" canEditGeometry ={1} hasGeometry />, document.getElementById("container"));
         button = document.getElementById("fg-delete-geometry");
         expect(isVisibleButton(button)).toBe(false);
-        ReactDOM.render(<Toolbar events={events} mode="EDIT" selectedCount={2} hasGeometry/>, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" canEditGeometry selectedCount={2} hasGeometry/>, document.getElementById("container"));
         button = document.getElementById("fg-delete-geometry");
         expect(isVisibleButton(button)).toBe(false);
     });
@@ -390,15 +401,15 @@ describe('Featuregrid toolbar component', () => {
     });
     describe('snap tool button', () => {
         it('visibility', () => {
-            ReactDOM.render(<Toolbar mapType="openlayers" pluginCfg={{ snapTool: true }} mode="EDIT" disableZoomAll />, document.getElementById("container"));
+            ReactDOM.render(<Toolbar mapType="openlayers" pluginCfg={{ snapTool: true }} canEditGeometry mode="EDIT" disableZoomAll />, document.getElementById("container"));
             expect(document.getElementById("snap-button")).toExist();
-            ReactDOM.render(<Toolbar mode="VIEW" disableZoomAll />, document.getElementById("container"));
+            ReactDOM.render(<Toolbar mode="VIEW" canEditGeometry disableZoomAll />, document.getElementById("container"));
             expect(document.getElementById("snap-button")).toNotExist();
         });
         it('active/inactive state', () => {
-            ReactDOM.render(<Toolbar mapType="openlayers" snapping pluginCfg={{ snapTool: true }} mode="EDIT" disableZoomAll />, document.getElementById("container"));
+            ReactDOM.render(<Toolbar mapType="openlayers" snapping pluginCfg={{ snapTool: true }} canEditGeometry mode="EDIT" disableZoomAll />, document.getElementById("container"));
             expect(document.getElementById("snap-button").className.split(' ')).toInclude('btn-success');
-            ReactDOM.render(<Toolbar mapType="openlayers" pluginCfg={{ snapTool: true }} mode="EDIT" disableZoomAll />, document.getElementById("container"));
+            ReactDOM.render(<Toolbar mapType="openlayers" pluginCfg={{ snapTool: true }} mode="EDIT" canEditGeometry disableZoomAll />, document.getElementById("container"));
             expect(document.getElementById("snap-button").className.split(' ')).toNotInclude('btn-success');
         });
         it('handler', () => {
@@ -406,10 +417,10 @@ describe('Featuregrid toolbar component', () => {
                 toggleSnapping: () => { }
             };
             const spy = spyOn(events, "toggleSnapping");
-            ReactDOM.render(<Toolbar mapType="openlayers" events={events} snapping pluginCfg={{ snapTool: true }} mode="EDIT" disableZoomAll />, document.getElementById("container"));
+            ReactDOM.render(<Toolbar mapType="openlayers" canEditGeometry events={events} snapping pluginCfg={{ snapTool: true }} mode="EDIT" disableZoomAll />, document.getElementById("container"));
             document.getElementById("snap-button").click();
             expect(spy.calls[0].arguments[0]).toBe(false);
-            ReactDOM.render(<Toolbar mapType="openlayers" events={events} pluginCfg={{ snapTool: true }} mode="EDIT" disableZoomAll />, document.getElementById("container"));
+            ReactDOM.render(<Toolbar mapType="openlayers" canEditGeometry events={events} pluginCfg={{ snapTool: true }} mode="EDIT" disableZoomAll />, document.getElementById("container"));
             document.getElementById("snap-button").click();
             expect(spy.calls[1].arguments[0]).toBe(true);
         });

--- a/web/client/components/misc/AutocompleteCombobox.jsx
+++ b/web/client/components/misc/AutocompleteCombobox.jsx
@@ -61,7 +61,6 @@ const addStateHandlers = compose(
     withStateHandlers((props) => ({
         delayDebounce: 0,
         performFetch: false,
-        disabled: false,
         open: false,
         openOnFocus: props.openOnFocus,
         disabled: props.disabled,

--- a/web/client/components/misc/AutocompleteCombobox.jsx
+++ b/web/client/components/misc/AutocompleteCombobox.jsx
@@ -38,7 +38,8 @@ const streamEnhancer = mapPropsStream(props$ => {
         busy: data.busy,
         dropUp: props.dropUp,
         attribute: props.column && props.column.key,
-        changeAttribute: props.changeAttribute
+        changeAttribute: props.changeAttribute,
+        disabled: props.disabled
     }));
 });
 
@@ -46,13 +47,13 @@ const streamEnhancer = mapPropsStream(props$ => {
 const PagedComboboxEnhanced = streamEnhancer(
     ({ open, toggle, select, focus, change, value, valuesCount,
         loadNextPage, loadPrevPage, maxFeatures, currentPage,
-        busy, data, loading = false, dropUp = false, attribute, changeAttribute}) => {
+        busy, data, loading = false, dropUp = false, attribute, changeAttribute, disabled = false}) => {
         const numberOfPages = Math.ceil(valuesCount / maxFeatures);
         return (<PagedCombobox
             pagination={{firstPage: currentPage === 1, lastPage: currentPage === numberOfPages, paginated: true, loadPrevPage, loadNextPage}}
             busy={busy} dropUp={dropUp} data={data} attribute={attribute} open={open}
             onFocus={focus} onToggle={toggle} onChange={change} onSelect={select} onChangeAttribute={changeAttribute}
-            selectedValue={value} loading={loading}/>);
+            selectedValue={value} loading={loading} disabled={disabled}/>);
     });
 
 // state enhancer for local props
@@ -60,8 +61,10 @@ const addStateHandlers = compose(
     withStateHandlers((props) => ({
         delayDebounce: 0,
         performFetch: false,
+        disabled: false,
         open: false,
         openOnFocus: props.openOnFocus,
+        disabled: props.disabled,
         currentPage: 1,
         maxFeatures: 5,
         url: props.url,

--- a/web/client/components/misc/combobox/ControlledCombobox.jsx
+++ b/web/client/components/misc/combobox/ControlledCombobox.jsx
@@ -13,7 +13,7 @@ import PagedCombobox from './PagedCombobox';
 // state enhancer for local props
 import addState from './addState';
 
-const ControlledCombobox = addState(({ toggle, select, focus, change, value, busy, data, loading = false, filter, open }) => {
+const ControlledCombobox = addState(({ toggle, select, focus, change, value, busy, data, loading = false, filter, open, disabled }) => {
     return (<PagedCombobox
         pagination={{paginated: false}}
         onFocus={focus}
@@ -27,6 +27,7 @@ const ControlledCombobox = addState(({ toggle, select, focus, change, value, bus
         open={open}
         loading={loading}
         filter={filter}
+        disabled={disabled}
     />);
 });
 

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -110,7 +110,9 @@ import {
     setPagination,
     launchUpdateFilterFunc,
     LAUNCH_UPDATE_FILTER_FUNC, SET_LAYER,
-    SET_VIEWPORT_FILTER, setViewportFilter
+    SET_VIEWPORT_FILTER, setViewportFilter,
+    GRID_ROW_UPDATE,
+    featureModified
 } from '../actions/featuregrid';
 
 import {
@@ -144,7 +146,8 @@ import {
     getAttributeFilters,
     selectedLayerSelector,
     multiSelect,
-    paginationSelector, isViewportFilterActive, viewportFilter
+    paginationSelector, isViewportFilterActive, viewportFilter,
+    getLayerById
 } from '../selectors/featuregrid';
 
 import { error, warning } from '../actions/notifications';
@@ -901,6 +904,16 @@ export const triggerDrawSupportOnSelectionChange = (action$, store) => action$.o
 export const onFeatureGridCreateNewFeature = (action$) => action$.ofType(CREATE_NEW_FEATURE)
     .switchMap( () => {
         return Rx.Observable.of(drawSupportReset());
+    });
+
+export const handleFeatureChanges = (action$, store) => action$.ofType(CREATE_NEW_FEATURE, GRID_ROW_UPDATE)
+    .flatMap(({features, updated}) => {
+        const layer = getLayerById(store.getState(), selectedLayerIdSelector(store.getState()));
+        // force value from fields
+        layer.fields.filter(f => f.value && f.source).forEach(f => {
+            updated[f.name] = f.value;
+        });
+        return Rx.Observable.of(featureModified(features, updated));
     });
 /**
  * control highlight support on view mode.

--- a/web/client/plugins/featuregrid/gridEvents.js
+++ b/web/client/plugins/featuregrid/gridEvents.js
@@ -2,9 +2,9 @@ import {
     sort,
     selectFeatures,
     deselectFeatures,
-    featureModified,
     updateFilter,
-    activateTemporaryChanges
+    activateTemporaryChanges,
+    gridRowUpdate
 } from '../../actions/featuregrid';
 
 const range = (start, end) => Array.from({length: (end + 1 - start)}, (v, k) => k + start);
@@ -17,7 +17,7 @@ export default {
         let features = range(fromRow, toRow).map(r => rowGetter(r)).filter(f =>
             Object.keys(updated || {}).filter(k => f.properties[k] !== updated[k]).length > 0
         );
-        return featureModified(features, updated);
+        return gridRowUpdate(features, updated);
     },
     onRowsToggled: (rows, rowGetter) => selectFeatures(rows.map(r => rowGetter(r.rowIdx)), false),
     onRowsSelected: (rows, rowGetter) => selectFeatures(rows.map(r => rowGetter(r.rowIdx)), true),

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -47,7 +47,8 @@ import {
     timeSyncActive,
     isViewportFilterActive,
     isFilterByViewportSupported,
-    selectedLayerSelector
+    selectedLayerSelector,
+    canEditGeometrySelector
 } from '../../../selectors/featuregrid';
 import { mapLayoutValuesSelector } from '../../../selectors/maplayout';
 import {isCesium, mapTypeSelector} from '../../../selectors/maptype';
@@ -95,6 +96,7 @@ const Toolbar = connect(
         disableZoomAll: (state) => state && state.featuregrid.virtualScroll || featureCollectionResultSelector(state).features.length === 0,
         isSearchAllowed: (state) => !isCesium(state),
         isEditingAllowed: isEditingAllowedSelector,
+        canEditGeometry: canEditGeometrySelector,
         hasSupportedGeometry,
         isFilterActive,
         showTimeSyncButton: showTimeSync,

--- a/web/client/plugins/tocitemssettings/tabs/Fields.jsx
+++ b/web/client/plugins/tocitemssettings/tabs/Fields.jsx
@@ -5,18 +5,32 @@ import LayerFields, {hasFields} from '../../../components/TOC/fragments/LayerFie
 import {connect} from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { currentLocaleSelector } from '../../../selectors/locale';
+import { userSelector } from '../../../selectors/security';
+import { find, get } from 'lodash';
 
 export {hasFields};
 
 
 export default connect(createStructuredSelector({
-    currentLocale: currentLocaleSelector
+    currentLocale: currentLocaleSelector,
+    userInfos: userSelector
 }), {
     updateLayerProperties: changeLayerProperties
 }
-)(({element = {}, updateLayerProperties = () => {}, ...props}) => {
+)(({element = {}, updateLayerProperties = () => {}, userInfos, ...props}) => {
     const layer = element;
     const updateFields = (fields) => {
+        // insert fields value from selected user prop source
+        fields?.forEach?.((field) => {
+            if (field.source) {
+                field.value = get(userInfos, field.source) || find(userInfos.attribute, ["name", field.source])?.value;
+                field.editable = false;
+            } else if (!field.source && field.value) {
+                field.value = null;
+                field.editable = null;
+            }
+        });
+        // update state
         updateLayerProperties(layer.id, {fields});
     };
     return <LayerFields {...props} layer={layer} updateFields={updateFields}/>;

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -134,9 +134,6 @@ export const featureTypeToGridColumns = (
     getAttributeFields(describe).filter(e => !(columnSettings[e.name] && columnSettings[e.name].hide)).map((desc) => {
         const option = options.find(o => o.name === desc.name);
         const field = fields.find(f => f.name === desc.name);
-        if(field && field.name === "id_emprise") {
-            field.editable = false;
-        }
         let columnProp = {
             sortable,
             key: desc.name,
@@ -147,7 +144,7 @@ export const featureTypeToGridColumns = (
             headerRenderer: getHeaderRenderer(),
             showTitleTooltip: !!option?.description,
             resizable,
-            editable: field.editable === false ? false : editable,
+            editable: field?.editable === false ? false : editable,
             filterable,
             editor: getEditor(desc, field),
             formatter: getFormatter(desc, field),

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -134,6 +134,9 @@ export const featureTypeToGridColumns = (
     getAttributeFields(describe).filter(e => !(columnSettings[e.name] && columnSettings[e.name].hide)).map((desc) => {
         const option = options.find(o => o.name === desc.name);
         const field = fields.find(f => f.name === desc.name);
+        if(field && field.name === "id_emprise") {
+            field.editable = false;
+        }
         let columnProp = {
             sortable,
             key: desc.name,
@@ -144,7 +147,7 @@ export const featureTypeToGridColumns = (
             headerRenderer: getHeaderRenderer(),
             showTitleTooltip: !!option?.description,
             resizable,
-            editable,
+            editable: field.editable === false ? false : editable,
             filterable,
             editor: getEditor(desc, field),
             formatter: getFormatter(desc, field),


### PR DESCRIPTION
## Description

> This pull request is link to 
>#10523
> #9849
>#10658
>https://groups.google.com/g/mapstore-developers/c/D717X0rzQHQ
>https://groups.google.com/g/mapstore-developers/c/JuZuElj19yg
>https://groups.google.com/g/mapstore-developers/c/d2QwLpXEHZI

**Documentation**

Nothing to document without corresponding UI (need fields settings UI enhancement).

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
 - [x] Feature


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**

This is new behavior. See issue to get more details.

#10523
#9849
#10658

**What is the new behavior?**

- ability to manage field editing independently
- ability to get a field from user info (e.g name get name)
- Ability to restrict geometric editing to certain groups (editors will only be able to modify attributes).  

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
