### PR TITLE
fetching the list of formats is disabled for a no-vendor WMS service #10480

### DIFF
--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -87,6 +87,8 @@ export default ({
 
     const tileSelectOptions = getTileSizeSelectOptions(tileSizeOptions);
     const serverTypeOptions = getServerTypeOptions();
+    // for CSW services with no vendor options, disable format and info format options
+    const canLoadInfo = !(['csw'].includes(service.type) && service.layerOptions?.serverType === ServerTypes.NO_VENDOR);
     return (<CommonAdvancedSettings {...props} onChangeServiceProperty={onChangeServiceProperty} service={service} >
         {(isLocalizedLayerStylesEnabled && !isNil(service.type) ? service.type === "wms" : false) && (<FormGroup controlId="localized-styles" key="localized-styles">
             <Checkbox data-qa="service-lacalized-layer-styles-option"
@@ -196,7 +198,8 @@ export default ({
                     title={<Message msgId="errorTitleDefault"/>}
                     text={<Message msgId="layerProperties.formatError" />} /> : null}
                 <Button
-                    disabled={props.formatsLoading || (['csw'].includes(service.type) && service.layerOptions?.serverType === ServerTypes.NO_VENDOR)}
+                    disabled={props.formatsLoading || !canLoadInfo
+                    }
                     tooltipId="catalog.format.refresh"
                     className="square-button-md no-border"
                     onClick={() => onFormatOptionsFetch(service.url, true)}
@@ -209,7 +212,7 @@ export default ({
             <ControlLabel><Message msgId="layerProperties.format.tile" /></ControlLabel>
             <InputGroup>
                 <Select
-                    disabled={['csw'].includes(service.type) && service.layerOptions?.serverType === ServerTypes.NO_VENDOR}
+                    disabled={!canLoadInfo}
                     isLoading={props.formatsLoading}
                     onOpen={() => onFormatOptionsFetch(service.url)}
                     value={service && service.format}
@@ -224,7 +227,7 @@ export default ({
             <ControlLabel><Message msgId="layerProperties.format.information" /></ControlLabel>
             <InputGroup>
                 <Select
-                    disabled={['csw'].includes(service.type) && service.layerOptions?.serverType === ServerTypes.NO_VENDOR}
+                    disabled={!canLoadInfo}
                     isLoading={props.formatsLoading}
                     onOpen={() => onFormatOptionsFetch(service.url)}
                     value={service && service.infoFormat}

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -196,7 +196,7 @@ export default ({
                     title={<Message msgId="errorTitleDefault"/>}
                     text={<Message msgId="layerProperties.formatError" />} /> : null}
                 <Button
-                    disabled={props.formatsLoading || service.layerOptions?.serverType === ServerTypes.NO_VENDOR}
+                    disabled={props.formatsLoading || (['csw'].includes(service.type) && service.layerOptions?.serverType === ServerTypes.NO_VENDOR)}
                     tooltipId="catalog.format.refresh"
                     className="square-button-md no-border"
                     onClick={() => onFormatOptionsFetch(service.url, true)}
@@ -209,7 +209,7 @@ export default ({
             <ControlLabel><Message msgId="layerProperties.format.tile" /></ControlLabel>
             <InputGroup>
                 <Select
-                    disabled={service.layerOptions?.serverType === ServerTypes.NO_VENDOR}
+                    disabled={['csw'].includes(service.type) && service.layerOptions?.serverType === ServerTypes.NO_VENDOR}
                     isLoading={props.formatsLoading}
                     onOpen={() => onFormatOptionsFetch(service.url)}
                     value={service && service.format}
@@ -224,7 +224,7 @@ export default ({
             <ControlLabel><Message msgId="layerProperties.format.information" /></ControlLabel>
             <InputGroup>
                 <Select
-                    disabled={service.layerOptions?.serverType === ServerTypes.NO_VENDOR}
+                    disabled={['csw'].includes(service.type) && service.layerOptions?.serverType === ServerTypes.NO_VENDOR}
                     isLoading={props.formatsLoading}
                     onOpen={() => onFormatOptionsFetch(service.url)}
                     value={service && service.infoFormat}

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -14,7 +14,7 @@ import TestUtils from "react-dom/test-utils";
 import { waitFor } from '@testing-library/react';
 import { setConfigProp } from "../../../../../utils/ConfigUtils";
 
-describe.only('Test Raster advanced settings', () => {
+describe('Test Raster advanced settings', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setConfigProp('miscSettings', { experimentalInteractiveLegend: true });

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -14,7 +14,7 @@ import TestUtils from "react-dom/test-utils";
 import { waitFor } from '@testing-library/react';
 import { setConfigProp } from "../../../../../utils/ConfigUtils";
 
-describe('Test Raster advanced settings', () => {
+describe.only('Test Raster advanced settings', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
@@ -37,6 +37,8 @@ describe('Test Raster advanced settings', () => {
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
         expect(fields.length).toBe(15);
+        // check disabled refresh button
+
     });
     it('test wms advanced options with no vendor serverType', () => {
         ReactDOM.render(<RasterAdvancedSettings service={{type: "wms", autoload: false, layerOptions: {serverType: 'no-vendor'}}} isLocalizedLayerStylesEnabled/>, document.getElementById("container"));
@@ -44,6 +46,9 @@ describe('Test Raster advanced settings', () => {
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
         expect(fields.length).toBe(13);
+        const refreshButton = document.querySelectorAll('button')[0];
+        expect(refreshButton).toBeTruthy();
+        expect(refreshButton.disabled).toBe(false);
     });
     it('test csw advanced options', () => {
         ReactDOM.render(<RasterAdvancedSettings service={{type: "csw", autoload: false}}/>, document.getElementById("container"));
@@ -66,6 +71,9 @@ describe('Test Raster advanced settings', () => {
         expect(fields.length).toBe(12);
         expect(cswFilters).toBeTruthy();
         expect(sortBy).toBeTruthy();
+        const refreshButton = document.querySelectorAll('button')[0];
+        expect(refreshButton).toBeTruthy();
+        expect(refreshButton.disabled).toBe(true);
     });
     it('test component onChangeServiceProperty autoload', () => {
         const action = {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
fixes [#10480](https://github.com/geosolutions-it/MapStore2/issues/10480) 
In case of Server type **No Vendor** the refresh and format buttons are enabled in Advanced Settings. _Disabled only for **CSW**._

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

[#10480](https://github.com/geosolutions-it/MapStore2/issues/10480)

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
[#10480](https://github.com/geosolutions-it/MapStore2/issues/10480)

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
For services other than CSW, refresh button and buttons on the format section are enabled while the Server Type is **No Vendor**.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
