### PR TITLE
Fix #10894 Persist resources grid filters on navigation

### DIFF
--- a/web/client/plugins/ResourcesCatalog/containers/ResourcesGrid.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourcesGrid.jsx
@@ -27,7 +27,8 @@ import {
     getMonitoredStateSelector,
     getRouterLocation,
     getCurrentPage,
-    getSearch
+    getSearch,
+    getCurrentParams
 } from '../selectors/resources';
 import { push } from 'connected-react-router';
 import useQueryResourcesByLocation from '../hooks/useQueryResourcesByLocation';
@@ -99,7 +100,8 @@ function ResourcesGrid({
     getResourceStatus,
     formatHref,
     getResourceTypesInfo,
-    getResourceId
+    getResourceId,
+    storedParams
 }) {
 
     const { query } = url.parse(location.search, true);
@@ -123,7 +125,8 @@ function ResourcesGrid({
         user,
         queryPage,
         onReset: () => onResetSearch(id),
-        search
+        search,
+        storedParams
     });
 
     const {
@@ -262,7 +265,8 @@ const ConnectedResourcesGrid = connect(
         error: getResourcesError,
         isFirstRequest: getIsFirstRequest,
         page: getCurrentPage,
-        search: getSearch
+        search: getSearch,
+        storedParams: getCurrentParams
     }),
     {
         onPush: push,

--- a/web/client/plugins/ResourcesCatalog/hooks/__tests__/useQueryResourcesByLocation-test.js
+++ b/web/client/plugins/ResourcesCatalog/hooks/__tests__/useQueryResourcesByLocation-test.js
@@ -269,4 +269,26 @@ describe('useQueryResourcesByLocation', () => {
         />, document.getElementById("container"));
         Simulate.click(document.querySelector('#clear'));
     });
+
+    it('should use stored parameter on initialization', (done) => {
+        ReactDOM.render(<Component
+            id="catalog"
+            pageSize={12}
+            storedParams={{ f: ['map'] }}
+            request={() => {
+                return Promise.resolve({
+                    resources: []
+                });
+            }}
+            location={{
+                pathname: '/',
+                search: '/',
+                hash: ''
+            }}
+            onPush={({ search }) => {
+                expect(search).toBe('?f=map');
+                done();
+            }}
+        />, document.getElementById("container"));
+    });
 });

--- a/web/client/plugins/ResourcesCatalog/reducers/resources.js
+++ b/web/client/plugins/ResourcesCatalog/reducers/resources.js
@@ -58,14 +58,15 @@ function resources(state = defaultState, action) {
         });
     }
     case UPDATE_RESOURCES_METADATA: {
-        return setStateById(state, action, {
+        return setStateById(state, action, (stateId) => ({
+            ...stateId,
             total: action.metadata.total,
             isNextPageAvailable: action.metadata.isNextPageAvailable,
             error: action.metadata.error,
             ...(action.metadata.params &&
                 {
                     params: action.metadata.params,
-                    previousParams: state.params,
+                    previousParams: stateId?.params,
                     nextParams: null
                 }),
             ...(!isNil(action.metadata.locationSearch) &&
@@ -76,7 +77,7 @@ function resources(state = defaultState, action) {
                 {
                     locationPathname: action.metadata.locationPathname
                 })
-        });
+        }));
     }
     case LOADING_RESOURCES: {
         return setStateById(state, action, {

--- a/web/client/plugins/ResourcesCatalog/selectors/__tests__/resources-test.js
+++ b/web/client/plugins/ResourcesCatalog/selectors/__tests__/resources-test.js
@@ -17,7 +17,8 @@ import {
     getSelectedResource,
     getShowDetails,
     getCurrentPage,
-    getSearch
+    getSearch,
+    getCurrentParams
 } from '../resources';
 import expect from 'expect';
 
@@ -72,5 +73,10 @@ describe('resources selectors', () => {
     it('getSearch', () => {
         expect(getSearch()).toBe(null);
         expect(getSearch({ resources: { search: { q: 'a' }  } }, { id: 'catalog' })).toEqual({ q: 'a' });
+    });
+    it('getCurrentParams', () => {
+        expect(getCurrentParams()).toBe(undefined);
+        expect(getCurrentParams({ resources: { sections: { catalog: { params: { page: 2 } } } } }, { id: 'catalog' })).toEqual({ page: 2 });
+        expect(getCurrentParams({ resources: { sections: { catalog: { params: { page: 3 } } } } }, { resourcesGridId: 'catalog' })).toEqual({ page: 3 });
     });
 });

--- a/web/client/plugins/ResourcesCatalog/selectors/resources.js
+++ b/web/client/plugins/ResourcesCatalog/selectors/resources.js
@@ -41,7 +41,8 @@ const getSelectedResourceState = (state, props) => {
 export const getInitialSelectedResource = (state, props) => getSelectedResourceState(state, props)?.initialSelectedResource;
 export const getSelectedResource = (state, props) => getSelectedResourceState(state, props)?.selectedResource;
 export const getShowDetails = (state, props) => !!getStatePart(state, props)?.showDetails;
-export const getCurrentPage = (state, props) => getStatePart(state, props)?.params?.page ?? 1;
+export const getCurrentParams = (state, props) => getStatePart(state, props)?.params;
+export const getCurrentPage = (state, props) => getCurrentParams(state, props)?.page ?? 1;
 export const getSearch = (state) => state?.resources?.search || null;
 
 export const getMonitoredStateSelector =  state => getMonitoredState(state, getConfigProp('monitorState'));


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR improves the request workflow inside the ResourcesGrid by including an additional initial check, now when the component mount will update the query if stored parameters exist

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Filter query parameters are persisted when redirected to homepage

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
