### PR TITLE
#10663: fix adding decimals in the aeronautical form in searcg by coordinates

### DIFF
--- a/web/client/components/I18N/IntlNumberFormControl.jsx
+++ b/web/client/components/I18N/IntlNumberFormControl.jsx
@@ -128,6 +128,7 @@ class IntlNumberFormControl extends React.Component {
                 }}
                 componentClass={"input"}
                 className="form-control intl-numeric"
+                locale={this.context && this.context.intl && this.context.intl.locale || "en-US"}
             />
         );
     }

--- a/web/client/components/I18N/__tests__/IntlNumberFormatControl-test.jsx
+++ b/web/client/components/I18N/__tests__/IntlNumberFormatControl-test.jsx
@@ -120,7 +120,7 @@ describe('IntlNumberFormControl', () => {
         TestUtils.Simulate.change(element, {target: {value: '12.'}});
         expect(element.value).toBe("12");
         TestUtils.Simulate.change(element, {target: {value: '12.0'}});
-        expect(element.value).toBe("12");
+        expect(element.value).toBe("12.0");
         TestUtils.Simulate.change(element, {target: {value: '12.04'}});
         expect(element.value).toBe("12.04");
         TestUtils.Simulate.change(element, {target: {value: '12.402'}});
@@ -128,9 +128,9 @@ describe('IntlNumberFormControl', () => {
         TestUtils.Simulate.change(element, {target: {value: '-12.04'}});
         expect(element.value).toBe("-12.04");
         TestUtils.Simulate.change(element, {target: {value: '-12.40'}});
-        expect(element.value).toBe("-12.4");
+        expect(element.value).toBe("-12.40");
         TestUtils.Simulate.change(element, {target: {value: '-12.0'}});
-        expect(element.value).toBe("-12");
+        expect(element.value).toBe("-12.0");
     });
     it('check calling passed onkeydown, onkeyup events', () => {
         const intl = {locale: "en-US"};

--- a/web/client/libs/numeric-input/NumericInput.jsx
+++ b/web/client/libs/numeric-input/NumericInput.jsx
@@ -417,7 +417,7 @@ class NumericInput extends Component {
         // incomplete number or number contains decimal symbol [centesimal decimal numbers]
         if ((loose && RE_INCOMPLETE_NUMBER.test(stringValue)) || RE_TRAILING_DECIMAL_ZEROS.test(stringValue)) {
             attrs.input.value = stringValue;
-        } else if ((loose && stringValue && !RE_NUMBER.test(stringValue))) {// Not a number and not empty (loose mode only)
+        } else if (loose && stringValue && !RE_NUMBER.test(stringValue)) {// Not a number and not empty (loose mode only)
             attrs.input.value = stringValue;
         } else if (state.value || state.value === 0) { // number
             attrs.input.value = this._format(state.value);

--- a/web/client/libs/numeric-input/NumericInput.jsx
+++ b/web/client/libs/numeric-input/NumericInput.jsx
@@ -414,10 +414,10 @@ class NumericInput extends Component {
         const escapedDecimalSymbol = decimalSymbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         const RE_TRAILING_DECIMAL_ZEROS = new RegExp(`\\d+${escapedDecimalSymbol}\\d*0+`);
 
-        // incomplete number
-        if (loose && RE_INCOMPLETE_NUMBER.test(stringValue)) {
+        // incomplete number or number contains decimal symbol [centesimal decimal numbers]
+        if ((loose && RE_INCOMPLETE_NUMBER.test(stringValue)) || RE_TRAILING_DECIMAL_ZEROS.test(stringValue)) {
             attrs.input.value = stringValue;
-        } else if ((loose && stringValue && !RE_NUMBER.test(stringValue)) || RE_TRAILING_DECIMAL_ZEROS.test(stringValue)) {// Not a number and not empty (loose mode only) || if number contains decimal symbol [centesimal decimal numbers]
+        } else if ((loose && stringValue && !RE_NUMBER.test(stringValue))) {// Not a number and not empty (loose mode only)
             attrs.input.value = stringValue;
         } else if (state.value || state.value === 0) { // number
             attrs.input.value = this._format(state.value);

--- a/web/client/libs/numeric-input/NumericInput.jsx
+++ b/web/client/libs/numeric-input/NumericInput.jsx
@@ -96,6 +96,7 @@ class NumericInput extends Component {
         defaultValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         strict: PropTypes.bool,
         componentClass: PropTypes.string,
+        locale: PropTypes.string,
         // eslint-disable-next-line consistent-return
         mobile(props, propName) {
             let prop = props[propName];
@@ -406,11 +407,16 @@ class NumericInput extends Component {
         );
 
         let loose = !this._isStrict && (this._inputFocus || !this._isMounted);
+        const numFormat = new Intl.NumberFormat(this.props.locale || "en-US");
+        const parts = numFormat.formatToParts(12345.6);
+        const decimalSymbol = parts.find(d => d.type === "decimal").value;
+        const escapedDecimalSymbol = decimalSymbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const RE_TRAILING_DECIMAL_ZEROS = new RegExp(`\\d+${escapedDecimalSymbol}\\d*0+`);
 
         // incomplete number
         if (loose && RE_INCOMPLETE_NUMBER.test(stringValue)) {
             attrs.input.value = stringValue;
-        } else if (loose && stringValue && !RE_NUMBER.test(stringValue)) {// Not a number and not empty (loose mode only)
+        } else if ((loose && stringValue && !RE_NUMBER.test(stringValue)) || RE_TRAILING_DECIMAL_ZEROS.test(stringValue)) {// Not a number and not empty (loose mode only)
             attrs.input.value = stringValue;
         } else if (state.value || state.value === 0) { // number
             attrs.input.value = this._format(state.value);

--- a/web/client/libs/numeric-input/NumericInput.jsx
+++ b/web/client/libs/numeric-input/NumericInput.jsx
@@ -407,6 +407,7 @@ class NumericInput extends Component {
         );
 
         let loose = !this._isStrict && (this._inputFocus || !this._isMounted);
+        // create regex for numbers that contains centesimal decimal numbers
         const numFormat = new Intl.NumberFormat(this.props.locale || "en-US");
         const parts = numFormat.formatToParts(12345.6);
         const decimalSymbol = parts.find(d => d.type === "decimal").value;
@@ -416,7 +417,7 @@ class NumericInput extends Component {
         // incomplete number
         if (loose && RE_INCOMPLETE_NUMBER.test(stringValue)) {
             attrs.input.value = stringValue;
-        } else if ((loose && stringValue && !RE_NUMBER.test(stringValue)) || RE_TRAILING_DECIMAL_ZEROS.test(stringValue)) {// Not a number and not empty (loose mode only)
+        } else if ((loose && stringValue && !RE_NUMBER.test(stringValue)) || RE_TRAILING_DECIMAL_ZEROS.test(stringValue)) {// Not a number and not empty (loose mode only) || if number contains decimal symbol [centesimal decimal numbers]
             attrs.input.value = stringValue;
         } else if (state.value || state.value === 0) { // number
             attrs.input.value = this._format(state.value);


### PR DESCRIPTION
## Description
This PR handles fixing the issue of prevent enters centesimal number after the comma/dot for 
- aeronautical form and 
- decimal form as well


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10663 

**What is the current behavior?**
#10663 

**What is the new behavior?**
Now user can enter any centesimal numbers after the comma/dot like 0.04 , 15.1236 ...etc

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

