### PR TITLE
[Backport 2024.02.xx] #10480: fetching the list of formats is disabled for a no-vendor WMS service #10480 #10594

### DIFF
--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -87,6 +87,8 @@ export default ({
 
     const tileSelectOptions = getTileSizeSelectOptions(tileSizeOptions);
     const serverTypeOptions = getServerTypeOptions();
+    // for CSW services with no vendor options, disable format and info format options
+    const canLoadInfo = !(['csw'].includes(service.type) && service.layerOptions?.serverType === ServerTypes.NO_VENDOR);
     return (<CommonAdvancedSettings {...props} onChangeServiceProperty={onChangeServiceProperty} service={service} >
         {(isLocalizedLayerStylesEnabled && !isNil(service.type) ? service.type === "wms" : false) && (<FormGroup controlId="localized-styles" key="localized-styles">
             <Checkbox data-qa="service-lacalized-layer-styles-option"
@@ -196,7 +198,8 @@ export default ({
                     title={<Message msgId="errorTitleDefault"/>}
                     text={<Message msgId="layerProperties.formatError" />} /> : null}
                 <Button
-                    disabled={props.formatsLoading || service.layerOptions?.serverType === ServerTypes.NO_VENDOR}
+                    disabled={props.formatsLoading || !canLoadInfo
+                    }
                     tooltipId="catalog.format.refresh"
                     className="square-button-md no-border"
                     onClick={() => onFormatOptionsFetch(service.url, true)}
@@ -209,7 +212,7 @@ export default ({
             <ControlLabel><Message msgId="layerProperties.format.tile" /></ControlLabel>
             <InputGroup>
                 <Select
-                    disabled={service.layerOptions?.serverType === ServerTypes.NO_VENDOR}
+                    disabled={!canLoadInfo}
                     isLoading={props.formatsLoading}
                     onOpen={() => onFormatOptionsFetch(service.url)}
                     value={service && service.format}
@@ -224,7 +227,7 @@ export default ({
             <ControlLabel><Message msgId="layerProperties.format.information" /></ControlLabel>
             <InputGroup>
                 <Select
-                    disabled={service.layerOptions?.serverType === ServerTypes.NO_VENDOR}
+                    disabled={!canLoadInfo}
                     isLoading={props.formatsLoading}
                     onOpen={() => onFormatOptionsFetch(service.url)}
                     value={service && service.infoFormat}

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -37,6 +37,8 @@ describe('Test Raster advanced settings', () => {
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
         expect(fields.length).toBe(15);
+        // check disabled refresh button
+
     });
     it('test wms advanced options with no vendor serverType', () => {
         ReactDOM.render(<RasterAdvancedSettings service={{type: "wms", autoload: false, layerOptions: {serverType: 'no-vendor'}}} isLocalizedLayerStylesEnabled/>, document.getElementById("container"));
@@ -44,6 +46,9 @@ describe('Test Raster advanced settings', () => {
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
         expect(fields.length).toBe(13);
+        const refreshButton = document.querySelectorAll('button')[0];
+        expect(refreshButton).toBeTruthy();
+        expect(refreshButton.disabled).toBe(false);
     });
     it('test csw advanced options', () => {
         ReactDOM.render(<RasterAdvancedSettings service={{type: "csw", autoload: false}}/>, document.getElementById("container"));
@@ -66,6 +71,9 @@ describe('Test Raster advanced settings', () => {
         expect(fields.length).toBe(12);
         expect(cswFilters).toBeTruthy();
         expect(sortBy).toBeTruthy();
+        const refreshButton = document.querySelectorAll('button')[0];
+        expect(refreshButton).toBeTruthy();
+        expect(refreshButton.disabled).toBe(true);
     });
     it('test component onChangeServiceProperty autoload', () => {
         const action = {


### PR DESCRIPTION
fixes: #10480.  fetching the list of formats is disabled for a no-vendor WMS service #10594