### PR TITLE
#10829: Fix - Issue creating Circle annotation with form radius

### DIFF
--- a/web/client/components/map/cesium/DrawGeometrySupport.jsx
+++ b/web/client/components/map/cesium/DrawGeometrySupport.jsx
@@ -74,7 +74,7 @@ function DrawGeometrySupport({
                 draw.current = null;
             }
         };
-    }, [map, active, geometryType, sampleTerrain, coordinatesLength, geodesic]);
+    }, [map, active, geometryType, sampleTerrain, coordinatesLength, geodesic, onDrawEnd]);
 
     return null;
 }

--- a/web/client/components/map/openlayers/DrawGeometrySupport.jsx
+++ b/web/client/components/map/openlayers/DrawGeometrySupport.jsx
@@ -60,7 +60,7 @@ function DrawGeometrySupport({
                 draw.current = null;
             }
         };
-    }, [map, active, geometryType, coordinatesLength, geodesic]);
+    }, [map, active, geometryType, coordinatesLength, geodesic, onDrawEnd]);
     return null;
 }
 

--- a/web/client/plugins/Annotations/containers/AnnotationsMapInteractionsSupport.jsx
+++ b/web/client/plugins/Annotations/containers/AnnotationsMapInteractionsSupport.jsx
@@ -33,6 +33,9 @@ function AnnotationsMapInteractionsSupport({
 }) {
 
     const getGeometryType = ({ properties } = {}) => properties?.annotationType === 'Text' ? 'Point' : properties?.annotationType;
+    const getDrawGeometryType = ({ geometry, properties } = {}) => properties?.annotationType === 'Text'
+    || (properties?.radius > 0 && !geometry) ? 'Point' : properties?.annotationType;
+
     if (!areAnnotationsMapInteractionsSupported(mapType)) {
         return null;
     }
@@ -40,6 +43,7 @@ function AnnotationsMapInteractionsSupport({
     const EditFeatureSupport = editGeoJSONSupportSupports[mapType];
     const isFeatureGeometryValid = validateFeature(feature, true);
     const selectedAnnotationType = getGeometryType(feature);
+    const drawGeometryType = getDrawGeometryType(feature);
     const isGeodesic = !!geodesic[selectedAnnotationType];
     return (
         <Suspense fallback={null}>
@@ -48,7 +52,7 @@ function AnnotationsMapInteractionsSupport({
                     map={map}
                     active={active && feature.geometry === null}
                     depthTestAgainstTerrain={false}
-                    geometryType={selectedAnnotationType}
+                    geometryType={drawGeometryType}
                     geodesic={isGeodesic}
                     getObjectsToExcludeOnPick={() => []}
                     onDrawEnd={({ feature: newFeature }) => {


### PR DESCRIPTION
## Description
This PR allows user to create circle with radius predefined by clicking on map from circle annotation type

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10829 

**What is the new behavior?**
- The annotation `circle` can be drawn with radius predefined and clicking on the map to places the circle.
- Fixes the issue with stale closure resulting in latest feature properties from used when annotation has fields other than coordinates (i.e `text` in Text annotation and `radius` in Circle annotation). `onDrawEnd` is added as dependency to avoid this.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
