### PR TITLE
#10717: Fix typo in localized component

### DIFF
--- a/web/client/components/I18N/Localized.jsx
+++ b/web/client/components/I18N/Localized.jsx
@@ -22,9 +22,11 @@ class Localized extends React.Component {
     static childContextTypes = {
         locale: PropTypes.string,
         messages: PropTypes.object,
+        localeKey: PropTypes.bool
+    };
+    static defaultProps = {
         localeKey: true
     };
-
     getChildContext() {
         return {
             locale: this.props.locale,


### PR DESCRIPTION
## Description
In this PR, I have fixed an existing typo in Localized.jsx component by correct prop type of 'localeKey' and added default value = true for it.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: correct a typo

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#10717 

**What is the new behavior?**
Typo is corrected now in code.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
