### PR TITLE
[Backport 2024.02.xx] Fix #10695 Handle empty values for and/or/not/nor filters (#10696)

### DIFF
--- a/web/client/utils/ogc/Filter/FilterBuilder.js
+++ b/web/client/utils/ogc/Filter/FilterBuilder.js
@@ -135,6 +135,7 @@ module.exports = function({filterNS = "ogc", gmlVersion, wfsVersion = "1.1.0"} =
         and: logical.and.bind(null, filterNS),
         or: logical.or.bind(null, filterNS),
         not: logical.not.bind(null, filterNS),
+        nor: logical.nor.bind(null, filterNS),
         func: func.bind(null, filterNS),
         literal: getValue,
         // note: use valueReference method for filters and SortBy conditions. PropertyName is used in WFS 2.0 only for listing required attributes, while the rest uses ValueReference.

--- a/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
@@ -66,7 +66,6 @@ describe('FilterBuilder', () => {
         expect(
             b.or([b.property("GEOMETRY").intersects(testGeom1), b.property("GEOMETRY").intersects(testGeom2)])
         ).toBe(`<ogc:Or>${intersectsElem1}${intersectsElem2}</ogc:Or>`);
-
         // not
         expect(
             b.not(b.property("GEOMETRY").intersects(testGeom1))
@@ -79,6 +78,12 @@ describe('FilterBuilder', () => {
         )).toBe(`<ogc:Or><ogc:And>${intersectsElem1}<ogc:Not>${intersectsElem2}</ogc:Not></ogc:And>`
             + `<ogc:And>${intersectsElem2}<ogc:Not>${intersectsElem1}</ogc:Not></ogc:And>`
             + `</ogc:Or>`);
+        // empty array returns empty filter instead of <And>undefined</And>
+        // to check if is better to return an empty filter like <ogc:And></ogc:And> or <ogc:Or/>
+        expect(b.and()).toBe("");
+        expect(b.or()).toBe("");
+        expect(b.not()).toBe("");
+        expect(b.nor()).toBe("");
     });
 
     it('valueReference 1.1.0', () => {

--- a/web/client/utils/ogc/Filter/__tests__/operators-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/operators-test.js
@@ -72,6 +72,11 @@ describe('OGC Operators', () => {
             ogcComparisonOperators["="]("ogc", "TEST")
         )).toBe('<ogc:Not><ogc:PropertyIsEqualTo>TEST</ogc:PropertyIsEqualTo></ogc:Not>');
     });
+    it('logical functions with empty content', () => {
+        expect(logical.and("ogc")).toBe('');
+        expect(logical.or("ogc")).toBe('');
+        expect(logical.not("ogc")).toBe('');
+    });
     it('spatial functions', () => {
         expect(spatial.intersects("ogc", propertyName("ogc", "GEOMETRY"), "TEST")).toBe("<ogc:Intersects><ogc:PropertyName>GEOMETRY</ogc:PropertyName>TEST</ogc:Intersects>");
         expect(spatial.bbox("ogc", propertyName("ogc", "GEOMETRY"), "TEST")).toBe("<ogc:BBOX><ogc:PropertyName>GEOMETRY</ogc:PropertyName>TEST</ogc:BBOX>");

--- a/web/client/utils/ogc/Filter/operators.js
+++ b/web/client/utils/ogc/Filter/operators.js
@@ -18,10 +18,10 @@ const ogcComparisonOperators = {
     "isNull": (ns, content) => `<${ns}:PropertyIsNull>${content}</${ns}:PropertyIsNull>`
 };
 const ogcLogicalOperators = {
-    "AND": (ns, content) => `<${ns}:And>${content}</${ns}:And>`,
-    "OR": (ns, content) => `<${ns}:Or>${content}</${ns}:Or>`,
-    "NOR": (ns, content) => `<${ns}:Not><${ns}:Or>${content}</${ns}:Or></${ns}:Not>`,
-    "NOT": (ns, content) => `<${ns}:Not>${content}</${ns}:Not>`
+    "AND": (ns, content) => content ? `<${ns}:And>${content}</${ns}:And>` : "",
+    "OR": (ns, content) => content ? `<${ns}:Or>${content}</${ns}:Or>` : "",
+    "NOR": (ns, content) => content ? `<${ns}:Not><${ns}:Or>${content}</${ns}:Or></${ns}:Not>` : "",
+    "NOT": (ns, content) => content ? `<${ns}:Not>${content}</${ns}:Not>` : ""
 };
 
 const ogcSpatialOperators = {


### PR DESCRIPTION
[Backport 2024.02.xx] Fix #10695 Handle empty values for and/or/not/nor filters (#10696)