### PR TITLE
#10736: fix issue of not hiding the enabled/disabled filter icon in case there is no filters after reseting the interactive legend

### DIFF
--- a/web/client/plugins/TOC/components/FilterNodeTool.jsx
+++ b/web/client/plugins/TOC/components/FilterNodeTool.jsx
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
+import { isFilterEmpty } from '../../../utils/FilterUtils';
 
 const FilterNodeTool = ({
     node,
@@ -14,7 +15,7 @@ const FilterNodeTool = ({
 }) => {
     const ItemComponent = itemComponent;
     const { layerFilter } = node || {};
-    if (!layerFilter || !ItemComponent) {
+    if (isFilterEmpty(layerFilter) || !ItemComponent) {
         return null;
     }
     const { disabled } = layerFilter || {};

--- a/web/client/plugins/TOC/components/__tests__/DefaultLayer-test.jsx
+++ b/web/client/plugins/TOC/components/__tests__/DefaultLayer-test.jsx
@@ -413,7 +413,42 @@ describe('test DefaultLayer module component', () => {
         expect(errorTooltip).toBeFalsy();
     });
 
-    it('should display the layer filter button', () => {
+    it('should display the layer filter button if there is filters in layerFilter like filterFields/spatialFilter/legendFilter', () => {
+        const layer = {
+            id: 'layer00',
+            name: 'layer00',
+            title: 'Layer',
+            visibility: false,
+            opacity: 0.5,
+            layerFilter: {
+                "filterFields": [
+                    {
+                        "rowId": 1,
+                        "groupId": 1,
+                        "attribute": "FIELD_01",
+                        "operator": "=",
+                        "value": "value01",
+                        "type": "string",
+                        "fieldOptions": {
+                            "valuesCount": 0,
+                            "currentPage": 1
+                        },
+                        "exception": null,
+                        "loading": false,
+                        "openAutocompleteMenu": false,
+                        "options": {
+                            "FIELD_01": []
+                        }
+                    }
+                ]
+            }
+        };
+
+        ReactDOM.render(<Layer node={layer} />, document.getElementById("container"));
+        const filter = document.querySelector('.glyphicon-filter');
+        expect(filter).toBeTruthy();
+    });
+    it('should hide the layer filter button if layerFilter is empty from any kind filters', () => {
         const layer = {
             id: 'layer00',
             name: 'layer00',
@@ -425,7 +460,7 @@ describe('test DefaultLayer module component', () => {
 
         ReactDOM.render(<Layer node={layer} />, document.getElementById("container"));
         const filter = document.querySelector('.glyphicon-filter');
-        expect(filter).toBeTruthy();
+        expect(filter).toBeFalsy();
     });
 
     it('should not display the layer filter button when hideFilter is true', () => {

--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -31,6 +31,7 @@ export const cqlToOgc = (cqlFilter, fOpts) => {
 
 import { get, isNil, isArray, find, findIndex, isString, flatten } from 'lodash';
 import { INTERACTIVE_LEGEND_ID } from './LegendUtils';
+import { getMiscSetting } from './ConfigUtils';
 let FilterUtils;
 
 const wrapValueWithWildcard = (value, condition) => {
@@ -1440,15 +1441,16 @@ export const updateLayerWFSVectorLegendFilter = (layerFilterObj, legendGeostyler
 };
 
 export function resetLayerLegendFilter(layer, reason, value) {
+    const experimentalInteractiveLegend = getMiscSetting('experimentalInteractiveLegend', false);
     const isResetForStyle = reason === 'style';      // here the reason for reset is change 'style' or change the enable/disable interactive legend config 'disableEnableInteractiveLegend'
     let needReset = false;
     if (isResetForStyle) {
         needReset = isResetForStyle && value !== layer.style;
     }
     // check if the layer has interactive legend or not, if not cancel the epic
-    const isLayerWithJSONLegend = layer?.enableInteractiveLegend;
+    const isLayerHasInterActiveLegend = experimentalInteractiveLegend && layer?.enableInteractiveLegend;
     let filterObj = !isFilterEmpty(layer.layerFilter) ? layer.layerFilter : undefined;
-    if (!needReset || !isLayerWithJSONLegend || !filterObj) return false;
+    if (!needReset || !isLayerHasInterActiveLegend || !filterObj) return false;
     // reset thte filter if legendCQLFilter is empty
     const isLegendFilterExist = filterObj?.filters?.find(f => f.id === INTERACTIVE_LEGEND_ID);
     if (isLegendFilterExist) {

--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -1332,7 +1332,7 @@ export const updateLayerLegendFilter = (layerFilterObj, legendFilter) => {
                 ...filterObj, filters: filterObj?.filters?.filter(f => f.id !== INTERACTIVE_LEGEND_ID)
             };
         }
-        let newFilter = filterObj ? filterObj : undefined;
+        let newFilter = !isFilterEmpty(filterObj) ? filterObj : undefined;
         return newFilter;
     }
     let interactiveLegendFilters = isLegendFilterExist ? isLegendFilterExist.filters || [] : [];
@@ -1355,7 +1355,7 @@ export const updateLayerLegendFilter = (layerFilterObj, legendFilter) => {
     }
     let newFilter = {
         ...(filterObj || {}), filters: [
-            ...(filterObj?.filters?.filter(f => f.id !== INTERACTIVE_LEGEND_ID) || []), ...[
+            ...(filterObj?.filters?.filter(f => f.id !== INTERACTIVE_LEGEND_ID) || []), ...(interactiveLegendFilters?.length ? [
                 {
                     "id": INTERACTIVE_LEGEND_ID,
                     "format": "logic",
@@ -1363,10 +1363,10 @@ export const updateLayerLegendFilter = (layerFilterObj, legendFilter) => {
                     "logic": "OR",
                     "filters": [...interactiveLegendFilters]
                 }
-            ]
+            ] : [])
         ]
     };
-    return newFilter;
+    return !isFilterEmpty(newFilter) ? newFilter : undefined;
 };
 
 /**
@@ -1407,7 +1407,7 @@ export const updateLayerWFSVectorLegendFilter = (layerFilterObj, legendGeostyler
                 ...filterObj, filters: filterObj?.filters?.filter(f => f.id !== INTERACTIVE_LEGEND_ID)
             };
         }
-        let newFilter = filterObj ? filterObj : undefined;
+        let newFilter = !isFilterEmpty(filterObj) ? filterObj : undefined;
         return newFilter;
     }
     let interactiveLegendFilters = isLegendFilterExist ? isLegendFilterExist.filters || [] : [];
@@ -1425,7 +1425,7 @@ export const updateLayerWFSVectorLegendFilter = (layerFilterObj, legendGeostyler
     }
     let newFilter = {
         ...(filterObj || {}), filters: [
-            ...(filterObj?.filters?.filter(f => f.id !== INTERACTIVE_LEGEND_ID) || []), ...[
+            ...(filterObj?.filters?.filter(f => f.id !== INTERACTIVE_LEGEND_ID) || []), ...(interactiveLegendFilters?.length ? [
                 {
                     "id": INTERACTIVE_LEGEND_ID,
                     "format": "logic",
@@ -1433,10 +1433,10 @@ export const updateLayerWFSVectorLegendFilter = (layerFilterObj, legendGeostyler
                     "logic": "OR",
                     "filters": [...interactiveLegendFilters]
                 }
-            ]
+            ] : [])
         ]
     };
-    return newFilter;
+    return !isFilterEmpty(newFilter) ? newFilter : undefined;
 };
 
 export function resetLayerLegendFilter(layer, reason, value) {
@@ -1447,7 +1447,7 @@ export function resetLayerLegendFilter(layer, reason, value) {
     }
     // check if the layer has interactive legend or not, if not cancel the epic
     const isLayerWithJSONLegend = layer?.enableInteractiveLegend;
-    let filterObj = layer.layerFilter ? layer.layerFilter : undefined;
+    let filterObj = !isFilterEmpty(layer.layerFilter) ? layer.layerFilter : undefined;
     if (!needReset || !isLayerWithJSONLegend || !filterObj) return false;
     // reset thte filter if legendCQLFilter is empty
     const isLegendFilterExist = filterObj?.filters?.find(f => f.id === INTERACTIVE_LEGEND_ID);
@@ -1455,9 +1455,9 @@ export function resetLayerLegendFilter(layer, reason, value) {
         filterObj = {
             ...filterObj, filters: filterObj?.filters?.filter(f => f.id !== INTERACTIVE_LEGEND_ID)
         };
-        return filterObj;
+        return !isFilterEmpty(filterObj) ? filterObj : undefined;
     }
-    return filterObj;
+    return !isFilterEmpty(filterObj) ? filterObj : undefined;
 }
 
 FilterUtils = {

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -2436,9 +2436,8 @@ describe('FilterUtils', () => {
             ]
         };
         const updatedFilterObj = updateLayerLegendFilter(layerFilterObj);
-        expect(updatedFilterObj).toBeTruthy();
-        expect(updatedFilterObj.filters.length).toEqual(0);
-        expect(updatedFilterObj.filters.find(i => i.id === INTERACTIVE_LEGEND_ID)).toBeFalsy();
+        // check if there is no any filters --> updatedFilterObj will be undefined
+        expect(updatedFilterObj).toBeFalsy();
     });
     it('test resetLayerLegendFilter in case change wms style', () => {
         const layerFilterObj = {
@@ -2491,9 +2490,8 @@ describe('FilterUtils', () => {
             style: "style_01"
         };
         const updatedFilterObj = resetLayerLegendFilter(layer, 'style', 'style_02');
-        expect(updatedFilterObj).toBeTruthy();
-        expect(updatedFilterObj.filters.length).toEqual(0);
-        expect(updatedFilterObj.filters.find(i => i.id === INTERACTIVE_LEGEND_ID)).toBeFalsy();
+        // check if there is no any filters --> updatedFilterObj will be undefined
+        expect(updatedFilterObj).toBeFalsy();
     });
     // for WFS
     it('test updateLayerWFSVectorLegendFilter for wfs, simple filter', () => {
@@ -2596,8 +2594,7 @@ describe('FilterUtils', () => {
             ]
         };
         const updatedFilterObj = updateLayerWFSVectorLegendFilter(layerFilterObj);
-        expect(updatedFilterObj).toBeTruthy();
-        expect(updatedFilterObj.filters.length).toEqual(0);
-        expect(updatedFilterObj.filters.find(i => i.id === INTERACTIVE_LEGEND_ID)).toBeFalsy();
+        // check if there is no any filters --> updatedFilterObj will be undefined
+        expect(updatedFilterObj).toBeFalsy();
     });
 });


### PR DESCRIPTION
## Description
This PR is to fix the issue of not hiding the enabled/disabled filter icon in case there is no filters after reseting the interactive legend.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
https://github.com/geosolutions-it/MapStore2/pull/10748#issuecomment-2627394718

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/pull/10748#issuecomment-2627394718

**What is the new behavior?**
If the layer has only interactive legend filter then user makes reset or removed this filter ---> the  enabled/disabled filter icon will be hidden as there is no filter to disable.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
