### PR TITLE
#10770: Vector files import limits

### DIFF
--- a/web/client/components/import/ImportDragZone.jsx
+++ b/web/client/components/import/ImportDragZone.jsx
@@ -26,7 +26,9 @@ export default compose(
         ...props
     }) => <DragZone
         onClose={onClose}
-        onDrop={onDrop}
+        onDrop={(files) => {
+            return onDrop({ files, options: { importedVectorFileMaxSizeInMB: props.importedVectorFileMaxSizeInMB} });
+        }}
         onRef={onRef}
     >
         <Content {...props} />

--- a/web/client/components/import/dragZone/enhancers/__tests__/processFiles-test.jsx
+++ b/web/client/components/import/dragZone/enhancers/__tests__/processFiles-test.jsx
@@ -46,7 +46,7 @@ describe('processFiles enhancer', () => {
     it('processFiles read error', (done) => {
         const Sink = compose(
             processFiles,
-            mapPropsStream(props$ => props$.merge(props$.take(1).do(({ onDrop = () => { } }) => onDrop(["ABC"])).ignoreElements()))
+            mapPropsStream(props$ => props$.merge(props$.take(1).do(({ onDrop = () => { } }) =>onDrop({ files: ["ABC"], options: {} })).ignoreElements()))
         )(createSink( props => {
             expect(props).toBeTruthy();
             if (props.error) {
@@ -61,7 +61,7 @@ describe('processFiles enhancer', () => {
             mapPropsStream(props$ => props$.merge(
                 props$
                     .take(1)
-                    .switchMap(({ onDrop = () => { } }) => getShapeFile().map((file) => onDrop([file]))).ignoreElements()))
+                    .switchMap(({ onDrop = () => { } }) => getShapeFile().map((file) => onDrop({ files: [file], options: {} }))).ignoreElements()))
         )(createSink(props => {
             expect(props).toBeTruthy();
             if (props.files) {
@@ -77,7 +77,7 @@ describe('processFiles enhancer', () => {
             mapPropsStream(props$ => props$.merge(
                 props$
                     .take(1)
-                    .switchMap(({ onDrop = () => { } }) => getKmzFile().map((file) => onDrop([file]))).ignoreElements()))
+                    .switchMap(({ onDrop = () => { } }) => getKmzFile().map((file) => onDrop({ files: [file], options: {} }))).ignoreElements()))
         )(createSink(props => {
             expect(props).toBeTruthy();
             if (props.files) {
@@ -93,7 +93,7 @@ describe('processFiles enhancer', () => {
             mapPropsStream(props$ => props$.merge(
                 props$
                     .take(1)
-                    .switchMap(({ onDrop = () => { } }) => getGpxFile().map((file) => onDrop([file]))).ignoreElements()))
+                    .switchMap(({ onDrop = () => { } }) => getGpxFile().map((file) => onDrop({ files: [file], options: {} }))).ignoreElements()))
         )(createSink(props => {
             expect(props).toBeTruthy();
             if (props.files) {
@@ -109,7 +109,7 @@ describe('processFiles enhancer', () => {
             mapPropsStream(props$ => props$.merge(
                 props$
                     .take(1)
-                    .switchMap(({ onDrop = () => { } }) => getKmlFile().map((file) => onDrop([file]))).ignoreElements()))
+                    .switchMap(({ onDrop = () => { } }) => getKmlFile().map((file) => onDrop({ files: [file], options: {} }))).ignoreElements()))
         )(createSink(props => {
             expect(props).toBeTruthy();
             if (props.files) {
@@ -125,7 +125,7 @@ describe('processFiles enhancer', () => {
             mapPropsStream(props$ => props$.merge(
                 props$
                     .take(1)
-                    .switchMap(({ onDrop = () => { } }) => getGeoJsonFile().map((file) => onDrop([file]))).ignoreElements()))
+                    .switchMap(({ onDrop = () => { } }) => getGeoJsonFile().map((file) => onDrop({ files: [file], options: {} }))).ignoreElements()))
         )(createSink(props => {
             expect(props).toBeTruthy();
             if (props.files) {
@@ -141,7 +141,7 @@ describe('processFiles enhancer', () => {
             mapPropsStream(props$ => props$.merge(
                 props$
                     .take(1)
-                    .switchMap(({ onDrop = () => { } }) => getAnnotationGeoJsonFile().map((file) => onDrop([file]))).ignoreElements()))
+                    .switchMap(({ onDrop = () => { } }) => getAnnotationGeoJsonFile().map((file) => onDrop({ files: [file], options: {} }))).ignoreElements()))
         )(createSink(props => {
             try {
                 expect(props).toBeTruthy();
@@ -163,7 +163,7 @@ describe('processFiles enhancer', () => {
             mapPropsStream(props$ => props$.merge(
                 props$
                     .take(1)
-                    .switchMap(({ onDrop = () => { } }) => getGeoJsonFile("file.geojson").map((file) => onDrop([file]))).ignoreElements()))
+                    .switchMap(({ onDrop = () => { } }) => getGeoJsonFile("file.geojson").map((file) => onDrop({ files: [file], options: {} }))).ignoreElements()))
         )(createSink(props => {
             expect(props).toBeTruthy();
             if (props.files) {
@@ -179,7 +179,7 @@ describe('processFiles enhancer', () => {
             mapPropsStream(props$ => props$.merge(
                 props$
                     .take(1)
-                    .switchMap(({ onDrop = () => { } }) => getMapFile().map((file) => onDrop([file]))).ignoreElements()))
+                    .switchMap(({ onDrop = () => { } }) => getMapFile().map((file) => onDrop({ files: [file], options: {} }))).ignoreElements()))
         )(createSink(props => {
             expect(props).toBeTruthy();
             if (props.files) {
@@ -196,7 +196,7 @@ describe('processFiles enhancer', () => {
             mapPropsStream(props$ => props$.merge(
                 props$
                     .take(1)
-                    .switchMap(({ onDrop = () => { } }) => getUnsupportedMapFile().map((file) => onDrop([file]))).ignoreElements()))
+                    .switchMap(({ onDrop = () => { } }) => getUnsupportedMapFile().map((file) => onDrop({ files: [file], options: {} }))).ignoreElements()))
         )(createSink(props => {
             expect(props).toBeTruthy();
             if (props.error) {

--- a/web/client/components/import/dragZone/enhancers/__tests__/useFiles-test.js
+++ b/web/client/components/import/dragZone/enhancers/__tests__/useFiles-test.js
@@ -185,6 +185,56 @@ describe('useFiles enhancer', () => {
             setLayers={actions.setLayers} warning={handlers.warning} onClose={handlers.onClose} />, document.getElementById("container"));
 
     });
+    it('useFiles rendering with layer having size exceed the max limit should call warnig()', (done) => {
+        const handlers = {
+            warning: () => {},
+            onClose: () => {},
+            loadAnnotations: () => {},
+            loadMap: () => {}
+        };
+        const warningSpy = expect.spyOn(handlers, 'warning');
+
+        const actions = {
+            setLayers: (layers) => {
+                expect(layers).toExist();
+                // length is 1 since just one layer is valid and the another is invalid for its size
+                expect(layers.length).toBe(1);
+                expect(warningSpy).toHaveBeenCalled();
+                done();
+            }
+        };
+
+        const sink = createSink( props => {
+            expect(props).toExist();
+            expect(props.layers).toExist();
+            expect(props.useFiles).toExist();
+            props.useFiles({layers: props.layers});
+
+        });
+        const EnhancedSink = useFiles(sink);
+
+        const layers = [{
+            type: 'vector', name: "FileName", hideLoading: true,
+            bbox: {crs: "EPSG:4326"},
+            "features": [{
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-20, 30]
+                },
+                "properties": {
+                    "prop0": "value0"
+                }
+            }]
+        }, {
+            type: 'vector', name: "FileName01", hideLoading: true,
+            exceedFileMaxSize: true,
+            "features": []
+        }];
+        ReactDOM.render(<EnhancedSink layers={layers}
+            setLayers={actions.setLayers} warning={handlers.warning} onClose={handlers.onClose} />, document.getElementById("container"));
+
+    });
     it('useFiles rendering with new annotation layer', (done) => {
 
         const actions = {

--- a/web/client/components/import/dragZone/enhancers/processFiles.jsx
+++ b/web/client/components/import/dragZone/enhancers/processFiles.jsx
@@ -68,7 +68,7 @@ const readFile = (onWarnings) => (file) => {
     const ext = recognizeExt(file.name);
     const type = file.type || MIME_LOOKUPS[ext];
     // Check the file size first before file conversion process to avoid this useless effort
-    const configurableFileSizeLimitInMB = getConfigProp('importedVectorFileSizeInMB');
+    const configurableFileSizeLimitInMB = getConfigProp('importedVectorFileMaxSizeInMB');
     const isVectorFile = type !== 'application/json';       // skip json as json is for map file
     if (configurableFileSizeLimitInMB && isVectorFile) {
         if (isFileSizeExceedMaxLimit(file, configurableFileSizeLimitInMB)) {

--- a/web/client/components/import/dragZone/enhancers/useFiles.js
+++ b/web/client/components/import/dragZone/enhancers/useFiles.js
@@ -41,7 +41,7 @@ export default compose(
                         layers.forEach((layer) => {
                             const isFileSizeNotValid = !!layer?.exceedFileMaxSize;     // this check is for file size limit for vector layer
                             const valid = layer.type === "vector" ? (checkIfLayerFitsExtentForProjection(layer) && !isFileSizeNotValid) : true;
-                            if (valid) {
+                            if (valid && !isFileSizeNotValid) {
                                 validLayers.push(layer);
                             } else if (isFileSizeNotValid) {
                                 warning({

--- a/web/client/components/import/dragZone/enhancers/useFiles.js
+++ b/web/client/components/import/dragZone/enhancers/useFiles.js
@@ -1,6 +1,7 @@
 
 import { compose, mapPropsStream, withHandlers } from 'recompose';
 import { checkIfLayerFitsExtentForProjection } from '../../../../utils/CoordinatesUtils';
+import { DEFAULT_VECTOR_FILE_MAX_SIZE_IN_MB } from '../../../../utils/FileUtils';
 
 /**
  * Enhancer for processing map configuration and layers object
@@ -49,7 +50,7 @@ export default compose(
                                     message: "mapImport.errors.exceedFileSizeLimit",
                                     autoDismiss: 6,
                                     position: "tc",
-                                    values: {filename: layer.name ?? " ", maxfilesize: layer?.fileSizeLimitInMB ?? 10}
+                                    values: {filename: layer.name ?? " ", maxfilesize: layer?.fileSizeLimitInMB ?? DEFAULT_VECTOR_FILE_MAX_SIZE_IN_MB}
                                 });
                             } else {
                                 warning({

--- a/web/client/components/import/dragZone/enhancers/useFiles.js
+++ b/web/client/components/import/dragZone/enhancers/useFiles.js
@@ -39,9 +39,18 @@ export default compose(
                     } else {
                         let validLayers = [];
                         layers.forEach((layer) => {
-                            const valid = layer.type === "vector" ? checkIfLayerFitsExtentForProjection(layer) : true;
+                            const isFileSizeNotValid = !!layer?.exceedFileMaxSize;     // this check is for file size limit for vector layer
+                            const valid = layer.type === "vector" ? (checkIfLayerFitsExtentForProjection(layer) && !isFileSizeNotValid) : true;
                             if (valid) {
                                 validLayers.push(layer);
+                            } else if (isFileSizeNotValid) {
+                                warning({
+                                    title: "notification.warning",
+                                    message: "mapImport.errors.exceedFileSizeLimit",
+                                    autoDismiss: 6,
+                                    position: "tc",
+                                    values: {filename: layer.name ?? " ", maxfilesize: layer?.fileSizeLimitInMB ?? 10}
+                                });
                             } else {
                                 warning({
                                     title: "notification.warning",

--- a/web/client/plugins/MapImport.jsx
+++ b/web/client/plugins/MapImport.jsx
@@ -31,6 +31,7 @@ import { toggleControl } from '../actions/controls';
 import assign from 'object-assign';
 import { Glyphicon } from 'react-bootstrap';
 import { mapTypeSelector } from '../selectors/maptype';
+import { DEFAULT_VECTOR_FILE_MAX_SIZE_IN_MB } from '../utils/FileUtils';
 
 /**
  * Allows the user to import a file into current map.
@@ -46,13 +47,14 @@ import { mapTypeSelector } from '../selectors/maptype';
  * @memberof plugins
  * @name MapImport
  * @class
+ * @prop {number} cfg.importedVectorFileMaxSizeInMB it is the max allowable file size for import vectir layers in mega bytes
  */
 export default {
     MapImportPlugin: assign({loadPlugin: (resolve) => {
         import('./import/Import').then((importMod) => {
             const Import = importMod.default;
 
-            const ImportPlugin = connect((state) => (
+            const ImportPlugin = connect((state, ownProps) =>(
                 {
                     enabled: state.controls && state.controls.mapimport && state.controls.mapimport.enabled,
                     layers: state.mapimport && state.mapimport.layers || null,
@@ -62,7 +64,8 @@ export default {
                     errors: state.mapimport && state.mapimport.errors || null,
                     shapeStyle: state.style || {},
                     mapType: mapTypeSelector(state),
-                    annotationsLayer: annotationsLayerSelector(state)
+                    annotationsLayer: annotationsLayerSelector(state),
+                    importedVectorFileMaxSizeInMB: ownProps?.importedVectorFileMaxSizeInMB || DEFAULT_VECTOR_FILE_MAX_SIZE_IN_MB
                 }
             ), {
                 setLayers,

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1585,7 +1585,8 @@
                     "fileNotSupported": "Datei wird nicht unterstützt",
                     "unknownError": "Beim Import ist ein unbekannter Fehler aufgetreten",
                     "projectionNotSupported": "Die Projektion der Datei, die Sie importieren möchten, wird nicht unterstützt",
-                    "fileBeyondBoundaries": "Die Datei {Dateiname} kann nicht importiert werden, da sie nicht zu den Kartengrenzen passt"
+                    "fileBeyondBoundaries": "Die Datei {Dateiname} kann nicht importiert werden, da sie nicht zu den Kartengrenzen passt",
+                    "exceedFileSizeLimit": "Die Datei {filename}, die Sie importieren möchten, überschreitet die maximale Dateigröße von {maxfilesize} MB"
                 }
             },
         "mapExport": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1546,6 +1546,7 @@
                 "fileNotSupported": "File not supported",
                 "unknownError": "there was an unknown error during import",
                 "projectionNotSupported": "The projection of the file(s) you're trying to import is not supported",
+                "exceedFileSizeLimit": "The file {filename} you're trying to import is exceeded the max file size limit {maxfilesize} MB",
                 "fileBeyondBoundaries": "The file  {filename} cannot be imported because it does not fit the map boundaries"
             }
         },

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1547,7 +1547,8 @@
                 "fileNotSupported": "Archivo no compatible",
                 "unknownError": "hubo un error desconocido durante la importación",
                 "projectionNotSupported": "La proyección del archivo que está intentando importar no es compatible",
-                "fileBeyondBoundaries": "El archivo {filename} no se pudo importar porque no encaja dentro de los límites del mapa"
+                "fileBeyondBoundaries": "El archivo {filename} no se pudo importar porque no encaja dentro de los límites del mapa",
+                "exceedFileSizeLimit": "El archivo {filename} que estás intentando importar ha superado el límite máximo de tamaño de archivo {maxfilesize} MB"
             }
         },
         "mapExport": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1547,7 +1547,8 @@
                 "fileNotSupported": "Fichier non pris en charge",
                 "unknownError": "il y a eu une erreur inconnue lors de l'import",
                 "projectionNotSupported": "La projection du/des fichier(s) que vous essayez d'importer n'est pas prise en charge",
-                "fileBeyondBoundaries": "Le fichier {filename} ne peut pas être importé car il ne correspond pas aux limites de la carte"
+                "fileBeyondBoundaries": "Le fichier {filename} ne peut pas être importé car il ne correspond pas aux limites de la carte",
+                "exceedFileSizeLimit": "Le fichier {filename} que vous essayez d'importer dépasse la limite de taille de fichier maximale {maxfilesize} Mo"
             }
         },
         "mapExport": {

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -1425,7 +1425,8 @@
         "fileNotSupported": "File not supported",
         "unknownError": "there was an unknown error during import",
         "projectionNotSupported": "The projection of the file(s) you're trying to import is not supported",
-        "fileBeyondBoundaries": "The file  {filename} cannot be imported because it does not fit the map boundaries"
+        "fileBeyondBoundaries": "The file  {filename} cannot be imported because it does not fit the map boundaries",
+        "exceedFileSizeLimit": "The file {filename} you're trying to import is exceeded the max file size limit {maxfilesize} MB"
       }
     },
     "mapExport": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1544,7 +1544,8 @@
                 "fileNotSupported": "File non supportato",
                 "unknownError": "si è verificato un errore sconosciuto durante l'importazione",
                 "projectionNotSupported": "La proiezione del file che stai tentando di importare non è supportata",
-                "fileBeyondBoundaries": "Il file {nomefile} non può essere importato perché non si adatta ai confini della mappa"
+                "fileBeyondBoundaries": "Il file {nomefile} non può essere importato perché non si adatta ai confini della mappa",
+                "exceedFileSizeLimit": "Il file {filename} che stai tentando di importare ha superato il limite massimo di dimensione file {maxfilesize} MB"
             }
         },
         "mapExport": {

--- a/web/client/utils/FileUtils.js
+++ b/web/client/utils/FileUtils.js
@@ -195,4 +195,4 @@ export const isFileSizeExceedMaxLimit = (file, fileSizeLimitInMb) => {
 /**
  * the max file size limit for import vector files
  */
-export const DEFAULT_VECTOR_FILE_MAX_SIZE_IN_MB = 2;
+export const DEFAULT_VECTOR_FILE_MAX_SIZE_IN_MB = 3;

--- a/web/client/utils/FileUtils.js
+++ b/web/client/utils/FileUtils.js
@@ -192,3 +192,7 @@ export const isFileSizeExceedMaxLimit = (file, fileSizeLimitInMb) => {
     }
     return true;
 };
+/**
+ * the max file size limit for import vector files
+ */
+export const DEFAULT_VECTOR_FILE_MAX_SIZE_IN_MB = 2;

--- a/web/client/utils/FileUtils.js
+++ b/web/client/utils/FileUtils.js
@@ -180,3 +180,15 @@ export const checkShapePrj = function(buffer) {
         });
     });
 };
+
+/**
+ * Checks if the file size exceeds the size limit or not. Returns true if exceeding the limit and false if not.
+ */
+export const isFileSizeExceedMaxLimit = (file, fileSizeLimitInMb) => {
+    const fileSizeLimitInByte = fileSizeLimitInMb * 1024 * 1024;
+    const fileSizeInBype = file.size;
+    if (fileSizeInBype <= fileSizeLimitInByte) {
+        return false;
+    }
+    return true;
+};

--- a/web/client/utils/__tests__/FileUtils-test.js
+++ b/web/client/utils/__tests__/FileUtils-test.js
@@ -7,7 +7,7 @@
 */
 import expect from 'expect';
 
-import {readJson, readZip, checkShapePrj} from '../FileUtils';
+import {readJson, readZip, checkShapePrj, isFileSizeExceedMaxLimit} from '../FileUtils';
 import axios from '../../libs/ajax';
 
 describe('FilterUtils', () => {
@@ -30,5 +30,17 @@ describe('FilterUtils', () => {
                 });
             });
         });
+    });
+    it('isFileSizeExceedMaxLimit with large size exceed the max', () => {
+        const maxLimitInMega = 1;
+        const fileWithSizeExceedMaxLimit = 2 * 1024 * 1024;
+        let isFileSizeValid = isFileSizeExceedMaxLimit({size: fileWithSizeExceedMaxLimit}, maxLimitInMega);
+        expect(isFileSizeValid).toEqual(true);
+    });
+    it('isFileSizeExceedMaxLimit with small file size less than max', () => {
+        const maxLimitInMega = 1;
+        const fileWithSizeNotExceedMaxLimit = 0.5 * 1024 * 1024;
+        let isFileSizeValid = isFileSizeExceedMaxLimit({size: fileWithSizeNotExceedMaxLimit}, maxLimitInMega);
+        expect(isFileSizeValid).toEqual(false);
     });
 });


### PR DESCRIPTION
## Description
This PR handles checking on imported vector files size if a confugrable prop is existing into localConfig.
This PR introduces a performed check by MS to verify if imported vector files are over a certain (configurable) file size. 

The size limit is allowed now to be configurable into localConfig by prop called 'importedVectorFileMaxSizeInMB' and its value is number of megabytes. If the file is exceeding the max limit, a warning notification is shown to user.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Enhancement

## Issue
#10770 

**What is the current behavior?**
#10770 

**What is the new behavior?**
If 'importedVectorFileMaxSizeInMB' is added into localConfig, and user wants to upload vector files with size larger that 'importedVectorFileMaxSizeInMB' it will show a warning notification about exceeding the max file size.


https://github.com/user-attachments/assets/cceeaed4-04f1-4c24-9fbd-ebcacde97088



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
