### PR TITLE
Counter widget sends double requests, the first one has viewport as undefined #10674

### DIFF
--- a/web/client/components/widgets/enhancers/wpsCounter.js
+++ b/web/client/components/widgets/enhancers/wpsCounter.js
@@ -21,6 +21,7 @@ const sameOptions = (o1 = {}, o2 = {}) =>
     && o1.aggregationAttribute === o2.aggregationAttribute
     && o1.viewParams === o2.viewParams;
 import { getWpsUrl } from '../../../utils/LayersUtils';
+import { validXMLFilter } from '../../../utils/XMLUtils';
 
 /**
  * Stream of props -> props to retrieve data from WPS aggregate process on params changes.
@@ -30,7 +31,7 @@ import { getWpsUrl } from '../../../utils/LayersUtils';
  */
 const dataStreamFactory = ($props) =>
     $props
-        .filter(({layer = {}, options}) => layer.name && getWpsUrl(layer) && options && options.aggregateFunction && options.aggregationAttribute)
+        .filter(({layer = {}, options, filter}) => layer.name && getWpsUrl(layer) && options && options.aggregateFunction && options.aggregationAttribute && validXMLFilter(filter))
         .distinctUntilChanged(
             ({layer = {}, options = {}, filter}, newProps) =>
                 (newProps.layer && layer.name === newProps.layer.name && layer.loadingError === newProps.layer.loadingError)

--- a/web/client/utils/XMLUtils.js
+++ b/web/client/utils/XMLUtils.js
@@ -166,3 +166,33 @@ export const objectToAttributes = (obj = {}, xmlns) => keys(obj).filter(key => o
 }));
 
 export const assignNamespace = (nodes, xmlns) => nodes.filter(node => !!node).map(node => ({...node, xmlns}));
+
+
+/**
+ * Checks if any <ogc:And> element in the XML string contains the text "undefined".
+ *
+ * @param {string} xmlString - The XML string to check.
+ * @returns {boolean} - Returns `false` if any <ogc:And> contains "undefined", otherwise `true`.
+ *
+ * @example
+ * validFilter('<ogc:Filter><ogc:And>undefined</ogc:And></ogc:Filter>'); // false
+ * validFilter('<ogc:Filter><ogc:And>valid</ogc:And></ogc:Filter>');    // true
+ */
+export function validXMLFilter(xmlString) {
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(xmlString, "application/xml");
+
+    // Find all <ogc:And> elements (you can have multiple <ogc:And> elements)
+    const andElements = xmlDoc.getElementsByTagName("ogc:And");
+
+    // Iterate through the <ogc:And> elements and check for "undefined"
+    for (let i = 0; i < andElements.length; i++) {
+        const andElement = andElements[i];
+
+        // If we find an <ogc:And> element with text "undefined", return false
+        if (andElement.textContent === "undefined") {
+            return false;
+        }
+    }
+    return true;
+}

--- a/web/client/utils/__tests__/XMLUtils-test.js
+++ b/web/client/utils/__tests__/XMLUtils-test.js
@@ -14,7 +14,8 @@ import {
     escapeText,
     escapeAttributeValue,
     removeEmptyNodes,
-    writeXML
+    writeXML,
+    validXMLFilter
 } from '../XMLUtils';
 
 const namespaces = {
@@ -154,5 +155,12 @@ describe('XMLUtils tests', () => {
   <SimpleElement/>
 </Root>`;
         expect(writeXML(removeEmptyNodes(tree), values(namespaces))).toBe(xml);
+    });
+
+    it('Check valid XML filter', () => {
+        const xmlFilter = '<ogc:Filter><ogc:And>filters></ogc:And></ogc:Filter>';
+        expect(validXMLFilter(xmlFilter)).toBe(true);
+        const invalidXMLFilter = '<ogc:Filter><ogc:And>undefined</ogc:And></ogc:Filter>';
+        expect(validXMLFilter(invalidXMLFilter)).toBe(false);
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

#10674

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10674 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
API call disabled when  called without polygon, specifically filter XML text with **undefined**  value

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
