### PR TITLE
Layer selectable even if the group it belongs to is turned off #10632

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ web/docs
 debug.log
 .vscode/settings.json
 site
+.DS_Store

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -146,6 +146,42 @@ describe('identify Epics', () => {
         }, state);
     });
 
+    it('getFeatureInfoOnFeatureInfoClick, no queryable if layer is visible but it"s group is invisible', (done)=>{
+        // remove previous hook
+        registerHook('RESOLUTION_HOOK', undefined);
+        const state = {
+            map: TEST_MAP_STATE,
+            mapInfo: {
+                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } }
+            },
+            layers: {
+                flat: [{
+                    id: "TEST",
+                    name: "TEST",
+                    "title": "TITLE",
+                    type: "wfs",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json',
+                    group: "TEST_GROUP"
+                }],
+                groups: [
+                    {
+                        id: "TEST_GROUP",
+                        title: "TEST_GROUP",
+                        visibility: false
+                    }
+                ]
+            }
+        };
+        const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } })];
+        testEpic(getFeatureInfoOnFeatureInfoClick, 2, sentActions, ([a0, a1]) => {
+            expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
+            expect(a1.type).toBe(NO_QUERYABLE_LAYERS);
+            done();
+        }, state);
+
+    });
+
     it('getFeatureInfoOnFeatureInfoClick WMS', (done) => {
         // remove previous hook
         registerHook('RESOLUTION_HOOK', undefined);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

[#10632](https://github.com/geosolutions-it/MapStore2/issues/10632)

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
The identify panel still shows results (even if the layer's group is not visible)

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Layers within invisible group will not show on identify on mapclick.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Also, Added .DS_Store to .gitignore to prevent macOS metadata files 
