### PR TITLE
Search by coordinate in 3D mode issue #10063

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -503,9 +503,9 @@ class CesiumMap extends React.Component {
         if (centerIsUpdate || zoomChanged) {
             const position = {
                 destination: Cesium.Cartesian3.fromDegrees(
-                    newProps.viewerOptions?.cameraPosition?.longitude ?? newProps.center.x,
-                    newProps.viewerOptions?.cameraPosition?.latitude ?? newProps.center.y,
-                    newProps.viewerOptions?.cameraPosition?.height ?? this.getHeightFromZoom(newProps.zoom ?? 0)
+                    newProps.center.x,
+                    newProps.center.y,
+                    newProps.zoom !== undefined ? this.getHeightFromZoom(newProps.zoom) : cameraPosition.height
                 ),
                 orientation: newProps.viewerOptions?.orientation
             };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
fixes [#10063](https://github.com/geosolutions-it/MapStore2/issues/10063)
vieweOptions had been prioritised in _updateMapPositionFromNewProps which was creating problem before.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10063
The map did not jump into the searched coordinates in the 3D map.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
After the search through coordinate the map jump into that coordinate

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
