### PR TITLE
Fix #10805 JAXBException while updating an existing dashboard

### DIFF
--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -27,7 +27,7 @@ const createAttributeList = (metadata = {}) => {
     const attributes = metadata.attributes || omit(metadata, ["name", "description", "id", "advertised"]);
 
     const xmlAttrs = Object.keys(attributes).map((key) => {
-        return "<attribute><name>" + key + "</name><value>" + attributes[key] + "</value><type>STRING</type></attribute>";
+        return "<attribute><name>" + key + "</name><value><![CDATA[" + attributes[key] + "]]></value><type>STRING</type></attribute>";
     });
     let attributesSection = "";
     if (xmlAttrs.length > 0) {

--- a/web/client/api/__tests__/GeoStoreDAO-test.jsx
+++ b/web/client/api/__tests__/GeoStoreDAO-test.jsx
@@ -207,9 +207,9 @@ describe('Test correctness of the GeoStore APIs', () => {
         metadata = API.createAttributeList(metadata);
         expect(metadata).toEqual(
             "<Attributes>" +
-                "<attribute><name>nina</name><value>nina</value><type>STRING</type></attribute>" +
-                "<attribute><name>eating</name><value>eating</value><type>STRING</type></attribute>" +
-                "<attribute><name>plastic</name><value>plastic</value><type>STRING</type></attribute>" +
+                "<attribute><name>nina</name><value><![CDATA[nina]]></value><type>STRING</type></attribute>" +
+                "<attribute><name>eating</name><value><![CDATA[eating]]></value><type>STRING</type></attribute>" +
+                "<attribute><name>plastic</name><value><![CDATA[plastic]]></value><type>STRING</type></attribute>" +
             "</Attributes>"
         );
     });

--- a/web/client/api/usersession/__tests__/server-test.js
+++ b/web/client/api/usersession/__tests__/server-test.js
@@ -33,9 +33,13 @@ describe('usersession API server implementation', () => {
             }
         });
         server.writeSession(null, "myname", "myuser", {myprop: "myvalue"}).subscribe((id) => {
-            expect(id).toBe(1);
-            expect(mockAxios.history.post[0].data).toContain("<name><![CDATA[myname]]></name>");
-            expect(mockAxios.history.post[0].data).toContain("<value>myuser</value>");
+            try {
+                expect(id).toBe(1);
+                expect(mockAxios.history.post[0].data).toContain("<name><![CDATA[myname]]></name>");
+                expect(mockAxios.history.post[0].data).toContain("<value><![CDATA[myuser]]></value>");
+            } catch (e) {
+                done(e);
+            }
             done();
         });
     });

