### PR TITLE
Fix #10455 update extension webpack

### DIFF
--- a/build/createExtensionWebpackConfig.js
+++ b/build/createExtensionWebpackConfig.js
@@ -90,6 +90,7 @@ module.exports = ({ prod = true, name, exposes, sharedLibrariesEager = true, ali
         ]
     },
     output: {
+        hashFunction: "xxhash64", // needed for newer version of node (> version 16)
         publicPath,
         chunkFilename: 'assets/js/[name].[chunkhash:8].js',
         path: destination,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds the hashFunction equal to "xxhash64" to the createExtensionWebpackConfig to be able to use node 20 on the MapStoreExtension repo

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10455

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Added the hashFunction equal to "xxhash64" to the createExtensionWebpackConfig

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
