### PR TITLE
Fixed test build failures caused by ChromeHeadless height and a test dependent on window height

### DIFF
--- a/web/client/components/geostory/common/enhancers/__tests__/withMediaVisibilityContainer-test.jsx
+++ b/web/client/components/geostory/common/enhancers/__tests__/withMediaVisibilityContainer-test.jsx
@@ -64,11 +64,12 @@ describe('withMediaVisibilityContainer HOC', () => {
 
     it('scroll in view should render the actual component (lazy loading)', (done) => {
         const DEBOUNCE_TIME = 1;
+        // note: this test fails if the window is too small in height
         ReactDOM.render(
             <div
                 id="scroll-container"
-                style={{ width: 512, height: 512, overflow: 'scroll' }}>
-                <div style={{ height: 1024 }}></div>
+                style={{ width: 10, height: 10, overflow: 'scroll' }}>
+                <div style={{ height: 20 }}></div>
                 <Media mediaViewer={withMediaVisibilityContainer(() => <div className="test-component"></div>)} debounceTime={DEBOUNCE_TIME}/>
             </div>,
             document.getElementById("container"));
@@ -101,8 +102,8 @@ describe('withMediaVisibilityContainer HOC', () => {
         ReactDOM.render(
             <div
                 id="scroll-container"
-                style={{ width: 512, height: 512, overflow: 'scroll' }}>
-                <div style={{ height: 1024 }}></div>
+                style={{ width: 10, height: 10, overflow: 'scroll' }}>
+                <div style={{ height: 20 }}></div>
                 <TestComponentWithVisibility
                     lazy
                     debounceTime={DEBOUNCE_TIME} />

--- a/web/client/components/geostory/common/enhancers/__tests__/withMediaVisibilityContainer-test.jsx
+++ b/web/client/components/geostory/common/enhancers/__tests__/withMediaVisibilityContainer-test.jsx
@@ -48,8 +48,8 @@ describe('withMediaVisibilityContainer HOC', () => {
         ReactDOM.render(
             <div
                 id="scroll-container"
-                style={{ width: 512, height: 512, overflow: 'scroll' }}>
-                <div style={{ height: 1024 }}></div>
+                style={{ width: 10, height: 10, overflow: 'scroll' }}>
+                <div style={{ height: 20 }}></div>
                 <TestComponentWithVisibility
                     lazy
                     debounceTime={DEBOUNCE_TIME} />


### PR DESCRIPTION
## Description
This PR is to fix the issue of failures happening during build with `npm test`. 

![image](https://github.com/user-attachments/assets/6c56dced-37c1-416a-add2-368c5077a185)

After some attempts I noticed that the failing test was not failing using ``test:watch` but as well as I resized the window to a smaller height (`523px` was the limit in the test), it started failing with the same error.
So I supposed that some changes on `ChromeHeadless` may set the window to a smaller value, so the test fails. 

I tried to execute the test with smaller height values on `scroll-container` in the given test and I noticed that the size needed to make it fail by resizing the window height decreased. 
So I tried the same approach with tests with ChromeHeadless, where I can not resize the window, by adjustind the height of `scroll-container`. 
I found the limit of scroll container to 430px in scroll-container to make it fail. 429 is successful on ChromeHeadless.

So I decided to put the pixel at a very small value (for security), that make anyway the tests work, and it looks to work also with ChromeHeadless.

Hope this fixes also the failures on the backend. This fix may need to be backported


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] CI related changes

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
No issue at the moment. @tdipisa should we create one.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
