### PR TITLE
Enhanced Customization for Highlight Styles in Feature Selection

### DIFF
--- a/web/client/actions/__tests__/highlight-test.js
+++ b/web/client/actions/__tests__/highlight-test.js
@@ -28,7 +28,7 @@ describe('Test correctness of the highlight actions', () => {
         expect(retval.type).toBe(HIGHLIGHT_STATUS);
         expect(retval.status).toBe("enabled");
     });
-    it('highlightStatus', () => {
+    it('setHighlightFeaturesPath', () => {
         let path = "my.path";
 
         let retval = setHighlightFeaturesPath(path);
@@ -36,6 +36,19 @@ describe('Test correctness of the highlight actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(SET_HIGHLIGHT_FEATURES_PATH);
         expect(retval.featuresPath).toBe(path);
+        expect(retval.highlightStyle).toEqual({});
+    });
+
+    it('setHighlightFeaturesPath with customized highlight style', () => {
+        let path = "my.path";
+        let style = {color: 'yellow'};
+
+        let retval = setHighlightFeaturesPath(path, style);
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(SET_HIGHLIGHT_FEATURES_PATH);
+        expect(retval.featuresPath).toBe(path);
+        expect(retval.highlightStyle).toBe(style);
     });
 
     it('updateHighlighted', () => {

--- a/web/client/actions/highlight.js
+++ b/web/client/actions/highlight.js
@@ -16,10 +16,11 @@ export function highlightStatus(status) {
         status
     };
 }
-export function setHighlightFeaturesPath(featuresPath) {
+export function setHighlightFeaturesPath(featuresPath, highlightStyle = {}) {
     return {
         type: SET_HIGHLIGHT_FEATURES_PATH,
-        featuresPath
+        featuresPath,
+        highlightStyle
     };
 }
 export function updateHighlighted(features, status) {

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -91,7 +91,8 @@ export const identifyLifecycle = compose(
                 },
                 maxItems,
                 showAllResponses,
-                highlight: pluginCfg?.highlightEnabledFromTheStart || false
+                highlight: pluginCfg?.highlightEnabledFromTheStart || false,
+                highlightStyle: pluginCfg?.highlightStyle || {}
             });
             if (hidePopupIfNoResults) {
                 enableHideEmptyPopupOption(true);

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -716,6 +716,7 @@ describe('featuregrid Epics', () => {
                 switch (action.type) {
                 case SET_HIGHLIGHT_FEATURES_PATH:
                     expect(action.featuresPath).toBe('featuregrid.select');
+                    expect(action.highlightStyle).toEqual({});
                     break;
                 case CHANGE_DRAWING_STATUS:
                     expect(action.status).toBe("clean");
@@ -737,6 +738,37 @@ describe('featuregrid Epics', () => {
         testEpic(setHighlightFeaturesPath, 3, toggleEditMode(), epicResult, stateWithGmlGeometry);
     });
 
+    it('set highlight feature path with geometry not supported EDIT MODE and costume highligth style', (done) => {
+        const highlightStyle = {color: 'red'};
+        const stateWithCustomHighlightStyle = set("featuregrid.highlightStyle", highlightStyle, stateWithGmlGeometry);
+        const epicResult = actions => {
+            expect(actions.length).toBe(3);
+            actions.map((action) => {
+                switch (action.type) {
+                case SET_HIGHLIGHT_FEATURES_PATH:
+                    expect(action.featuresPath).toBe('featuregrid.select');
+                    expect(action.highlightStyle).toBe(highlightStyle);
+                    break;
+                case CHANGE_DRAWING_STATUS:
+                    expect(action.status).toBe("clean");
+                    expect(action.method).toBe("");
+                    expect(action.features).toEqual([]);
+                    expect(action.options).toEqual({});
+                    expect(action.style).toBe(undefined);
+                    break;
+                case SHOW_NOTIFICATION:
+                    expect(action.uid).toBe("notSupportedGeometryWarning");
+                    break;
+                default:
+                    expect(true).toBe(false);
+                }
+            });
+            done();
+        };
+
+        testEpic(setHighlightFeaturesPath, 3, toggleEditMode(), epicResult, stateWithCustomHighlightStyle);
+    });
+
     it('set highlight feature path VIEW MODE', (done) => {
         const epicResult = actions => {
             try {
@@ -745,6 +777,7 @@ describe('featuregrid Epics', () => {
                     switch (action.type) {
                     case SET_HIGHLIGHT_FEATURES_PATH:
                         expect(action.featuresPath).toBe('featuregrid.select');
+                        expect(action.highlightStyle).toEqual({});
                         break;
                     case CHANGE_DRAWING_STATUS:
                         expect(action.status).toBe("clean");
@@ -764,6 +797,38 @@ describe('featuregrid Epics', () => {
         };
 
         testEpic(setHighlightFeaturesPath, 2, toggleViewMode(), epicResult, state);
+    });
+
+    it('set highlight feature path VIEW MODE with costume highlight style', (done) => {
+        const highlightStyle = {color: 'red'};
+        const stateWithCustomHighlightStyle = set("featuregrid.highlightStyle", highlightStyle, state);
+        const epicResult = actions => {
+            try {
+                expect(actions.length).toBe(2);
+                actions.map((action) => {
+                    switch (action.type) {
+                    case SET_HIGHLIGHT_FEATURES_PATH:
+                        expect(action.featuresPath).toBe('featuregrid.select');
+                        expect(action.highlightStyle).toBe(highlightStyle);
+                        break;
+                    case CHANGE_DRAWING_STATUS:
+                        expect(action.status).toBe("clean");
+                        expect(action.method).toBe("");
+                        expect(action.features).toEqual([]);
+                        expect(action.options).toEqual({});
+                        expect(action.style).toBe(undefined);
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+            } catch (e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(setHighlightFeaturesPath, 2, toggleViewMode(), epicResult, stateWithCustomHighlightStyle);
     });
 
     it('set highlight feature path EDIT MODE', (done) => {

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -142,7 +142,7 @@ import {
     getAttributeFilters,
     selectedLayerSelector,
     multiSelect,
-    paginationSelector, isViewportFilterActive, viewportFilter
+    paginationSelector, isViewportFilterActive, viewportFilter, highlightStyleSelector
 } from '../selectors/featuregrid';
 
 import { error, warning } from '../actions/notifications';
@@ -897,11 +897,12 @@ export const onFeatureGridCreateNewFeature = (action$) => action$.ofType(CREATE_
  */
 export const setHighlightFeaturesPath = (action$, store) => action$.ofType(TOGGLE_MODE)
     .switchMap( (a) => {
+        const highlightStyle = highlightStyleSelector(store.getState());
         if (a.mode === MODES.VIEW) {
-            return Rx.Observable.of(drawSupportReset(), setHighlightFeaturesPathAction("featuregrid.select"));
+            return Rx.Observable.of(drawSupportReset(), setHighlightFeaturesPathAction("featuregrid.select", highlightStyle));
         }
         if (a.mode === MODES.EDIT && !hasSupportedGeometry(store.getState())) {
-            return Rx.Observable.of(drawSupportReset(), setHighlightFeaturesPathAction("featuregrid.select"), warning({
+            return Rx.Observable.of(drawSupportReset(), setHighlightFeaturesPathAction("featuregrid.select", highlightStyle), warning({
                 title: "featuregrid.notSupportedGeometryTitle",
                 message: "featuregrid.notSupportedGeometry",
                 uid: "notSupportedGeometryWarning",

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -104,6 +104,7 @@ import {isViewportFilterActive} from "../selectors/featuregrid";
   * @prop {boolean} cfg.useUTCOffset avoid using UTC dates in attribute table and datetime editor, should be kept consistent with dateFormats
   * @prop {object} cfg.dateFormats Allows to specify custom date formats ( in [ISO_8601](https://en.wikipedia.org/wiki/ISO_8601)  format) to use to display dates in the table. `date` `date-time` and `time` are the supported entries for the date format. Example:
   * @prop {boolean} cfg.showPopoverSync default false. Hide the popup of map sync if false, shows the popup of map sync if true
+  * @prop {object} cfg.highlightStyle default empty. Custom style for highlighted features.
   * ```
   * "dateFormats": {
   *    "date-time": "MM DD YYYY - HH:mm:ss",
@@ -151,7 +152,12 @@ import {isViewportFilterActive} from "../selectors/featuregrid";
   *   },
  *    "filterByViewport": true,
  *    "showFilterByViewportTool": true
-  *   }
+  *   },
+  *   "highlightStyle": {
+  *     "color": "#00ffff",
+  *     "width": 4,
+  *     "lineColor": "#00ffff",
+  *     "fillOpacity": 0.3
   * }
   * ```
   *
@@ -200,24 +206,27 @@ const EditorPlugin = connect(
                 virtualScroll: this.props.virtualScroll ?? true,
                 editingAllowedRoles: this.props.editingAllowedRoles,
                 editingAllowedGroups: this.props.editingAllowedGroups,
-                maxStoredPages: this.props.maxStoredPages
+                maxStoredPages: this.props.maxStoredPages,
+                highlightStyle: this.props.highlightStyle
             });
         },
         componentDidUpdate(prevProps) {
             // Re-Initialize configurations
             !this.props.viewportFilterInitialized && this.props.filterByViewport && this.props.setViewportFilter(true);
 
-            const {virtualScroll, editingAllowedRoles, editingAllowedGroups, maxStoredPages} = this.props ?? {};
+            const {virtualScroll, editingAllowedRoles, editingAllowedGroups, maxStoredPages, highlightStyle} = this.props ?? {};
             if (prevProps.virtualScroll !== virtualScroll
                 || !isEqual(prevProps.editingAllowedRoles, editingAllowedRoles)
                 || !isEqual(prevProps.editingAllowedGroups, editingAllowedGroups)
                 || prevProps.maxStoredPages !== maxStoredPages
+                || !isEqual(prevProps.highlightStyle, highlightStyle)
             ) {
                 this.props.initPlugin({
                     virtualScroll: virtualScroll ?? true,
                     editingAllowedRoles,
                     editingAllowedGroups,
-                    maxStoredPages
+                    maxStoredPages,
+                    highlightStyle
                 });
             }
         }

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -199,6 +199,7 @@ const identifyDefaultProps = defaultProps({
  * @prop cfg.showHighlightFeatureButton {boolean} show the highlight feature button if the interrogation returned valid features (openlayers only)
  * @prop cfg.hidePopupIfNoResults {boolean} hide/show the identify popup in case of no results
  * @prop cfg.highlightEnabledFromTheStart {boolean} the highlight feature button will be activated by default if true
+ * @prop cfg.highlightSytle {object} the style to apply to highlight features, when not defined a default style is applied
  * @prop cfg.viewerOptions.container {expression} the container of the viewer, expression from the context
  * @prop cfg.viewerOptions.header {expression} the header of the viewer, expression from the context{expression}
  * @prop cfg.disableCenterToMarker {bool} disable zoom to marker action
@@ -221,6 +222,12 @@ const identifyDefaultProps = defaultProps({
  *       "viewerOptions": {
  *          "container": "{context.ReactSwipe}",
  *          "header": "{context.SwipeHeader}"
+ *       },
+ *       "highlightStyle": {
+ *          "color": "#00ffff",
+ *          "width": 4,
+ *          "lineColor": "#00ffff",
+ *          "fillOpacity": 0.3
  *       }
  *    }
  * }

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -212,7 +212,8 @@ class MapPlugin extends React.Component {
         onLoadingMapPlugins: PropTypes.func,
         onMapTypeLoaded: PropTypes.func,
         pluginsCreator: PropTypes.func,
-        mapTitle: PropTypes.string
+        mapTitle: PropTypes.string,
+        highlightStyle: PropTypes.object
     };
 
     static defaultProps = {
@@ -288,7 +289,7 @@ class MapPlugin extends React.Component {
 
     getHighlightLayer = (projection, index, env) => {
         const plugins = this.state.plugins;
-        const {features, ...options} = getHighlightLayerOptions({features: this.props.features});
+        const {features, ...options} = getHighlightLayerOptions({features: this.props.features}, this.props?.highlightStyle);
         return (<plugins.Layer type="vector"
             srs={projection}
             position={index}

--- a/web/client/plugins/__tests__/FeatureEditor-test.jsx
+++ b/web/client/plugins/__tests__/FeatureEditor-test.jsx
@@ -34,7 +34,11 @@ describe('FeatureEditor Plugin', () => {
         const props = {
             virtualScroll: false,
             editingAllowedRoles: ['USER', 'ADMIN'],
-            maxStoredPages: 5
+            maxStoredPages: 5,
+            highlightStyle: {
+                color: 'red',
+                weight: 3
+            }
         };
         const {Plugin, store} = getPluginForTest(FeatureEditor, { featuregrid: { open: false } });
         ReactDOM.render(<Plugin {...props}/>, document.getElementById("container"));
@@ -43,13 +47,18 @@ describe('FeatureEditor Plugin', () => {
         expect(state.virtualScroll).toBeFalsy();
         expect(state.editingAllowedRoles).toEqual(props.editingAllowedRoles);
         expect(state.maxStoredPages).toBe(props.maxStoredPages);
+        expect(state.highlightStyle).toEqual(props.highlightStyle);
     });
     it('onInit FeatureEditor plugin be-recalled when props change', () => {
         const props = {
             virtualScroll: false,
             editingAllowedRoles: ['ADMIN'],
             editingAllowedGroups: ['GROUP1'],
-            maxStoredPages: 5
+            maxStoredPages: 5,
+            highlightStyle: {
+                color: 'red',
+                weight: 3
+            }
         };
         const props2 = {
             editingAllowedRoles: ['USER', 'ADMIN'],
@@ -68,15 +77,18 @@ describe('FeatureEditor Plugin', () => {
         expect(state.editingAllowedRoles).toEqual(props.editingAllowedRoles);
         expect(state.editingAllowedGroups).toEqual(props.editingAllowedGroups);
         expect(state.maxStoredPages).toBe(props.maxStoredPages);
+        expect(state.highlightStyle).toEqual(props.highlightStyle);
         ReactDOM.render(<Plugin {...props2}/>, document.getElementById("container"));
         const state2 = store.getState().featuregrid;
         expect(state2.virtualScroll).toBeTruthy(); // the default
         expect(state2.editingAllowedRoles).toEqual(props2.editingAllowedRoles); // changed
         expect(state2.editingAllowedGroups).toEqual(props2.editingAllowedGroups); // changed
         expect(state2.maxStoredPages).toBe(props2.maxStoredPages);
+        expect(state2.highlightStyle).toEqual({});
         ReactDOM.render(<Plugin {...props3}/>, document.getElementById("container"));
         const state3 = store.getState().featuregrid;
         expect(isEqual(state2.editingAllowedRoles, state3.editingAllowedRoles)).toBeTruthy(); // no double call
         expect(isEqual(state2.editingAllowedGroups, state3.editingAllowedGroups)).toBeTruthy(); // no double call
+        expect(state2).toBe(state3); // no double call
     });
 });

--- a/web/client/plugins/map/__tests__/selector-test.jsx
+++ b/web/client/plugins/map/__tests__/selector-test.jsx
@@ -18,6 +18,19 @@ import { registerEventListener } from '../../../actions/map';
 
 const stateMocker = createStateMocker({ map, layers, additionallayers});
 describe('Map plugin state to pros selector', () => {
+    it('test getting highlightStyle from selector', () => {
+        const stateWithHighlightStyle = selector({highlight: {
+            highlightStyle: {
+                color: 'red',
+                weight: 3
+            }
+        }});
+        expect(stateWithHighlightStyle.highlightStyle).toBeTruthy();
+        expect(stateWithHighlightStyle.highlightStyle).toEqual({
+            color: 'red',
+            weight: 3
+        });
+    });
     it('test getting mapTitle from selector', () => {
         const stateWithMapTitle = selector({map: {
             info: {

--- a/web/client/plugins/map/selector.js
+++ b/web/client/plugins/map/selector.js
@@ -1,7 +1,7 @@
 import { mapSelector, projectionDefsSelector, isMouseMoveCoordinatesActiveSelector, mapNameSelector } from '../../selectors/map';
 import { mapTypeSelector } from '../../selectors/maptype';
 import { layerSelectorWithMarkers } from '../../selectors/layers';
-import { highlighedFeatures } from '../../selectors/highlight';
+import { highlighedFeatures, highlightStyleSelector } from '../../selectors/highlight';
 import { securityTokenSelector } from '../../selectors/security';
 import { currentLocaleLanguageSelector } from '../../selectors/locale';
 import { isLocalizedLayerStylesEnabledSelector, localizedLayerStylesNameSelector } from '../../selectors/localizedLayerStyles';
@@ -18,6 +18,7 @@ export default createShallowSelectorCreator(isEqual)(
     mapTypeSelector,
     layerSelectorWithMarkers,
     highlighedFeatures,
+    highlightStyleSelector,
     state => state.mapInitialConfig && state.mapInitialConfig.loadingError && state.mapInitialConfig.loadingError.data,
     securityTokenSelector,
     isMouseMoveCoordinatesActiveSelector,
@@ -25,12 +26,13 @@ export default createShallowSelectorCreator(isEqual)(
     localizedLayerStylesNameSelector,
     currentLocaleLanguageSelector,
     mapNameSelector,
-    (projectionDefs, map, mapType, layers, features, loadingError, securityToken, elevationEnabled, isLocalizedLayerStylesEnabled, localizedLayerStylesName, currentLocaleLanguage, mapTitle) => ({
+    (projectionDefs, map, mapType, layers, features, highlightStyle, loadingError, securityToken, elevationEnabled, isLocalizedLayerStylesEnabled, localizedLayerStylesName, currentLocaleLanguage, mapTitle) => ({
         projectionDefs,
         map,
         mapType,
         layers,
         features,
+        highlightStyle,
         loadingError,
         securityToken,
         elevationEnabled,

--- a/web/client/reducers/__tests__/featuregrid-test.js
+++ b/web/client/reducers/__tests__/featuregrid-test.js
@@ -128,6 +128,17 @@ describe('Test the featuregrid reducer', () => {
         expect(state.editingAllowedRoles[0]).toBe(someValue);
         expect(state.editingAllowedGroups[0]).toBe(someValue);
     });
+    it('initPlugin with default highlight style', () => {
+        let state = featuregrid({}, initPlugin({}));
+        expect(state).toExist();
+        expect(state.highlightStyle).toEqual({});
+    });
+    it('initPlugin with costume highlight style', () => {
+        const highlightStyle = {color: 'yellow'};
+        let state = featuregrid({}, initPlugin({highlightStyle}));
+        expect(state).toExist();
+        expect(state.highlightStyle).toBe(highlightStyle);
+    });
     it('openFeatureGrid', () => {
         let state = featuregrid(undefined, openFeatureGrid());
         expect(state).toExist();

--- a/web/client/reducers/__tests__/highlight-test.js
+++ b/web/client/reducers/__tests__/highlight-test.js
@@ -77,4 +77,18 @@ describe('Test the highlight reducer', () => {
         expect(state.featuresPath).toBe(path);
 
     });
+    it('Change the SET_HIGHLIGHT_FEATURES_PATH with customized highlight style for features', () => {
+        let path = "store.my.path";
+        let highlightStyle = { color: 'yellow', weight: 3 };
+        let testAction = {
+            type: SET_HIGHLIGHT_FEATURES_PATH,
+            featuresPath: path,
+            highlightStyle: highlightStyle
+        };
+        let state = highlight( undefined, testAction);
+        expect(state).toExist();
+
+        expect(state.featuresPath).toBe(path);
+        expect(state.highlightStyle).toBe(highlightStyle);
+    });
 });

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -155,7 +155,8 @@ function featuregrid(state = emptyResultsState, action) {
             editingAllowedRoles: action.options.editingAllowedRoles || state.editingAllowedRoles || ["ADMIN"],
             editingAllowedGroups: action.options.editingAllowedGroups || state.editingAllowedGroups || [],
             virtualScroll: !!action.options.virtualScroll,
-            maxStoredPages: action.options.maxStoredPages || 5
+            maxStoredPages: action.options.maxStoredPages || 5,
+            highlightStyle: action.options.highlightStyle || {}
         });
     }
     case LOAD_MORE_FEATURES:

--- a/web/client/reducers/highlight.js
+++ b/web/client/reducers/highlight.js
@@ -14,14 +14,16 @@ const initialState = {
     features: [],
     highlighted: 0,
     featuresPath: "highlight.emptyFeatures",
-    emptyFeatures: []
+    emptyFeatures: [],
+    highlightStyle: {}
 };
 
 function highlight(state = initialState, action) {
     switch (action.type) {
     case SET_HIGHLIGHT_FEATURES_PATH: {
         return Object.assign({}, state, {
-            featuresPath: action.featuresPath || "highlight.emptyFeatures"
+            featuresPath: action.featuresPath || "highlight.emptyFeatures",
+            highlightStyle: action.highlightStyle || {}
         });
     }
     case HIGHLIGHT_STATUS: {

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -40,7 +40,8 @@ import {
     isFilterByViewportSupported,
     selectedLayerFieldsSelector,
     editingAllowedGroupsSelector,
-    isEditingAllowedSelector
+    isEditingAllowedSelector,
+    highlightStyleSelector
 } from '../featuregrid';
 
 const idFt1 = "idFt1";
@@ -792,6 +793,29 @@ describe('Test featuregrid selectors', () => {
                     }
                 }
             })).toBeTruthy();
+        });
+    });
+    it('test highlightStyleSelector without a custom highlight style', () => {
+        const highlightStyle = highlightStyleSelector(initialState);
+        expect(highlightStyle).toExist();
+        expect(highlightStyle).toEqual({});
+    });
+    it('test highlightStyleSelector with a custom highlight style', () => {
+        const state = {
+            ...initialState,
+            featuregrid: {
+                ...initialState.featuregrid,
+                highlightStyle: {
+                    color: '#ff0000',
+                    weight: 2
+                }
+            }
+        };
+        const highlightStyle = highlightStyleSelector(state);
+        expect(highlightStyle).toExist();
+        expect(highlightStyle).toEqual({
+            color: '#ff0000',
+            weight: 2
         });
     });
 });

--- a/web/client/selectors/__tests__/highlight-test.js
+++ b/web/client/selectors/__tests__/highlight-test.js
@@ -17,7 +17,8 @@ import {
     filteredSpatialObjectCrs,
     filteredspatialObjectType,
     filteredFeatures,
-    highlighedFeatures
+    highlighedFeatures,
+    highlightStyleSelector
 } from '../highlight';
 
 const idFt1 = "idFt1";
@@ -148,5 +149,28 @@ describe('Test highlight selectors', () => {
         const combinedFeatures = [...featuresSelected, ...feature3];
         expect(features).toExist();
         expect(features).toEqual(combinedFeatures);
+    });
+    it('test if there is not a custom highlight style', () => {
+        const highlightStyle = highlightStyleSelector(initialState);
+        expect(highlightStyle).toExist();
+        expect(highlightStyle).toEqual({});
+    });
+    it('test if there is a custom highlight style', () => {
+        const state = {
+            ...initialState,
+            highlight: {
+                ...initialState.highlight,
+                highlightStyle: {
+                    color: '#ff0000',
+                    weight: 2
+                }
+            }
+        };
+        const highlightStyle = highlightStyleSelector(state);
+        expect(highlightStyle).toExist();
+        expect(highlightStyle).toEqual({
+            color: '#ff0000',
+            weight: 2
+        });
     });
 });

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -286,20 +286,24 @@ describe('Test mapinfo selectors', () => {
         const TEST = {
             color: 'test'
         };
-        // check default
-        expect(highlightStyleSelector({})).toEqual({
+        const defaultStyle = {
             color: '#3388ff',
             weight: 4,
             radius: 4,
             dashArray: '',
             fillColor: '#3388ff',
             fillOpacity: 0.2
-        });
+        };
+        // check default
+        expect(highlightStyleSelector({})).toEqual(defaultStyle);
         expect(highlightStyleSelector({
             mapInfo: {
                 highlightStyle: TEST
             }
-        })).toBe(TEST);
+        })).toEqual({
+            ...defaultStyle,
+            ...TEST
+        });
     });
     it('test clickPointSelector', () => {
         expect(clickPointSelector(RESPONSE_STATE)).toBe(RESPONSE_STATE.mapInfo.clickPoint);

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -235,3 +235,5 @@ export const viewportFilter = createShallowSelectorCreator(isEqual)(
         } : {};
     }
 );
+
+export const highlightStyleSelector = state => get(state, 'featuregrid.highlightStyle', {});

--- a/web/client/selectors/highlight.js
+++ b/web/client/selectors/highlight.js
@@ -11,6 +11,7 @@ import { createSelector } from 'reselect';
 import { reprojectGeoJson } from '../utils/CoordinatesUtils';
 
 export const selectedFeatures = (state) => get(state, state && state.highlight && state.highlight.featuresPath || "highlight.emptyFeatures") || [];
+export const highlightStyleSelector = (state) => get(state, 'highlight.highlightStyle', {});
 export const filteredspatialObject = (state) => get(state, state && state.featuregrid && state.featuregrid.open && state.featuregrid.showFilteredObject && "query.filterObj.spatialField" || "emptyObject");
 export const filteredGeometry = (state) => filteredspatialObject(state) && filteredspatialObject(state).geometry;
 export const filteredspatialObjectType = (state) => filteredGeometry(state) && filteredGeometry(state).type || "Polygon";

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -162,14 +162,21 @@ export const applyMapInfoStyle = style => f => ({
  * @param {object} state the application state
  * @returns {object} style object
  */
-export const highlightStyleSelector = state => get(state, 'mapInfo.highlightStyle', {
+const defaultHighlightStyle = {
     color: '#3388ff',
     weight: 4,
     radius: 4,
     dashArray: '',
     fillColor: '#3388ff',
     fillOpacity: 0.2
-});
+};
+// merge and replace default highlight style with custom values
+export const highlightStyleSelector = state => {
+    return {
+        ...defaultHighlightStyle,
+        ...get(state, 'mapInfo.highlightStyle', {})
+    };
+};
 
 export const clickedPointWithFeaturesSelector = createSelector(
     clickPointSelector,

--- a/web/client/utils/HighlightUtils.js
+++ b/web/client/utils/HighlightUtils.js
@@ -1,62 +1,71 @@
+export const GEOMETRY_PROPERTY = '__geometry__type__';
+export function createHighlightStyle(highlightStyle = {}) {
+    const defaultStyle = {
+        color: '#f2f2f2',
+        lineColor: '#3075e9',
+        fillOpacity: 0.3,
+        opacity: 1,
+        width: 2,
+        radius: 10
+    };
 
-export const GEOMETRY_PROPERTY  = '__geometry__type__';
-export const HIGH_LIGHT_STYLE = {
-    format: 'geostyler',
-    body: {
-        name: "highlight",
-        rules: [{
-            name: 'Default Polygon Style',
-            ruleId: "defaultPolygon",
-            filter: ['||',
-                ['==', GEOMETRY_PROPERTY, 'Polygon'],
-                ['==', GEOMETRY_PROPERTY, 'MultiPolygon']
-            ],
-            symbolizers: [
-                {
+    // Merge custom styles with default values
+    const style = { ...defaultStyle, ...highlightStyle };
+
+    return {
+        format: 'geostyler',
+        body: {
+            name: "highlight",
+            rules: [{
+                name: 'Default Polygon Style',
+                ruleId: "defaultPolygon",
+                filter: ['||',
+                    ['==', GEOMETRY_PROPERTY, 'Polygon'],
+                    ['==', GEOMETRY_PROPERTY, 'MultiPolygon']
+                ],
+                symbolizers: [{
                     kind: 'Fill',
-                    color: '#f2f2f2',
-                    fillOpacity: 0.3,
-                    outlineColor: '#3075e9',
-                    outlineOpacity: 1,
-                    outlineWidth: 2
-                }
-            ]
-        }, {
-            name: 'Default Line Style',
-            ruleId: "defaultLine",
-            filter: ['||',
-                ['==', GEOMETRY_PROPERTY, 'LineString'],
-                ['==', GEOMETRY_PROPERTY, 'MultiLineString']
-            ],
-            symbolizers: [
-                {
+                    color: style.color,
+                    fillOpacity: style.fillOpacity,
+                    outlineColor: style.lineColor,
+                    outlineOpacity: style.opacity,
+                    outlineWidth: style.width
+                }]
+            }, {
+                name: 'Default Line Style',
+                ruleId: "defaultLine",
+                filter: ['||',
+                    ['==', GEOMETRY_PROPERTY, 'LineString'],
+                    ['==', GEOMETRY_PROPERTY, 'MultiLineString']
+                ],
+                symbolizers: [{
                     kind: 'Line',
-                    color: '#3075e9',
-                    opacity: 1,
-                    width: 2
-                }
-            ]
-        }, {
-            name: 'Default Point Style',
-            ruleId: "defaultPoint",
-            filter: ['||',
-                ['==', GEOMETRY_PROPERTY, 'Point'],
-                ['==', GEOMETRY_PROPERTY, 'MultiPoint']
-            ],
-            symbolizers: [{
-                kind: 'Mark',
-                color: '#f2f2f2',
-                fillOpacity: 0.3,
-                strokeColor: '#3075e9',
-                strokeOpacity: 1,
-                strokeWidth: 2,
-                radius: 10,
-                wellKnownName: 'Circle',
-                msBringToFront: true
+                    color: style.lineColor,
+                    opacity: style.opacity,
+                    width: style.width
+                }]
+            }, {
+                name: 'Default Point Style',
+                ruleId: "defaultPoint",
+                filter: ['||',
+                    ['==', GEOMETRY_PROPERTY, 'Point'],
+                    ['==', GEOMETRY_PROPERTY, 'MultiPoint']
+                ],
+                symbolizers: [{
+                    kind: 'Mark',
+                    color: style.color,
+                    fillOpacity: style.fillOpacity,
+                    strokeColor: style.lineColor,
+                    strokeOpacity: style.opacity,
+                    strokeWidth: style.width,
+                    radius: style.radius,
+                    wellKnownName: 'Circle',
+                    msBringToFront: true
+                }]
             }]
-        }]
-    }
-};
+        }
+    };
+}
 
 /**
  * Add the the proper options to the highlight layer:
@@ -64,9 +73,10 @@ export const HIGH_LIGHT_STYLE = {
  * - `features`: the features to highlight should be enhanced with the geometry type in properties, to allow the default style to work
  * - `style`: the default style applies a different style for each geometry type. The geometry type is extracted from the geometry type and added to the feature properties
  * @param {options} base options
+ * @param highlightStyle
  * @returns the new options with the highlight layer
  */
-export const getHighlightLayerOptions = ({features, ...options}) => {
+export const getHighlightLayerOptions = ({ features, ...options }, highlightStyle = {}) => {
     return {
         ...options,
         visibility: true, // required by cesium
@@ -78,6 +88,6 @@ export const getHighlightLayerOptions = ({features, ...options}) => {
             }
 
         })),
-        style: HIGH_LIGHT_STYLE
+        style: createHighlightStyle(highlightStyle)
     };
 };

--- a/web/client/utils/__tests__/HighlightUtils-test.js
+++ b/web/client/utils/__tests__/HighlightUtils-test.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import {getHighlightLayerOptions, GEOMETRY_PROPERTY, HIGH_LIGHT_STYLE} from '../HighlightUtils';
+import {getHighlightLayerOptions, GEOMETRY_PROPERTY, createHighlightStyle} from '../HighlightUtils';
 
 describe('HighlightUtils', () => {
     it('getHighlightLayerOptions', () => {
@@ -29,7 +29,42 @@ describe('HighlightUtils', () => {
                     coordinates: [0, 0]
                 }
             }],
-            style: HIGH_LIGHT_STYLE
+            style: createHighlightStyle()
+        });
+    });
+
+    it('getHighlightLayerOptions with custom highlight style', () => {
+        const costumHighlightStyle = {
+            color: '#33eeff',
+            width: 4
+        };
+        // adds standard options
+        const options = getHighlightLayerOptions({
+            features: [{
+                type: 'Feature',
+                properties: {
+                    id: '1'
+                },
+                geometry: {
+                    type: 'Point',
+                    coordinates: [0, 0]
+                }
+            }]
+        }, costumHighlightStyle);
+        expect(options).toEqual({
+            visibility: true, // required by cesium
+            features: [{
+                type: 'Feature',
+                properties: {
+                    id: '1',
+                    [GEOMETRY_PROPERTY]: 'Point' // required by default style
+                },
+                geometry: {
+                    type: 'Point',
+                    coordinates: [0, 0]
+                }
+            }],
+            style: createHighlightStyle(costumHighlightStyle)
         });
     });
 });


### PR DESCRIPTION
Enhanced customization for highlight styles of selected features in FeatureEditor and Identify plugins
- enabled defining `highlightStyle` object under `FeatureEditor` and `Identify` plugins in localConfig.json to allow custome of highlight styles.
- updated and added relevant tests to reflect these changes.
- updated jsdoc for both plugins

On behalf of DB Systel GmbH

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->
