### PR TITLE
#10577: Fix - GFI in identify popup does not trigger when one of the responses is an error

### DIFF
--- a/web/client/components/common/enhancers/withIdentifyPopup.jsx
+++ b/web/client/components/common/enhancers/withIdentifyPopup.jsx
@@ -90,7 +90,7 @@ export const withIdentifyRequest  = mapPropsStream(props$ => {
                                     }
                                 })
                         )
-                        .catch((e) => ({
+                        .catch((e) => Observable.of({
                             error: e.data || e.statusText || e.status,
                             reqId,
                             queryParams,

--- a/web/client/components/geostory/common/enhancers/withPopupSupport.jsx
+++ b/web/client/components/geostory/common/enhancers/withPopupSupport.jsx
@@ -117,7 +117,7 @@ const withIdentifyRequest  = mapPropsStream(props$ => {
                                 })
                         ) : Observable.empty()
                     )
-                        .catch((e) => ({
+                        .catch((e) => Observable.of({
                             error: e.data || e.statusText || e.status,
                             reqId,
                             queryParams,


### PR DESCRIPTION
## Description
This PR fixes the issue with GFI calls not triggered in identify popup when a request end up with an error response

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10577 

**What is the new behavior?**
The GFI calls are triggered correctly, even when one of the requests results in an error. The rest of the calls are executed and displayed properly in the identify panel (popup), and subsequent calls are also triggered correctly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
