### PR TITLE
#10545: fix Option to disable identify popup in case of no results

### DIFF
--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -965,6 +965,54 @@ describe('identify Epics', () => {
 
         testEpic(zoomToVisibleAreaEpic,  3, sentActions, expectedAction, state);
     });
+    it('test zoomToVisibleAreaEpic remove shown marker of identify if no results + existing hideEmptyPopupOption flag = true', (done) => {
+        // remove previous hook
+        registerHook('RESOLUTION_HOOK', undefined);
+
+        const state = {
+            mapInfo: {
+                centerToMarker: true
+            },
+            mapPopups: {
+                hideEmptyPopupOption: true
+            },
+            map: {present: {...TEST_MAP_STATE.present, eventListeners: {mousemove: ["identifyFloatingTool"]}}},
+            maplayout: {
+                boundingMapRect: {
+                    left: 500,
+                    bottom: 250
+                }
+            }
+        };
+
+        const sentActions = [
+            featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } }),
+            loadFeatureInfo(1, "no features were found")
+        ];
+
+        const expectedAction = actions => {
+            try {
+                expect(actions.length).toBe(2);
+                actions.map((action) => {
+                    switch (action.type) {
+                    case HIDE_MAPINFO_MARKER:
+                        done();
+                        break;
+                    case UPDATE_CENTER_TO_MARKER:
+                        expect(action.status).toBe('disabled');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+            } catch (ex) {
+                done(ex);
+            }
+            done();
+        };
+
+        testEpic(zoomToVisibleAreaEpic,  2, sentActions, expectedAction, state);
+    });
 
     it('onMapClick triggers featureinfo when selected', done => {
         registerHook(GET_COORDINATES_FROM_PIXEL_HOOK, undefined);


### PR DESCRIPTION
## Description
In this PR, I have fixed the issue mentioned in this comment: https://github.com/geosolutions-it/MapStore2/pull/10557#issuecomment-2418937384 by removing the marker in case no identify result + hover identify mode active and identify cfg hideEmptyPopupOption with true

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10545  

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/pull/10557#issuecomment-2418937384
**What is the new behavior?**
If user activates hover identify mode and there is identify cfg hideEmptyPopupOption = true in localConfig then user clicks on a place with no identify results ---> the blue marker will be removed automatically from map.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
