### PR TITLE
#10825: Fix - Unnecessary re-rendering of the resource plugin

### DIFF
--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -10,6 +10,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { loadLocale } from '../../actions/locale';
 import castArray from 'lodash/castArray';
+import isEqual from 'lodash/isEqual';
 import axios from '../../libs/ajax';
 import ConfigUtils from '../../utils/ConfigUtils';
 import PluginsUtils from '../../utils/PluginsUtils';
@@ -44,10 +45,10 @@ function withExtensions(AppComponent) {
         };
 
         shouldComponentUpdate(nextProps, nextState) {
-            if (this.state.pluginsRegistry !== nextState.pluginsRegistry) {
+            if (!isEqual(this.state.pluginsRegistry, nextState.pluginsRegistry)) {
                 return true;
             }
-            if (this.props.pluginsDef !== nextProps.pluginsDef) {
+            if (!isEqual(this.props.pluginsDef, nextProps.pluginsDef)) {
                 return true;
             }
             return false;

--- a/web/client/plugins/ResourcesCatalog/api/__tests__/resources-test.js
+++ b/web/client/plugins/ResourcesCatalog/api/__tests__/resources-test.js
@@ -27,6 +27,7 @@ describe('resources api', () => {
             try {
                 expect(config.url).toBe('/extjs/search/list');
                 expect(config.params).toEqual({ includeAttributes: true, includeTags: true, start: 0, limit: 12, sortBy: 'name', sortOrder: 'asc' });
+                expect(config.testConfig).toBe('test');
                 let json;
                 xml2js.parseString(config.data, { explicitArray: false }, (ignore, result) => {
                     json = result;
@@ -61,7 +62,7 @@ describe('resources api', () => {
                 }
             }];
         });
-        requestResources()
+        requestResources({config: { testConfig: "test"}})
             .then((response) => {
                 expect(response).toEqual({
                     total: 0,

--- a/web/client/plugins/ResourcesCatalog/api/resources.js
+++ b/web/client/plugins/ResourcesCatalog/api/resources.js
@@ -140,7 +140,8 @@ const getFilter = ({
 };
 
 export const requestResources = ({
-    params
+    params,
+    config
 } = {}, { user } = {}) => {
 
     const {
@@ -160,6 +161,7 @@ export const requestResources = ({
         query
     }),
     {
+        ...config,
         params: {
             includeAttributes: true,
             includeTags: true,

--- a/web/client/plugins/ResourcesCatalog/hooks/useQueryResourcesByLocation.js
+++ b/web/client/plugins/ResourcesCatalog/hooks/useQueryResourcesByLocation.js
@@ -89,11 +89,15 @@ const useQueryResourcesByLocation = ({
         source.current = cancelToken.source();
     };
 
-    requestResources.current = (params) => {
+    const clearRequestTimeout = () => {
         if (requestTimeout.current) {
             clearTimeout(requestTimeout.current);
             requestTimeout.current = undefined;
         }
+    };
+
+    requestResources.current = (params) => {
+        clearRequestTimeout();
         createToken();
         setLoading(true, id);
         requestTimeout.current = setTimeout(() => {
@@ -211,6 +215,7 @@ const useQueryResourcesByLocation = ({
                 source.current.cancel();
                 source.current = undefined;
             }
+            clearRequestTimeout();
         };
     }, []);
 


### PR DESCRIPTION
## Description
This PR fixes redundant updates causing resource plugin re-renders 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10825 

**What is the new behavior?**
Unnecessary resources fetch calls are avoided and

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
