### PR TITLE
Fix #10848 Align height of resource cards

### DIFF
--- a/web/client/plugins/ResourcesCatalog/components/ResourceCard.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/ResourceCard.jsx
@@ -212,18 +212,19 @@ const ResourceCardGridBody = ({
     const footerEntry = metadata.find(entry => entry.target === 'footer');
 
     return (
-        <div>
+        <FlexBox.Fill className="ms-resource-card-body" flexBox column>
             <ResourceCardImage
                 className="ms-resource-card-img ms-image-colors"
                 src={thumbnailUrl}
                 icon={icon}
             />
-            <FlexBox
+            <FlexBox.Fill
+                flexBox
                 column
                 gap="sm"
                 classNames={['_padding-sm']}
             >
-                <FlexBox gap="sm" centerChildrenVertically>
+                <FlexBox className="ms-resource-card-body-header" gap="sm" centerChildrenVertically>
                     <FlexBox.Fill flexBox>
                         <Text fontSize="md" ellipsis>
                             {(icon && !loading && !downloading) && (
@@ -256,7 +257,7 @@ const ResourceCardGridBody = ({
                         />
                     );
                 })}
-                <FlexBox gap="sm" centerChildrenVertically>
+                <FlexBox className="ms-resource-card-body-footer" gap="sm" centerChildrenVertically>
                     <FlexBox.Fill flexBox>
                         {footerEntry?.path ? <ResourceCardMetadataEntry
                             entry={footerEntry}
@@ -280,7 +281,7 @@ const ResourceCardGridBody = ({
                         })}
                     </FlexBox>
                 </FlexBox>
-            </FlexBox>
+            </FlexBox.Fill>
             {!readOnly && options?.length > 0
                 ? (
                     <ResourceCardActionButtons
@@ -293,7 +294,7 @@ const ResourceCardGridBody = ({
                     />
                 )
                 : null}
-        </div>
+        </FlexBox.Fill>
     );
 };
 
@@ -317,7 +318,7 @@ const ResourceCardListBody = ({
         ...(optionsProp || [])
     ];
     return (
-        <FlexBox centerChildrenVertically>
+        <FlexBox className="ms-resource-card-body" centerChildrenVertically>
             <div className="ms-resource-card-limit">
                 {(icon && !loading && !downloading) && (
                     <Icon {...icon} />

--- a/web/client/themes/default/less/resources-catalog/_resources-container.less
+++ b/web/client/themes/default/less/resources-catalog/_resources-container.less
@@ -13,6 +13,14 @@
 .ms-resources-container-grid {
     > li {
         width: calc(25% - 0.75rem);
+        display: flex;
+        .ms-resource-card {
+            flex: 1;
+            .ms-resource-card-body-footer {
+                margin-top: auto;
+                margin-bottom: 0;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds needed styles to get same height of resource cards on the same row

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10848

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Resource cards on the same row have same height

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
