### PR TITLE
Home and Login Plugins do not appear on the page if the Burger Menu is activated in the context in 2024.01.01 version #10503

### DIFF
--- a/docs/user-guide/application-context.md
+++ b/docs/user-guide/application-context.md
@@ -136,8 +136,10 @@ In the *Enabled Plugins* list, the following buttons are displayed for each exte
   
 !!! warning
     When adding the following plugins to the context:
-    *Login
-    *Home
+
+    * Login
+  
+    * Home
   
     Please ensure that the priority is set to **5** in the configuration. Here’s an example of how to structure it:
     ``` JavaScript

--- a/docs/user-guide/application-context.md
+++ b/docs/user-guide/application-context.md
@@ -136,9 +136,8 @@ In the *Enabled Plugins* list, the following buttons are displayed for each exte
   
 !!! warning
     When adding the following plugins to the context:
-      
-      * Login
-      * Home
+    *Login
+    *Home
   
     Please ensure that the priority is set to **5** in the configuration. Here’s an example of how to structure it:
     ``` JavaScript
@@ -151,8 +150,6 @@ In the *Enabled Plugins* list, the following buttons are displayed for each exte
             }
         }
     ```
-
-
 
 ### How to update extensions
 

--- a/docs/user-guide/application-context.md
+++ b/docs/user-guide/application-context.md
@@ -133,6 +133,7 @@ In the *Enabled Plugins* list, the following buttons are displayed for each exte
 <img src="../img/application-context/plugin-config.jpg" class="ms-docimage" style="max-width:300px;"/>
 
 * The **Open plugin configuration documentation** button <img src="../img/button/docu-plugin.jpg" class="ms-docbutton"/> opens the [Plugins Documentation](https://mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins) in another page.
+
 ### How to update extensions
 
 Extension can be updated using two steps:

--- a/docs/user-guide/application-context.md
+++ b/docs/user-guide/application-context.md
@@ -133,6 +133,26 @@ In the *Enabled Plugins* list, the following buttons are displayed for each exte
 <img src="../img/application-context/plugin-config.jpg" class="ms-docimage" style="max-width:300px;"/>
 
 * The **Open plugin configuration documentation** button <img src="../img/button/docu-plugin.jpg" class="ms-docbutton"/> opens the [Plugins Documentation](https://mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins) in another page.
+  
+!!! warning
+    When adding the following plugins to the context:
+      
+      * Login
+      * Home
+  
+    Please ensure that the priority is set to **5** in the configuration. Here’s an example of how to structure it:
+    ``` JavaScript
+        {
+            "cfg": {},
+            "override": {
+                "OmniBar": {
+                "priority": 5
+                }
+            }
+        }
+    ```
+
+
 
 ### How to update extensions
 

--- a/docs/user-guide/application-context.md
+++ b/docs/user-guide/application-context.md
@@ -133,26 +133,6 @@ In the *Enabled Plugins* list, the following buttons are displayed for each exte
 <img src="../img/application-context/plugin-config.jpg" class="ms-docimage" style="max-width:300px;"/>
 
 * The **Open plugin configuration documentation** button <img src="../img/button/docu-plugin.jpg" class="ms-docbutton"/> opens the [Plugins Documentation](https://mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins) in another page.
-  
-!!! warning
-    When adding the following plugins to the context:
-
-    * Login
-  
-    * Home
-  
-    Please ensure that the priority is set to **5** in the configuration. Here’s an example of how to structure it:
-    ``` JavaScript
-        {
-            "cfg": {},
-            "override": {
-                "OmniBar": {
-                "priority": 5
-                }
-            }
-        }
-    ```
-
 ### How to update extensions
 
 Extension can be updated using two steps:

--- a/web/client/plugins/Home.jsx
+++ b/web/client/plugins/Home.jsx
@@ -44,6 +44,20 @@ const HomeConnected = connect((state) => ({
  * It can be rendered in {@link #plugins.OmniBar|OmniBar}.
  * Supports as containers at lower priority {@link #plugins.Toolbar|Toolbar}.
  * You can configure the home target path globally by setting `miscSettings.homePath` in `localConfig.json`. By default it redirects to `"#/"`;
+ *
+ * If you want to show this plugin with BurgerMenu (so without Sidebar), apply the following configuration:
+ *
+ * ```javascript
+ * {
+ *     "cfg": {},
+ *     "override": {
+ *         "OmniBar": {
+ *             "priority": 5
+ *         }
+ *     }
+ * }
+ * ```
+ *
  * @name Home
  * @class
  * @memberof plugins

--- a/web/client/plugins/Login.jsx
+++ b/web/client/plugins/Login.jsx
@@ -30,13 +30,27 @@ import { isAdminUserSelector } from '../selectors/security';
   * - `url` optional URL to redirect in case of `openID`. By default it will use the standard convention to `rest/geostore/{provider}/login`.
   * - `imageURL` optional URL for the image to use in the link of the login form. (certain pre-defined services like `google` may have their own default logo)
   * - `title` a text to show in the link to the login page of the provider, if logo is present, this text is used as `alt` text in for the image.
-  * Example of configuration.
+ * Example of configuration.
   * ```json
   * {
   *  "authenticationProviders": [{"type": "openID", "provider": "google"}, {"type": "basic", "provider": "geostore"}]
   * }
   * ```
   * By default, if not set, it will use classic `{"type": "basic", "provider": "geostore"}` setup for GeoStore.
+ *
+ * If you want to show this plugin with BurgerMenu (so without Sidebar), apply the following configuration:
+ *
+ * ```javascript
+ * {
+ *     "cfg": {},
+ *     "override": {
+ *         "OmniBar": {
+ *             "priority": 5
+ *         }
+ *     }
+ * }
+ * ```
+ *
   * @class Login
   * @memberof plugins
   * @static

--- a/web/client/plugins/Login.jsx
+++ b/web/client/plugins/Login.jsx
@@ -30,7 +30,7 @@ import { isAdminUserSelector } from '../selectors/security';
   * - `url` optional URL to redirect in case of `openID`. By default it will use the standard convention to `rest/geostore/{provider}/login`.
   * - `imageURL` optional URL for the image to use in the link of the login form. (certain pre-defined services like `google` may have their own default logo)
   * - `title` a text to show in the link to the login page of the provider, if logo is present, this text is used as `alt` text in for the image.
- * Example of configuration.
+  * Example of configuration.
   * ```json
   * {
   *  "authenticationProviders": [{"type": "openID", "provider": "google"}, {"type": "basic", "provider": "geostore"}]


### PR DESCRIPTION
#10503 
In the map of context with plugins **login and home**. More priority has been given to the sidebar which is a hidden plugin in the context map.
Probable introduction of this issue is from PR https://github.com/geosolutions-it/MapStore2/pull/9841/files
Overriding priority while creating the context for those plugins solves the issue.

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

#10503 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10503

**What is the new behavior?**
Docs have been updated showing how to override the priority of the plugin home and login

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
