### PR TITLE
backport 2024.02.xx - Fix #10508 fix tileprovider crash when using {-y} (#10509)

### DIFF
--- a/web/client/components/map/cesium/plugins/TileProviderLayer.js
+++ b/web/client/components/map/cesium/plugins/TileProviderLayer.js
@@ -55,6 +55,13 @@ export function template(str, data) {
         if (['x', 'y', 'z', 's'].includes(key)) {
             return textMatched;
         }
+        if (key === '-x') {
+            return "{reverseX}";
+        }
+        if (key === '-y') {
+            return "{reverseY}";
+        }
+
         let value = data[key];
 
         if (value === undefined) {

--- a/web/client/utils/TileProviderUtils.js
+++ b/web/client/utils/TileProviderUtils.js
@@ -11,7 +11,7 @@ export function template(str = "", data = {}) {
     return str.replace(/(\{(.*?)\})/g, function() {
         let st = arguments[0];
         let key = arguments[2] ? arguments[2] : arguments[1];
-        if (["x", "y", "z"].includes(key)) {
+        if (["x", "-x", "y", "-y", "z"].includes(key)) {
             return arguments[0];
         }
         let value = data[key];

--- a/web/client/utils/__tests__/TileProviderUtils-test.js
+++ b/web/client/utils/__tests__/TileProviderUtils-test.js
@@ -57,8 +57,13 @@ describe('Test the TileProviderUtils', () => {
         expect(
             template("https://test.com/6510a8722129af6954196fbb26dfadc/1.0.0/topowebb/default/3857/{z}/{y}/{x}.png", optArray))
             .toEqual("https://test.com/6510a8722129af6954196fbb26dfadc/1.0.0/topowebb/default/3857/{z}/{y}/{x}.png");
-        // expect().toBe();
+        // test negative y (-y in template)
+        expect(
+            template("https://test.com/default/3857/{z}/{-y}/{x}.png", optArray))
+            .toEqual("https://test.com/default/3857/{z}/{-y}/{x}.png");
+        expect(
+            template("https://test.com/default/3857/{z}/{-y}/{-x}.png", optArray))
+            .toEqual("https://test.com/default/3857/{z}/{-y}/{-x}.png");
     });
-
 
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport 2024.02.xx - Fix #10508 fix tileprovider crash when using {-y} (#10509)