### PR TITLE
[Backport 2024.02.xx] - #10544: fix Embedded maps - details loads panel even if the details attribute value is NODATA (#10548)

### DIFF
--- a/web/client/plugins/Details.jsx
+++ b/web/client/plugins/Details.jsx
@@ -133,7 +133,7 @@ export default createPlugin('Details', {
             action: openDetailsPanel,
             selector: (state) => {
                 const detailsUri = detailsUriSelector(state);
-                if (detailsUri) {
+                if (detailsUri  && detailsUri !== 'NODATA') {
                     return {};
                 }
                 return { style: {display: "none"} };


### PR DESCRIPTION
[Backport 2024.02.xx] - #10544: fix Embedded maps - details loads panel even if the details attribute value is NODATA (#10548)