### PR TITLE
The default catalog changes after the catalog is opened from the background tool #10486

### DIFF
--- a/web/client/actions/backgroundselector.js
+++ b/web/client/actions/backgroundselector.js
@@ -25,6 +25,7 @@ export const CLEAR_MODAL_PARAMETERS = 'BACKGROUND_SELECTOR:CLEAR_MODAL_PARAMETER
 export const CONFIRM_DELETE_BACKGROUND_MODAL = 'BACKGROUND_SELECTOR:CONFIRM_DELETE_BACKGROUND_MODAL';
 export const ALLOW_BACKGROUNDS_DELETION = 'BACKGROUND_SELECTOR:ALLOW_BACKGROUNDS_DELETION';
 export const SYNC_CURRENT_BACKGROUND_LAYER = 'BACKGROUND_SELECTOR:SYNC_CURRENT_BACKGROUND_LAYER';
+export const ADD_BACKUP_BACKGROUND = 'BACKGROUND_SELECTOR:ADD_BACKUP_BACKGROUND';
 
 export function createBackgroundsList(backgrounds) {
     return {
@@ -123,5 +124,12 @@ export function confirmDeleteBackgroundModal(show, layerTitle = null, layerId = 
         show,
         layerTitle,
         layerId
+    };
+}
+
+export function addBackupBackground(background) {
+    return {
+        type: ADD_BACKUP_BACKGROUND,
+        background
     };
 }

--- a/web/client/actions/backgroundselector.js
+++ b/web/client/actions/backgroundselector.js
@@ -25,7 +25,7 @@ export const CLEAR_MODAL_PARAMETERS = 'BACKGROUND_SELECTOR:CLEAR_MODAL_PARAMETER
 export const CONFIRM_DELETE_BACKGROUND_MODAL = 'BACKGROUND_SELECTOR:CONFIRM_DELETE_BACKGROUND_MODAL';
 export const ALLOW_BACKGROUNDS_DELETION = 'BACKGROUND_SELECTOR:ALLOW_BACKGROUNDS_DELETION';
 export const SYNC_CURRENT_BACKGROUND_LAYER = 'BACKGROUND_SELECTOR:SYNC_CURRENT_BACKGROUND_LAYER';
-export const ADD_BACKUP_BACKGROUND = 'BACKGROUND_SELECTOR:ADD_BACKUP_BACKGROUND';
+export const STASH_SELECTED_SERVICE = 'BACKGROUND_SELECTOR:STASH_SELECTED_SERVICE';
 
 export function createBackgroundsList(backgrounds) {
     return {
@@ -127,9 +127,19 @@ export function confirmDeleteBackgroundModal(show, layerTitle = null, layerId = 
     };
 }
 
-export function addBackupBackground(background) {
+/**
+ * Stashes the currently selected catalog service for later restoration.
+ * This is useful when closing the catalog and reopening it for background selection,
+ * allowing the user to easily return to their previous selection.
+ *
+ * @param {Object} service - The service object representing the currently selected catalog.
+ * @returns {Object} An action object with the type `STASH_SELECTED_SERVICE`
+ *                  and the selected service.
+ */
+
+export function stashSelectedCatalogService(service) {
     return {
-        type: ADD_BACKUP_BACKGROUND,
-        background
+        type: STASH_SELECTED_SERVICE,
+        service
     };
 }

--- a/web/client/epics/backgroundselector.js
+++ b/web/client/epics/backgroundselector.js
@@ -23,7 +23,8 @@ import {
     setBackgroundModalParams,
     setCurrentBackgroundLayer,
     allowBackgroundsDeletion,
-    backgroundAdded
+    backgroundAdded,
+    addBackupBackground
 } from '../actions/backgroundselector';
 
 import { setControlProperty } from '../actions/controls';
@@ -36,13 +37,15 @@ import { getCustomTileGridProperties, getLayerOptions } from '../utils/WMSUtils'
 import { getLayerTileMatrixSetsInfo } from '../api/WMTS';
 import { generateGeoServerWMTSUrl } from '../utils/WMTSUtils';
 
-const accessMetadataExplorer = (action$) =>
+const accessMetadataExplorer = (action$, store) =>
     action$.ofType(ADD_BACKGROUND)
         .switchMap(() => Rx.Observable.of(
             setControlProperty('metadataexplorer', 'enabled', true),
             allowBackgroundsDeletion(false),
+            addBackupBackground(store.getState().catalog.selectedService),
             changeSelectedService('default_map_backgrounds')
         ));
+
 
 const addBackgroundPropertiesEpic = (action$) =>
     action$.ofType(ADD_BACKGROUND_PROPERTIES)

--- a/web/client/epics/backgroundselector.js
+++ b/web/client/epics/backgroundselector.js
@@ -24,7 +24,7 @@ import {
     setCurrentBackgroundLayer,
     allowBackgroundsDeletion,
     backgroundAdded,
-    addBackupBackground
+    stashSelectedCatalogService
 } from '../actions/backgroundselector';
 
 import { setControlProperty } from '../actions/controls';
@@ -36,13 +36,14 @@ import { getLayerCapabilities } from '../observables/wms';
 import { getCustomTileGridProperties, getLayerOptions } from '../utils/WMSUtils';
 import { getLayerTileMatrixSetsInfo } from '../api/WMTS';
 import { generateGeoServerWMTSUrl } from '../utils/WMTSUtils';
+import { selectedServiceSelector } from '../selectors/catalog';
 
 const accessMetadataExplorer = (action$, store) =>
     action$.ofType(ADD_BACKGROUND)
         .switchMap(() => Rx.Observable.of(
             setControlProperty('metadataexplorer', 'enabled', true),
             allowBackgroundsDeletion(false),
-            addBackupBackground(store.getState().catalog.selectedService),
+            stashSelectedCatalogService(selectedServiceSelector(store.getState())),
             changeSelectedService('default_map_backgrounds')
         ));
 

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -592,13 +592,12 @@ export default (API) => ({
             .switchMap(() => {
                 const state = store.getState();
                 const metadataSource = metadataSourceSelector(state);
-                const services = servicesSelector(state);
                 return Rx.Observable.of(...([
                     setControlProperties('metadataexplorer', "enabled", false, "group", null),
                     changeCatalogMode("view"),
                     resetCatalog()
                 ].concat(metadataSource === 'backgroundSelector' ?
-                    [changeSelectedService(head(keys(services))), allowBackgroundsDeletion(true)] : [])));
+                    [changeSelectedService(state.backgroundSelector.backupBackground), allowBackgroundsDeletion(true)] : [])));
             }),
 
     /**

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -52,7 +52,7 @@ import {
     catalogSearchInfoSelector,
     isActiveSelector, servicesSelectorWithBackgrounds
 } from '../selectors/catalog';
-import { metadataSourceSelector } from '../selectors/backgroundselector';
+import { metadataSourceSelector, stashedServiceSelector } from '../selectors/backgroundselector';
 import { currentMessagesSelector } from "../selectors/locale";
 import { getSelectedLayer, selectedNodesSelector } from '../selectors/layers';
 
@@ -592,12 +592,13 @@ export default (API) => ({
             .switchMap(() => {
                 const state = store.getState();
                 const metadataSource = metadataSourceSelector(state);
+                const stashedService = stashedServiceSelector(state);
                 return Rx.Observable.of(...([
                     setControlProperties('metadataexplorer', "enabled", false, "group", null),
                     changeCatalogMode("view"),
                     resetCatalog()
                 ].concat(metadataSource === 'backgroundSelector' ?
-                    [changeSelectedService(state.backgroundSelector.backupBackground), allowBackgroundsDeletion(true)] : [])));
+                    [changeSelectedService(stashedService), allowBackgroundsDeletion(true)] : [])));
             }),
 
     /**

--- a/web/client/reducers/backgroundselector.js
+++ b/web/client/reducers/backgroundselector.js
@@ -15,7 +15,8 @@ import {
     REMOVE_BACKGROUND,
     CREATE_BACKGROUNDS_LIST,
     CLEAR_MODAL_PARAMETERS,
-    CONFIRM_DELETE_BACKGROUND_MODAL
+    CONFIRM_DELETE_BACKGROUND_MODAL,
+    ADD_BACKUP_BACKGROUND
 } from '../actions/backgroundselector';
 
 import { RESET_CATALOG } from '../actions/catalog';
@@ -102,6 +103,13 @@ function backgroundselector(state = null, action) {
     case ALLOW_BACKGROUNDS_DELETION: {
         return assign({}, state, {allowDeletion: action.allow || false});
     }
+    case ADD_BACKUP_BACKGROUND : {
+        return assign({}, state, {
+            backupBackground: action.background
+        });
+    }
+
+
     default:
         return state;
     }

--- a/web/client/reducers/backgroundselector.js
+++ b/web/client/reducers/backgroundselector.js
@@ -16,7 +16,7 @@ import {
     CREATE_BACKGROUNDS_LIST,
     CLEAR_MODAL_PARAMETERS,
     CONFIRM_DELETE_BACKGROUND_MODAL,
-    ADD_BACKUP_BACKGROUND
+    STASH_SELECTED_SERVICE
 } from '../actions/backgroundselector';
 
 import { RESET_CATALOG } from '../actions/catalog';
@@ -103,9 +103,9 @@ function backgroundselector(state = null, action) {
     case ALLOW_BACKGROUNDS_DELETION: {
         return assign({}, state, {allowDeletion: action.allow || false});
     }
-    case ADD_BACKUP_BACKGROUND : {
+    case STASH_SELECTED_SERVICE : {
         return assign({}, state, {
-            backupBackground: action.background
+            stashedService: action.service
         });
     }
 

--- a/web/client/selectors/backgroundselector.js
+++ b/web/client/selectors/backgroundselector.js
@@ -23,3 +23,4 @@ export const backgroundLayersSelector = createSelector(layersSelector, mapTypeSe
     const  backgroundLayers = layers.filter((l) => l && l.group === "background");
     return loaded && loaded[maptype] ? backgroundLayers.map((l) => invalidateUnsupportedLayer(l, maptype)) || [] : backgroundLayers;
 });
+export const stashedServiceSelector = state => state?.backgroundSelector.stashedService;

--- a/web/client/selectors/backgroundselector.js
+++ b/web/client/selectors/backgroundselector.js
@@ -23,4 +23,4 @@ export const backgroundLayersSelector = createSelector(layersSelector, mapTypeSe
     const  backgroundLayers = layers.filter((l) => l && l.group === "background");
     return loaded && loaded[maptype] ? backgroundLayers.map((l) => invalidateUnsupportedLayer(l, maptype)) || [] : backgroundLayers;
 });
-export const stashedServiceSelector = state => state?.backgroundSelector.stashedService;
+export const stashedServiceSelector = state => state.backgroundSelector && state?.backgroundSelector.stashedService;


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
While adding the background layer, a backup for the selected catalog service is stored in the backgroundselector store.
And same service is set while closing the Catalog Modal.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10486
The selected catalog service changes after trying to add a background layer

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Selected Catalog service remains same even after trying to add background layer

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
