### PR TITLE
Returning wrong pixel xy value on mousemove for leaflet engine

### DIFF
--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -488,7 +488,7 @@ class LeafletMap extends React.Component {
             crs: "EPSG:4326",
             pixel: {
                 x: event.containerPoint.x,
-                y: event.containerPoint.x
+                y: event.containerPoint.y
             },
             latlng: {
                 lat: event.latlng.lat,


### PR DESCRIPTION
## Description
<!--On mouse move over map using leaflet engine, it returns wrong pixel xy value.  It always return x value for x and y. -->
**On mouse move over map using leaflet engine, it returns wrong pixel xy value.  It always return x value for x and y.**

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- On mouse move on map using leaflet engine, return x pixel value for both x and y pixel value. -->
**On mouse move on map using leaflet engine, return x pixel value for both x and y pixel value. **
#<issue>

**What is the new behavior?**
<!--After this fix, on mouse move over map return correct xy pixel value for leaflet engine-->
**After this fix, on mouse move over map return correct xy pixel value for leaflet engine**
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
