### PR TITLE
feat(Cesium): Add configuration to optionally disable surface collision detection.

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -192,6 +192,9 @@ class CesiumMap extends React.Component {
             }
         }
 
+        // Allow camera to clip through surface for viewing underground objects.
+        map.scene.screenSpaceCameraController.enableCollisionDetection = this.props.mapOptions?.enableCollisionDetection ?? true;
+
         this.forceUpdate();
         map.scene.requestRender();
     }

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -40,6 +40,7 @@
           "showGroundAtmosphere": false,
           "enableFog": false,
           "depthTestAgainstTerrain": false,
+          "enableCollisionDetection": true,
           "terrainProvider": {
               "type": "ellipsoid"
           }


### PR DESCRIPTION
## Description
Cesium offers multiple settings for view behavior. One is to allow zooming below surface. It's needed to view elements under the map itself.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) -> Single line of code change
- [ ] Docs have been added / updated (for bug fixes / features) -> New setting is reflected inside localConfig.json and documented in code.


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
Zoom on a 3D map can't go below surface. Disabling the collision would require changing the cesium/Map.jsx module fully.

**What is the new behavior?**
This PR adds an optional flag to disable collision which can be set by customers via localConfig.json setting.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No -> Introducing an optional setting which uses default Cesium value when not set.

## Other useful information
* CesiumJS' official documentation about [_enableCollisionDetection_](https://cesium.com/learn/cesiumjs/ref-doc/ScreenSpaceCameraController.html#enableCollisionDetection)