--- a/web/client/plugins/ResourcesCatalog/api/__tests__/resources-test.js
+++ b/web/client/plugins/ResourcesCatalog/api/__tests__/resources-test.js
@@ -252,7 +252,10 @@ describe('resources api', () => {
                         "category": { "id": 5, "name": "MAP" },
                         "id": 1,
                         "name": "Map",
-                        "attributes": { "context": 2 },
+                        "attributes": {
+                            "context": 2,
+                            "detailsSettings": {}
+                        },
                         "@extras": {
                             "context": {
                                 "category": { "id": 3, "name": "CONTEXT" },

--- a/web/client/plugins/ResourcesCatalog/api/resources.js
+++ b/web/client/plugins/ResourcesCatalog/api/resources.js
@@ -139,6 +139,17 @@ const getFilter = ({
     };
 };
 
+const parseDetailsSettings = (detailsSettings) => {
+    if (isString(detailsSettings)) {
+        try {
+            return JSON.parse(detailsSettings);
+        } catch (e) {
+            return {};
+        }
+    }
+    return detailsSettings || {};
+};
+
 export const requestResources = ({
     params
 } = {}, { user } = {}) => {
@@ -199,8 +210,13 @@ export const requestResources = ({
                         isNextPageAvailable: page < (response?.totalCount / pageSize),
                         resources: resources
                             .map(({ tags, ...resource }) => {
+                                const detailsSettings = parseDetailsSettings(resource?.attributes?.detailsSettings);
                                 return {
                                     ...resource,
+                                    attributes: {
+                                        ...resource?.attributes,
+                                        detailsSettings
+                                    },
                                     ...(tags && { tags: castArray(tags) })
                                 };
                             })
@@ -219,17 +235,6 @@ export const requestResources = ({
                     };
                 });
         });
-};
-
-const parseDetailsSettings = (detailsSettings) => {
-    if (isString(detailsSettings)) {
-        try {
-            return JSON.parse(detailsSettings);
-        } catch (e) {
-            return {};
-        }
-    }
-    return detailsSettings || {};
 };
 
 export const requestResource = ({ resource, user }) => {

--- a/web/client/plugins/ResourcesCatalog/utils/ResourcesUtils.js
+++ b/web/client/plugins/ResourcesCatalog/utils/ResourcesUtils.js
@@ -105,6 +105,7 @@ export const computePendingChanges = (initialResource, resource, resourceData) =
     ];
     const categoryOptions = {
         'thumbnail': {
+            // this forces the reload the thumbnail image when updated
             tail: `/raw?decode=datauri&v=${uuid()}`,
             category: 'THUMBNAIL'
         },

--- a/web/client/plugins/ResourcesCatalog/utils/ResourcesUtils.js
+++ b/web/client/plugins/ResourcesCatalog/utils/ResourcesUtils.js
@@ -8,6 +8,7 @@
 
 import { isEmpty, isEqual, omit, isArray, isObject } from 'lodash';
 import merge from 'lodash/fp/merge';
+import uuid from 'uuid/v1';
 
 const NODATA = 'NODATA';
 
@@ -104,7 +105,7 @@ export const computePendingChanges = (initialResource, resource, resourceData) =
     ];
     const categoryOptions = {
         'thumbnail': {
-            tail: '/raw?decode=datauri',
+            tail: `/raw?decode=datauri&v=${uuid()}`,
             category: 'THUMBNAIL'
         },
         'details': {

--- a/web/client/plugins/ResourcesCatalog/utils/__tests__/ResourcesUtils-test.js
+++ b/web/client/plugins/ResourcesCatalog/utils/__tests__/ResourcesUtils-test.js
@@ -128,38 +128,6 @@ describe('ResourcesUtils', () => {
         );
 
         expect(computePendingChanges(
-            { id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } },
-            { id: 1, name: 'Title', attributes: { thumbnail: '' }, category: { name: 'MAP' } })).toEqual(
-            {
-                initialResource: { id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } },
-                resource: { id: 1, name: 'Title', attributes: { thumbnail: '' }, category: { name: 'MAP' } },
-                saveResource: {
-                    id: 1,
-                    permission: undefined,
-                    category: 'MAP',
-                    metadata: { id: 1, name: 'Title', attributes: { thumbnail: '/thumb' } },
-                    linkedResources: { thumbnail: { tail: '/raw?decode=datauri', category: 'THUMBNAIL', value: '/thumb', data: 'NODATA' } }
-                },
-                changes: { linkedResources: { thumbnail: { tail: '/raw?decode=datauri', category: 'THUMBNAIL', value: '/thumb', data: 'NODATA' } } } }
-        );
-
-        expect(computePendingChanges(
-            { id: 1, name: 'Title', attributes: {}, category: { name: 'MAP' } },
-            { id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } })).toEqual(
-            {
-                initialResource: { id: 1, name: 'Title', attributes: { }, category: { name: 'MAP' } },
-                resource: { id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } },
-                saveResource: {
-                    id: 1,
-                    permission: undefined,
-                    category: 'MAP',
-                    metadata: { id: 1, name: 'Title', attributes: {} },
-                    linkedResources: { thumbnail: { tail: '/raw?decode=datauri', category: 'THUMBNAIL', value: 'NODATA', data: '/thumb' } }
-                },
-                changes: { linkedResources: { thumbnail: {  tail: '/raw?decode=datauri', category: 'THUMBNAIL', value: 'NODATA', data: '/thumb' } } } }
-        );
-
-        expect(computePendingChanges(
             { id: 1, name: 'Title', attributes: {}, category: { name: 'MAP' } },
             { id: 1, name: 'Title', attributes: { details: '/details' }, category: { name: 'MAP' } })).toEqual(
             {
@@ -183,6 +151,26 @@ describe('ResourcesUtils', () => {
                 changes: { data: true }
             }
         );
+    });
+    it('computePendingChanges with thumbnail', () => {
+        let computedChanges = computePendingChanges(
+            { id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } },
+            { id: 1, name: 'Title', attributes: { thumbnail: '' }, category: { name: 'MAP' } });
+        expect(computedChanges.initialResource).toEqual({ id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } });
+        expect(computedChanges.resource).toEqual({ id: 1, name: 'Title', attributes: { thumbnail: '' }, category: { name: 'MAP' } });
+        expect(computedChanges.changes.linkedResources.thumbnail.value).toBe('/thumb');
+        expect(computedChanges.changes.linkedResources.thumbnail.data).toBe('NODATA');
+
+        computedChanges = computePendingChanges(
+            { id: 1, name: 'Title', attributes: {}, category: { name: 'MAP' } },
+            { id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } });
+        expect(computedChanges.initialResource).toEqual({ id: 1, name: 'Title', attributes: { }, category: { name: 'MAP' } });
+        expect(computedChanges.resource).toEqual({ id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } });
+        expect(computedChanges.changes.linkedResources.thumbnail.value).toBe('NODATA');
+        expect(computedChanges.changes.linkedResources.thumbnail.data).toBe('/thumb');
+        const tailsParts = computedChanges.changes.linkedResources.thumbnail.tail.split('&');
+        expect(tailsParts[0]).toBe('/raw?decode=datauri');
+        expect(tailsParts[1].includes('v=')).toBe(true);
     });
     it('computePendingChanges with tags', () => {
         const computed = computePendingChanges(


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR review the payload for resources PUT request making sure the attribute value can support special chars.
As found here https://github.com/geosolutions-it/MapStore2/issues/10805#issuecomment-2650733366 the problem was related to the `&` char inside the thumbnail url in previous version of MS this was not happening because the request workflow was using other api functions.
There is also a fix related to the detailsSettings parameter not correctly parsed by the resources catalog api

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10805

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

It is possible to save resources with attributes with special chars

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
