### PR TITLE
dashboardSave should use floppy-disk

### DIFF
--- a/web/client/plugins/DashboardSave.jsx
+++ b/web/client/plugins/DashboardSave.jsx
@@ -67,7 +67,7 @@ export const DashboardSave = createPlugin('DashboardSave', {
             name: 'dashboardSave',
             position: 30,
             text: <Message msgId="save"/>,
-            icon: <Glyphicon glyph="floppy-open"/>,
+            icon: <Glyphicon glyph="floppy-disk"/>,
             action: triggerSave.bind(null, true),
             tooltip: "saveDialog.saveTooltip",
             // display the BurgerMenu button only if the map can be edited
@@ -83,7 +83,7 @@ export const DashboardSave = createPlugin('DashboardSave', {
             name: 'dashboardSave',
             position: 30,
             text: <Message msgId="save"/>,
-            icon: <Glyphicon glyph="floppy-open"/>,
+            icon: <Glyphicon glyph="floppy-disk"/>,
             action: triggerSave.bind(null, true),
             tooltip: "saveDialog.saveTooltip",
             // display the BurgerMenu button only if the map can be edited


### PR DESCRIPTION
## Description
To distinguish it from 'dashboardSaveAs', 'dashboardSave' should have floppy-disk glyph and 'dashboardSaveAs' has floppy-open
This is analogous to save and saveAs for maps.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?**
both dashboardSave and dashboardSaveAs have floppy-open glyph 

**What is the new behavior?**
'dashboardSave' has floppy-disk and 'dashboardSaveAs' has floppy-open glyphs.
This is just like for maps where 'save' has floppy-disk and 'saveAs' has floppy-open glyphs

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
