### PR TITLE
Updated Bar Chart Widget on hover element to display accurate value

### DIFF
--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -278,9 +278,25 @@ const chartDataTypes = {
             }).filter(chart => chart !== null);
         }
         const sortedData = [...data].sort((a, b) => a[xDataKey] > b[xDataKey] ? 1 : -1);
-        const x = sortedData.map(d => d[xDataKey]);
-        const y = sortedData.map(d => d[yDataKey]);
+        
+        //changes that we made **********************************************************************
+        const aggregatedData = sortedData.reduce((acc, item) => {
+            const xValue = item[xDataKey];
+            const yValue = item[yDataKey];
+        
+            if (!acc[xValue])
+                acc[xValue] = 0;
+            acc[xValue] += yValue; // Summing up y-values for each unique x-value
+            return acc;
+        }, {});
+        
+        const x = Object.keys(aggregatedData);
+        const y = Object.values(aggregatedData);
+        // const x = sortedData.map(d => d[xDataKey]);
+        // const y = sortedData.map(d => d[yDataKey]);
+
         const name = traceName || yDataKey;
+        
         return {
             ...style,
             type: 'bar',


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Onhover element for bar charts was displaying wrong value for certain data. Recalculated how data is populated

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ x] Bugfix
 

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

Barnhart on hover element displays wrong Y value sum for certain data

**What is the new behavior?**

recalculated how onhover element is populated so now it is accurate for all data types

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
