### PR TITLE
#10544: fix Embedded maps - details loads panel even if the details attribute value is NODATA

### DIFF
--- a/web/client/plugins/Details.jsx
+++ b/web/client/plugins/Details.jsx
@@ -133,7 +133,7 @@ export default createPlugin('Details', {
             action: openDetailsPanel,
             selector: (state) => {
                 const detailsUri = detailsUriSelector(state);
-                if (detailsUri) {
+                if (detailsUri  && detailsUri !== 'NODATA') {
                     return {};
                 }
                 return { style: {display: "none"} };


### PR DESCRIPTION
## Description
In this PR, adding check of no data condition for show/hide details panel in toolbar has been implemented to fix the issue.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#10544 

**What is the current behavior?**
#10544 

**What is the new behavior?**
The details panel is hidden in the toolbar for embeded maps if the details attribute value is NODATA.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
