### PR TITLE
 [Backport 2024.02.xx] #10732 fix displaying WMS layers from data.geopf.fr in 3d mode (#10592)

### DIFF
--- a/web/client/utils/cesium/WMSUtils.js
+++ b/web/client/utils/cesium/WMSUtils.js
@@ -120,6 +120,7 @@ export function wmsToCesiumOptions(options) {
             format: isVectorFormat(options.format) && 'image/png' || options.format || 'image/png',
             transparent: options.transparent !== undefined ? options.transparent : true,
             opacity: opacity,
+            version: options.version || "1.1.1",
             tiled: options.tiled !== undefined ? options.tiled : true,
             width: options.tileSize || 256,
             height: options.tileSize || 256,

--- a/web/client/utils/cesium/__tests__/WMSUtils-test.js
+++ b/web/client/utils/cesium/__tests__/WMSUtils-test.js
@@ -56,6 +56,7 @@ describe('Test the WMSUtil for Cesium', () => {
         expect(cesiumOptions.layers).toBe('workspace:layer');
         expect(cesiumOptions.parameters).toEqual({
             styles: '',
+            version: '1.1.1',
             format: 'image/png',
             transparent: true,
             opacity: 1,
@@ -63,6 +64,16 @@ describe('Test the WMSUtil for Cesium', () => {
             width: 256,
             height: 256
         });
+    });
+    it('wmsToCesiumOptions with version', () => {
+        const options = {
+            type: 'wms',
+            version: '1.3.0',
+            url: '/geoserver/wms',
+            name: 'workspace:layer'
+        };
+        const cesiumOptions = wmsToCesiumOptions(options);
+        expect(cesiumOptions.parameters.version).toBe('1.3.0');
     });
     it('wmsToCesiumOptionsSingleTile', () => {
         const options = {


### PR DESCRIPTION
data.geopf.fr only supports WMS 1.3.0. Cesium defaults to 1.1.1. Pass the version from the options, and default to 1.1.1 if unset.

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10592

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
