### PR TITLE
Fix #10701 enabling failures for wms requests with exception, for ImageWMS sources

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -320,6 +320,37 @@ describe('Openlayers layer', () => {
         expect(layer).toBeTruthy();
         expect(map.getLayers().getLength()).toBe(1);
     });
+    it.only('render wms singleTile layer with error', (done) => {
+        mockAxios.onGet().reply(r => {
+            expect(r.url.indexOf('SAMPLE_URL') >= 0 ).toBeTruthy();
+            return [200, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<ows:ExceptionReport xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+            "  <ows:Exception exceptionCode=\"InvalidParameterValue\" locator=\"srsname\">\n" +
+            "    <ows:ExceptionText>msWFSGetFeature(): WFS server error. Invalid GetFeature Request</ows:ExceptionText>\n" +
+            "  </ows:Exception>\n" +
+            "</ows:ExceptionReport>"];
+        });
+        const options = {
+            type: 'wms',
+            visibility: true,
+            singleTile: true,
+            url: 'SAMPLE_URL',
+            name: 'osm:vector_tile'
+        };
+        const layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={{
+                ...options
+            }}
+            map={map} />, document.getElementById("container"));
+        expect(layer.layer.getSource()).toBeTruthy();
+        layer.layer.getSource().on('imageloaderror', (e)=> {
+            setTimeout(() => {
+                expect(e).toBeTruthy();
+                done();
+            }, 200);
+        });
+    });
     it('creates a tiled wms layer for openlayers map with long url', (done) => {
         let options = {
             "type": "wms",

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -29,7 +29,7 @@ import TileWMS from 'ol/source/TileWMS';
 import VectorTileSource from 'ol/source/VectorTile';
 import VectorTileLayer from 'ol/layer/VectorTile';
 
-import { isVectorFormat } from '../../../../utils/VectorTileUtils';
+import { isVectorFormat, isValidResponse } from '../../../../utils/VectorTileUtils';
 import { OL_VECTOR_FORMATS, applyStyle } from '../../../../utils/openlayers/VectorTileUtils';
 
 import { proxySource, getWMSURLs, wmsToOpenlayersOptions, toOLAttributions, generateTileGrid } from '../../../../utils/openlayers/WMSUtils';
@@ -74,10 +74,14 @@ const loadFunction = (options, headers) => function(image, src) {
                 headers,
                 responseType: 'blob'
             }).then(response => {
-                if (response.status === 200 && response.data) {
+                if (isValidResponse(response)) {
                     image.getImage().src = URL.createObjectURL(response.data);
                 } else {
-                    console.error("Status code: " + response.status);
+                    // #10701 this is needed to trigger the imageloaderror event
+                    // in ol otherwise this event is not triggered if you assign
+                    // the xml content of the exception to the src attribute
+                    image.getImage().src = null;
+                    console.error("error: " + response.data);
                 }
             }).catch(e => {
                 console.error(e);

--- a/web/client/utils/VectorTileUtils.js
+++ b/web/client/utils/VectorTileUtils.js
@@ -13,3 +13,7 @@ export const VECTOR_FORMATS = [
 ];
 
 export const isVectorFormat = (format) => VECTOR_FORMATS.indexOf(format) !== -1;
+
+export const isValidResponse = (response) => {
+    return response?.status === 200 && response?.data && response?.data?.type !== "text/xml";
+};

--- a/web/client/utils/__tests__/VectorTileUtils-test.js
+++ b/web/client/utils/__tests__/VectorTileUtils-test.js
@@ -7,7 +7,10 @@
  */
 
 import expect from 'expect';
-import { isVectorFormat } from '../VectorTileUtils';
+import {
+    isValidResponse,
+    isVectorFormat
+} from '../VectorTileUtils';
 
 describe('VectorTileUtils', () => {
     it('test isVectorFormat with vector formats', () => {
@@ -32,5 +35,13 @@ describe('VectorTileUtils', () => {
 
         const GIF = 'image/gif';
         expect(isVectorFormat(GIF)).toBe(false);
+    });
+    it('test isValidResponse', () => {
+        // invalid responses
+        expect(isValidResponse({data: {type: "text/xml"}})).toBeFalsy();
+        expect(isValidResponse({data: {type: "blob"}})).toBeFalsy();
+        expect(isValidResponse({data: {type: "blob"}, status: 401})).toBeFalsy();
+        // valid responses
+        expect(isValidResponse({data: {type: "blob"}, status: 200})).toBeTruthy();
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Fix #10701 enabling failures for wms requests with exception, for ImageWMS sources

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10701

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

now it correctly triggers layerLoadError

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
