### PR TITLE
[Backport 2024.02.xx] Fix #10595 add missing 'FORMAT' parameter to WMTS GetFeatureInfo requests (#10596)

### DIFF
--- a/web/client/utils/mapinfo/__tests__/wmts-test.js
+++ b/web/client/utils/mapinfo/__tests__/wmts-test.js
@@ -213,6 +213,7 @@ describe('mapinfo wmts utils', () => {
             request: 'GetFeatureInfo',
             layer: 'gs:us_states',
             infoformat: 'text/plain',
+            format: 'image/png',
             style: '',
             tilecol: 3,
             tilerow: 5,

--- a/web/client/utils/mapinfo/wmts.js
+++ b/web/client/utils/mapinfo/wmts.js
@@ -95,6 +95,7 @@ export default {
                 request: 'GetFeatureInfo',
                 layer: layer.name,
                 infoformat: props.format,
+                format: layer.format,
                 style: layer.style || '',
                 ...assign({}, params),
                 tilecol: tileCol,


### PR DESCRIPTION
## Description
See #10595

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10595

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
GetFeatureInfo requests on https://data.geopf.fr/wmts works.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
