### PR TITLE
#10622: Fix Not possible to remove widget from Map - JavaScript error

### DIFF
--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -218,6 +218,34 @@ describe('Test the widgets reducer', () => {
         expect(uWidgets[0].dependenciesMap).toBeFalsy();
         expect(uWidgets[0].id).toBe("2");
     });
+    it('test deleteWidget if the some other widgets [not deleted] has dependenciesMap = {}', () => {
+        const state = {
+            containers: {
+                [DEFAULT_TARGET]: {
+                    widgets: [{
+                        id: "1",
+                        maps: [{mapId: 1, layers: [1, 2]}]
+                    }, {
+                        id: "2",
+                        mapSync: true,
+                        dependenciesMap: {
+                            layers: "widgets[1].maps[1].layers"
+                        }
+                    }, {
+                        id: "3",
+                        mapSync: true,
+                        dependenciesMap: {}
+                    }]
+                }
+            }
+        };
+        const newState = widgets(state, deleteWidget({id: "1"}));
+        const uWidgets = newState.containers[DEFAULT_TARGET].widgets;
+        expect(uWidgets.length).toBe(2);
+        expect(uWidgets[0].mapSync).toBeFalsy();
+        expect(uWidgets[0].dependenciesMap).toBeFalsy();
+        expect(uWidgets[0].id).toBe("2");
+    });
     it('init', () => {
         const defaults = {initialSize: {
             w: 4,

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -182,7 +182,7 @@ function widgetsReducer(state = emptyState, action) {
         const allWidgets = get(updatedState, path, []);
         return set(path, allWidgets.map(m => {
             if (m.dependenciesMap) {
-                const [, dependentWidgetId] = WIDGETS_REGEX.exec((Object.values(m.dependenciesMap) || [])[0]);
+                const [, dependentWidgetId] = WIDGETS_REGEX.exec((Object.values(m.dependenciesMap) || [])[0]) || [];
                 if (dependentWidgetId) {
                     if (action.widget.id === dependentWidgetId) {
                         return {...omit(m, "dependenciesMap"), mapSync: false};


### PR DESCRIPTION
## Description
This PR fixes the issue of not remove widget from map in case of existing other widgets has dependenciesMap prop = empty object.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10622 

**What is the current behavior?**
#10622 

**What is the new behavior?**
The delete confirmation dialog window closes and the widget is removed from the map normally.


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
