### PR TITLE
chore: Fixed the attribute value of tooltipid ("remove-alias-button" instead of "add-alias-button").

### DIFF
--- a/web/client/components/catalog/editor/AdvancedSettings/WMSDomainAliases.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/WMSDomainAliases.js
@@ -50,7 +50,7 @@ export default ({
             {toInteger(k) !== 0 &&
             <TooltipButton
                 tooltip={<Message msgId="catalog.domainAliases.removeAliasTooltip" />}
-                tooltipid="add-alias-button"
+                tooltipid="remove-alias-button"
                 tooltipPosition="left"
                 className="remove-alias"
                 onClick={onRemoveAlias(k)}>


### PR DESCRIPTION
## Description

This pull request fixes the incorrect attribute value for `tooltipid` in the relevant component. The previous value was set to `"add-alias-button"`, which has been corrected to `"remove-alias-button"` to ensure proper functionality and alignment with the intended behavior.

## Changes

- Updated the `tooltipid` attribute value from `"add-alias-button"` to `"remove-alias-button"`.
