### PR TITLE
Fix #10852 Edit properties button for Anonymuos user

### DIFF
--- a/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
@@ -119,6 +119,13 @@ function ResourceDetails({
         onChange(options, resourcesGridId);
     }
 
+    // resource details component can be used with the resources grid (resourceType equal to undefined)
+    // or inside a specific viewer viewer
+    const isSpecificResourceType = resourceType !== undefined;
+
+    // canCopy is possible only inside a specific viewer
+    const canEditResource = !!(resource?.canEdit
+        || (isSpecificResourceType && resource?.canCopy));
     return (
         <div className="ms-details-panel">
             <DetailsHeader
@@ -126,7 +133,7 @@ function ResourceDetails({
                 editing={editing}
                 tools={
                     <FlexBox centerChildrenVertically gap="sm">
-                        {resourceType === undefined && editing ? <Button
+                        {!isSpecificResourceType && editing ? <Button
                             tooltipId="resourcesCatalog.apply"
                             className={isEmpty(pendingChanges?.changes) ? undefined : 'ms-notification-circle warning'}
                             disabled={isEmpty(pendingChanges?.changes)}
@@ -134,7 +141,7 @@ function ResourceDetails({
                         >
                             <Icon glyph="floppy-disk" type="glyphicon" />
                         </Button> : null}
-                        {(resource?.canEdit || resource?.canCopy) ? <Button
+                        {canEditResource ? <Button
                             tooltipId="resourcesCatalog.editResourceProperties"
                             square
                             variant={editing ? 'success' : undefined}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR improve the canEdit check to make sure the edit button is not visible for anonymous users

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10852

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The editing button inside the ResourceDetails plugin is not visible for anonymous users

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
