### PR TITLE
#10648: Issue editing multiple fields in MapStore Attribute Table

### DIFF
--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -235,11 +235,9 @@ const addPagination = (filterObj, pagination) => ({
 const createChangesTransaction = (changes, newFeatures, {insert, update, propertyChange, getPropertyName, transaction})=>
     transaction(
         newFeatures.map(f => insert(f)),
-        Object.keys(changes).map( id =>
-            Object.keys(changes[id]).map(name =>
-                update([propertyChange(getPropertyName(name), changes[id][name]), fidFilter("ogc", id)])
-            )
-        )
+        Object.keys(changes).map( id =>{
+            return update(Object.keys(changes[id]).map(prop => propertyChange(getPropertyName(prop), changes[id][prop])), fidFilter("ogc", id));
+        })
     );
 const createDeleteTransaction = (features, {transaction, deleteFeature}) => transaction(
     features.map(deleteFeature)

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -11,8 +11,7 @@ import {get, head, isEmpty, find, castArray, includes, reduce} from 'lodash';
 import { LOCATION_CHANGE } from 'connected-react-router';
 import axios from '../libs/ajax';
 import bbox from '@turf/bbox';
-import { fidFilter } from '../utils/ogc/Filter/filter';
-import { getDefaultFeatureProjection, getPagesToLoad, gridUpdateToQueryUpdate, updatePages  } from '../utils/FeatureGridUtils';
+import { createChangesTransaction, getDefaultFeatureProjection, getPagesToLoad, gridUpdateToQueryUpdate, updatePages  } from '../utils/FeatureGridUtils';
 
 import assign from 'object-assign';
 import {
@@ -232,13 +231,6 @@ const addPagination = (filterObj, pagination) => ({
     pagination
 });
 
-const createChangesTransaction = (changes, newFeatures, {insert, update, propertyChange, getPropertyName, transaction})=>
-    transaction(
-        newFeatures.map(f => insert(f)),
-        Object.keys(changes).map( id =>{
-            return update(Object.keys(changes[id]).map(prop => propertyChange(getPropertyName(prop), changes[id][prop])), fidFilter("ogc", id));
-        })
-    );
 const createDeleteTransaction = (features, {transaction, deleteFeature}) => transaction(
     features.map(deleteFeature)
 );

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -18,6 +18,7 @@ import {
 } from './ogc/WFS/base';
 
 import { applyDefaultToLocalizedString } from '../components/I18N/LocalizedString';
+import { fidFilter } from './ogc/Filter/filter';
 
 const getGeometryName = (describe) => get(findGeometryProperty(describe), "name");
 const getPropertyName = (name, describe) => name === "geometry" ? getGeometryName(describe) : name;
@@ -392,3 +393,17 @@ export const supportsFeatureEditing = (layer) => includes(supportedEditLayerType
  * @returns {boolean} flag
  */
 export const areLayerFeaturesEditable = (layer) =>  !layer?.disableFeaturesEditing && supportsFeatureEditing(layer);
+/**
+ * Create wfs-t xml payload for insert/edit/delete features in featuregrid
+ * @param {array} changes array of update/delete objects
+ * @param {array} newFeatures array of new inserted features
+ * @param {object} wfsutils object of wfs utils that includes insert/update/propertyChange/getPropertyName/transaction
+ * @returns {string} wfs-transaction xml payload
+ */
+export const createChangesTransaction = (changes, newFeatures, {insert, update, propertyChange, getPropertyName: getPropertyNameFunc, transaction})=>
+    transaction(
+        newFeatures.map(f => insert(f)),
+        Object.keys(changes).map( id =>{
+            return update(Object.keys(changes[id]).map(prop => propertyChange(getPropertyNameFunc(prop), changes[id][prop])), fidFilter("ogc", id));
+        })
+    );

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -394,9 +394,9 @@ export const supportsFeatureEditing = (layer) => includes(supportedEditLayerType
  */
 export const areLayerFeaturesEditable = (layer) =>  !layer?.disableFeaturesEditing && supportsFeatureEditing(layer);
 /**
- * Create wfs-t xml payload for insert/edit/delete features in featuregrid
- * @param {array} changes array of update/delete objects
- * @param {array} newFeatures array of new inserted features
+ * Create wfs-t xml payload for insert/edit features in featuregrid
+ * @param {object} changes object that contains updates e.g: {LAYER_NAME.id: {"FIELD1": 55, "FIELD2":"edit 02"}}
+ * @param {object[]} newFeatures array of new inserted features
  * @param {object} wfsutils object of wfs utils that includes insert/update/propertyChange/getPropertyName/transaction
  * @returns {string} wfs-transaction xml payload
  */


### PR DESCRIPTION
## Description
This PR includes: 
- edit in update wfs-t xml payload in case of multi-edit in each sigle row
- add unit test for 'savePendingFeatureGridChanges'

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10648

**What is the current behavior?**
#10648 

**What is the new behavior?**
The save operation in user makes multi-edits for each feature row data, it saves properly as expected.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
