### PR TITLE
#10684: Legend filtering for GeoServer WMS layers

### DIFF
--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -6,10 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { clamp, isNil, isNumber } from 'lodash';
-import PropTypes from 'prop-types';
 import React from 'react';
+import clamp from 'lodash/clamp';
+import isNil from 'lodash/isNil';
+import isNumber from 'lodash/isNumber';
+import pick from 'lodash/pick';
+import PropTypes from 'prop-types';
 import {Checkbox, Col, ControlLabel, FormGroup, Glyphicon, Grid, Row, Button as ButtonRB } from 'react-bootstrap';
+
 import tooltip from '../../../misc/enhancers/buttonTooltip';
 const Button = tooltip(ButtonRB);
 import IntlNumberFormControl from '../../../I18N/IntlNumberFormControl';
@@ -26,6 +30,7 @@ import ThreeDTilesSettings from './ThreeDTilesSettings';
 import ModelTransformation from './ModelTransformation';
 import StyleBasedWMSJsonLegend from '../../../../plugins/TOC/components/StyleBasedWMSJsonLegend';
 import { getMiscSetting } from '../../../../utils/ConfigUtils';
+
 export default class extends React.Component {
     static propTypes = {
         opacityText: PropTypes.node,
@@ -38,6 +43,8 @@ export default class extends React.Component {
         isLocalizedLayerStylesEnabled: PropTypes.bool,
         isCesiumActive: PropTypes.bool,
         projection: PropTypes.string,
+        mapSize: PropTypes.object,
+        mapBbox: PropTypes.object,
         resolutions: PropTypes.array,
         zoom: PropTypes.number,
         hideInteractiveLegendOption: PropTypes.bool
@@ -122,6 +129,9 @@ export default class extends React.Component {
         }
         return null;
     };
+    getLegendProps = () => {
+        return pick(this.props, ['projection', 'mapSize', 'mapBbox']);
+    }
     render() {
         const formatValue = this.props.element && this.props.element.format || "image/png";
         const experimentalInteractiveLegend = getMiscSetting('experimentalInteractiveLegend', false);
@@ -324,6 +334,7 @@ export default class extends React.Component {
                                             this.useLegendOptions() && this.state.legendOptions.legendWidth || undefined}
                                         language={
                                             this.props.isLocalizedLayerStylesEnabled ? this.props.currentLocaleLanguage : undefined}
+                                        {...this.getLegendProps()}
                                     /> :
                                     <Legend
                                         style={this.setOverFlow() && {} || undefined}
@@ -334,6 +345,7 @@ export default class extends React.Component {
                                             this.useLegendOptions() && this.state.legendOptions.legendWidth || undefined}
                                         language={
                                             this.props.isLocalizedLayerStylesEnabled ? this.props.currentLocaleLanguage : undefined}
+                                        {...this.getLegendProps()}
                                     />}
                             </div>
                         </Col>

--- a/web/client/components/widgets/builder/wizard/map/TOC.jsx
+++ b/web/client/components/widgets/builder/wizard/map/TOC.jsx
@@ -35,6 +35,9 @@ function WidgetTOC({
                 visualizationMode: map?.visualizationMode,
                 layerOptions: {
                     legendOptions: {
+                        projection: map?.projection,
+                        mapSize: map?.size,
+                        mapBbox: map?.bbox,
                         WMSLegendOptions: 'forceLabels:on',
                         scaleDependent: true,
                         legendWidth: 12,

--- a/web/client/components/widgets/builder/wizard/map/enhancers/nodeEditor.js
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/nodeEditor.js
@@ -80,6 +80,9 @@ export default compose(
                         : 1
             }
         },
+        projection: map.projection,
+        mapSize: map.size,
+        mapBbox: map.bbox,
         groups: get(splitMapAndLayers(map), 'layers.groups')
     })),
     // adapter for handlers

--- a/web/client/components/widgets/enhancers/legendWidget.js
+++ b/web/client/components/widgets/enhancers/legendWidget.js
@@ -7,34 +7,63 @@
  */
 import {compose, withHandlers, withProps} from 'recompose';
 
-import { castArray, get } from 'lodash';
+import { castArray, get, isEmpty, find } from 'lodash';
 import deleteWidget from './deleteWidget';
 import { editableWidget, defaultIcons, withHeaderTools } from './tools';
 import { getScales } from '../../../utils/MapUtils';
 import { WIDGETS_MAPS_REGEX } from "../../../actions/widgets";
 import { getInactiveNode, DEFAULT_GROUP_ID } from '../../../utils/LayersUtils';
+import { composeFilterObject } from './utils';
+import { toCQLFilter } from '../../../utils/FilterUtils';
+import { arrayUpdate } from '../../../utils/ImmutableUtils';
+import { optionsToVendorParams } from '../../../utils/VendorParamsUtils';
 
 /**
  * map dependencies to layers, scales and current zoom level to show legend items for current zoom.
  * Add also base tools and menu to the widget
  */
 export default compose(
-    withProps(({ dependencies = {}, dependenciesMap = {} }) => {
+    withProps(({ dependencies = {}, dependenciesMap = {}, mapSync }) => {
         const allLayers = dependencies[dependenciesMap.layers] || dependencies.layers || [];
         const groups = castArray(dependencies[dependenciesMap.groups] || dependencies.groups || []);
-        const layers = allLayers
+        let layers = allLayers
             // filter backgrounds and inactive layer
             // the inactive layers are the one with a not visible parent group
             .filter((layer = {}) =>
                 layer.group !== 'background' && !getInactiveNode(layer?.group || DEFAULT_GROUP_ID, groups)
             )
             .map(({ group, ...layer }) => layer);
+        const targetLayerName = dependencies && dependencies.layer && dependencies.layer.name;
+        const filterObj = dependencies.filter || {};
+        const layerInCommon = find(layers, {name: targetLayerName}) || {};
+        let filterObjCollection = {};
+        let layersUpdatedWithCql = {};
+        let cqlFilter = undefined;
+
+        if (mapSync && !isEmpty(layerInCommon) && (filterObj.featureTypeName ? filterObj.featureTypeName === targetLayerName : true)) {
+            if (dependencies.quickFilters) {
+                filterObjCollection = {...filterObjCollection, ...composeFilterObject(filterObj, dependencies.quickFilters, dependencies.options)};
+            }
+            cqlFilter = toCQLFilter(filterObjCollection);
+            if (!isEmpty(filterObjCollection) && cqlFilter) {
+                layersUpdatedWithCql = arrayUpdate(false,
+                    {...layerInCommon, params: optionsToVendorParams({ params: {CQL_FILTER: cqlFilter}})},
+                    {name: targetLayerName},
+                    layers
+                );
+            }
+        } else {
+            layersUpdatedWithCql = layers.map(l => ({...l, params: {...l.params, CQL_FILTER: undefined}}));
+        }
+        layers = layersUpdatedWithCql;
         return {
             allLayers,
             map: {
                 layers,
                 // use empty so it creates the default group that will be hidden in the layers tree
-                groups: []
+                groups: [],
+                projection: dependencies.projection,
+                bbox: dependencies.viewport
             },
             dependencyMapPath: dependenciesMap.layers || '',
             scales: getScales(

--- a/web/client/components/widgets/widget/LegendView.jsx
+++ b/web/client/components/widgets/widget/LegendView.jsx
@@ -35,7 +35,12 @@ export default ({
                 scales,
                 zoom: currentZoomLvl,
                 layerOptions: {
-                    legendOptions: legendProps,
+                    legendOptions: {
+                        ...legendProps,
+                        projection: map?.projection,
+                        mapSize: map?.size,
+                        mapBbox: map?.bbox
+                    },
                     hideFilter: true
                 }
             }}

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -605,7 +605,8 @@ export default {
                         this.props.onBeforePrint();
                         this.props.printingService.print({
                             layers: this.getMapConfiguration()?.layers,
-                            scales: this.props.useFixedScales ? getPrintScales(this.props.capabilities) : undefined
+                            scales: this.props.useFixedScales ? getPrintScales(this.props.capabilities) : undefined,
+                            bbox: this.props.map?.bbox
                         })
                             .then((spec) =>
                                 this.props.onPrint(this.props.capabilities.createURL, { ...spec, ...this.props.overrideOptions })

--- a/web/client/plugins/TOC/components/TOC.jsx
+++ b/web/client/plugins/TOC/components/TOC.jsx
@@ -192,7 +192,18 @@ function TOC({
             onSelectNode={onSelectNode}
             onSort={handleOnSort}
             onChange={handleUpdateNode}
-            config={config}
+            config={{
+                ...config,
+                layerOptions: {
+                    ...config?.layerOptions,
+                    legendOptions: {
+                        ...config?.layerOptions?.legendOptions,
+                        mapSize: map?.size,
+                        mapBbox: map?.bbox,
+                        projection: map?.projection
+                    }
+                }
+            }}
             nodeItems={nodeItems}
             nodeToolItems={nodeToolItems}
             singleDefaultGroup={singleDefaultGroup}

--- a/web/client/plugins/TOC/components/WMSLegend.jsx
+++ b/web/client/plugins/TOC/components/WMSLegend.jsx
@@ -9,7 +9,9 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
-import { isEmpty, isNumber } from 'lodash';
+import pick from 'lodash/pick';
+import isEmpty from 'lodash/isEmpty';
+import isNumber from 'lodash/isNumber';
 import StyleBasedWMSJsonLegend from './StyleBasedWMSJsonLegend';
 import Legend from './Legend';
 import { getMiscSetting } from '../../../utils/ConfigUtils';
@@ -40,7 +42,10 @@ class WMSLegend extends React.Component {
         language: PropTypes.string,
         legendWidth: PropTypes.number,
         legendHeight: PropTypes.number,
-        onChange: PropTypes.func
+        onChange: PropTypes.func,
+        projection: PropTypes.string,
+        mapSize: PropTypes.object,
+        mapBbox: PropTypes.object
     };
 
     static defaultProps = {
@@ -63,7 +68,9 @@ class WMSLegend extends React.Component {
         const containerWidth = this.containerRef.current && this.containerRef.current.clientWidth;
         this.setState({ containerWidth, ...this.state });
     }
-
+    getLegendProps = () => {
+        return pick(this.props, ['currentZoomLvl', 'scales', 'scaleDependent', 'language', 'projection', 'mapSize', 'mapBbox']);
+    }
     render() {
         let node = this.props.node || {};
         const experimentalInteractiveLegend = getMiscSetting('experimentalInteractiveLegend', false);
@@ -76,8 +83,6 @@ class WMSLegend extends React.Component {
                     <Legend
                         style={!this.setOverflow() ? this.props.legendStyle : {}}
                         layer={node}
-                        currentZoomLvl={this.props.currentZoomLvl}
-                        scales={this.props.scales}
                         legendHeight={
                             useOptions &&
                             this.props.node.legendOptions &&
@@ -93,8 +98,7 @@ class WMSLegend extends React.Component {
                             undefined
                         }
                         legendOptions={this.props.WMSLegendOptions}
-                        scaleDependent={this.props.scaleDependent}
-                        language={this.props.language}
+                        {...this.getLegendProps()}
                     />
                 </div>
             );
@@ -105,8 +109,6 @@ class WMSLegend extends React.Component {
                     <StyleBasedWMSJsonLegend
                         style={!this.setOverflow() ? this.props.legendStyle : {}}
                         layer={node}
-                        currentZoomLvl={this.props.currentZoomLvl}
-                        scales={this.props.scales}
                         legendHeight={
                             useOptions &&
                             this.props.node.legendOptions &&
@@ -122,9 +124,8 @@ class WMSLegend extends React.Component {
                             undefined
                         }
                         legendOptions={this.props.WMSLegendOptions}
-                        scaleDependent={this.props.scaleDependent}
-                        language={this.props.language}
                         onChange={this.props.onChange}
+                        {...this.getLegendProps()}
                     />
                 </div>
             );

--- a/web/client/plugins/TOC/index.js
+++ b/web/client/plugins/TOC/index.js
@@ -354,6 +354,9 @@ function TOC({
 
     groupOptions = {},
     layerOptions = {},
+    projection,
+    mapSize,
+    mapBbox,
     currentLocale,
     language,
     scales,
@@ -499,7 +502,13 @@ function TOC({
                     groupOptions,
                     layerOptions: {
                         ...layerOptions,
-                        hideLegend: !activateLegendTool
+                        hideLegend: !activateLegendTool,
+                        legendOptions: {
+                            ...layerOptions?.legendOptions,
+                            projection,
+                            mapSize,
+                            mapBbox
+                        }
                     }
                 }}
                 onContextMenu={({ event, node: currentNode, nodeType, parentId }) => {
@@ -599,7 +608,10 @@ const tocSelector = createShallowSelectorCreator(isEqual)(
             map && map.projection || 'EPSG:3857',
             map && map.mapOptions && map.mapOptions.view && map.mapOptions.view.DPI || null
         ),
+        projection: map && map.projection || 'EPSG:3857',
         zoom: map?.zoom,
+        mapSize: map?.size,
+        mapBbox: map?.bbox,
         resolutions,
         resolution,
         visualizationMode,

--- a/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
+++ b/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
@@ -37,7 +37,7 @@ import { StyleSelector } from '../styleeditor/index';
 const StyleList = defaultProps({ readOnly: true })(StyleSelector);
 
 const ConnectedDisplay = connect(
-    createSelector([mapSelector], ({ zoom, projection }) => ({ zoom, projection }))
+    createSelector([mapSelector], ({ zoom, projection, size, bbox }) => ({ zoom, projection, mapSize: size, mapBbox: bbox }))
 )(Display);
 
 const ConnectedVectorStyleEditor = connect(

--- a/web/client/themes/default/less/toc.less
+++ b/web/client/themes/default/less/toc.less
@@ -403,6 +403,14 @@
             margin-right: 8px;
         }
     }
+    .legend-filter-warning {
+        display: flex;
+        align-items: center;
+        margin: 8px 0;
+        .reset-legend-filter {
+            width: 45px;
+        }
+    }
 }
 
 // legend style

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -240,7 +240,11 @@
               "clearCustomizationConfirm": "Möchten Sie wirklich alle Anpassungen entfernen?",
               "error": "Die Felder konnten nicht automatisch geladen werden"
             },
-            "disableFeaturesEditing": "Deaktivieren Sie die Bearbeitung der Attributtabelle"
+            "disableFeaturesEditing": "Deaktivieren Sie die Bearbeitung der Attributtabelle",
+            "interactiveLegend": {
+                "incompatibleFilterWarning": "Angewendete Legendenfilter sind mit dem aktiven Ebenenfilter nicht kompatibel",
+                "resetLegendFilterTooltip": "Setzen Sie den Legendenfilter auf den Anfangszustand zurück"
+            }
         },
         "localizedInput": {
           "localize": "Diesen Text lokalisieren...",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -240,7 +240,11 @@
               "clearCustomizationConfirm": "Are you sure you want to remove all customizations?",
               "error": "It was not possible to automatically load the fields"
             },
-          "disableFeaturesEditing": "Disable editing on Attribute table"
+          "disableFeaturesEditing": "Disable editing on Attribute table",
+          "interactiveLegend": {
+            "incompatibleFilterWarning": "Applied legend filters are incompatible with the active layer filter",
+            "resetLegendFilterTooltip": "Reset the legend filter to the initial state"
+          }
         },
         "localizedInput": {
           "localize": "Localize this text...",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -240,7 +240,11 @@
               "clearCustomizationConfirm": "¿Está seguro de que desea borrar la personalización de los campos?",
               "error": "Error al recuperar los campos"
             },
-            "disableFeaturesEditing": "Deshabilitar la edición en la tabla de atributos"
+            "disableFeaturesEditing": "Deshabilitar la edición en la tabla de atributos",
+            "interactiveLegend": {
+                "incompatibleFilterWarning": "Los filtros de leyenda aplicados son incompatibles con el filtro de capa activo",
+                "resetLegendFilterTooltip": "Restablecer el filtro de leyenda al estado inicial"
+            } 
         },
         "localizedInput": {
           "localize": "Localizar cadena...",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -240,7 +240,11 @@
               "clearCustomizationConfirm": "Voulez-vous vraiment supprimer les personnalisations ?",
               "error":  "Échec de la récupération des champs"
             },
-            "disableFeaturesEditing": "Désactiver la modification sur la table attributaire"
+            "disableFeaturesEditing": "Désactiver la modification sur la table attributaire",
+            "interactiveLegend": {
+                "incompatibleFilterWarning": "Les filtres de légende appliqués sont incompatibles avec le filtre de couche actif",
+                "resetLegendFilterTooltip": "Réinitialiser le filtre de légende à l'état initial"
+            }
         },
          "localizedInput": {
           "localize": "Localiser ce texte...",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -240,8 +240,11 @@
               "clearCustomizationConfirm": "Sei sicuro di voler rimuovere tutte le modifiche effettuate ai campi?",
               "error": "Non è stato possibile recuperare i campi dalla sorgente dati"
             },
-            "disableFeaturesEditing": "Disabilita la modifica sulla tabella degli attributi"
-        },
+            "disableFeaturesEditing": "Disabilita la modifica sulla tabella degli attributi",
+            "interactiveLegend": {
+                "incompatibleFilterWarning": "I filtri della legenda applicati non sono compatibili con il filtro del livello attivo",
+                "resetLegendFilterTooltip": "Reimposta il filtro della legenda allo stato iniziale"
+            }    },
         "localizedInput": {
           "localize": "Traduci questo testo...",
           "title": "Traduci testo",

--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -30,6 +30,7 @@ export const cqlToOgc = (cqlFilter, fOpts) => {
 };
 
 import { get, isNil, isArray, find, findIndex, isString, flatten } from 'lodash';
+import { INTERACTIVE_LEGEND_ID } from './LegendUtils';
 let FilterUtils;
 
 const wrapValueWithWildcard = (value, condition) => {
@@ -1323,12 +1324,12 @@ export const updateLayerLegendFilter = (layerFilterObj, legendFilter) => {
         }
     };
     let filterObj = {...defaultLayerFilter, ...layerFilterObj};
-    const isLegendFilterExist = filterObj?.filters?.find(f => f.id === 'interactiveLegend');
+    const isLegendFilterExist = filterObj?.filters?.find(f => f.id === INTERACTIVE_LEGEND_ID);
     if (!legendFilter) {
         // clear legend filter with id = 'interactiveLegend'
         if (isLegendFilterExist) {
             filterObj = {
-                ...filterObj, filters: filterObj?.filters?.filter(f => f.id !== 'interactiveLegend')
+                ...filterObj, filters: filterObj?.filters?.filter(f => f.id !== INTERACTIVE_LEGEND_ID)
             };
         }
         let newFilter = filterObj ? filterObj : undefined;
@@ -1354,9 +1355,9 @@ export const updateLayerLegendFilter = (layerFilterObj, legendFilter) => {
     }
     let newFilter = {
         ...(filterObj || {}), filters: [
-            ...(filterObj?.filters?.filter(f => f.id !== 'interactiveLegend') || []), ...[
+            ...(filterObj?.filters?.filter(f => f.id !== INTERACTIVE_LEGEND_ID) || []), ...[
                 {
-                    "id": "interactiveLegend",
+                    "id": INTERACTIVE_LEGEND_ID,
                     "format": "logic",
                     "version": "1.0.0",
                     "logic": "OR",
@@ -1379,10 +1380,10 @@ export function resetLayerLegendFilter(layer, reason, value) {
     let filterObj = layer.layerFilter ? layer.layerFilter : undefined;
     if (!needReset || !isLayerWithJSONLegend || !filterObj) return false;
     // reset thte filter if legendCQLFilter is empty
-    const isLegendFilterExist = filterObj?.filters?.find(f => f.id === 'interactiveLegend');
+    const isLegendFilterExist = filterObj?.filters?.find(f => f.id === INTERACTIVE_LEGEND_ID);
     if (isLegendFilterExist) {
         filterObj = {
-            ...filterObj, filters: filterObj?.filters?.filter(f => f.id !== 'interactiveLegend')
+            ...filterObj, filters: filterObj?.filters?.filter(f => f.id !== INTERACTIVE_LEGEND_ID)
         };
         return filterObj;
     }
@@ -1414,5 +1415,6 @@ FilterUtils = {
     processOGCSpatialFilter,
     createFeatureFilter,
     mergeFiltersToOGC,
-    convertFiltersToOGC
+    convertFiltersToOGC,
+    INTERACTIVE_LEGEND_ID
 };

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -32,6 +32,7 @@ import {
     isFilterEmpty,
     updateLayerLegendFilter, resetLayerLegendFilter
 } from '../FilterUtils';
+import { INTERACTIVE_LEGEND_ID } from '../LegendUtils';
 
 
 describe('FilterUtils', () => {
@@ -2337,8 +2338,8 @@ describe('FilterUtils', () => {
         const updatedFilterObj = updateLayerLegendFilter(layerFilterObj, lgegendFilter);
         expect(updatedFilterObj).toBeTruthy();
         expect(updatedFilterObj.filters.length).toEqual(1);
-        expect(updatedFilterObj.filters.filter(i => i.id === 'interactiveLegend')?.length).toEqual(1);
-        expect(updatedFilterObj.filters.find(i => i.id === 'interactiveLegend').filters.length).toEqual(1);
+        expect(updatedFilterObj.filters.filter(i => i.id === INTERACTIVE_LEGEND_ID)?.length).toEqual(1);
+        expect(updatedFilterObj.filters.find(i => i.id === INTERACTIVE_LEGEND_ID).filters.length).toEqual(1);
     });
     it('test updateLayerLegendFilter for wms, apply multi legend filter', () => {
         const layerFilterObj = {
@@ -2364,7 +2365,7 @@ describe('FilterUtils', () => {
             },
             "filters": [
                 {
-                    "id": "interactiveLegend",
+                    "id": INTERACTIVE_LEGEND_ID,
                     "format": "logic",
                     "version": "1.0.0",
                     "logic": "OR",
@@ -2383,8 +2384,8 @@ describe('FilterUtils', () => {
         const updatedFilterObj = updateLayerLegendFilter(layerFilterObj, lgegendFilter);
         expect(updatedFilterObj).toBeTruthy();
         expect(updatedFilterObj.filters.length).toEqual(1);
-        expect(updatedFilterObj.filters.filter(i => i.id === 'interactiveLegend')?.length).toEqual(1);
-        expect(updatedFilterObj.filters.find(i => i.id === 'interactiveLegend').filters.length).toEqual(2);
+        expect(updatedFilterObj.filters.filter(i => i.id === INTERACTIVE_LEGEND_ID)?.length).toEqual(1);
+        expect(updatedFilterObj.filters.find(i => i.id === INTERACTIVE_LEGEND_ID).filters.length).toEqual(2);
     });
     it('test reset legend filter using updateLayerLegendFilter', () => {
         const layerFilterObj = {
@@ -2410,7 +2411,7 @@ describe('FilterUtils', () => {
             },
             "filters": [
                 {
-                    "id": "interactiveLegend",
+                    "id": INTERACTIVE_LEGEND_ID,
                     "format": "logic",
                     "version": "1.0.0",
                     "logic": "OR",
@@ -2434,7 +2435,7 @@ describe('FilterUtils', () => {
         const updatedFilterObj = updateLayerLegendFilter(layerFilterObj);
         expect(updatedFilterObj).toBeTruthy();
         expect(updatedFilterObj.filters.length).toEqual(0);
-        expect(updatedFilterObj.filters.find(i => i.id === 'interactiveLegend')).toBeFalsy();
+        expect(updatedFilterObj.filters.find(i => i.id === INTERACTIVE_LEGEND_ID)).toBeFalsy();
     });
     it('test resetLayerLegendFilter in case change wms style', () => {
         const layerFilterObj = {
@@ -2460,7 +2461,7 @@ describe('FilterUtils', () => {
             },
             "filters": [
                 {
-                    "id": "interactiveLegend",
+                    "id": INTERACTIVE_LEGEND_ID,
                     "format": "logic",
                     "version": "1.0.0",
                     "logic": "OR",
@@ -2489,6 +2490,6 @@ describe('FilterUtils', () => {
         const updatedFilterObj = resetLayerLegendFilter(layer, 'style', 'style_02');
         expect(updatedFilterObj).toBeTruthy();
         expect(updatedFilterObj.filters.length).toEqual(0);
-        expect(updatedFilterObj.filters.find(i => i.id === 'interactiveLegend')).toBeFalsy();
+        expect(updatedFilterObj.filters.find(i => i.id === INTERACTIVE_LEGEND_ID)).toBeFalsy();
     });
 });

--- a/web/client/utils/__tests__/LegendUtils-test.js
+++ b/web/client/utils/__tests__/LegendUtils-test.js
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import expect from 'expect';
+import {
+    getWMSLegendConfig,
+    getLayerFilterByLegendFormat,
+    INTERACTIVE_LEGEND_ID,
+    LEGEND_FORMAT
+} from '../LegendUtils';
+import { ServerTypes } from '../LayersUtils';
+
+describe('LegendUtils', () => {
+    describe('getLayerFilterByLegendFormat', () => {
+        it('should return layer filter without interactive legend filter for JSON format', () => {
+            const layer = {
+                type: 'wms',
+                url: 'http://example.com',
+                layerFilter: {
+                    filters: [{ id: INTERACTIVE_LEGEND_ID }, { id: 'otherFilter' }]
+                }
+            };
+            const format = LEGEND_FORMAT.JSON;
+            const result = getLayerFilterByLegendFormat(layer, format);
+            expect(result.filters).toEqual([{ id: 'otherFilter' }]);
+        });
+
+        it('should return original layer filter for non-JSON format', () => {
+            const layer = {
+                type: 'wms',
+                url: 'http://example.com',
+                layerFilter: {
+                    filters: [{ id: INTERACTIVE_LEGEND_ID }, { id: 'otherFilter' }]
+                }
+            };
+            const format = LEGEND_FORMAT.IMAGE;
+            const result = getLayerFilterByLegendFormat(layer, format);
+            expect(result.filters).toEqual([{ id: INTERACTIVE_LEGEND_ID }, { id: 'otherFilter' }]);
+        });
+
+        it('should return empty filter if layerFilter is undefined', () => {
+            const layer = {
+                type: 'wms',
+                url: 'http://example.com'
+            };
+            const format = LEGEND_FORMAT.JSON;
+            const result = getLayerFilterByLegendFormat(layer, format);
+            expect(result).toBe(undefined);
+        });
+    });
+
+    describe('getWMSLegendConfig', () => {
+        it('should return correct WMS legend config for non-vendor server type', () => {
+            const layer = {
+                name: 'testLayer',
+                type: 'wms',
+                url: 'http://example.com',
+                serverType: ServerTypes.NO_VENDOR,
+                params: { customParam: 'value' }
+            };
+            const config = getWMSLegendConfig({
+                format: LEGEND_FORMAT.IMAGE,
+                legendHeight: 20,
+                legendWidth: 20,
+                layer,
+                mapSize: { width: 800, height: 600 },
+                projection: 'EPSG:4326',
+                mapBbox: { bounds: { minx: -30, miny: 20, maxx: 50, maxy: 60 } },
+                legendOptions: 'fontSize:10'
+            });
+            expect(config).toEqual({
+                service: 'WMS',
+                request: 'GetLegendGraphic',
+                format: LEGEND_FORMAT.IMAGE,
+                height: 20,
+                width: 20,
+                layer: 'testLayer',
+                style: null,
+                version: '1.3.0',
+                SLD_VERSION: '1.1.0',
+                LEGEND_OPTIONS: 'fontSize:10',
+                customParam: 'value'
+            });
+        });
+
+        it('should return correct WMS legend config for vendor server type', () => {
+            const layer = {
+                name: 'testLayer',
+                type: 'wms',
+                url: 'http://example.com',
+                serverType: 'VENDOR',
+                group: 'foreground'
+            };
+            const config = getWMSLegendConfig({
+                format: LEGEND_FORMAT.IMAGE,
+                legendHeight: 20,
+                legendWidth: 20,
+                layer,
+                mapSize: { width: 800, height: 600 },
+                projection: 'EPSG:4326',
+                mapBbox: { bounds: {minx: -30, miny: 20, maxx: 50, maxy: 60}, crs: "EPSG:4326" },
+                legendOptions: 'fontSize:10'
+            });
+            expect(config).toEqual({
+                service: 'WMS',
+                request: 'GetLegendGraphic',
+                format: LEGEND_FORMAT.IMAGE,
+                height: 20,
+                width: 20,
+                layer: 'testLayer',
+                style: null,
+                version: '1.3.0',
+                SLD_VERSION: '1.1.0',
+                LEGEND_OPTIONS: 'hideEmptyRules:true;fontSize:10',
+                SRCWIDTH: 800,
+                SRCHEIGHT: 600,
+                SRS: 'EPSG:4326',
+                CRS: 'EPSG:4326',
+                BBOX: '-30,20,50,60'
+            });
+        });
+        it('should return correct WMS legend config for vendor server type with background group', () => {
+            const layer = {
+                name: 'testLayer',
+                type: 'wms',
+                url: 'http://example.com',
+                serverType: 'VENDOR',
+                group: 'background'
+            };
+            const config = getWMSLegendConfig({
+                format: LEGEND_FORMAT.IMAGE,
+                legendHeight: 20,
+                legendWidth: 20,
+                layer,
+                mapSize: { width: 800, height: 600 },
+                projection: 'EPSG:4326',
+                mapBbox: { bounds: { minx: -30, miny: 20, maxx: 50, maxy: 60 }, crs: "EPSG:4326" },
+                legendOptions: 'fontSize:10'
+            });
+            expect(config).toEqual({
+                service: 'WMS',
+                request: 'GetLegendGraphic',
+                format: LEGEND_FORMAT.IMAGE,
+                height: 20,
+                width: 20,
+                layer: 'testLayer',
+                style: null,
+                version: '1.3.0',
+                SLD_VERSION: '1.1.0',
+                LEGEND_OPTIONS: 'hideEmptyRules:false;fontSize:10',
+                SRCWIDTH: 800,
+                SRCHEIGHT: 600,
+                SRS: 'EPSG:4326',
+                CRS: 'EPSG:4326',
+                BBOX: '-30,20,50,60'
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Description
This PR implements legend filtering of the WMS layer including both the formats (image and json). Incorporates filtering factoring map extents and additional layer filter and interactions between them

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #10684 
- #10241 

**What is the new behavior?**
- **Layer and legend filtering**

  https://github.com/user-attachments/assets/7144bf51-c7f4-4f51-b38e-460d9027b163

- **Legend filtering in printing**

  <img width="1920" alt="Screenshot 2024-12-05 at 7 26 25 PM" src="https://github.com/user-attachments/assets/54280fa6-f6bd-40f0-b4a6-942c974f3747">
  <img width="1920" alt="Screenshot 2024-12-05 at 7 27 10 PM" src="https://github.com/user-attachments/assets/0a4991f4-afe9-473b-8467-bce46e0c2350">


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
