### PR TITLE
Fix #10824 Adjust placement of Map Views plugin

### DIFF
--- a/web/client/themes/default/less/map-views.less
+++ b/web/client/themes/default/less/map-views.less
@@ -125,9 +125,9 @@
 .ms-map-views {
     position: absolute;
     z-index: 1000;
-    margin: 0 5px;
+    margin: 4px;
     top: 0;
-    left: 40px;
+    left: 44px;
     width: 500px;
     .ms-layers-tree {
         padding: 0;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adjusts the placement of Map Views plugin

![image](https://github.com/user-attachments/assets/4df4fec2-d2d9-463c-8823-d15606c8ed3a)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10824 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The Map Views plugin has the same margin of the TOC button

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
