### PR TITLE
Fix #10893 Making sure scripts from extensions are not cached

### DIFF
--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -137,7 +137,7 @@ function withExtensions(AppComponent) {
                     castArray(translationsPath).filter(p => p !== this.getAssetPath(translations)));
             }
             // remove the script element associated with the plugin, if it exists
-            const script = document.querySelector(`script[src="${this.getAssetPath(plugin)}/index.js"]`);
+            const script = document.querySelector(`script[src^="${this.getAssetPath(plugin)}/index.js"]`);
             script && script.remove();
         };
 

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -15,6 +15,7 @@ import curry from 'lodash/curry';
 import {combineEpics as originalCombineEpics} from 'redux-observable';
 import {combineReducers as originalCombineReducers} from 'redux';
 import {wrapEpics} from "./EpicsUtils";
+import { randomInt } from './RandomUtils';
 
 /**
  * Loads a script inside the current page.
@@ -25,7 +26,7 @@ function loadScript(src) {
         const s = document.createElement('script');
         let r = false;
         s.type = 'text/javascript';
-        s.src = src;
+        s.src = src + "?v=" + randomInt();
         s.async = true;
         s.onerror = function(err) {
             reject(err, s);

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -627,7 +627,7 @@ export const createPlugin = (name, { component, options = {}, containers = {}, r
  * @returns {Promise} a Promise that resolves to a lazy plugin object.
  */
 export const loadPlugin = (pluginUrl, pluginName) => {
-    const script = document.querySelector(`script[src="${pluginUrl}"]`);
+    const script = document.querySelector(`script[src^="${pluginUrl}"]`);
     // load the script if not already loaded
     const load = script ? Promise.resolve() : loadScript(pluginUrl);
     return load


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This way intex.js is appended by a random param making sure that script will not be cached.
I just noticed that removeExtensions seems not be triggered when removing the installed extension. can you double check is the case? 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10893

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
index.js of the extensions will not be cached


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

to test this locally when targeting dev env 

```
 '/extensions/': {
            target: MAPSTORE_BACKEND_URL,
            secure: false,
            headers: {
                host: domain
            }
        },
        '/configs/pluginsConfig.json': {
            target: MAPSTORE_BACKEND_URL,
            secure: false,
            headers: {
                host: domain
            }
        }
```