### PR TITLE
#10816: Allow dynamic management of style editing permissions

### DIFF
--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -14,7 +14,7 @@ import { branch, compose, lifecycle, toClass } from 'recompose';
 import { createSelector } from 'reselect';
 
 import { updateSettingsParams } from '../actions/layers';
-import { initStyleService, setEditPermissionStyleEditor, toggleStyleEditor } from '../actions/styleeditor';
+import { initStyleService, toggleStyleEditor } from '../actions/styleeditor';
 import HTML from '../components/I18N/HTML';
 import BorderLayout from '../components/layout/BorderLayout';
 import emptyState from '../components/misc/enhancers/emptyState';
@@ -43,8 +43,7 @@ const StyleEditorPanel = ({
     editingAllowedGroups,
     enableSetDefaultStyle,
     canEdit,
-    editorConfig,
-    onSetPermission
+    editorConfig
 }) => {
 
     useEffect(() => {
@@ -56,10 +55,6 @@ const StyleEditorPanel = ({
             }
         );
     }, []);
-
-    useEffect(() => {
-        onSetPermission(canEdit);
-    }, [canEdit]);
 
     return (
         <BorderLayout
@@ -168,8 +163,7 @@ const StyleEditorPlugin = compose(
         ),
         {
             onInit: initStyleService,
-            onUpdateParams: updateSettingsParams,
-            onSetPermission: setEditPermissionStyleEditor
+            onUpdateParams: updateSettingsParams
         },
         (stateProps, dispatchProps, ownProps) => {
             // detect if the static service has been updated with new information in the global state

--- a/web/client/plugins/__tests__/StyleEditor-test.jsx
+++ b/web/client/plugins/__tests__/StyleEditor-test.jsx
@@ -14,8 +14,7 @@ import { getPluginForTest } from './pluginsTestUtils';
 import { act } from 'react-dom/test-utils';
 import {
     INIT_STYLE_SERVICE,
-    TOGGLE_STYLE_EDITOR,
-    SET_EDIT_PERMISSION
+    TOGGLE_STYLE_EDITOR
 } from '../../actions/styleeditor';
 
 describe('StyleEditor Plugin', () => {
@@ -45,9 +44,9 @@ describe('StyleEditor Plugin', () => {
                 styleService={cfgStyleService}
             />, document.getElementById("container"));
         });
-        expect(actions.length).toBe(3);
+        expect(actions.length).toBe(2);
         expect(actions.map(action => action.type))
-            .toEqual([ TOGGLE_STYLE_EDITOR, INIT_STYLE_SERVICE, SET_EDIT_PERMISSION ]);
+            .toEqual([ TOGGLE_STYLE_EDITOR, INIT_STYLE_SERVICE ]);
         expect(actions[1].service).toBeTruthy();
         expect(actions[1].service).toEqual({ ...cfgStyleService, isStatic: true });
         expect(actions[1].permissions.editingAllowedRoles).toEqual(['ADMIN']);
@@ -86,9 +85,9 @@ describe('StyleEditor Plugin', () => {
                 {...permissions}
             />, document.getElementById("container"));
         });
-        expect(actions.length).toBe(3);
+        expect(actions.length).toBe(2);
         expect(actions.map(action => action.type))
-            .toEqual([ TOGGLE_STYLE_EDITOR, INIT_STYLE_SERVICE, SET_EDIT_PERMISSION ]);
+            .toEqual([ TOGGLE_STYLE_EDITOR, INIT_STYLE_SERVICE ]);
         expect(actions[1].service).toBeTruthy();
         expect(actions[1].service).toEqual(stateStyleService);
         expect(actions[1].permissions).toEqual(permissions);
@@ -110,9 +109,9 @@ describe('StyleEditor Plugin', () => {
                 active
             />, document.getElementById("container"));
         });
-        expect(actions.length).toBe(3);
+        expect(actions.length).toBe(2);
         expect(actions.map(action => action.type))
-            .toEqual([ TOGGLE_STYLE_EDITOR, INIT_STYLE_SERVICE, SET_EDIT_PERMISSION ]);
+            .toEqual([ TOGGLE_STYLE_EDITOR, INIT_STYLE_SERVICE ]);
         expect(actions[1].service).toBeTruthy();
         expect(actions[1].service).toEqual(styleService);
     });

