### PR TITLE
Fix #10695 Handle empty values for and/or/not/nor filters

### DIFF
--- a/web/client/utils/ogc/Filter/FilterBuilder.js
+++ b/web/client/utils/ogc/Filter/FilterBuilder.js
@@ -135,6 +135,7 @@ module.exports = function({filterNS = "ogc", gmlVersion, wfsVersion = "1.1.0"} =
         and: logical.and.bind(null, filterNS),
         or: logical.or.bind(null, filterNS),
         not: logical.not.bind(null, filterNS),
+        nor: logical.nor.bind(null, filterNS),
         func: func.bind(null, filterNS),
         literal: getValue,
         // note: use valueReference method for filters and SortBy conditions. PropertyName is used in WFS 2.0 only for listing required attributes, while the rest uses ValueReference.

--- a/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
@@ -66,7 +66,6 @@ describe('FilterBuilder', () => {
         expect(
             b.or([b.property("GEOMETRY").intersects(testGeom1), b.property("GEOMETRY").intersects(testGeom2)])
         ).toBe(`<ogc:Or>${intersectsElem1}${intersectsElem2}</ogc:Or>`);
-
         // not
         expect(
             b.not(b.property("GEOMETRY").intersects(testGeom1))
@@ -79,6 +78,20 @@ describe('FilterBuilder', () => {
         )).toBe(`<ogc:Or><ogc:And>${intersectsElem1}<ogc:Not>${intersectsElem2}</ogc:Not></ogc:And>`
             + `<ogc:And>${intersectsElem2}<ogc:Not>${intersectsElem1}</ogc:Not></ogc:And>`
             + `</ogc:Or>`);
+        // empty array returns empty filter instead of <And>undefined</And>
+        // to check if is better to return an empty filter like <ogc:And></ogc:And> or <ogc:Or/>
+        expect(
+            b.and()
+        ).toBe("");
+        expect(
+            b.or()
+        ).toBe("");
+        expect(
+            b.not()
+        ).toBe("");
+        expect(
+            b.nor()
+        ).toBe("");
     });
 
     it('valueReference 1.1.0', () => {

--- a/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
@@ -80,18 +80,10 @@ describe('FilterBuilder', () => {
             + `</ogc:Or>`);
         // empty array returns empty filter instead of <And>undefined</And>
         // to check if is better to return an empty filter like <ogc:And></ogc:And> or <ogc:Or/>
-        expect(
-            b.and()
-        ).toBe("");
-        expect(
-            b.or()
-        ).toBe("");
-        expect(
-            b.not()
-        ).toBe("");
-        expect(
-            b.nor()
-        ).toBe("");
+        expect(b.and()).toBe("");
+        expect(b.or()).toBe("");
+        expect(b.not()).toBe("");
+        expect(b.nor()).toBe("");
     });
 
     it('valueReference 1.1.0', () => {

--- a/web/client/utils/ogc/Filter/__tests__/operators-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/operators-test.js
@@ -73,15 +73,9 @@ describe('OGC Operators', () => {
         )).toBe('<ogc:Not><ogc:PropertyIsEqualTo>TEST</ogc:PropertyIsEqualTo></ogc:Not>');
     });
     it('logical functions with empty content', () => {
-        expect(logical.and("ogc"
-
-        )).toBe('');
-        expect(logical.or("ogc"
-
-        )).toBe('');
-        expect(logical.not("ogc"
-
-        )).toBe('');
+        expect(logical.and("ogc")).toBe('');
+        expect(logical.or("ogc")).toBe('');
+        expect(logical.not("ogc")).toBe('');
     });
     it('spatial functions', () => {
         expect(spatial.intersects("ogc", propertyName("ogc", "GEOMETRY"), "TEST")).toBe("<ogc:Intersects><ogc:PropertyName>GEOMETRY</ogc:PropertyName>TEST</ogc:Intersects>");

--- a/web/client/utils/ogc/Filter/__tests__/operators-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/operators-test.js
@@ -72,6 +72,17 @@ describe('OGC Operators', () => {
             ogcComparisonOperators["="]("ogc", "TEST")
         )).toBe('<ogc:Not><ogc:PropertyIsEqualTo>TEST</ogc:PropertyIsEqualTo></ogc:Not>');
     });
+    it('logical functions with empty content', () => {
+        expect(logical.and("ogc"
+
+        )).toBe('');
+        expect(logical.or("ogc"
+
+        )).toBe('');
+        expect(logical.not("ogc"
+
+        )).toBe('');
+    });
     it('spatial functions', () => {
         expect(spatial.intersects("ogc", propertyName("ogc", "GEOMETRY"), "TEST")).toBe("<ogc:Intersects><ogc:PropertyName>GEOMETRY</ogc:PropertyName>TEST</ogc:Intersects>");
         expect(spatial.bbox("ogc", propertyName("ogc", "GEOMETRY"), "TEST")).toBe("<ogc:BBOX><ogc:PropertyName>GEOMETRY</ogc:PropertyName>TEST</ogc:BBOX>");

--- a/web/client/utils/ogc/Filter/operators.js
+++ b/web/client/utils/ogc/Filter/operators.js
@@ -44,7 +44,7 @@ const upper = (ns, value) => `<${ns}:UpperBoundary>${value}</${ns}:UpperBoundary
  * @param {string|Array} content content
  * @returns the operation result
  */
-const multiop = (ns, op, content) => op(ns, Array.isArray(content) ? content.join("") : content );
+const multiop = (ns, op, content) => op(ns, Array.isArray(content) ? content.join("") : content);
 const logical = {
     and: (ns, content, ...other) => other && other.length > 0 ? multiop(ns, ogcLogicalOperators.AND, [content, ...other]) : multiop(ns, ogcLogicalOperators.AND, content),
     or: (ns, content, ...other) => other && other.length > 0 ? multiop(ns, ogcLogicalOperators.OR, [content, ...other]) : multiop(ns, ogcLogicalOperators.OR, content),

--- a/web/client/utils/ogc/Filter/operators.js
+++ b/web/client/utils/ogc/Filter/operators.js
@@ -18,10 +18,10 @@ const ogcComparisonOperators = {
     "isNull": (ns, content) => `<${ns}:PropertyIsNull>${content}</${ns}:PropertyIsNull>`
 };
 const ogcLogicalOperators = {
-    "AND": (ns, content) => `<${ns}:And>${content}</${ns}:And>`,
-    "OR": (ns, content) => `<${ns}:Or>${content}</${ns}:Or>`,
-    "NOR": (ns, content) => `<${ns}:Not><${ns}:Or>${content}</${ns}:Or></${ns}:Not>`,
-    "NOT": (ns, content) => `<${ns}:Not>${content}</${ns}:Not>`
+    "AND": (ns, content) => content ? `<${ns}:And>${content}</${ns}:And>` : "",
+    "OR": (ns, content) => content ? `<${ns}:Or>${content}</${ns}:Or>` : "",
+    "NOR": (ns, content) => content ? `<${ns}:Not><${ns}:Or>${content}</${ns}:Or></${ns}:Not>` : "",
+    "NOT": (ns, content) => content ? `<${ns}:Not>${content}</${ns}:Not>` : ""
 };
 
 const ogcSpatialOperators = {
@@ -44,7 +44,7 @@ const upper = (ns, value) => `<${ns}:UpperBoundary>${value}</${ns}:UpperBoundary
  * @param {string|Array} content content
  * @returns the operation result
  */
-const multiop = (ns, op, content) => op(ns, Array.isArray(content) ? content.join("") : content);
+const multiop = (ns, op, content) => op(ns, Array.isArray(content) ? content.join("") : content );
 const logical = {
     and: (ns, content, ...other) => other && other.length > 0 ? multiop(ns, ogcLogicalOperators.AND, [content, ...other]) : multiop(ns, ogcLogicalOperators.AND, content),
     or: (ns, content, ...other) => other && other.length > 0 ? multiop(ns, ogcLogicalOperators.OR, [content, ...other]) : multiop(ns, ogcLogicalOperators.OR, content),


### PR DESCRIPTION
## Description
This PR avoids the `<ogc:And>undefined</ogc:And>` in OGC filters that happens when having an empty filter.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10695 

**What is the new behavior?**

Fix #10695 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
