### PR TITLE
#10867: Fix - Saving context loads duplicate extensions as scripts

### DIFF
--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import { loadLocale } from '../../actions/locale';
 import castArray from 'lodash/castArray';
 import isEqual from 'lodash/isEqual';
+import uniq from 'lodash/uniq';
 import axios from '../../libs/ajax';
 import ConfigUtils from '../../utils/ConfigUtils';
 import PluginsUtils from '../../utils/PluginsUtils';
@@ -68,7 +69,7 @@ function withExtensions(AppComponent) {
             });
             if (translations.length > 0) {
                 // remove any duplicate paths
-                const translationsPath = [...new Set([...castArray(ConfigUtils.getConfigProp("translationsPath")), ...translations.map(this.getAssetPath)])];
+                const translationsPath = uniq([...castArray(ConfigUtils.getConfigProp("translationsPath")), ...translations.map(this.getAssetPath)]);
                 ConfigUtils.setConfigProp("translationsPath", translationsPath);
             }
             const locale =  ConfigUtils.getConfigProp('locale');

--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -67,7 +67,9 @@ function withExtensions(AppComponent) {
                 pluginsRegistry: plugins
             });
             if (translations.length > 0) {
-                ConfigUtils.setConfigProp("translationsPath", [...castArray(ConfigUtils.getConfigProp("translationsPath")), ...translations.map(this.getAssetPath)]);
+                // remove any duplicate paths
+                const translationsPath = [...new Set([...castArray(ConfigUtils.getConfigProp("translationsPath")), ...translations.map(this.getAssetPath)])];
+                ConfigUtils.setConfigProp("translationsPath", translationsPath);
             }
             const locale =  ConfigUtils.getConfigProp('locale');
             store.dispatch(loadLocale(null, locale));

--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -135,6 +135,9 @@ function withExtensions(AppComponent) {
                 ConfigUtils.setConfigProp("translationsPath",
                     castArray(translationsPath).filter(p => p !== this.getAssetPath(translations)));
             }
+            // remove the script element associated with the plugin, if it exists
+            const script = document.querySelector(`script[src="${this.getAssetPath(plugin)}/index.js"]`);
+            script && script.remove();
         };
 
         filterRemoved = (registry, removed) => {

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -626,10 +626,14 @@ export const createPlugin = (name, { component, options = {}, containers = {}, r
  * @returns {Promise} a Promise that resolves to a lazy plugin object.
  */
 export const loadPlugin = (pluginUrl, pluginName) => {
-    return loadScript(pluginUrl)
-        .then(() =>importPlugin(pluginName))
-        .then((plugin) => ({ name: pluginName, plugin}));
-
+    return new Promise((resolve, reject) => {
+        const script = document.querySelector(`script[src="${pluginUrl}"]`);
+        // load the script if not already loaded
+        const load = script ? Promise.resolve() : loadScript(pluginUrl);
+        load.then(() => importPlugin(pluginName))
+            .then(plugin => resolve({ name: pluginName, plugin }))
+            .catch(reject);
+    });
 };
 
 /**

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -626,14 +626,12 @@ export const createPlugin = (name, { component, options = {}, containers = {}, r
  * @returns {Promise} a Promise that resolves to a lazy plugin object.
  */
 export const loadPlugin = (pluginUrl, pluginName) => {
-    return new Promise((resolve, reject) => {
-        const script = document.querySelector(`script[src="${pluginUrl}"]`);
-        // load the script if not already loaded
-        const load = script ? Promise.resolve() : loadScript(pluginUrl);
-        load.then(() => importPlugin(pluginName))
-            .then(plugin => resolve({ name: pluginName, plugin }))
-            .catch(reject);
-    });
+    const script = document.querySelector(`script[src="${pluginUrl}"]`);
+    // load the script if not already loaded
+    const load = script ? Promise.resolve() : loadScript(pluginUrl);
+    return load
+        .then(() => importPlugin(pluginName))
+        .then((plugin) => ({ name: pluginName, plugin}));
 };
 
 /**


### PR DESCRIPTION
## Description
This PR fixes an issue with load script duplicates without checking for existence and caused multiple instances of the extensions script, leading to redundant locale calls.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10867

**What is the new behavior?**
When loading the extension, there are no duplicate locale calls, and the load script is not imported multiple times

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
