### PR TITLE
Fix #10812 excluding fixed list of layers

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -101,6 +101,7 @@ import { MapLibraries } from '../utils/MapTypeUtils';
  * @prop {object} cfg.outputFormatOptions options for the output formats
  * @prop {object[]} cfg.outputFormatOptions.allowedFormats array of allowed formats, e.g. [{"name": "PDF", "value": "pdf"}]
  * @prop {object} cfg.projectionOptions options for the projections
+ * @prop {string[]} cfg.excludeLayersFromLegend list of layer names e.g. ["workspace:layerName"] to exclude from printed document
  * @prop {object[]} cfg.projectionOptions.projections array of available projections, e.g. [{"name": "EPSG:3857", "value": "EPSG:3857"}]
  * @prop {object} cfg.overlayLayersOptions options for overlay layers
  * @prop {boolean} cfg.overlayLayersOptions.enabled if true a checkbox will be shown to exclude or include overlay layers to the print
@@ -288,6 +289,7 @@ export default {
                         currentLocale: PropTypes.string,
                         overrideOptions: PropTypes.object,
                         items: PropTypes.array,
+                        excludeLayersFromLegend: PropTypes.array,
                         addPrintParameter: PropTypes.func,
                         printingService: PropTypes.object,
                         printMap: PropTypes.object
@@ -309,6 +311,7 @@ export default {
                         onPrint: () => {},
                         configurePrintMap: () => {},
                         printSpecTemplate: {},
+                        excludeLayersFromLegend: [],
                         getLayoutName: getLayoutName,
                         getZoomForExtent: defaultGetZoomForExtent,
                         pdfUrl: null,
@@ -604,6 +607,7 @@ export default {
                         this.props.setPage(0);
                         this.props.onBeforePrint();
                         this.props.printingService.print({
+                            excludeLayersFromLegend: this.props.excludeLayersFromLegend,
                             layers: this.getMapConfiguration()?.layers,
                             scales: this.props.useFixedScales ? getPrintScales(this.props.capabilities) : undefined,
                             bbox: this.props.map?.bbox

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -17,7 +17,7 @@ import { extractValidBaseURL } from './TileProviderUtils';
 import { getTileMatrix } from './WMTSUtils';
 import { guessFormat } from './TMSUtils';
 import { get as getProjection } from 'ol/proj';
-import { isArray, filter, find, isEmpty, toNumber, castArray, reverse } from 'lodash';
+import { isArray, filter, find, isEmpty, toNumber, castArray, reverse, includes } from 'lodash';
 import { getFeature } from '../api/WFS';
 import { generateEnvString } from './LayerLocalizationUtils';
 import { ServerTypes } from './LayersUtils';
@@ -277,7 +277,7 @@ export const getLayersCredits = (layers) => {
  * @memberof utils.PrintUtils
  */
 export const getMapfishPrintSpecification = (rawSpec, state) => {
-    const {params, ...baseSpec} = rawSpec;
+    const {params, excludeLayersFromLegend, ...baseSpec} = rawSpec;
     const spec = {...baseSpec, ...params};
     const printMap = state?.print?.map;
     const projectedCenter = reproject(spec.center, 'EPSG:4326', spec.projection);
@@ -291,6 +291,8 @@ export const getMapfishPrintSpecification = (rawSpec, state) => {
         center: projectedCenter,
         scaleZoom: projectedZoom
     };
+    let legendLayers = spec.layers.filter(layer => !includes(excludeLayersFromLegend, layer.name));
+    legendLayers = PrintUtils.getMapfishLayersSpecification(legendLayers, projectedSpec, state, 'legend');
     return {
         "units": getUnits(spec.projection),
         "srs": normalizeSRS(spec.projection || 'EPSG:3857'),
@@ -311,7 +313,7 @@ export const getMapfishPrintSpecification = (rawSpec, state) => {
                 "rotation": !isNil(spec.rotation) ? -Number(spec.rotation) : 0 // negate the rotation value to match rotation in map preview and printed output
             }
         ],
-        "legends": PrintUtils.getMapfishLayersSpecification(spec.layers, projectedSpec, state, 'legend'),
+        "legends": legendLayers,
         "credits": getLayersCredits(spec.layers),
         ...params
     };

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -560,6 +560,66 @@ describe('PrintUtils', () => {
         expect(printSpec).toExist();
         expect(printSpec.custom).toBe("customvalue");
     });
+    it("getMapfishPrintSpecification, valid spec with legend, and excluded layer from legeng", () => {
+        const spec = {
+            projection: "EPSG:4326",
+            sheet: "A4",
+            landscape: true,
+            resolution: "96",
+            name: "Test print",
+            user: "user1",
+            scale: 500000,
+            printCrs: "World WGS 84 (EPSG:4326)",
+            description: "Test description",
+            includeLegend: true,
+            includeNotes: true,
+            layers: [
+                {
+                    external: true,
+                    url: "/wms",
+                    singleTile: false,
+                    opacity: 0.8,
+                    name: "layer-test",
+                    title: "layer-test",
+                    format: "png",
+                    style: "style1",
+                    cql_filter: "x=1",
+                    visibility: true,
+                    type: "wms"
+                },
+                {
+                    external: true,
+                    url: "/wms",
+                    singleTile: false,
+                    opacity: 0.8,
+                    name: "layer-test-exclude",
+                    title: "layer-test",
+                    format: "png",
+                    style: "style1",
+                    cql_filter: "x=1",
+                    visibility: true,
+                    type: "wms"
+                }
+            ],
+            geoserverUrls: [
+                "/rest/geoserver",
+                "/rest/geoserver1",
+                "/rest/geoserver2"
+            ],
+            center: {x: 0, y: 0, crs: "EPSG:4326"},
+            type: "WMS"
+        };
+        let mapFishSpec = getMapfishPrintSpecification({
+            ...spec,
+            forceLabels: true,
+            antiAliasing: true,
+            legendDpi: 96,
+            bold: true,
+            excludeLayersFromLegend: ["layer-test-exclude"]
+        });
+        expect(mapFishSpec.legends.length).toBe(1);
+
+    });
     it('getMapfishPrintSpecification with fixed scales', () => {
         const printSpec = getMapfishPrintSpecification({
             ...testSpec,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

added a property to exclude layers from legend

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10812 excluding fixed list of layers

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
listed layers that match the layer name (with workspace name) are excluded from legend print
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
