### PR TITLE
Fix #10890 Error when timeline and widgets plugins are enabled at same time

### DIFF
--- a/web/client/plugins/timeline/TimelineToggle.jsx
+++ b/web/client/plugins/timeline/TimelineToggle.jsx
@@ -39,6 +39,8 @@ const togglePopover = props$ =>
                 }))
         ).startWith({});
 
+const ButtonWithTooltip = tooltip(RButton);
+
 /**
  * Combine render props with ones coming from the stream
  */
@@ -61,7 +63,10 @@ const withTempHintPopover = () =>
                 })
             )
         ),
-        branch(({ popoverOptions }) => popoverOptions, withPopover, tooltip)
+        branch(({ popoverOptions }) => popoverOptions,
+            withPopover,
+            () => (props) => <ButtonWithTooltip {...props}/>
+        )
     );
 
 const Button = withTempHintPopover()(RButton);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Extracted the tooltip from the recompose composition of the TimelineToggle button

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10890

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The map containing Timeline and WidgetsTray are not throwing an error

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
