### PR TITLE
#10902: Support for configuring editing of default style of the layer

### DIFF
--- a/web/client/actions/__tests__/styleeditor-test.js
+++ b/web/client/actions/__tests__/styleeditor-test.js
@@ -163,16 +163,16 @@ describe('Test the styleeditor actions', () => {
     });
     it('initStyleService', () => {
         const service = { baseUrl: '/geoserver/' };
-        const cfg = {
+        const config = {
             editingAllowedRoles: ["USER"],
             editingAllowedGroups: ["testGroup"],
             enableEditDefaultStyle: true
         };
-        const retval = initStyleService(service, cfg);
+        const retval = initStyleService(service, config);
         expect(retval).toExist();
         expect(retval.type).toBe(INIT_STYLE_SERVICE);
         expect(retval.service).toBe(service);
-        expect(retval.cfg).toEqual(cfg);
+        expect(retval.config).toEqual(config);
     });
     it('setEditPermissionStyleEditor', () => {
         const canEdit = true;

--- a/web/client/actions/__tests__/styleeditor-test.js
+++ b/web/client/actions/__tests__/styleeditor-test.js
@@ -163,15 +163,16 @@ describe('Test the styleeditor actions', () => {
     });
     it('initStyleService', () => {
         const service = { baseUrl: '/geoserver/' };
-        const permissions = {
+        const cfg = {
             editingAllowedRoles: ["USER"],
-            editingAllowedGroups: ["testGroup"]
+            editingAllowedGroups: ["testGroup"],
+            enableEditDefaultStyle: true
         };
-        const retval = initStyleService(service, permissions);
+        const retval = initStyleService(service, cfg);
         expect(retval).toExist();
         expect(retval.type).toBe(INIT_STYLE_SERVICE);
         expect(retval.service).toBe(service);
-        expect(retval.permissions).toEqual(permissions);
+        expect(retval.cfg).toEqual(cfg);
     });
     it('setEditPermissionStyleEditor', () => {
         const canEdit = true;

--- a/web/client/actions/styleeditor.js
+++ b/web/client/actions/styleeditor.js
@@ -186,14 +186,14 @@ export function deleteStyle(styleName) {
 * Setup the style editor service
 * @memberof actions.styleeditor
 * @param {object} service style editor service
-* @param {object} permissions editing allowed roles and groups permission object
+* @param {object} cfg configuration to be initialized for the style editor
 * @return {object} of type `INIT_STYLE_SERVICE`
 */
-export function initStyleService(service, permissions) {
+export function initStyleService(service, cfg) {
     return {
         type: INIT_STYLE_SERVICE,
         service,
-        permissions
+        cfg
     };
 }
 /**

--- a/web/client/actions/styleeditor.js
+++ b/web/client/actions/styleeditor.js
@@ -186,14 +186,14 @@ export function deleteStyle(styleName) {
 * Setup the style editor service
 * @memberof actions.styleeditor
 * @param {object} service style editor service
-* @param {object} cfg configurations to be initialized for the style editor
+* @param {object} config configurations to be initialized for the style editor
 * @return {object} of type `INIT_STYLE_SERVICE`
 */
-export function initStyleService(service, cfg) {
+export function initStyleService(service, config) {
     return {
         type: INIT_STYLE_SERVICE,
         service,
-        cfg
+        config
     };
 }
 /**

--- a/web/client/actions/styleeditor.js
+++ b/web/client/actions/styleeditor.js
@@ -186,7 +186,7 @@ export function deleteStyle(styleName) {
 * Setup the style editor service
 * @memberof actions.styleeditor
 * @param {object} service style editor service
-* @param {object} cfg configuration to be initialized for the style editor
+* @param {object} cfg configurations to be initialized for the style editor
 * @return {object} of type `INIT_STYLE_SERVICE`
 */
 export function initStyleService(service, cfg) {

--- a/web/client/components/styleeditor/StyleToolbar.jsx
+++ b/web/client/components/styleeditor/StyleToolbar.jsx
@@ -24,6 +24,7 @@ import { Alert } from 'react-bootstrap';
  * @prop {bool} editEnabled enable/disable edit/templates buttons
  * @prop {array} defaultStyles array of style names not editable
  * @prop {bool} enableSetDefaultStyle enable/disable set default style button
+ * @prop {bool} enableEditDefaultStyle enable/disable editing default style
  * @prop {bool} loading loading state
  */
 
@@ -40,6 +41,7 @@ const StyleToolbar = ({
     layerDefaultStyleName,
     editEnabled,
     enableSetDefaultStyle,
+    enableEditDefaultStyle,
     defaultStyles = [
         'generic',
         'point',
@@ -110,7 +112,8 @@ const StyleToolbar = ({
                         // empty or "" means layer's default style.
                         // You can edit this only if it not one of GeoServer's default
                         || !selectedStyle && defaultStyles.indexOf(layerDefaultStyleName) !== -1
-                        || disableCodeEditing,
+                        || disableCodeEditing
+                        || !enableEditDefaultStyle && !selectedStyle,
                     onClick: () => onEditStyle()
                 },
                 {

--- a/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
+++ b/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
@@ -72,13 +72,13 @@ describe('test StyleToolbar module component', () => {
             const disabledButtons = document.querySelectorAll('button.disabled');
             expect(disabledButtons.length).toBe(disabled);
         };
-        ReactDOM.render(<StyleToolbar selectedStyle="" layerDefaultStyleName="polygon" editEnabled />, document.getElementById("container"));
+        ReactDOM.render(<StyleToolbar selectedStyle="" layerDefaultStyleName="polygon" editEnabled enableEditDefaultStyle />, document.getElementById("container"));
         checkButtons({ present: 3, disabled: 2 }); // default is "" and it's name is one of GeoServer's default styles
-        ReactDOM.render(<StyleToolbar selectedStyle="" layerDefaultStyleName="custom" editEnabled />, document.getElementById("container"));
+        ReactDOM.render(<StyleToolbar selectedStyle="" layerDefaultStyleName="custom" editEnabled enableEditDefaultStyle/>, document.getElementById("container"));
         checkButtons({ present: 3, disabled: 1 }); // only remove is disabled, because you can not remove the default style of the layer
-        ReactDOM.render(<StyleToolbar selectedStyle="polygon" editEnabled />, document.getElementById("container"));
+        ReactDOM.render(<StyleToolbar selectedStyle="polygon" editEnabled enableEditDefaultStyle/>, document.getElementById("container"));
         checkButtons({ present: 3, disabled: 2 }); // default is in the list and is one of the GeoServer's default styles
-        ReactDOM.render(<StyleToolbar selectedStyle="custom" editEnabled />, document.getElementById("container"));
+        ReactDOM.render(<StyleToolbar selectedStyle="custom" editEnabled enableEditDefaultStyle/>, document.getElementById("container"));
         checkButtons({ present: 3, disabled: 0 });
     } );
     it('test StyleToolbar do not restrict when editing of default style is allowed', () => {

--- a/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
+++ b/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
@@ -81,4 +81,14 @@ describe('test StyleToolbar module component', () => {
         ReactDOM.render(<StyleToolbar selectedStyle="custom" editEnabled />, document.getElementById("container"));
         checkButtons({ present: 3, disabled: 0 });
     } );
+    it('test StyleToolbar do not restrict when editing of default style is allowed', () => {
+        ReactDOM.render(<StyleToolbar editEnabled enableEditDefaultStyle selectedStyle="" />, document.getElementById("container"));
+        const editButton = document.querySelector('.btn .glyphicon-code');
+        expect(editButton).toBeTruthy();
+    });
+    it('test StyleToolbar restrict default style editing', () => {
+        ReactDOM.render(<StyleToolbar editEnabled enableEditDefaultStyle={false} selectedStyle="" />, document.getElementById("container"));
+        const editButton = document.querySelector('button.disabled .glyphicon-code');
+        expect(editButton).toBeTruthy();
+    });
 });

--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -42,7 +42,7 @@ const StyleEditorPanel = ({
     editingAllowedRoles,
     editingAllowedGroups,
     enableSetDefaultStyle,
-    enableEditDefaultStyle = true,
+    enableEditDefaultStyle,
     canEdit,
     editorConfig
 }) => {
@@ -99,7 +99,8 @@ StyleEditorPanel.defaultProps = {
         'ADMIN'
     ],
     editingAllowedGroups: [],
-    editorConfig: {}
+    editorConfig: {},
+    enableEditDefaultStyle: true
 };
 
 /**

--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -42,6 +42,7 @@ const StyleEditorPanel = ({
     editingAllowedRoles,
     editingAllowedGroups,
     enableSetDefaultStyle,
+    enableEditDefaultStyle = true,
     canEdit,
     editorConfig
 }) => {
@@ -51,7 +52,8 @@ const StyleEditorPanel = ({
             styleService,
             {
                 editingAllowedRoles,
-                editingAllowedGroups
+                editingAllowedGroups,
+                enableEditDefaultStyle
             }
         );
     }, []);
@@ -85,6 +87,7 @@ StyleEditorPanel.propTypes = {
     editingAllowedRoles: PropTypes.array,
     editingAllowedGroups: PropTypes.array,
     enableSetDefaultStyle: PropTypes.bool,
+    enableEditDefaultStyle: PropTypes.bool,
     canEdit: PropTypes.bool,
     editorConfig: PropTypes.object,
     onSetPermission: PropTypes.func
@@ -118,6 +121,8 @@ StyleEditorPanel.defaultProps = {
  * @prop {string[]} cfg.editingAllowedGroups array of user groups allowed to enter in edit mode.
  * When configured, gives the editing permissions to users members of one of the groups listed.
  * @prop {array} cfg.enableSetDefaultStyle enable set default style functionality
+ * @prop {array} cfg.enableEditDefaultStyle enable edit default style functionality.
+ * By default it is `true`, allows editing of default style of the layer
  * @prop {object} cfg.editorConfig contains editor configurations
  * @prop {object} cfg.editorConfig.classification configuration of the classification symbolizer
  * For example adding default editor configuration to the classification

--- a/web/client/plugins/__tests__/StyleEditor-test.jsx
+++ b/web/client/plugins/__tests__/StyleEditor-test.jsx
@@ -49,7 +49,7 @@ describe('StyleEditor Plugin', () => {
             .toEqual([ TOGGLE_STYLE_EDITOR, INIT_STYLE_SERVICE ]);
         expect(actions[1].service).toBeTruthy();
         expect(actions[1].service).toEqual({ ...cfgStyleService, isStatic: true });
-        expect(actions[1].cfg.editingAllowedRoles).toEqual(['ADMIN']);
+        expect(actions[1].config.editingAllowedRoles).toEqual(['ADMIN']);
     });
     it('should use the static service from the state', () => {
         const cfgStyleService = {
@@ -74,7 +74,7 @@ describe('StyleEditor Plugin', () => {
                 service: stateStyleService
             }
         });
-        const cfg = {
+        const config = {
             "editingAllowedRoles": ["USER"],
             "editingAllowedGroups": ["temp"],
             "enableEditDefaultStyle": false
@@ -83,7 +83,7 @@ describe('StyleEditor Plugin', () => {
             ReactDOM.render(<Plugin
                 active
                 styleService={cfgStyleService}
-                {...cfg}
+                {...config}
             />, document.getElementById("container"));
         });
         expect(actions.length).toBe(2);
@@ -91,7 +91,7 @@ describe('StyleEditor Plugin', () => {
             .toEqual([ TOGGLE_STYLE_EDITOR, INIT_STYLE_SERVICE ]);
         expect(actions[1].service).toBeTruthy();
         expect(actions[1].service).toEqual(stateStyleService);
-        expect(actions[1].cfg).toEqual(cfg);
+        expect(actions[1].config).toEqual(config);
     });
     it('should use the service from the state', () => {
         const styleService = {

--- a/web/client/plugins/__tests__/StyleEditor-test.jsx
+++ b/web/client/plugins/__tests__/StyleEditor-test.jsx
@@ -49,7 +49,7 @@ describe('StyleEditor Plugin', () => {
             .toEqual([ TOGGLE_STYLE_EDITOR, INIT_STYLE_SERVICE ]);
         expect(actions[1].service).toBeTruthy();
         expect(actions[1].service).toEqual({ ...cfgStyleService, isStatic: true });
-        expect(actions[1].permissions.editingAllowedRoles).toEqual(['ADMIN']);
+        expect(actions[1].cfg.editingAllowedRoles).toEqual(['ADMIN']);
     });
     it('should use the static service from the state', () => {
         const cfgStyleService = {
@@ -74,15 +74,16 @@ describe('StyleEditor Plugin', () => {
                 service: stateStyleService
             }
         });
-        const permissions = {
+        const cfg = {
             "editingAllowedRoles": ["USER"],
-            "editingAllowedGroups": ["temp"]
+            "editingAllowedGroups": ["temp"],
+            "enableEditDefaultStyle": false
         };
         act(() => {
             ReactDOM.render(<Plugin
                 active
                 styleService={cfgStyleService}
-                {...permissions}
+                {...cfg}
             />, document.getElementById("container"));
         });
         expect(actions.length).toBe(2);
@@ -90,7 +91,7 @@ describe('StyleEditor Plugin', () => {
             .toEqual([ TOGGLE_STYLE_EDITOR, INIT_STYLE_SERVICE ]);
         expect(actions[1].service).toBeTruthy();
         expect(actions[1].service).toEqual(stateStyleService);
-        expect(actions[1].permissions).toEqual(permissions);
+        expect(actions[1].cfg).toEqual(cfg);
     });
     it('should use the service from the state', () => {
         const styleService = {

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -39,6 +39,7 @@ import {
     errorStyleSelector,
     geometryTypeSelector,
     getAllStyles,
+    getEditDefaultStyle,
     getUpdatedLayer,
     initialCodeStyleSelector,
     loadingStyleSelector,
@@ -159,9 +160,9 @@ export const StyleToolbar = compose(
                 getAllStyles,
                 styleServiceSelector,
                 selectedStyleFormatSelector,
-                getSelectedLayer
+                getEditDefaultStyle
             ],
-            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit, { defaultStyle }, { formats = [ 'sld' ] } = {}, format) => ({
+            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit, { defaultStyle }, { formats = [ 'sld' ] } = {}, format, enableEditDefaultStyle) => ({
                 status,
                 templateId,
                 error,
@@ -171,7 +172,8 @@ export const StyleToolbar = compose(
                 selectedStyle: defaultStyle === selectedStyle ? '' : selectedStyle,
                 editEnabled: canEdit,
                 // enable edit only if service support current format
-                disableCodeEditing: formats.indexOf(format) === -1
+                disableCodeEditing: formats.indexOf(format) === -1,
+                enableEditDefaultStyle
             })
         ),
         {

--- a/web/client/reducers/__tests__/styleeditor-test.js
+++ b/web/client/reducers/__tests__/styleeditor-test.js
@@ -28,14 +28,15 @@ describe('Test styleeditor reducer', () => {
         const service = {
             baseUrl: '/geoserver'
         };
-        const permissions = {
+        const cfg = {
             editingAllowedRoles: ['ADMIN'],
-            editingAllowedGroups: ['test']
+            editingAllowedGroups: ['test'],
+            enableEditDefaultStyle: true
         };
-        const state = styleeditor({}, initStyleService(service, permissions));
+        const state = styleeditor({}, initStyleService(service, cfg));
         expect(state).toEqual({
             service,
-            ...permissions
+            ...cfg
         });
     });
     it('test setEditPermissionStyleEditor', () => {

--- a/web/client/reducers/__tests__/styleeditor-test.js
+++ b/web/client/reducers/__tests__/styleeditor-test.js
@@ -28,15 +28,15 @@ describe('Test styleeditor reducer', () => {
         const service = {
             baseUrl: '/geoserver'
         };
-        const cfg = {
+        const config = {
             editingAllowedRoles: ['ADMIN'],
             editingAllowedGroups: ['test'],
             enableEditDefaultStyle: true
         };
-        const state = styleeditor({}, initStyleService(service, cfg));
+        const state = styleeditor({}, initStyleService(service, config));
         expect(state).toEqual({
             service,
-            ...cfg
+            ...config
         });
     });
     it('test setEditPermissionStyleEditor', () => {

--- a/web/client/reducers/styleeditor.js
+++ b/web/client/reducers/styleeditor.js
@@ -27,8 +27,9 @@ function styleeditor(state = {}, action) {
         return {
             ...state,
             service: action.service,
-            editingAllowedRoles: action?.permissions?.editingAllowedRoles || state.editingAllowedRoles,
-            editingAllowedGroups: action?.permissions?.editingAllowedGroups || state.editingAllowedGroups
+            editingAllowedRoles: action?.cfg?.editingAllowedRoles || state.editingAllowedRoles,
+            editingAllowedGroups: action?.cfg?.editingAllowedGroups || state.editingAllowedGroups,
+            enableEditDefaultStyle: action?.cfg?.enableEditDefaultStyle || state.enableEditDefaultStyle
         };
     }
     case SET_EDIT_PERMISSION: {

--- a/web/client/reducers/styleeditor.js
+++ b/web/client/reducers/styleeditor.js
@@ -27,9 +27,9 @@ function styleeditor(state = {}, action) {
         return {
             ...state,
             service: action.service,
-            editingAllowedRoles: action?.cfg?.editingAllowedRoles || state.editingAllowedRoles,
-            editingAllowedGroups: action?.cfg?.editingAllowedGroups || state.editingAllowedGroups,
-            enableEditDefaultStyle: action?.cfg?.enableEditDefaultStyle || state.enableEditDefaultStyle
+            editingAllowedRoles: action?.config?.editingAllowedRoles || state.editingAllowedRoles,
+            editingAllowedGroups: action?.config?.editingAllowedGroups || state.editingAllowedGroups,
+            enableEditDefaultStyle: action?.config?.enableEditDefaultStyle || state.enableEditDefaultStyle
         };
     }
     case SET_EDIT_PERMISSION: {

--- a/web/client/selectors/__tests__/styleeditor-test.js
+++ b/web/client/selectors/__tests__/styleeditor-test.js
@@ -32,7 +32,8 @@ import {
     selectedStyleMetadataSelector,
     editingAllowedRolesSelector,
     editingAllowedGroupsSelector,
-    canEditSelector
+    canEditSelector,
+    getEditDefaultStyle
 } from '../styleeditor';
 import {
     setCustomUtils,
@@ -821,5 +822,17 @@ describe('Test styleeditor selector', () => {
             })).toBeTruthy();
             expect(canEditSelector()).toBeFalsy();
         });
+    });
+    it('test getEditDefaultStyle', () => {
+        expect(getEditDefaultStyle({
+            styleeditor: {
+                enableEditDefaultStyle: true
+            }
+        })).toBeTruthy();
+        expect(getEditDefaultStyle({
+            styleeditor: {
+                enableEditDefaultStyle: false
+            }
+        })).toBeFalsy();
     });
 });

--- a/web/client/selectors/styleeditor.js
+++ b/web/client/selectors/styleeditor.js
@@ -231,6 +231,8 @@ export const selectedStyleMetadataSelector = (state) => {
     return style.metadata || {};
 };
 
+export const getEditDefaultStyle = (state) => get(state, 'styleeditor.enableEditDefaultStyle', false);
+
 export default {
     temporaryIdSelector,
     templateIdSelector,
@@ -252,5 +254,6 @@ export default {
     selectedStyleFormatSelector,
     getAllStyles,
     editorMetadataSelector,
-    selectedStyleMetadataSelector
+    selectedStyleMetadataSelector,
+    getEditDefaultStyle
 };


### PR DESCRIPTION
## Description
This PR add support for configuration of editing default style of the layer via StyleEditor plugin. 
`cfg.enableEditDefaultStyle`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #10902 

**What is the new behavior?**
By using the configuration `enableEditDefaultStyle`, user can now restrict/permit allowing editing of default style of the layer via StyleEditor plugin

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
