### PR TITLE
#10799: Cesium map dark when opened in the evening

### DIFF
--- a/web/client/components/map/cesium/__tests__/Map-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test.jsx
@@ -651,5 +651,72 @@ describe('CesiumMap', () => {
             expect(customHooRegister.getHook(ZOOM_TO_EXTENT_HOOK)).toBeTruthy();
         });
     });
-
+    it('should flashlight effect on map', () => {
+        let ref;
+        act(() => {
+            ReactDOM.render(
+                <CesiumMap
+                    ref={value => { ref = value; } }
+                    center={{y: 10, x: 44}}
+                    zoom={5}
+                    mapOptions={{
+                        lighting3DOption: {
+                            value: 'flashlight'
+                        }
+                    }}
+                />
+                , document.getElementById("container"));
+        });
+        expect(ref.map).toBeTruthy();
+        expect(ref.map.scene.light).toBeTruthy();
+        expect(ref.map.scene.light.intensity).toEqual(3);
+    });
+    it('should sunlight effect on map', () => {
+        let ref;
+        act(() => {
+            ReactDOM.render(
+                <CesiumMap
+                    ref={value => { ref = value; } }
+                    center={{y: 10, x: 44}}
+                    zoom={5}
+                    mapOptions={{
+                        lighting3DOption: {
+                            value: 'sunlight'
+                        }
+                    }}
+                />
+                , document.getElementById("container"));
+        });
+        // for sunlight: default intentsity = 2, color [The light's color] is white and shouldAnimate with true
+        expect(ref.map).toBeTruthy();
+        expect(ref.map.scene.light).toBeTruthy();
+        expect(ref.map.scene.light.intensity).toEqual(2);
+        expect(ref.map.scene.light.color.red).toEqual(1);
+        expect(ref.map.scene.light.color.green).toEqual(1);
+        expect(ref.map.scene.light.color.blue).toEqual(1);
+        expect(ref.map.scene.light.color.alpha).toEqual(1);
+        expect(ref.map.clock.shouldAnimate).toBeTruthy();
+    });
+    it('should lighting effect with specific date-time on map', () => {
+        let ref;
+        act(() => {
+            ReactDOM.render(
+                <CesiumMap
+                    ref={value => { ref = value; } }
+                    center={{y: 10, x: 44}}
+                    zoom={5}
+                    mapOptions={{
+                        lighting3DOption: {
+                            value: 'dateTime',
+                            dateTime: (new Date()).toISOString()
+                        }
+                    }}
+                />
+                , document.getElementById("container"));
+        });
+        expect(ref.map).toBeTruthy();
+        expect(ref.map.scene.light).toBeTruthy();
+        expect(ref.map.clock.shouldAnimate).toBeFalsy();
+        expect(ref.map.clock.currentTime).toBeTruthy();
+    });
 });

