### PR TITLE
[Backport 2024.02.xx] #10577: Fix - GFI in identify popup does not trigger when one of the responses is an error (#10578)

### DIFF
--- a/web/client/components/common/enhancers/withIdentifyPopup.jsx
+++ b/web/client/components/common/enhancers/withIdentifyPopup.jsx
@@ -90,7 +90,7 @@ export const withIdentifyRequest  = mapPropsStream(props$ => {
                                     }
                                 })
                         )
-                        .catch((e) => ({
+                        .catch((e) => Observable.of({
                             error: e.data || e.statusText || e.status,
                             reqId,
                             queryParams,

--- a/web/client/components/geostory/common/enhancers/withPopupSupport.jsx
+++ b/web/client/components/geostory/common/enhancers/withPopupSupport.jsx
@@ -117,7 +117,7 @@ const withIdentifyRequest  = mapPropsStream(props$ => {
                                 })
                         ) : Observable.empty()
                     )
-                        .catch((e) => ({
+                        .catch((e) => Observable.of({
                             error: e.data || e.statusText || e.status,
                             reqId,
                             queryParams,


### PR DESCRIPTION
#10577: Fix - GFI in identify popup does not trigger when one of the responses is an error (#10578)

> [!WARNING]
**Merge this PR when 2024.02.00 is released**