### PR TITLE
Bugfix: Link for shared maps without context

### DIFF
--- a/web/client/components/resources/enhancers/__tests__/withShareTool-test.js
+++ b/web/client/components/resources/enhancers/__tests__/withShareTool-test.js
@@ -49,7 +49,7 @@ describe('withShareTool enhancer', () => {
             expect(sharePanel).toExist('Share panel doesn\'t exist');
             const directLink = sharePanel.querySelector('#sharePanel-tabs-pane-1 .input-link input');
             expect(directLink).toExist('directLink doesn\'t exist');
-            expect(directLink.value).toBe(window.location.origin + window.location.pathname + "#/" + FAKE_RESOURCE_PATH);
+            expect(directLink.value).toBe(window.location.origin + window.location.pathname + "#/" + FAKE_RESOURCE_PATH + '/config');
         });
         it('URL is generated using application path', () => {
             const Sink = addSharePanel(createSink(() => {}));
@@ -67,8 +67,8 @@ describe('withShareTool enhancer', () => {
             expect(sharePanel).toExist('Share panel doesn\'t exist');
             const directLink = sharePanel.querySelector('#sharePanel-tabs-pane-1 .input-link input');
             expect(directLink).toExist('directLink doesn\'t exist');
-            expect(directLink.value).toBe(FAKE_RESOURCE_URL);
-            expect(directLink.value).toBe("http://some-location/mapstore/#/FAKE_RESOURCE_PATH"); // double check
+            expect(directLink.value).toBe(FAKE_RESOURCE_URL + '/config');
+            expect(directLink.value).toBe("http://some-location/mapstore/#/FAKE_RESOURCE_PATH/config"); // double check
             document.getElementById('sharePanel-tabs-tab-3').click();
             const codeBlock = document.getElementsByTagName('code')[0];
             expect(codeBlock).toExist();

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -214,6 +214,7 @@ class SharePanel extends React.Component {
         const { settings, advancedSettings, mapType, viewerOptions } = this.props;
         const shouldRemoveSectionId = !settings.showSectionId && advancedSettings && advancedSettings.sectionId;
         let shareUrl = getSharedGeostoryUrl(removeQueryFromUrl(this.props.shareUrl), shouldRemoveSectionId);
+        if (!shareUrl.endsWith('config')) shareUrl += `${!shareUrl.endsWith('/') ? '/' : ''}config`;
         if (settings.bboxEnabled && advancedSettings && advancedSettings.bbox && this.state.bbox) shareUrl = `${shareUrl}?bbox=${this.state.bbox}`;
         if (settings.showHome && advancedSettings && advancedSettings.homeButton) shareUrl = `${shareUrl}?showHome=true`;
         if (settings.centerAndZoomEnabled && advancedSettings && advancedSettings.centerAndZoom) {


### PR DESCRIPTION
If you use the share functionality in a map, that is not created out of a context, the shared link will not show the correct center and zoom, as long as the /config part in the URL is missing.
As the documentations states in
https://docs.mapstore.geosolutionsgroup.com/en/latest/developer-guide/map-query-parameters/#center-zoom and in
https://docs.mapstore.geosolutionsgroup.com/en/latest/developer-guide/map-query-parameters/#marker-zoom that such a /config part should be part of configured URLs, this fix adds the /config part

Test is adapted to the new solution.

Bugfix on behalf of DB Systel GmbH

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
If you use the share functionality in a map, that is not created out of a context, the shared link will not show the correct center and zoom, as long as the /config part in the URL is missing.
The documentations states in
https://docs.mapstore.geosolutionsgroup.com/en/latest/developer-guide/map-query-parameters/#center-zoom and in
https://docs.mapstore.geosolutionsgroup.com/en/latest/developer-guide/map-query-parameters/#marker-zoom that such a /config part should be part of configured URLs.

**What is the new behavior?**
As the documentations states in
https://docs.mapstore.geosolutionsgroup.com/en/latest/developer-guide/map-query-parameters/#center-zoom and in
https://docs.mapstore.geosolutionsgroup.com/en/latest/developer-guide/map-query-parameters/#marker-zoom that such a /config part should be part of configured URLs, this fix adds the /config part.
So now if you use the share functionality in a map, even if it is not created out of a context, the shared link will show the correct center and zoom.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Bugfix on behalf of DB Systel GmbH