### PR TITLE
backport 2024.02.xx - Fix #10615 removed eval from marker utils (#10616)

### DIFF
--- a/web/client/utils/MarkerUtils.js
+++ b/web/client/utils/MarkerUtils.js
@@ -27,7 +27,7 @@ const loadGlyphs = (font) => {
     return Object.keys(fontJSON).reduce((acc, key) => {
         return {
             ...acc,
-            [key]: eval("'\\u" + fontJSON[key] + "'") // eslint-disable-line
+            [key]: String.fromCharCode(parseInt(fontJSON[key], 16))
         };
     }, {});
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport 2024.02.xx - Fix #10615 removed eval from marker utils (#10616)