### PR TITLE
Fix #10884 Permissions already present on a resource are no longer visible if the properties edit starts from the info tab

### DIFF
--- a/web/client/plugins/ResourcesCatalog/containers/ResourcePermissions.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourcePermissions.jsx
@@ -41,7 +41,8 @@ function ResourcePermissions({
                     });
                 }))
                 .finally(() => isMounted(() => {
-                    setLoading(false);
+                    // include a delay to visualize the spinner
+                    setTimeout(() => setLoading(false), 500);
                 }));
         }
     }, [resource?.permissions]);
@@ -74,6 +75,18 @@ function ResourcePermissions({
                     </Text>
                     <Text fontSize="lg" textAlign="center">
                         <Message msgId="resourcesCatalog.noPermissionsAvailable" />
+                    </Text>
+                </div>
+            </FlexBox>
+        );
+    }
+
+    if (loading) {
+        return (
+            <FlexBox classNames={["ms-details-message", '_padding-tb-lg']} centerChildren>
+                <div>
+                    <Text fontSize="xxl" textAlign="center">
+                        <Spinner />
                     </Text>
                 </div>
             </FlexBox>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Include a spinner to correctly mount the permission editor component with the updated permissions

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10884

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The existing permissions are correctly rendered after updating

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
