### PR TITLE
#10831: Improve how printing map preview is managed

### DIFF
--- a/web/client/components/print/MapPreview.jsx
+++ b/web/client/components/print/MapPreview.jsx
@@ -156,7 +156,7 @@ class MapPreview extends React.Component {
                 {...this.props.map}
                 resize={this.props.height}
                 style={style}
-                interactive={false}
+                interactive     // to enable zoom/use wheel in print preview map
                 onMapViewChanges={this.props.onMapViewChanges}
                 zoomControl={false}
                 zoom={this.props.useFixedScales ? this.props.map.scaleZoom : this.props.map.zoom}

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -322,7 +322,7 @@ export default {
                         usePreview: true,
                         mapPreviewOptions: {
                             enableScalebox: false,
-                            enableRefresh: false
+                            enableRefresh: true
                         },
                         syncMapPreview: false,      // make it false to prevent map sync
                         useFixedScales: false,

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -324,7 +324,7 @@ export default {
                             enableScalebox: false,
                             enableRefresh: false
                         },
-                        syncMapPreview: true,
+                        syncMapPreview: false,      // make it false to prevent map sync
                         useFixedScales: false,
                         scales: [],
                         ignoreLayers: ["google", "bing"],

--- a/web/client/reducers/__tests__/print-test.js
+++ b/web/client/reducers/__tests__/print-test.js
@@ -172,10 +172,23 @@ describe('Test the print reducer', () => {
     it('change map print preview', () => {
         const state = print({capabilities: {}, spec: {}}, {
             type: CHANGE_MAP_PRINT_PREVIEW,
-            size: 1000
+            size: 1000,
+            center: {
+                "x": 15.935325658757531,
+                "y": 42.729598714490606,
+                "crs": "EPSG:4326"
+            },
+            zoom: 6
         });
         expect(state.map).toExist();
-        expect(state.map.size).toBe(1000);
+        expect(state.map.size).toEqual(1000);
+        expect(state.map.zoom).toEqual(6);
+        expect(state.map.scaleZoom).toEqual(6);
+        expect(state.map.center).toEqual({
+            "x": 15.935325658757531,
+            "y": 42.729598714490606,
+            "crs": "EPSG:4326"
+        });
     });
 
     it('print submitting', () => {

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -118,7 +118,11 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
     case CHANGE_MAP_PRINT_PREVIEW: {
         return assign({}, state, {
             map: assign({}, state.map, {
-                size: action.size
+                size: action.size,
+                zoom: action.zoom,
+                scaleZoom: action.zoom,
+                bbox: action.bbox,
+                center: action.center
             })
         }
         );


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes: 
- handling printing map preview is no longer synchronized with the viewer's map
- handling printing map preview can be moved and zoomed independently using the mouse wheel and/or the scale selector, if present
- enable the user to click on print, the final print will in fact use the center and scale (properly converted) on the map preview, with the result of printing the same viewport (the image may change in resolution because of the DPI selector)
- handling sync button in the preview map just for manually synching the preview with the viewer's map remain available as is (if configured)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#10831 

**What is the new behavior?**
- The printing map preview is no longer synchronized with the viewer's map
- The printing map preview can be moved and zoomed independently using the mouse wheel and/or the scale selector, if present.
- When the user clicks on print, the final print will in fact use the center and scale (properly converted) on the map preview, with the result of printing the same viewport (the image may change in resolution because of the DPI selector).
- The sync button in the preview map for manually synching the preview with the viewer's map remain available as is (if configured)

https://github.com/user-attachments/assets/ae60b312-332b-4e2e-a348-f2c58e34eb38


This demo assumes setting cfg for print plugin: ``` mapPreviewOptions: { enableScalebox: true, enableRefresh: true} ```

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