--- a/web/client/selectors/__tests__/styleeditor-test.js
+++ b/web/client/selectors/__tests__/styleeditor-test.js
@@ -31,7 +31,8 @@ import {
     editorMetadataSelector,
     selectedStyleMetadataSelector,
     editingAllowedRolesSelector,
-    editingAllowedGroupsSelector
+    editingAllowedGroupsSelector,
+    canEditSelector
 } from '../styleeditor';
 import {
     setCustomUtils,
@@ -791,6 +792,34 @@ describe('Test styleeditor selector', () => {
                     }
                 }
             })).toBeFalsy();
+        });
+        it('test `canEdit` taking precedence over allowed roles and groups', () => {
+            expect(canEditStyleSelector({
+                styleeditor: {
+                    canEdit: true,
+                    editingAllowedRoles: ['USER1'],
+                    editingAllowedGroups: ['some']
+                },
+                security: {
+                    user: {
+                        role: 'USER',
+                        groups: {
+                            group: {
+                                enabled: true,
+                                groupName: 'test'
+                            }
+                        }
+                    }
+                }
+            })).toBeTruthy();
+        });
+        it('test canEditSelector', () => {
+            expect(canEditSelector({
+                styleeditor: {
+                    canEdit: true
+                }
+            })).toBeTruthy();
+            expect(canEditSelector()).toBeFalsy();
         });
     });
 });

--- a/web/client/selectors/styleeditor.js
+++ b/web/client/selectors/styleeditor.js
@@ -129,6 +129,13 @@ export const editingAllowedRolesSelector = (state) => get(state, 'styleeditor.ed
  */
 export const editingAllowedGroupsSelector = (state) => get(state, 'styleeditor.editingAllowedGroups', []);
 /**
+ * Selects canEdit configuration value if any
+ * @memberof selectors.styleeditor
+ * @param  {object} state the state
+ * @returns {object}
+ */
+export const canEditSelector = (state) => get(state, 'styleeditor.canEdit', false);
+/**
  * selects canEdit status of styleeditor service from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
@@ -137,12 +144,13 @@ export const editingAllowedGroupsSelector = (state) => get(state, 'styleeditor.e
 export const canEditStyleSelector = (state) => {
     const allowedRoles = editingAllowedRolesSelector(state);
     const allowedGroups = editingAllowedGroupsSelector(state);
+    const canEdit = canEditSelector(state);
     const _isSameOrigin = isSameOrigin(getUpdatedLayer(state), styleServiceSelector(state));
     const isAllowed = isUserAllowedSelectorCreator({
         allowedRoles,
         allowedGroups
     })(state);
-    return isAllowed && _isSameOrigin;
+    return canEdit || (isAllowed && _isSameOrigin);
 };
 /**
  * selects geometry type of selected layer from state

--- a/web/client/selectors/styleeditor.js
+++ b/web/client/selectors/styleeditor.js
@@ -142,15 +142,16 @@ export const canEditSelector = (state) => get(state, 'styleeditor.canEdit', fals
  * @return {bool}
  */
 export const canEditStyleSelector = (state) => {
+    const canEdit = canEditSelector(state);
+    if (canEdit) return canEdit;
     const allowedRoles = editingAllowedRolesSelector(state);
     const allowedGroups = editingAllowedGroupsSelector(state);
-    const canEdit = canEditSelector(state);
     const _isSameOrigin = isSameOrigin(getUpdatedLayer(state), styleServiceSelector(state));
     const isAllowed = isUserAllowedSelectorCreator({
         allowedRoles,
         allowedGroups
     })(state);
-    return canEdit || (isAllowed && _isSameOrigin);
+    return isAllowed && _isSameOrigin;
 };
 /**
  * selects geometry type of selected layer from state


### PR DESCRIPTION
## Description
This PR allows dynamic management of style editor's permission

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #10816 

**What is the new behavior?**
The user can dynamically manage the permission of style editor and where the permission structure differs from that of geostore

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
