### PR TITLE
[Backport 2024.02.xx]- widgets in map wrongly align with a specific config #10676 #10681

### DIFF
--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -144,7 +144,7 @@ compose(
             } : {};
             const widthOptions = width ? {width: viewWidth - 1} : {};
             const baseHeight = isSingleWidgetLayout
-                ? rowHeight || rowHeightRecalculated
+                ? rowHeightRecalculated
                 : Math.floor((height - 100) / (rowHeightRecalculated + 10)) * (rowHeightRecalculated + 10);
             return ({
                 rowHeight: isSingleWidgetLayout ? rowHeightRecalculated : rowHeight || rowHeightRecalculated,


### PR DESCRIPTION
fixes #10676 - widgets in map wrongly align with a specific config