### PR TITLE
#10753: Improve the way group names are visualized in user settings by showing tooltip for selected items

### DIFF
--- a/web/client/components/manager/users/UserGroups.jsx
+++ b/web/client/components/manager/users/UserGroups.jsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 
 import React from 'react';
 
-// const Message = require('../I18N/Message').default;
 import Select from 'react-select';
 
 import Message from '../../I18N/Message';
@@ -69,7 +68,7 @@ class UserCard extends React.Component {
             options={this.getOptions()}
             onChange={this.onChange}
             style={{marginTop: "10px"}}
-            // * NOTE: valueRenderer: is responsible for custom rendering for shwon selected values in react-select version 1.3.0
+            // * NOTE: valueRenderer: is responsible for custom rendering for shown selected values in react-select version 1.3.0
             valueRenderer={this.customValueRenderer}
         />);
     };

--- a/web/client/components/manager/users/UserGroups.jsx
+++ b/web/client/components/manager/users/UserGroups.jsx
@@ -69,6 +69,7 @@ class UserCard extends React.Component {
             options={this.getOptions()}
             onChange={this.onChange}
             style={{marginTop: "10px"}}
+            // * NOTE: valueRenderer: is responsible for custom rendering for shwon selected values in react-select version 1.3.0
             valueRenderer={this.customValueRenderer}
         />);
     };

--- a/web/client/components/manager/users/UserGroups.jsx
+++ b/web/client/components/manager/users/UserGroups.jsx
@@ -16,10 +16,7 @@ import Select from 'react-select';
 import Message from '../../I18N/Message';
 import { findIndex } from 'lodash';
 import SecurityUtils from '../../../utils/SecurityUtils';
-
-// const ConfirmModal = require('./modals/ConfirmModal');
-// const GroupManager = require('./GroupManager');
-
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 class UserCard extends React.Component {
     static propTypes = {
         // props
@@ -55,7 +52,13 @@ class UserCard extends React.Component {
             clearableValue: group.groupName !== SecurityUtils.USER_GROUP_ALL
         }));
     };
-
+    customValueRenderer = (option) => {
+        return ( <OverlayTrigger
+            placement="top"
+            overlay={<Tooltip id={`tooltip-${option.value}`}>{option.label}</Tooltip>}
+        ><div className="Select-value-label" data-tip={option.label}> {option.label}</div>
+        </OverlayTrigger>);
+    };
     renderGroupsSelector = () => {
         return (<Select key="groupSelector"
             clearable={false}
@@ -66,6 +69,7 @@ class UserCard extends React.Component {
             options={this.getOptions()}
             onChange={this.onChange}
             style={{marginTop: "10px"}}
+            valueRenderer={this.customValueRenderer}
         />);
     };
 


### PR DESCRIPTION
## Description
This PR improves the way that group names are visualized in user settings modal by showing a tooltip for the selected items to cover the truncated long names with ellipsis.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

## Issue
#10753 

**What is the current behavior?**
#10753 

**What is the new behavior?**

https://github.com/user-attachments/assets/75aeb6d1-a8cb-454d-ab31-8f6e8d739256



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
