### PR TITLE
Update upload-artifact and cache github action to most recent versions

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -64,19 +64,19 @@ jobs:
         id: "build"
         run: "./build.sh ${{ github.event.inputs.version }} binary,printingbundle"
       - name: "Upload war"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: war
+          name: release-war
           path: product/target/mapstore.war
       - name: "Upload binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binary
+          name: release-binary
           path: "binary/target/mapstore2-${{ github.event.inputs.version }}-bin.zip"
       - name: "Upload printing"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: printing
+          name: release-printing
           path: "java/printing/target/mapstore-printing.zip"
   release:
     runs-on: ubuntu-latest
@@ -86,6 +86,8 @@ jobs:
         uses: actions/download-artifact@v4.1.7
         with:
           path: artifacts/
+          pattern: release-*
+          merge-multiple: true
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: artifacts
@@ -127,7 +129,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: artifacts/war/mapstore.war
+          asset_path: artifacts/mapstore.war
           asset_name: mapstore.war
           asset_content_type: application/zip
       - name: Upload Release binary
@@ -137,7 +139,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: "artifacts/binary/mapstore2-${{github.event.inputs.version}}-bin.zip"
+          asset_path: "artifacts/mapstore2-${{github.event.inputs.version}}-bin.zip"
           asset_name: "mapstore2-${{github.event.inputs.version}}-bin.zip"
           asset_content_type: application/zip
       - name: Upload Release printing
@@ -147,6 +149,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: artifacts/printing/mapstore-printing.zip
+          asset_path: artifacts/mapstore-printing.zip
           asset_name: mapstore-printing.zip
           asset_content_type: application/zip


### PR DESCRIPTION
## Description

This PR updates github actions versions for `actions/cache@1`-2 and `actions/upload-artifact@v2`to the most recent versions.

In particular 
- [migrate](https://github.com/actions/cache/discussions/1510) `cache` actions because of [deprecation notice](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/). 
     - No need particular changes as reported [here](https://github.com/actions/cache/discussions/1510) so only version change should be enough.
- [migrate](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) upload to v4 (only create-release) because of [deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Properly tested on my fork, [it worked](https://github.com/offtherailz/MapStore2/actions/runs/13049044335). 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
