### PR TITLE
Fix #10709 Allow to set the CESIUM_BASE_URL dynamically

### DIFF
--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -166,10 +166,13 @@ module.exports = (...args) => mapArgumentsToObject(args, ({
         }),
         new DefinePlugin({ '__MAPSTORE_PROJECT_CONFIG__': JSON.stringify(projectConfig) }),
         VERSION_INFO_DEFINE_PLUGIN,
-        new DefinePlugin({
-            // Define relative base path in cesium for loading assets
-            'CESIUM_BASE_URL': JSON.stringify(cesiumBaseUrl ? cesiumBaseUrl : path.join('dist', 'cesium'))
-        }),
+        ...(cesiumBaseUrl !== false
+            ? [
+                new DefinePlugin({
+                    // Define relative base path in cesium for loading assets
+                    'CESIUM_BASE_URL': JSON.stringify(cesiumBaseUrl ? cesiumBaseUrl : path.join('dist', 'cesium'))
+                })
+            ] : []),
         new CopyWebpackPlugin([
             { from: path.join(getCesiumPath({ paths, prod }), 'Workers'), to: path.join(paths.dist, 'cesium', 'Workers') },
             { from: path.join(getCesiumPath({ paths, prod }), 'Assets'), to: path.join(paths.dist, 'cesium', 'Assets') },


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR allows to pass false as value for `cesiumBaseUrl` to prevent the DefinePlugin usage.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Build related changes

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10709

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The `cesiumBaseUrl` property of buildConfig allows to pass a false value to prevent the DefinePlugin usage.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
