### PR TITLE
IFC request fails due to proxy issue #10694

### DIFF
--- a/web/client/components/map/cesium/plugins/ModelLayer.js
+++ b/web/client/components/map/cesium/plugins/ModelLayer.js
@@ -189,9 +189,12 @@ const createLayer = (options, map) => {
 
 Layers.registerType('model', {
     create: createLayer,
-    update: (layer, newOptions, oldOptions) => {
+    update: (layer, newOptions, oldOptions, map) => {
         if (layer?.primitives && !isEqual(newOptions?.features?.[0], oldOptions?.features?.[0])) {
             updatePrimitivesMatrix(layer?.primitives, newOptions?.features?.[0]);
+        }
+        if (newOptions?.forceProxy !== oldOptions?.forceProxy) {
+            return createLayer(newOptions, map);
         }
         return null;
     }


### PR DESCRIPTION
## Description
The proxy test is common for all layers, the logic to recreate the layer if the test fails for Model layer was missing.
This PR fixes that missed logic for Model layer( #10694) 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

#10694

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10694 - not calling through proxy after CORS test

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Model layer recreation after preflight test.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
