### PR TITLE
Fix #10807 load map error and correctly update view when sharing a map

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -488,7 +488,8 @@ class CesiumMap extends React.Component {
                 return false;
             }
             // avoid errors like 44.40641479 !== 44.40641478999999
-            return a.toFixed(12) - b.toFixed(12) <= 0.000000000001;
+            // using abs because the difference can be negative, creating a false positive
+            return Math.abs(a.toFixed(12) - b.toFixed(12)) <= 0.000000000001;
         };
 
         // there are some transition cases where the center is not defined

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -543,7 +543,8 @@ class OpenlayersMap extends React.Component {
         if (a === undefined || b === undefined) {
             return false;
         }
-        return a.toFixed(8) - b.toFixed(8) <= 0.00000001;
+        // using abs because the difference can be negative, creating a false positive
+        return Math.abs(a.toFixed(8) - b.toFixed(8)) <= 0.00000001;
     };
 
     _updateMapPositionFromNewProps = (newProps) => {
@@ -553,7 +554,6 @@ class OpenlayersMap extends React.Component {
             this.isNearlyEqual(newProps.center.x, currentCenter.x);
 
         if (!centerIsUpdated) {
-            // let center = ol.proj.transform([newProps.center.x, newProps.center.y], 'EPSG:4326', newProps.projection);
             let center = reproject({ x: newProps.center.x, y: newProps.center.y }, 'EPSG:4326', newProps.projection, true);
             view.setCenter([center.x, center.y]);
         }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

There were some cases where center was not updated from the changeMapView action and this was because the isNearlyEqual Function was wrongly working with negative values when a values was lesser than the b value, this was causing false positives

this was caused by https://github.com/geosolutions-it/MapStore2/commit/842b59b307dbf77c549b5ae2e51d7f0318350e44

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10807

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
it loads correctly the view from query params center and no error is triggered

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
