### PR TITLE
Bump spring-security version to 5.7.12 (fixes #10611)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <ehcache-web.version>2.0.4</ehcache-web.version>
         <commons-pool.version>1.5.4</commons-pool.version>
         <jaxws-api.version>2.3.1</jaxws-api.version>
-        <spring.security.version>5.6.12</spring.security.version>
+        <spring.security.version>5.7.12</spring.security.version>
         <log4j-version>2.19.0</log4j-version>
         <jackson-version>2.16.1</jackson-version>
         <json-patch.version>1.12</json-patch.version>


### PR DESCRIPTION
somehow something in the build already drags this version, and we end up with two conflicting versions of spring-security in the war which results in at least failure to authenticate with basic auth.

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10611

**What is the new behavior?**
auth succeeds, because there's now only one version of spring-security jars in the war
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
