### PR TITLE
Fix #10697 parsing of CQL ILIKE filter

### DIFF
--- a/web/client/utils/ogc/Filter/CQL/__tests__/parser-test.js
+++ b/web/client/utils/ogc/Filter/CQL/__tests__/parser-test.js
@@ -60,6 +60,12 @@ const COMPARISON_TESTS = [
             args: [{type: "property", name: "PROP"}, {type: "literal", value: 'a'}],
             type: "like"
         }
+    }, {
+        cql: "PROP ilike 'a'",
+        expected: {
+            args: [{type: "property", name: "PROP"}, {type: "literal", value: 'a'}],
+            type: "ilike"
+        }
     },
     {
         cql: "INCLUDE",

--- a/web/client/utils/ogc/Filter/CQL/parser.js
+++ b/web/client/utils/ogc/Filter/CQL/parser.js
@@ -19,7 +19,7 @@ export const functionOperator = "func";
 export const patterns = {
     INCLUDE: /^INCLUDE$/,
     PROPERTY: /^"?[_a-zA-Z"]\w*"?/,
-    COMPARISON: /^(=|<>|<=|<|>=|>|LIKE)/i,
+    COMPARISON: /^(=|<>|<=|<|>=|>|LIKE|ILIKE)/i,
     IS_NULL: /^IS NULL/i,
     COMMA: /^,/,
     AND: /^(AND)/i,

--- a/web/client/utils/ogc/Filter/__tests__/fromObject-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/fromObject-test.js
@@ -39,6 +39,10 @@ const COMPARISON_TESTS = [
         expected: '<ogc:PropertyIsLike matchCase="true" wildCard="*" singleChar="." escapeChar="!"><ogc:PropertyName>PROP</ogc:PropertyName><ogc:Literal>a</ogc:Literal></ogc:PropertyIsLike>'
     },
     {
+        cql: "PROP ilike 'a'",
+        expected: '<ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!"><ogc:PropertyName>PROP</ogc:PropertyName><ogc:Literal>a</ogc:Literal></ogc:PropertyIsLike>'
+    },
+    {
         cql: "PROP between 1 and 3",
         expected: '<ogc:PropertyIsBetween><ogc:PropertyName>PROP</ogc:PropertyName><ogc:LowerBoundary><ogc:Literal>1</ogc:Literal></ogc:LowerBoundary><ogc:UpperBoundary><ogc:Literal>3</ogc:Literal></ogc:UpperBoundary></ogc:PropertyIsBetween>'
     }


### PR DESCRIPTION
## Description
The internal parser was missingthe ILIKE recognition. 
Added 2 tests that now passes. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10697

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
