### PR TITLE
Update tomcat base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9-jdk11-openjdk AS mother
+FROM tomcat:9-jdk11 AS mother
 LABEL maintainer="Alessandro Parma<alessandro.parma@geosolutionsgroup.com>"
 ARG MAPSTORE_WEBAPP_SRC="https://github.com/geosolutions-it/MapStore2/releases/latest/download/mapstore.war"
 ADD "${MAPSTORE_WEBAPP_SRC}" "/mapstore/"
@@ -6,7 +6,7 @@ ADD "${MAPSTORE_WEBAPP_SRC}" "/mapstore/"
 COPY ./docker/* /mapstore/docker/
 WORKDIR /mapstore
 
-FROM tomcat:9-jdk11-openjdk
+FROM tomcat:9-jdk11
 
 # Tomcat specific options
 ENV CATALINA_BASE "$CATALINA_HOME"


### PR DESCRIPTION
Solve many security warning on external components. Fixes #10476

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Build related changes

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10476

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Old base image was de facto based on Debian 11.4 from two years ago, and isn't maintained any more
Suggested base image is up to date based on Ubuntu 24.04 (LTS)
