### PR TITLE
#10826: Fix - URL aliases ignored on added layers

### DIFF
--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -195,6 +195,44 @@ describe('catalog Epics', () => {
             }
         });
     });
+    it('autoSearchEpic - wms with domain aliases', (done) => {
+        const NUM_ACTIONS = 1;
+        const domainAliases = ['url1', 'url2'];
+        testEpic(autoSearchEpic, NUM_ACTIONS, changeText(""), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            expect(actions[0].type).toBe(TEXT_SEARCH);
+            expect(actions[0].url).toBe("url,url1,url2");
+            expect(actions[0].options).toEqual({
+                service: {
+                    type: "wms",
+                    url: "url",
+                    filter: "test",
+                    domainAliases
+                }
+            });
+            done();
+        }, {
+            catalog: {
+                delayAutoSearch: 50,
+                selectedService: "wmsCatalog",
+                services: {
+                    "wmsCatalog": {
+                        type: "wms",
+                        url: "url",
+                        filter: "test",
+                        domainAliases
+                    }
+                },
+                pageSize: 2
+            },
+            layers: {
+                selected: ["TEST"],
+                flat: [{
+                    id: "TEST"
+                }]
+            }
+        });
+    });
     it('openCatalogEpic', (done) => {
         const NUM_ACTIONS = 2;
         testEpic(openCatalogEpic, NUM_ACTIONS, toggleControl("metadataexplorer", "enabled"), (actions) => {

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -57,6 +57,7 @@ import { currentMessagesSelector } from "../selectors/locale";
 import { getSelectedLayer, selectedNodesSelector } from '../selectors/layers';
 
 import {
+    buildServiceUrl,
     buildSRSMap,
     extractOGCServicesReferences,
     updateServiceData
@@ -583,8 +584,7 @@ export default (API) => ({
                 const state = getState();
                 const pageSize = pageSizeSelector(state);
                 const service = selectedCatalogSelector(state);
-                const { type, url } = service;
-                return Rx.Observable.of(textSearch({ format: type, url, startPosition: 1, maxRecords: pageSize, text, options: { service }}));
+                return Rx.Observable.of(textSearch({ format: service.type, url: buildServiceUrl(service), startPosition: 1, maxRecords: pageSize, text, options: { service }}));
             }),
 
     catalogCloseEpic: (action$, store) =>


### PR DESCRIPTION
## Description
This PR fixes the URL aliases getting ignored on adding a layer from catalog service (wms)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10826 

**What is the new behavior?**
The domain aliases configured for the layer are used in fetching the tiles when configured in wms

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
