### PR TITLE
#10766: Remove error notified by GeoFence when moving a rule for geofence stand-alone version only

### DIFF
--- a/web/client/observables/rulesmanager.js
+++ b/web/client/observables/rulesmanager.js
@@ -61,12 +61,12 @@ const fullUpdate = (update$) => update$.filter(({rule: r, origRule: oR}) =>getUp
                 .catch((e) => {
                     const {priority: p, id: omit, ...oldRule} = origRule;
                     oldRule.position = {value: p, position: "fixedPriority"};
-                    // We have to restore original rule and to throw the exception!!
-                    return Rx.Observable.defer(() => GeoFence.addRule(oldRule)).concat(Rx.Observable.of({type: RULE_SAVED}).do(() => { throw (e); }));
+                    // We have to restore original rule and throw the exception if failed!!
+                    return Rx.Observable.defer(() => GeoFence.addRule(oldRule)).catch(() => { throw (e); });
                 });
         })
         .switchMap(({data: id}) => {
-            return Rx.Observable.defer(() => GeoFence.moveRules(rule.priority, [{id}]));
+            return Rx.Observable.defer(() => GeoFence.moveRules(rule.priority, [{id}])).concat(Rx.Observable.of({type: RULE_SAVED}));
         }
         ));
 const grantUpdate = (update$) => update$.filter(({rule: r, origRule: oR}) => getUpdateType(oR, r) === 'grant')


### PR DESCRIPTION
## Description
This PR fixed the shown error for user in rule manager page that happens while trying to edit priority. Handling this was by moving the **RULE_SAVED** action to be after move rule in case full update and throw error only if addRule is failed


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#10766 

**What is the new behavior?**
The edit priority can be edited successfully without showing any error notification messages.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
This issue is just for the geofence stand-alone version only