### PR TITLE
Fix #10857 There is the Edit properties from an unsaved resource option

### DIFF
--- a/web/client/plugins/ResourcesCatalog/SaveAs.jsx
+++ b/web/client/plugins/ResourcesCatalog/SaveAs.jsx
@@ -122,6 +122,12 @@ function SaveAs({
         handleSaveAs();
     }
 
+    function handleShowModal() {
+        // use the currently edited name and fallback to empty name
+        setName(pendingChanges?.changes?.name || '');
+        setShowModal(true);
+    }
+
     if (!((pendingChanges?.resource?.canCopy || pendingChanges?.resource?.canEdit) && user)) {
         return null;
     }
@@ -137,7 +143,7 @@ function SaveAs({
         <>
             <Component
                 className={changes && !hideIndicator ? 'ms-notification-circle warning' : ''}
-                onClick={() => setShowModal(true)}
+                onClick={handleShowModal}
                 labelId="saveDialog.saveAsTooltip"
                 menuItem={menuItem}
                 glyph="floppy-open"

--- a/web/client/plugins/ResourcesCatalog/utils/ResourcesUtils.js
+++ b/web/client/plugins/ResourcesCatalog/utils/ResourcesUtils.js
@@ -103,10 +103,10 @@ export const getResourceId = (resource) => {
 const recursivePendingChanges = (a, b) => {
     return Object.keys(a).reduce((acc, key) => {
         if (!isArray(a[key]) && isObject(a[key])) {
-            const obj = recursivePendingChanges(a[key], b[key]);
+            const obj = recursivePendingChanges(a[key], b?.[key]);
             return isEmpty(obj) ? acc : { ...acc, [key]: obj };
         }
-        return !isEqual(a[key], b[key])
+        return !isEqual(a[key], b?.[key])
             ? { ...acc, [key]: a[key] }
             : acc;
     }, {});

--- a/web/client/plugins/ResourcesCatalog/utils/__tests__/ResourcesUtils-test.js
+++ b/web/client/plugins/ResourcesCatalog/utils/__tests__/ResourcesUtils-test.js
@@ -183,4 +183,12 @@ describe('ResourcesUtils', () => {
             { tag: { id: '03' }, action: 'link' }
         ]);
     });
+
+    it('computePendingChanges with empty attributes in initial resource', () => {
+        const computed = computePendingChanges(
+            { },
+            { attributes: { featured: true } }
+        );
+        expect(computed.changes).toEqual({ attributes: { featured: true } });
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds a fix inside the computation of pending changes and a review of the SaveAs plugin workflow

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10857

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The editing of resource metadata works also for unsaved resources

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
