### PR TITLE
#10758: Support for Cesium Ion Terrain Provider

### DIFF
--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -1242,8 +1242,8 @@ The `terrain` layer of the `cesium-ion` type enables the use of Cesium Ion terra
   "provider": "cesium-ion",
   "visibility": true,
   "options": {
-    "assetId": "", // cesium ion asset id to be requested
-    "accessToken": "", // cesium access token to be used
+    "assetId": "", // cesium ion asset id to be requested (mandatory)
+    "accessToken": "", // cesium access token to be used (mandatory)
     "server": undefined, // resource from the Cesium ion API server. Defaults to https://api.cesium.com when unspecified
     "credit": "" // optional, additional credit to be displayed along side credit and attribution from ion resource
   }

--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -1232,6 +1232,24 @@ The `terrain` layer of `cesium` type allows using Cesium terrain format complian
 }
 ```
 
+##### Cesium Ion terrain provider
+
+The `terrain` layer of the `cesium-ion` type enables the use of Cesium Ion terrain format-compliant services (i.e., Cesium Ion resources). The options attribute allows for the configuration and access of Ion resources and their associated assets.
+
+```json
+{
+  "type": "terrain",
+  "provider": "cesium-ion",
+  "visibility": true,
+  "options": {
+    "assetId": "", // cesium ion asset id to be requested
+    "accessToken": "", // cesium access token to be used
+    "server": undefined, // resource from the Cesium ion API server. Defaults to https://api.cesium.com when unspecified
+    "credit": "" // optional, additional credit to be displayed along side credit and attribution from ion resource
+  }
+}
+```
+
 #### Elevation
 
 This layer provides information related to elevation based on a provided DTM layer. **It does not provide the terrain profile for 3D visualization**, see [terrain](#terrain) layer type for this feature.

--- a/web/client/components/map/cesium/plugins/TerrainLayer.js
+++ b/web/client/components/map/cesium/plugins/TerrainLayer.js
@@ -26,6 +26,20 @@ function cesiumOptionsMapping(config) {
     };
 }
 
+function cesiumIonOptionsMapping(config) {
+    const options = config.options ?? {};
+    return {
+        ...(options.assetId && {
+            url: Cesium.IonResource.fromAssetId(options.assetId, {
+                accessToken: options.accessToken,
+                server: options.server
+            })
+        }),
+        credit: options.credit,
+        requestMetadata: options.requestMetadata
+    };
+}
+
 const createLayer = (config, map) => {
     map.terrainProvider = undefined;
     let terrainProvider;
@@ -40,6 +54,10 @@ const createLayer = (config, map) => {
     }
     case 'ellipsoid': {
         terrainProvider = new Cesium.EllipsoidTerrainProvider();
+        break;
+    }
+    case 'cesium-ion': {
+        terrainProvider = new Cesium.CesiumTerrainProvider(cesiumIonOptionsMapping(config));
         break;
     }
     default:
@@ -61,7 +79,8 @@ const createLayer = (config, map) => {
 const updateLayer = (layer, newOptions, oldOptions, map) => {
     if (newOptions.securityToken !== oldOptions.securityToken
     || oldOptions.credits !== newOptions.credits
-    || oldOptions.provider !== newOptions.provider || oldOptions.forceProxy !== newOptions.forceProxy) {
+    || oldOptions.provider !== newOptions.provider
+    || oldOptions.forceProxy !== newOptions.forceProxy) {
         return createLayer(newOptions, map);
     }
     return null;


### PR DESCRIPTION
## Description
This PR adds support for cesium ion terrain provider

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #10758 

**What is the new behavior?**
With new cesium-ion provider, ion resource based on the asset is loaded in cesium map view

### Test data
Test cesium-ion-terrain with this context `/context/cesium-ion-terrain`, for access token refer to support ticket

### Configuration
```json
{
  "type": "terrain",
  "visibility": true,
  "provider": "cesium-ion",
  "options": {
    "assetId": 1,
    "accessToken": "",
  }
}
```

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