--- a/web/client/components/map/cesium/__tests__/Map-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test.jsx
@@ -660,7 +660,7 @@ describe('CesiumMap', () => {
                     center={{y: 10, x: 44}}
                     zoom={5}
                     mapOptions={{
-                        lighting3DOption: {
+                        lighting: {
                             value: 'flashlight'
                         }
                     }}
@@ -680,7 +680,7 @@ describe('CesiumMap', () => {
                     center={{y: 10, x: 44}}
                     zoom={5}
                     mapOptions={{
-                        lighting3DOption: {
+                        lighting: {
                             value: 'sunlight'
                         }
                     }}
@@ -706,7 +706,7 @@ describe('CesiumMap', () => {
                     center={{y: 10, x: 44}}
                     zoom={5}
                     mapOptions={{
-                        lighting3DOption: {
+                        lighting: {
                             value: 'dateTime',
                             dateTime: (new Date()).toISOString()
                         }

--- a/web/client/plugins/map/mapsettings/MapSettings.jsx
+++ b/web/client/plugins/map/mapsettings/MapSettings.jsx
@@ -19,7 +19,6 @@ import { mapSelector } from '../../../selectors/map';
 import { mapTypeSelector, isCesium as isCesiumSelector } from '../../../selectors/maptype';
 import localizedProps from '../../../components/misc/enhancers/localizedProps';
 import utcDateWrapper from '../../../components/misc/enhancers/utcDateWrapper';
-import { DATE_TYPE } from '../../../utils/FeatureGridUtils';
 import { getMessageById } from '../../../utils/LocaleUtils';
 import PropTypes from 'prop-types';
 import DateTimePicker from '../../../components/misc/datetimepicker';
@@ -49,23 +48,6 @@ const Component = ({
     mapOptions: defaultMapOptions
 }, { messages }) => {
     const SelectLocalized = localizedProps(["placeholder", "options"])(Select);
-    const DEFAULT_QUICK_TIME_SELECTORS = [
-        {
-            "type": DATE_TYPE.DATE_TIME,
-            "value": "{now}+P0D",
-            "labelId": "queryform.attributefilter.datefield.quickSelectors.now"
-        },
-        {
-            "type": DATE_TYPE.DATE_TIME,
-            "value": "{now}-P1D",
-            "labelId": "queryform.attributefilter.datefield.quickSelectors.yesterday"
-        },
-        {
-            "type": DATE_TYPE.DATE_TIME,
-            "value": "{now}+P1D",
-            "labelId": "queryform.attributefilter.datefield.quickSelectors.tomorrow"
-        }
-    ];
 
     const mapOptions = {
         ...(defaultMapOptions && defaultMapOptions[mapType]
@@ -108,40 +90,42 @@ const Component = ({
             >
                 <Message msgId="map.settings.depthTest" />
             </Checkbox>
-            <>
-                <label className="control-label"><Message msgId="map.settings.lighting3DOptions.title"/></label>
+            <FormGroup>
+                <ControlLabel><Message msgId="map.settings.lightings.title"/></ControlLabel>
                 <SelectLocalized
                     options={[
-                        {label: "map.settings.lighting3DOptions.flashlightOption", value: "flashlight"},
-                        {label: "map.settings.lighting3DOptions.sunlightOption", value: "sunlight"},
-                        {label: "map.settings.lighting3DOptions.dateTimeOption", value: "dateTime"}
+                        {label: "map.settings.lightings.sunlightOption", value: "sunlight"},
+                        {label: "map.settings.lightings.flashlightOption", value: "flashlight"},
+                        {label: "map.settings.lightings.dateTimeOption", value: "dateTime"}
                     ]}
                     wrapperStyle = {{ marginTop: "10px"}}
-                    value={mapOptions && mapOptions.lighting3DOption?.value || ""}
+                    value={mapOptions && mapOptions.lighting?.value || "sunlight"}
                     clearable={false}
                     onChange={(val) => {
                         if (val !== 'dateTime') {
-                            updateConfigAction({"lighting3DOption": {value: val.value}});
+                            updateConfigAction({"lighting": {value: val.value}});
                         } else {
-                            updateConfigAction({"lighting3DOption": {value: val.value, dateTime: new Date().toISOString()}});
+                            updateConfigAction({"lighting": {value: val.value, dateTime: new Date().toISOString()}});
                         }
                     }}
-                    placeholder="map.settings.lighting3DOptions.placeholder"
+                    placeholder="map.settings.lightings.placeholder"
                 />
-                {mapOptions?.lighting3DOption?.value === 'dateTime' ?
-                    <UTCDateTimePicker
-                        value={mapOptions.lighting3DOption?.dateTime ? new Date(mapOptions.lighting3DOption?.dateTime) : new Date()}
-                        quickDateTimeSelectors={DEFAULT_QUICK_TIME_SELECTORS}
-                        hideOperator
-                        time
-                        calendar
-                        type={'date-time'}
-                        onChange={(date) => {
-                            updateConfigAction({"lighting3DOption": {...mapOptions.lighting3DOption, dateTime: date}});
-                        }}
-                        placeholder={getMessageById(messages, "map.settings.lighting3DOptions.dateTimePlaceholder")} /> :
+                {mapOptions?.lighting?.value === 'dateTime' ?
+                    <div className="lighting-dateTime-picker">
+                        <UTCDateTimePicker
+                            value={mapOptions.lighting?.dateTime ? new Date(mapOptions.lighting?.dateTime) : new Date()}
+                            hideOperator
+                            time
+                            popupPosition={"top"}
+                            calendar
+                            type={'date-time'}
+                            onChange={(date) => {
+                                updateConfigAction({"lighting": {...mapOptions.lighting, dateTime: date}});
+                            }}
+                            placeholder={getMessageById(messages, "map.settings.lightings.dateTimePlaceholder")} />
+                    </div> :
                     null}
-            </>
+            </FormGroup>
         </form>
     ) : null;
 };

--- a/web/client/plugins/map/mapsettings/MapSettings.jsx
+++ b/web/client/plugins/map/mapsettings/MapSettings.jsx
@@ -9,13 +9,20 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { FormGroup, Checkbox, ControlLabel } from 'react-bootstrap';
-import Message from '../../../components/I18N/Message';
+import Select from 'react-select';
 import { createSelector } from 'reselect';
+import Message from '../../../components/I18N/Message';
 import { updateMapOptions } from '../../../actions/map';
 import ConfigUtils from '../../../utils/ConfigUtils';
 
 import { mapSelector } from '../../../selectors/map';
 import { mapTypeSelector, isCesium as isCesiumSelector } from '../../../selectors/maptype';
+import localizedProps from '../../../components/misc/enhancers/localizedProps';
+import utcDateWrapper from '../../../components/misc/enhancers/utcDateWrapper';
+import { DATE_TYPE } from '../../../utils/FeatureGridUtils';
+import { getMessageById } from '../../../utils/LocaleUtils';
+import PropTypes from 'prop-types';
+import DateTimePicker from '../../../components/misc/datetimepicker';
 
 const mapStateToProps = createSelector(
     mapSelector,
@@ -28,13 +35,37 @@ const actions = {
     updateConfigAction: updateMapOptions
 };
 
+const UTCDateTimePicker = utcDateWrapper({
+    dateProp: "value",
+    dateTypeProp: "type",
+    setDateProp: "onChange"
+})(DateTimePicker);
+
 const Component = ({
     map,
     mapType,
     isCesium,
     updateConfigAction,
     mapOptions: defaultMapOptions
-}) => {
+}, { messages }) => {
+    const SelectLocalized = localizedProps(["placeholder", "options"])(Select);
+    const DEFAULT_QUICK_TIME_SELECTORS = [
+        {
+            "type": DATE_TYPE.DATE_TIME,
+            "value": "{now}+P0D",
+            "labelId": "queryform.attributefilter.datefield.quickSelectors.now"
+        },
+        {
+            "type": DATE_TYPE.DATE_TIME,
+            "value": "{now}-P1D",
+            "labelId": "queryform.attributefilter.datefield.quickSelectors.yesterday"
+        },
+        {
+            "type": DATE_TYPE.DATE_TIME,
+            "value": "{now}+P1D",
+            "labelId": "queryform.attributefilter.datefield.quickSelectors.tomorrow"
+        }
+    ];
 
     const mapOptions = {
         ...(defaultMapOptions && defaultMapOptions[mapType]
@@ -77,8 +108,44 @@ const Component = ({
             >
                 <Message msgId="map.settings.depthTest" />
             </Checkbox>
+            <>
+                <label className="control-label"><Message msgId="map.settings.lighting3DOptions.title"/></label>
+                <SelectLocalized
+                    options={[
+                        {label: "map.settings.lighting3DOptions.flashlightOption", value: "flashlight"},
+                        {label: "map.settings.lighting3DOptions.sunlightOption", value: "sunlight"},
+                        {label: "map.settings.lighting3DOptions.dateTimeOption", value: "dateTime"}
+                    ]}
+                    wrapperStyle = {{ marginTop: "10px"}}
+                    value={mapOptions && mapOptions.lighting3DOption?.value || ""}
+                    clearable={false}
+                    onChange={(val) => {
+                        if (val !== 'dateTime') {
+                            updateConfigAction({"lighting3DOption": {value: val.value}});
+                        } else {
+                            updateConfigAction({"lighting3DOption": {value: val.value, dateTime: new Date().toISOString()}});
+                        }
+                    }}
+                    placeholder="map.settings.lighting3DOptions.placeholder"
+                />
+                {mapOptions?.lighting3DOption?.value === 'dateTime' ?
+                    <UTCDateTimePicker
+                        value={mapOptions.lighting3DOption?.dateTime ? new Date(mapOptions.lighting3DOption?.dateTime) : new Date()}
+                        quickDateTimeSelectors={DEFAULT_QUICK_TIME_SELECTORS}
+                        hideOperator
+                        time
+                        calendar
+                        type={'date-time'}
+                        onChange={(date) => {
+                            updateConfigAction({"lighting3DOption": {...mapOptions.lighting3DOption, dateTime: date}});
+                        }}
+                        placeholder={getMessageById(messages, "map.settings.lighting3DOptions.dateTimePlaceholder")} /> :
+                    null}
+            </>
         </form>
     ) : null;
 };
-
+Component.contextTypes = {
+    messages: PropTypes.object
+};
 export default connect(mapStateToProps, actions)(Component);

--- a/web/client/themes/default/less/settings.less
+++ b/web/client/themes/default/less/settings.less
@@ -30,5 +30,8 @@
     .modal-body .form-group {
         border-top-width: 1px !important;
         border-top-style: solid !important;
+        .lighting-dateTime-picker{
+            margin-top: 10px;
+        }
     }
 }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -559,7 +559,15 @@
               "skyAtmosphere": "Himmelsatmosphäre zeigen",
               "groundAtmosphere": "Atmosphäre auf dem Gelände anzeigen",
               "fog": "Nebel anzeigen",
-              "depthTest": "Tiefentest gegen Gelände aktivieren"
+              "depthTest": "Tiefentest gegen Gelände aktivieren",
+              "lighting3DOptions": {
+                    "title": "3D-Beleuchtungsoptionen",
+                    "placeholder": "Wähle die 3D-Beleuchtungsoption aus",
+                    "flashlightOption": "Taschenlampe",
+                    "sunlightOption": "Sonnenlicht",
+                    "dateTimeOption": "Spezifisches UTC-Datum-Uhrzeit",
+                    "dateTimePlaceholder": "Wählen Sie Datum und Uhrzeit"
+                }
             },
             "thumbnailError": {
                 "error403": "Sie haben keine Berechtigung um Miniaturansichten hochzuladen",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -560,9 +560,9 @@
               "groundAtmosphere": "Atmosphäre auf dem Gelände anzeigen",
               "fog": "Nebel anzeigen",
               "depthTest": "Tiefentest gegen Gelände aktivieren",
-              "lighting3DOptions": {
-                    "title": "3D-Beleuchtungsoptionen",
-                    "placeholder": "Wähle die 3D-Beleuchtungsoption aus",
+              "lightings": {
+                    "title": "Beleuchtungsoptionen",
+                    "placeholder": "Wähle die Beleuchtungsoption aus",
                     "flashlightOption": "Taschenlampe",
                     "sunlightOption": "Sonnenlicht",
                     "dateTimeOption": "Spezifisches UTC-Datum-Uhrzeit",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -521,7 +521,15 @@
               "skyAtmosphere": "Show sky atmosphere",
               "groundAtmosphere": "Show ground atmosphere",
               "fog": "Show fog",
-              "depthTest": "Enable depth test against terrain"
+              "depthTest": "Enable depth test against terrain",
+              "lighting3DOptions": {
+                "title": "3D Lighting Options",
+                "placeholder": "Select the 3d lighting option",
+                "flashlightOption": "Flashlight",
+                "sunlightOption": "Sunlight",
+                "dateTimeOption": "Specific UTC Date-Time",
+                "dateTimePlaceholder": "Select the dateTime"
+              }
             },
             "thumbnailError": {
                 "error403": "You are not allowed to update the thumbnail",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -522,9 +522,9 @@
               "groundAtmosphere": "Show ground atmosphere",
               "fog": "Show fog",
               "depthTest": "Enable depth test against terrain",
-              "lighting3DOptions": {
-                "title": "3D Lighting Options",
-                "placeholder": "Select the 3d lighting option",
+              "lightings": {
+                "title": "Lighting Options",
+                "placeholder": "Select the lighting option",
                 "flashlightOption": "Flashlight",
                 "sunlightOption": "Sunlight",
                 "dateTimeOption": "Specific UTC Date-Time",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -521,7 +521,15 @@
               "skyAtmosphere": "Mostrar la atmósfera del cielo",
               "groundAtmosphere": "Mostrar la atmósfera de la superficie",
               "fog": "Mostrar niebla",
-              "depthTest": "Activar depthTest contra el terreno"
+              "depthTest": "Activar depthTest contra el terreno",
+              "lighting3DOptions": {
+                    "title": "Opciones de Iluminación 3D",
+                    "placeholder": "Selecciona la opción de iluminación 3D",
+                    "flashlightOption": "Linterna",
+                    "sunlightOption": "Luz solar",
+                    "dateTimeOption": "Fecha-Hora UTC específica",
+                    "dateTimePlaceholder": "Seleccione la fecha y hora"
+                }
             },
             "thumbnailError": {
                 "error403": "Error al modificar la miniatura",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -522,9 +522,9 @@
               "groundAtmosphere": "Mostrar la atmósfera de la superficie",
               "fog": "Mostrar niebla",
               "depthTest": "Activar depthTest contra el terreno",
-              "lighting3DOptions": {
-                    "title": "Opciones de Iluminación 3D",
-                    "placeholder": "Selecciona la opción de iluminación 3D",
+              "lightings": {
+                    "title": "Opciones de Iluminación",
+                    "placeholder": "Selecciona la opción de iluminación",
                     "flashlightOption": "Linterna",
                     "sunlightOption": "Luz solar",
                     "dateTimeOption": "Fecha-Hora UTC específica",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -521,7 +521,15 @@
               "skyAtmosphere": "Afficher l'atmosphère du ciel",
               "groundAtmosphere": "Montrer l'atmosphère du terrain",
               "fog": "Afficher le brouillard",
-              "depthTest": "Activer le depthTest sur le terrain"
+              "depthTest": "Activer le depthTest sur le terrain",
+              "lighting3DOptions": {
+                "title": "Options d'éclairage 3D",
+                "placeholder": "Sélectionnez l'option d'éclairage 3D",
+                "flashlightOption": "Lampe de poche",
+                "sunlightOption": "Lumière du soleil",
+                "dateTimeOption": "Date-heure UTC spécifique",
+                "dateTimePlaceholder": "Sélectionnez la date et l'heure"
+                }
             },
             "thumbnailError": {
                 "error403": "Une erreur est survenue lors de la suppression de la vignette",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -522,9 +522,9 @@
               "groundAtmosphere": "Montrer l'atmosphère du terrain",
               "fog": "Afficher le brouillard",
               "depthTest": "Activer le depthTest sur le terrain",
-              "lighting3DOptions": {
-                "title": "Options d'éclairage 3D",
-                "placeholder": "Sélectionnez l'option d'éclairage 3D",
+              "lightings": {
+                "title": "Options d'éclairage",
+                "placeholder": "Sélectionnez l'option d'éclairage",
                 "flashlightOption": "Lampe de poche",
                 "sunlightOption": "Lumière du soleil",
                 "dateTimeOption": "Date-heure UTC spécifique",

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -475,7 +475,15 @@
         "skyAtmosphere": "Show sky atmosphere",
         "groundAtmosphere": "Show ground atmosphere",
         "fog": "Show fog",
-        "depthTest": "Enable depth test against terrain"
+        "depthTest": "Enable depth test against terrain",
+        "lighting3DOptions": {
+          "title": "3D Lighting Options",
+          "placeholder": "Select the 3d lighting option",
+          "flashlightOption": "Flashlight",
+          "sunlightOption": "Sunlight",
+          "dateTimeOption": "Specific UTC Date-Time",
+          "dateTimePlaceholder": "Select the dateTime"
+        }
       },
       "thumbnailError": {
         "error403": "You are not allowed to update the thumbnail",

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -476,9 +476,9 @@
         "groundAtmosphere": "Show ground atmosphere",
         "fog": "Show fog",
         "depthTest": "Enable depth test against terrain",
-        "lighting3DOptions": {
-          "title": "3D Lighting Options",
-          "placeholder": "Select the 3d lighting option",
+        "lightings": {
+          "title": "Lighting Options",
+          "placeholder": "Select the lighting option",
           "flashlightOption": "Flashlight",
           "sunlightOption": "Sunlight",
           "dateTimeOption": "Specific UTC Date-Time",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -519,7 +519,15 @@
               "skyAtmosphere": "Mostra l'atmosfera del cielo",
               "groundAtmosphere": "Mostra l'atmosfera del terreno",
               "fog": "Mostra nebbia",
-              "depthTest": "Abilita il depthTest sul terreno"
+              "depthTest": "Abilita il depthTest sul terreno",
+              "lighting3DOptions": {
+                "title": "Opzioni di Illuminazione 3D",
+                "placeholder": "Seleziona l'opzione di illuminazione 3D",
+                "flashlightOption": "Torcia elettrica",
+                "sunlightOption": "Luce solare",
+                "dateTimeOption": "Data-Ora UTC specifica",
+                "dateTimePlaceholder": "Seleziona la data e l'ora"
+            }
             },
             "thumbnailError": {
                 "error403": "Non disponi dei permessi per aggiornare la thumbnail",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -520,9 +520,9 @@
               "groundAtmosphere": "Mostra l'atmosfera del terreno",
               "fog": "Mostra nebbia",
               "depthTest": "Abilita il depthTest sul terreno",
-              "lighting3DOptions": {
-                "title": "Opzioni di Illuminazione 3D",
-                "placeholder": "Seleziona l'opzione di illuminazione 3D",
+              "lightings": {
+                "title": "Opzioni di Illuminazione",
+                "placeholder": "Seleziona l'opzione di illuminazione",
                 "flashlightOption": "Torcia elettrica",
                 "sunlightOption": "Luce solare",
                 "dateTimeOption": "Data-Ora UTC specifica",


### PR DESCRIPTION
## Description
This PR includes enabling change the cesium 3D map lighting theme. It also includes:
- handling showing DD in mapSettings for 3D with 3 options: 'flashlight', 'sunlight', 'custom dateTime'
- handle logic of setting lighting options for cesium if user select one of the 3 available options

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#10799

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10799

**What is the new behavior?**
For 3D map, user can change lighting theme for cesium 3D map to be sunlight, flashlight or sunlight with custom UTC date time.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
For the current used Cesium version '1.106', it miss some features like **dynamicAtmosphereLighting** which is introduced in the next version 1.107 and **dynamicAtmosphereLightingFromSun ** as well.
Added Light, DirectionalLight, and SunLight classes for creating custom light sources.

check this for more details: https://github.com/CesiumGS/cesium/blob/1.107/CHANGES.md
