### PR TITLE
Fix #10824 Adjust placement of Search and TOC button

### DIFF
--- a/web/client/themes/default/less/drawer-menu.less
+++ b/web/client/themes/default/less/drawer-menu.less
@@ -33,6 +33,7 @@
     .shadow;
     left: 0;
     top: 0;
+    margin: 4px;
 }
 
 #mapstore-drawermenu {

--- a/web/client/themes/default/less/map-search-bar.less
+++ b/web/client/themes/default/less/map-search-bar.less
@@ -76,6 +76,15 @@
     z-index: 1031;
 }
 
+#mapstore-navbar-container {
+    &:has(#search-bar-container) {
+        margin: 4px 0;
+        &:has(#mapstore-burger-menu-container) {
+            margin: 4px;
+        }
+    }
+}
+
 #search-bar-container.no-sidebar {
     margin-right: 0;
     position: relative;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds margin styles for toc button and map search bar 

![image](https://github.com/user-attachments/assets/add02885-54c2-451d-8a03-6a9e7023c397)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10824

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

TOC button and map search bar have a margin around

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
