### PR TITLE
Fix #10830 eol LF for json files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 web/client/test-resources/* -text
+*.json text eol=lf


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Prettier adds LF as end of line every time it writes the files in Windows OS it will change it to CRLF when git config is `autocrlf=true`.

This PR includes a new rule in .gitattributes to always use LF for end line in json files. This is needed to avoid false positive while running `json:check`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Code style update (formatting, local variables)

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10830

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

JSON files use LF eol

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
