### PR TITLE
Visibility limits - The resolution option is not retained as Limits type #10391

### DIFF
--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -210,6 +210,7 @@ export default class extends React.Component {
                                 projection={this.props.projection}
                                 resolutions={this.props.resolutions}
                                 zoom={this.props.zoom}
+                                defaultLimitsType={this.props.element.visibilityLimitType}
                             />
                         </FormGroup>
                     </Col>

--- a/web/client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx
+++ b/web/client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx
@@ -392,6 +392,9 @@ function VisibilityLimitsForm({
                 disabled={disableResolutionLimits || loading}
                 onChange={({ value }) => {
                     setLimitsType(value);
+                    onChange({
+                        visibilityLimitType: value
+                    });
                     clearMessages();
                 }}
             />

--- a/web/client/components/TOC/fragments/settings/__tests__/VisibilityLimitsForm-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/VisibilityLimitsForm-test.jsx
@@ -9,7 +9,7 @@
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { act } from 'react-dom/test-utils';
+import ReactTestUtils, { act } from 'react-dom/test-utils';
 import VisibilityLimitsForm from '../VisibilityLimitsForm';
 
 describe('VisibilityLimitsForm', () => {
@@ -96,4 +96,32 @@ describe('VisibilityLimitsForm', () => {
         const buttons = document.querySelectorAll('.square-button-md');
         expect(buttons.length).toBe(1);
     });
+
+    it("Should call onChange after visibilityLimitType change ", () => {
+        const layer = {
+            type: 'wms'
+        };
+        const handlers = {
+            onChange: () => {}
+        };
+        let spyUpdate = expect.spyOn(handlers, "onChange");
+
+        act(()=>ReactDOM.render(<VisibilityLimitsForm
+            layer={layer}
+            onChange={handlers.onChange}
+        />, document.getElementById('container')));
+
+        // Simpulate selection
+        const selectArrow = document.getElementById("container").querySelectorAll('.Select-arrow');
+        const selectControl = document.getElementById("container").querySelectorAll('.Select-control');
+        const inputs = document.getElementsByTagName("input");
+        ReactTestUtils.Simulate.mouseDown(selectArrow[2], { button: 0 });
+        ReactTestUtils.Simulate.keyDown(selectControl[2], { keyCode: 40, key: 'ArrowDown' });
+        ReactTestUtils.Simulate.keyDown(inputs[3], { keyCode: 13, key: 'Enter' });
+        expect(spyUpdate.calls.length).toBe(1);
+        expect(Object.keys(spyUpdate.calls[0].arguments[0])).toEqual(['visibilityLimitType']);
+
+    });
+
+
 });

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -708,7 +708,7 @@ export const saveLayer = (layer) => {
         tileSize: layer.tileSize,
         version: layer.version,
         expanded: layer.expanded || false,
-        visibilityLimitType: layer.visibilityLimitType || null
+        ...(layer.visibilityLimitType ? { ...layer.visibilityLimitType, ...layer.visibilityLimitType } : {})
     },
     layer?.enableInteractiveLegend !== undefined ? { enableInteractiveLegend: layer?.enableInteractiveLegend } : {},
     layer.sources ? { sources: layer.sources } : {},

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -707,8 +707,7 @@ export const saveLayer = (layer) => {
         legendOptions: layer.legendOptions,
         tileSize: layer.tileSize,
         version: layer.version,
-        expanded: layer.expanded || false,
-        ...(layer.visibilityLimitType ? { visibilityLimitType: layer.visibilityLimitType } : undefined)
+        expanded: layer.expanded || false
     },
     layer?.enableInteractiveLegend !== undefined ? { enableInteractiveLegend: layer?.enableInteractiveLegend } : {},
     layer.sources ? { sources: layer.sources } : {},

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -707,7 +707,8 @@ export const saveLayer = (layer) => {
         legendOptions: layer.legendOptions,
         tileSize: layer.tileSize,
         version: layer.version,
-        expanded: layer.expanded || false
+        expanded: layer.expanded || false,
+        visibilityLimitType: layer.visibilityLimitType || null
     },
     layer?.enableInteractiveLegend !== undefined ? { enableInteractiveLegend: layer?.enableInteractiveLegend } : {},
     layer.sources ? { sources: layer.sources } : {},

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -708,7 +708,7 @@ export const saveLayer = (layer) => {
         tileSize: layer.tileSize,
         version: layer.version,
         expanded: layer.expanded || false,
-        ...(layer.visibilityLimitType ? { ...layer.visibilityLimitType, ...layer.visibilityLimitType } : {})
+        ...(layer.visibilityLimitType ? { visibilityLimitType: layer.visibilityLimitType } : undefined)
     },
     layer?.enableInteractiveLegend !== undefined ? { enableInteractiveLegend: layer?.enableInteractiveLegend } : {},
     layer.sources ? { sources: layer.sources } : {},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
fixes #10391
Persist Visibility limit type after saving the map.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

#10391

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10391
Visibility limit type reset back to Scale even selecting Resolution

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Visibility Limit type persist even after saving map

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
