### PR TITLE
Fix #10739 Changing correctly resolutions limits when switching map CRS

### DIFF
--- a/web/client/actions/map.js
+++ b/web/client/actions/map.js
@@ -108,7 +108,20 @@ export function changeMapCrs(crs) {
                 options.maxResolution = convertResolution(sourceCRS, crs, layer.maxResolution).transformedResolution;
                 const diffs = newResolutions.map((resolution, zoom) => ({ diff: Math.abs(resolution - options.maxResolution), zoom }));
                 const { zoom } = minBy(diffs, 'diff');
+                // check if min and max resolutions are not the same
                 options.maxResolution = newResolutions[zoom];
+                if (options.minResolution === options.maxResolution) {
+                    if ((zoom - 1) >= 0) {
+                        // increase max res if possible
+                        options.maxResolution = newResolutions[zoom - 1];
+                    } else if (zoom + 1 < newResolutions.length) {
+                        // decrease max res if possible
+                        options.minResolution = newResolutions[zoom + 1];
+                    } else {
+                        // keep only min res if none of the previous is happening
+                        options.maxResolution = undefined;
+                    }
+                }
             }
             // the minimum difference represents the nearest zoom to the target resolution
             dispatch(updateNode(layer.id, "layer", options));

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -529,7 +529,8 @@ class OpenlayersMap extends React.Component {
             multiWorld: true,
             // does not allow intermediary zoom levels
             // we need this at true to set correctly the scale box
-            constrainResolution: true
+            constrainResolution: true,
+            resolutions: this.getResolutions(normalizeSRS(projection))
         }, newOptions || {});
         return new View(viewOptions);
     };

--- a/web/client/epics/__tests__/map-test.js
+++ b/web/client/epics/__tests__/map-test.js
@@ -209,7 +209,7 @@ describe('map epics', () => {
             done();
         }, state);
     });
-    it.only('test changeMapCrs causes limits change. ', (done) => {
+    it('test changeMapCrs causes limits change. ', (done) => {
         const state = {
             map: {
                 present: {

--- a/web/client/epics/__tests__/map-test.js
+++ b/web/client/epics/__tests__/map-test.js
@@ -9,7 +9,7 @@
 import expect from 'expect';
 
 import { resetLimitsOnInit, zoomToExtentEpic, checkMapPermissions } from '../map';
-import { CHANGE_MAP_VIEW, zoomToExtent, CHANGE_MAP_LIMITS, changeMapCrs } from '../../actions/map';
+import { CHANGE_MAP_VIEW, zoomToExtent, CHANGE_MAP_LIMITS, changeCRS } from '../../actions/map';
 import { LOAD_MAP_INFO, configureMap } from '../../actions/config';
 import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
 import MapUtils from '../../utils/MapUtils';
@@ -209,7 +209,7 @@ describe('map epics', () => {
             done();
         }, state);
     });
-    it('test changeMapCrs causes limits change. ', (done) => {
+    it.only('test changeMapCrs causes limits change. ', (done) => {
         const state = {
             map: {
                 present: {
@@ -226,7 +226,7 @@ describe('map epics', () => {
                 }
             }
         };
-        testEpic(resetLimitsOnInit, 1, changeMapCrs("EPSG:1234"), ([action]) => {
+        testEpic(resetLimitsOnInit, 1, changeCRS("EPSG:1234"), ([action]) => {
             const { restrictedExtent, type, minZoom } = action;
             expect(restrictedExtent.length).toBe(4);
             expect(restrictedExtent).toEqual([1, 1, 1, 1]);

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -41,7 +41,9 @@ import {
     mapUpdated,
     getZoomFromResolution,
     getResolutionObject,
-    reprojectZoom
+    reprojectZoom,
+    getRandomPointInCRS,
+    convertResolution
 } from '../MapUtils';
 import { VisualizationModes } from '../MapTypeUtils';
 
@@ -2416,6 +2418,7 @@ describe('Test the MapUtils', () => {
         const resolution = 1000; // ~zoom 7 in Web Mercator
         expect(getZoomFromResolution(resolution)).toBe(7);
     });
+
     it('reprojectZoom', () => {
         expect(reprojectZoom(5, 'EPSG:3857', 'EPSG:4326')).toBe(4);
         expect(reprojectZoom(5.2, 'EPSG:3857', 'EPSG:4326')).toBe(4);
@@ -2430,5 +2433,12 @@ describe('Test the MapUtils', () => {
             expect(getResolutionObject(9028, 'scale1', {projection: "EPSG:900913", resolutions}))
                 .toEqual({ resolution: 9028, scale: 34121574.80314961, zoom: 4 });
         });
+    });
+    it('getRandomPointInCRS', () => {
+        expect(getRandomPointInCRS('EPSG:3857').length).toBe(2);
+        expect(getRandomPointInCRS('EPSG:4326').length).toBe(2);
+    });
+    it('convertResolution', () => {
+        expect(convertResolution('EPSG:3857', 'EPSG:4326', 2000).transformedResolution).toBe(0.017986440587896155);
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

We are changing resolutions also in the view because these were not aligned to the layers especially when switching to 4326. ol map view was having a different list causing a misalignment between current resolution and zoom level

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10739

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
