### PR TITLE
[Backport 2024.02.xx] #10503 - Home and Login Plugins do not appear on the page if the Burger Menu is activated in the context in 2024.01.01 version #10503 #10590

### DIFF
--- a/web/client/plugins/Home.jsx
+++ b/web/client/plugins/Home.jsx
@@ -44,6 +44,20 @@ const HomeConnected = connect((state) => ({
  * It can be rendered in {@link #plugins.OmniBar|OmniBar}.
  * Supports as containers at lower priority {@link #plugins.Toolbar|Toolbar}.
  * You can configure the home target path globally by setting `miscSettings.homePath` in `localConfig.json`. By default it redirects to `"#/"`;
+ *
+ * If you want to show this plugin with BurgerMenu (so without Sidebar), apply the following configuration:
+ *
+ * ```javascript
+ * {
+ *     "cfg": {},
+ *     "override": {
+ *         "OmniBar": {
+ *             "priority": 5
+ *         }
+ *     }
+ * }
+ * ```
+ *
  * @name Home
  * @class
  * @memberof plugins

--- a/web/client/plugins/Login.jsx
+++ b/web/client/plugins/Login.jsx
@@ -37,6 +37,20 @@ import { isAdminUserSelector } from '../selectors/security';
   * }
   * ```
   * By default, if not set, it will use classic `{"type": "basic", "provider": "geostore"}` setup for GeoStore.
+ *
+ * If you want to show this plugin with BurgerMenu (so without Sidebar), apply the following configuration:
+ *
+ * ```javascript
+ * {
+ *     "cfg": {},
+ *     "override": {
+ *         "OmniBar": {
+ *             "priority": 5
+ *         }
+ *     }
+ * }
+ * ```
+ *
   * @class Login
   * @memberof plugins
   * @static


### PR DESCRIPTION
fixes #10503 -  Home and Login Plugins do not appear on the page if the Burger Menu is activated in the context in 2024.01.01 version #10503