### PR TITLE
Fix #10859 Share button on new dashbaord

### DIFF
--- a/web/client/actions/__tests__/geostory-test.js
+++ b/web/client/actions/__tests__/geostory-test.js
@@ -63,7 +63,9 @@ import {
     hideCarouselItems,
     HIDE_CAROUSEL_ITEMS,
     enableDraw,
-    ENABLE_DRAW
+    ENABLE_DRAW,
+    RESET_GEOSTORY,
+    resetGeostory
 } from '../geostory';
 
 describe('test geostory action creators', () => {
@@ -288,5 +290,9 @@ describe('test geostory action creators', () => {
         const action = geostoryImport(file);
         expect(action.type).toBe(GEOSTORY_IMPORT);
         expect(action.file).toEqual(file);
+    });
+    it('resetGeostory', () => {
+        const action = resetGeostory();
+        expect(action.type).toBe(RESET_GEOSTORY);
     });
 });

--- a/web/client/actions/geostory.js
+++ b/web/client/actions/geostory.js
@@ -46,6 +46,8 @@ export const HIDE_CAROUSEL_ITEMS = "GEOSTORY:HIDE_CAROUSEL_ITEMS";
 export const ENABLE_DRAW = "GEOSTORY:ENABLE_DRAW";
 export const GEOSTORY_EXPORT = "GEOSTORY:EXPORT";
 export const GEOSTORY_IMPORT = "GEOSTORY:IMPORT";
+export const RESET_GEOSTORY = "GEOSTORY:RESET";
+
 /**
  * Adds an entry to current story. The entry can be a section, a content or anything to append in an array (even sub-content)
  *
@@ -269,3 +271,8 @@ export const enableDraw = (drawOptions) => ({
 
 export const geostoryExport = (data, fileName) => ({type: GEOSTORY_EXPORT, data, fileName});
 export const geostoryImport = (file) => ({type: GEOSTORY_IMPORT, file});
+
+/**
+ * reset geostory on page unmount
+ */
+export const resetGeostory = () => ({ type: RESET_GEOSTORY });

--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -18,16 +18,17 @@ import { versionSelector } from '../selectors/version';
 import shareEpics from '../epics/queryparams';
 import SharePanel from '../components/share/SharePanel';
 import { createSelector } from 'reselect';
-import { mapSelector } from '../selectors/map';
+import { mapIdSelector, mapSelector } from '../selectors/map';
 import { currentContextSelector } from '../selectors/context';
 import { get } from 'lodash';
 import controls from '../reducers/controls';
 import { changeFormat } from '../actions/mapInfo';
 import { addMarker, hideMarker } from '../actions/search';
 import { updateMapView } from '../actions/map';
-import { updateUrlOnScrollSelector } from '../selectors/geostory';
+import { resourceSelector as geostoryResourceSelector, updateUrlOnScrollSelector } from '../selectors/geostory';
 import { shareSelector } from "../selectors/controls";
 import { mapTypeSelector } from "../selectors/maptype";
