### PR TITLE
#10521 - Update center comparison in OL map component

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -534,11 +534,23 @@ class OpenlayersMap extends React.Component {
         return new View(viewOptions);
     };
 
+    isNearlyEqual = (a, b) => {
+        /**
+         * this implementation will update the map only if the movement
+         * between 8 decimals (coordinate precision in mm) in the reference system
+         * to avoid rounded value changes due to float mathematic operations or transformed value
+        */
+        if (a === undefined || b === undefined) {
+            return false;
+        }
+        return a.toFixed(8) - b.toFixed(8) <= 0.00000001;
+    };
+
     _updateMapPositionFromNewProps = (newProps) => {
         var view = this.map.getView();
         const currentCenter = this.props.center;
-        const centerIsUpdated = newProps.center.y === currentCenter.y &&
-            newProps.center.x === currentCenter.x;
+        const centerIsUpdated = this.isNearlyEqual(newProps.center.y, currentCenter.y) &&
+            this.isNearlyEqual(newProps.center.x, currentCenter.x);
 
         if (!centerIsUpdated) {
             // let center = ol.proj.transform([newProps.center.x, newProps.center.y], 'EPSG:4326', newProps.projection);

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -1489,4 +1489,40 @@ describe('OpenlayersMap', () => {
             expect(customHooRegister.getHook(MapUtils.ZOOM_TO_EXTENT_HOOK)).toBeTruthy();
         });
     });
+    it('update map position center based on nearly equal match when receiving new props', () => {
+        let map = ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 43.9323233378, x: 10.3346776780}}
+                zoom={1}
+                projection="EPSG:4326"
+                measurement={{}}
+            />
+            , document.getElementById("map"));
+        map = ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 43.9323233388, x: 10.3346776790}}
+                zoom={1}
+                measurement={{}}
+                projection="EPSG:4326"
+                mapOptions={undefined}
+            />
+            , document.getElementById("map")
+        );
+        expect(map).toBeTruthy();
+        // center is not modified
+        expect(map.map.getView().getCenter()).toEqual([10.3346776780, 43.9323233378]);
+
+        map = ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 43.9323234388, x: 10.3346773790}}
+                zoom={1}
+                measurement={{}}
+                projection="EPSG:4326"
+                mapOptions={undefined}
+            />
+            , document.getElementById("map")
+        );
+        // center is modified
+        expect(map.map.getView().getCenter()).toEqual([10.3346773790, 43.9323234388]);
+    });
 });


### PR DESCRIPTION
## Description
This PR updates OL map component's map position update in comparing center. Instead of performing an exact match comparison, a nearly equal match is performed with precision of 0.00000001

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #10521 

**What is the new behavior?**
The map update is skipped when center is nearly equal avoiding unnecessary map update

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
@ElenaGallo 
We cannot test it effectively in MS, but we can test for regression to ensure the change hasn't impacted any map functionality 