### PR TITLE
#10719: enable upload images within Text widgets

### DIFF
--- a/web/client/components/mapviews/settings/CompactRichTextEditor.jsx
+++ b/web/client/components/mapviews/settings/CompactRichTextEditor.jsx
@@ -57,7 +57,7 @@ function CompactRichTextEditor({
                 image: {
                     urlEnabled: true,
                     // upload controlled via props, disabled by default
-                    uploadEnabled: props.uploadEnabled || false,
+                    uploadEnabled: props.enableUploadImg || false,
                     alignmentEnabled: false,
                     uploadCallback: (file) => new Promise((resolve, reject) => {
                         const reader = new FileReader();

--- a/web/client/components/mapviews/settings/CompactRichTextEditor.jsx
+++ b/web/client/components/mapviews/settings/CompactRichTextEditor.jsx
@@ -57,7 +57,7 @@ function CompactRichTextEditor({
                 image: {
                     urlEnabled: true,
                     // upload controlled via props, disabled by default
-                    uploadEnabled: props.enableUploadImg || false,
+                    uploadEnabled: props.uploadEnabled || false,
                     alignmentEnabled: false,
                     uploadCallback: (file) => new Promise((resolve, reject) => {
                         const reader = new FileReader();

--- a/web/client/components/mapviews/settings/__tests__/CompactRichTextEditor-test.jsx
+++ b/web/client/components/mapviews/settings/__tests__/CompactRichTextEditor-test.jsx
@@ -36,8 +36,8 @@ describe('CompactRichTextEditor component', () => {
         const uploadImgInput = document.querySelector(".rdw-image-modal-upload-option");
         expect(uploadImgInput).toBeFalsy();
     });
-    it('test rendering TextEditor with enabling image upload [enableUploadImg]', () => {
-        ReactDOM.render(<CompactRichTextEditor enableUploadImg />, document.getElementById("container"));
+    it('test rendering TextEditor with enabling image upload [uploadEnabled]', () => {
+        ReactDOM.render(<CompactRichTextEditor uploadEnabled />, document.getElementById("container"));
         const textEditorContainer = document.querySelector(".ms-compact-text-editor.rdw-editor-wrapper");
         expect(textEditorContainer).toBeTruthy();
         const imageWidget = document.querySelector(".rdw-image-wrapper .rdw-option-wrapper");

--- a/web/client/components/mapviews/settings/__tests__/CompactRichTextEditor-test.jsx
+++ b/web/client/components/mapviews/settings/__tests__/CompactRichTextEditor-test.jsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import CompactRichTextEditor from '../CompactRichTextEditor';
+import expect from 'expect';
+import TestUtils from 'react-dom/test-utils';
+
+describe('CompactRichTextEditor component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render with default which does not include image upload', () => {
+        ReactDOM.render(<CompactRichTextEditor />, document.getElementById("container"));
+        const textEditorContainer = document.querySelector(".ms-compact-text-editor.rdw-editor-wrapper");
+        expect(textEditorContainer).toBeTruthy();
+        // check img upload btn
+        const imageWidget = document.querySelector(".rdw-image-wrapper .rdw-option-wrapper");
+        TestUtils.act(() => {
+            TestUtils.Simulate.click(imageWidget);
+        });
+        const uploadImgInput = document.querySelector(".rdw-image-modal-upload-option");
+        expect(uploadImgInput).toBeFalsy();
+    });
+    it('test rendering TextEditor with enabling image upload [enableUploadImg]', () => {
+        ReactDOM.render(<CompactRichTextEditor enableUploadImg />, document.getElementById("container"));
+        const textEditorContainer = document.querySelector(".ms-compact-text-editor.rdw-editor-wrapper");
+        expect(textEditorContainer).toBeTruthy();
+        const imageWidget = document.querySelector(".rdw-image-wrapper .rdw-option-wrapper");
+        TestUtils.act(() => {
+            TestUtils.Simulate.click(imageWidget);
+        });
+        const uploadImgInput = document.querySelector(".rdw-image-modal-upload-option");
+        expect(uploadImgInput).toBeTruthy();
+    });
+});

--- a/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
@@ -48,7 +48,7 @@ function TextOptions({ data = {}, onChange = () => {} }) {
                 </Form>
             </Col>
             <DescriptorEditor
-                enableUploadImg
+                uploadEnabled
                 editorState={editorState}
                 onEditorStateChange={(newEditorState) => {
                     const previousHTML = draftJSEditorStateToHtml(editorState);

--- a/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
@@ -48,6 +48,7 @@ function TextOptions({ data = {}, onChange = () => {} }) {
                 </Form>
             </Col>
             <DescriptorEditor
+                enableUploadImg
                 editorState={editorState}
                 onEditorStateChange={(newEditorState) => {
                     const previousHTML = draftJSEditorStateToHtml(editorState);


### PR DESCRIPTION
## Description
This PR handles enabling upload image in Text Editor within Text Widgets by adding 'prop' called 'enableUploadImg' passing it to 'CompactRichTextEditor' component 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10719 

**What is the current behavior?**
#10719 
Text Widgets don't include upload image within image button, it is just adding image by providing URL.

**What is the new behavior?**
Now Text Widgets include upload image beside image URL within adding image feature.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