+import { dashboardResource } from '../selectors/dashboard';
 /**
  * Share Plugin allows to share the current URL (location.href) in some different ways.
  * You can share it on socials networks(facebook,twitter,google+,linkedIn)
@@ -146,17 +147,22 @@ const ActionCardShareButton = connect(
         iconType="glyphicon"
         glyph="share-alt"
         labelId="share.title"
-        // tooltipId=""
         onClick={handleToggle}
     />);
 });
 
+const shareButtonSelector = createSelector([
+    mapIdSelector,
+    dashboardResource,
+    geostoryResourceSelector
+], (mapId, dashboard, geostory) => {
+    return {
+        style: mapId || dashboard?.id || geostory?.id ? { } : { display: 'none' }
+    };
+});
 
 const SharePlugin = createPlugin('Share', {
     component: Share,
-    options: {
-        disablePluginIf: "{state('router') && (state('router').endsWith('new') || state('router').includes('newgeostory') || state('router').endsWith('dashboard'))}"
-    },
     containers: {
         BurgerMenu: {
             name: 'share',
@@ -166,7 +172,8 @@ const SharePlugin = createPlugin('Share', {
             text: <Message msgId="share.title"/>,
             tooltip: "share.tooltip",
             icon: <Glyphicon glyph="share-alt"/>,
-            action: toggleControl.bind(null, 'share', null)
+            action: toggleControl.bind(null, 'share', null),
+            selector: shareButtonSelector
         },
         SidebarMenu: {
             name: 'share',
@@ -177,7 +184,8 @@ const SharePlugin = createPlugin('Share', {
             text: <Message msgId="share.title"/>,
             icon: <Glyphicon glyph="share-alt"/>,
             action: toggleControl.bind(null, 'share', null),
-            toggle: true
+            toggle: true,
+            selector: shareButtonSelector
         },
         Toolbar: {
             name: 'share',
@@ -187,7 +195,8 @@ const SharePlugin = createPlugin('Share', {
             doNotHide: true,
             tooltip: "share.title",
             icon: <Glyphicon glyph="share-alt"/>,
-            action: toggleControl.bind(null, 'share', null)
+            action: toggleControl.bind(null, 'share', null),
+            selector: shareButtonSelector
         },
         ResourcesGrid: {
             priority: 1,

--- a/web/client/product/pages/GeoStory.jsx
+++ b/web/client/product/pages/GeoStory.jsx
@@ -16,7 +16,8 @@ import Page from '../../containers/Page';
 import {
     loadGeostory,
     setEditing,
-    updateUrlOnScroll
+    updateUrlOnScroll,
+    resetGeostory
 } from '../../actions/geostory';
 import { geostoryIdSelector } from '../../selectors/geostory';
 import { isLoggedIn } from '../../selectors/security';
@@ -126,6 +127,6 @@ export default connect((state) => ({
 {
     loadResource: loadGeostory,
     setEditing,
-    updateUrlOnScroll
-    // reset: resetGeostory
+    updateUrlOnScroll,
+    reset: resetGeostory
 })(GeoStoryPage);

--- a/web/client/reducers/__tests__/geostory-test.js
+++ b/web/client/reducers/__tests__/geostory-test.js
@@ -32,7 +32,8 @@ import {
     updateUrlOnScroll,
     updateMediaEditorSettings,
     hideCarouselItems,
-    enableDraw
+    enableDraw,
+    resetGeostory
 } from '../../actions/geostory';
 import geostory from '../../reducers/geostory';
 import {
@@ -482,5 +483,9 @@ describe('geostory reducer', () => {
         const drawOptions = {};
         let state = geostory(undefined, enableDraw(drawOptions));
         expect(state.drawOptions).toBe(drawOptions);
+    });
+    it('RESET_GEOSTORY', () => {
+        const state = geostory({ resource: { id: 10 }}, resetGeostory());
+        expect(state.resource).toBe(undefined);
     });
 });

--- a/web/client/reducers/geostory.js
+++ b/web/client/reducers/geostory.js
@@ -41,7 +41,8 @@ import {
     SET_UPDATE_URL_SCROLL,
     UPDATE_MEDIA_EDITOR_SETTINGS,
     HIDE_CAROUSEL_ITEMS,
-    ENABLE_DRAW
+    ENABLE_DRAW,
+    RESET_GEOSTORY
 } from '../actions/geostory';
 
 
@@ -374,6 +375,9 @@ export default (state = INITIAL_STATE, action) => {
     }
     case ENABLE_DRAW: {
         return set('drawOptions', action.drawOptions, state);
+    }
+    case RESET_GEOSTORY: {
+        return INITIAL_STATE;
     }
     default:
         return state;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR removes the `disablePluginIf` inside the Share plugin in favor of a selector. The `disablePluginIf` property was based on the current router path and just the addition of trailing slash `/` was causing the problem. The PR includes also the reset geostory action to clean the state when the page unmounts.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10859

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The Share plugin is visible when a resource has been already saved and visible to the user

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
