### PR TITLE
[Backport 2024.02.xx] Fix #10448 Map plugin should not initizialize invalid maps (#10449)

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -251,9 +251,8 @@ class MapPlugin extends React.Component {
         onMapTypeLoaded: () => {},
         pluginsCreator
     };
-    state = {
-        canRender: true
-    };
+
+    state = {};
 
     UNSAFE_componentWillMount() {
         // moved the font load of FontAwesome only to styleParseUtils (#9653)
@@ -378,7 +377,7 @@ class MapPlugin extends React.Component {
     };
 
     render() {
-        if (this.props.map && this.state.canRender && this.state.plugins) {
+        if (this.isValidMapConfiguration(this.props.map) && this.state.plugins) {
             const {mapOptions = {}} = this.props.map;
 
             return (
@@ -440,6 +439,15 @@ class MapPlugin extends React.Component {
             }
         });
     };
+    isValidMapConfiguration = (map) => {
+        // when the center is included inside the map config
+        // we know that the configuration has been loaded
+        // we should prevent to mount the map component
+        // in case we have a configuration like this one: { eventListeners: {}, mousePointer: '' }
+        // if we allow invalid configuration default props will be used instead
+        // initializing the map in the wrong position
+        return !!map?.center;
+    }
 }
 
 export default createPlugin('Map', {

--- a/web/client/plugins/__tests__/Map-test.jsx
+++ b/web/client/plugins/__tests__/Map-test.jsx
@@ -113,4 +113,31 @@ describe('Map Plugin', () => {
             })
             .catch(done);
     });
+    it('should not mount the map if the configuration is not valid', (done) => {
+        const { Plugin } = getPluginForTest(MapPlugin, { map: { eventListeners: {} } });
+        ReactDOM.render(<Plugin
+            onLoadingMapPlugins={(loading) => {
+                if (!loading) {
+                    expect(document.querySelector('.mapLoadingMessage')).toBeTruthy();
+                    done();
+                }
+            }}
+            pluginsCreator={() => Promise.resolve({
+                Map: ({ children }) => <div className="map">{children}</div>,
+                Layer: ({ options }) => <div id={options.id} className="layers">{options.type}</div>,
+                Feature: () => null,
+                tools: {
+                    overview: () => null,
+                    scalebar: () => null,
+                    draw: () => null,
+                    highlight: () => null,
+                    selection: () => null,
+                    popup: () => null,
+                    box: () => null
+                },
+                mapType: 'openlayers'
+            })}
+            on
+        />, document.getElementById("container"));
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR includes following fixes:
- add a validation check for map configuration in Map plugin
- remove canRender internal state from the Map plugins because it's not used anymore, it was introduced for font loading

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10448

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Map plugin components mount only when a valid configuration is provided

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
