### PR TITLE
Update release steps

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_steps.md
+++ b/.github/ISSUE_TEMPLATE/release_steps.md
@@ -43,6 +43,7 @@ This steps have to be followed always when preparing a new release.
 - [ ] Check `pom.xml` dependencies are all in fixed stable versions ( no `-SNAPSHOT` usage release). If not, You use the action  [`Update dependencies versions`](https://github.com/geosolutions-it/MapStore2/actions/workflows/update_dependencies_versions.yml) to fix them, setting:
     - [ ] the branch to `YYYY.XX.xx`
     - [ ] the of geostore, http_proxy and mapfish-print versions accordingly with the [MapStore release calendar](https://github.com/geosolutions-it/MapStore2/wiki/MapStore-Release-Calendars)
+- [ ] Merge the PR created after the action avove has been finshed
 - [ ] Check that [MapStoreExtension](https://github.com/geosolutions-it/MapStoreExtension) repository is aligned and working. 
 - [ ] Run the [Submodule Update](https://github.com/geosolutions-it/MapStoreExtension/actions/workflows/submodules_update.yml) of [MapStoreExtension](https://github.com/geosolutions-it/MapStoreExtension) to generate the `SampleExtension.zip` to use for testing.
     - [ ] Use workflow from `YYYY.XX.xx` branch
@@ -129,6 +130,9 @@ When the processes are finished, the release is ready to be published on github 
 - [ ] Run the [`Post Release`](https://github.com/geosolutions-it/MapStore2/actions/workflows/post_release.yml) workflow on github with the following parameters:
     - Use workflow from branch `YYYY.XX.xx` (the release branch)
     - Version of Java Packages to restore accordingly with [release calendar](https://github.com/geosolutions-it/MapStore2/wiki/MapStore-Release-Calendars) with `-SNAPSHOT` E.g. `1.7-SNAPSHOT`
+- [ ] Use the action  [`Update dependencies versions`](https://github.com/geosolutions-it/MapStore2/actions/workflows/update_dependencies_versions.yml) to restore the `-SNAPSHOT` version of GeoStore, setting:
+    - [ ] the branch to `YYYY.XX.xx`
+    - [ ] the of geostore, http_proxy and mapfish-print versions accordingly with the [MapStore release calendar](https://github.com/geosolutions-it/MapStore2/wiki/MapStore-Release-Calendars) and use `-SNAPSHOT` version of geostore.
 - [ ] Write to the mailing list about the current release news and the next release major changes
 - [ ] Optional - prepare a PR for updating release procedure, if needed
 - [ ] Close this issue

--- a/.github/ISSUE_TEMPLATE/release_steps.md
+++ b/.github/ISSUE_TEMPLATE/release_steps.md
@@ -31,7 +31,7 @@ This steps have to be followed always when preparing a new release.
     - A Pull request will be created to the master
     - A new branch named `YYYY.XX.xx` with fixed versions
 - [ ] Merge the incoming PR created by the workflow
-- [ ] Create on [ReadTheDocs](https://readthedocs.org/projects/mapstore/) project the version build for `YYYY.XX.xx` (click on "Versions" and activate the version of the branch)
+- [ ] Create on [ReadTheDocs](https://app.readthedocs.org/projects/mapstore/) project the version build for `YYYY.XX.xx` (click on "Versions" and activate the version of the branch)
 - [ ] Run the [`Cut Release Branch`](https://github.com/geosolutions-it/MapStoreExtension/actions/workflows/cut_release_branch.yml) workflow on MapStoreExtension project, indicating:
     - [ ] Use workflow from branch `master`
     - [ ] MapStore branch name to use: `YYYY.XX.xx`
@@ -122,8 +122,8 @@ When the processes are finished, the release is ready to be published on github 
 
 ## Update ReadTheDocs
 
-- [ ] create on [ReadTheDocs](https://readthedocs.org/projects/mapstore/) project the version build for `vYYYY.XX.mm` (click on "Versions" and activate the version of the tag, created when release was published)
-- [ ] Update `Default version` to point the release version in the `Advanced Settings` menu of the [ReadTheDocs](https://readthedocs.org/dashboard/mapstore/advanced/) admin panel
+- [ ] create on [ReadTheDocs](https://app.readthedocs.org/dashboard/mapstore/version/create/) project the version build for `vYYYY.XX.mm` (search for the tag, check the `active` toggle and click on update verson )
+- [ ] Update `Default version` to point the new tag (`vYYYY.XX.mm`) in read the [ReadTheDocs Settings](https://app.readthedocs.org/dashboard/mapstore/edit/)  panel and click on save.
 
 ## Finalize Release
 


### PR DESCRIPTION
## Description

This PR improve the release procedure to: 
- explicitly ask to merge the update release
- add a point to restore the snapshot version of GeoStore.
- Updated links to readthedocs, that now has a new dashboard and the old links will be dismissed in early 2025

This list have to be improved a little bit, so it is in draft

Note:

There are 2 ways of keeping mapstore and geostore aligned:
1.release geostore more frequently and before the mapstore release, changing the fixed version when ready
2- using the -SNAPSHOT version on release branch, until we effectively use it.

- Solution 1 makes things more stable, but need alignments and the geostore versions in the middle will not be tested
- Solution 2 is more unstable, but guarantees a continuous testing until the release.

For this reason we are going to choose the 2nd strategy.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10645 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
