### PR TITLE
Fix #10910 search bar overlap gfi panel

### DIFF
--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -261,7 +261,7 @@ export const zoomToVisibleAreaEpic = (action$, store) =>
                     const state = store.getState();
                     const hideIdentifyPopupIfNoResults = hideEmptyPopupSelector(state);
                     const hoverIdentifyActive = isMouseMoveIdentifyActiveSelector(state);
-                    const noResultFeatures = loadFeatInfoAction.type === LOAD_FEATURE_INFO && loadFeatInfoAction?.data?.includes?.("no features were found");
+                    const noResultFeatures = loadFeatInfoAction.type === LOAD_FEATURE_INFO && typeof loadFeatInfoAction?.data === "string" && loadFeatInfoAction?.data?.includes("no features were found");
                     // remove marker in case activated identify hover mode and no fetched results plus existing hideIdentifyPopupIfNoResults = true
                     if (noResultFeatures && hideIdentifyPopupIfNoResults && hoverIdentifyActive) {
                         return Rx.Observable.from([updateCenterToMarker('disabled'), hideMapinfoMarker()]);

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -261,7 +261,7 @@ export const zoomToVisibleAreaEpic = (action$, store) =>
                     const state = store.getState();
                     const hideIdentifyPopupIfNoResults = hideEmptyPopupSelector(state);
                     const hoverIdentifyActive = isMouseMoveIdentifyActiveSelector(state);
-                    const noResultFeatures = loadFeatInfoAction.type === LOAD_FEATURE_INFO && loadFeatInfoAction?.data?.includes("no features were found");
+                    const noResultFeatures = loadFeatInfoAction.type === LOAD_FEATURE_INFO && loadFeatInfoAction?.data?.includes?.("no features were found");
                     // remove marker in case activated identify hover mode and no fetched results plus existing hideIdentifyPopupIfNoResults = true
                     if (noResultFeatures && hideIdentifyPopupIfNoResults && hoverIdentifyActive) {
                         return Rx.Observable.from([updateCenterToMarker('disabled'), hideMapinfoMarker()]);

--- a/web/client/reducers/context.js
+++ b/web/client/reducers/context.js
@@ -34,7 +34,7 @@ import { migrateContextConfiguration } from '../utils/ContextCreatorUtils';
 export default (state = {}, action) => {
     switch (action.type) {
     case MAP_CONFIG_LOADED: {
-        const userPlugins = action.config?.context?.userPlugins ?? state.resource?.data?.userPlugins
+        const userPlugins = action.config?.context?.userPlugins ?? state.resource?.data?.userPlugins;
         return  userPlugins ? set('currentContext.userPlugins', userPlugins, state) : state;
     }
     case SET_CURRENT_CONTEXT: {

--- a/web/client/reducers/context.js
+++ b/web/client/reducers/context.js
@@ -34,10 +34,9 @@ import { migrateContextConfiguration } from '../utils/ContextCreatorUtils';
 export default (state = {}, action) => {
     switch (action.type) {
     case MAP_CONFIG_LOADED: {
-
-        return set('currentContext.userPlugins',
+        return action.config?.context?.userPlugins ?? state.resource?.data?.userPlugins ? set('currentContext.userPlugins',
             action.config?.context?.userPlugins ?? state.resource?.data?.userPlugins
-            , state);
+            , state) : state;
     }
     case SET_CURRENT_CONTEXT: {
         return set('currentContext', migrateContextConfiguration(action.context), state);

--- a/web/client/reducers/context.js
+++ b/web/client/reducers/context.js
@@ -36,7 +36,6 @@ export default (state = {}, action) => {
     case MAP_CONFIG_LOADED: {
         const userPlugins = action.config?.context?.userPlugins ?? state.resource?.data?.userPlugins
         return  userPlugins ? set('currentContext.userPlugins', userPlugins, state) : state;
-            , state) : state;
     }
     case SET_CURRENT_CONTEXT: {
         return set('currentContext', migrateContextConfiguration(action.context), state);

--- a/web/client/reducers/context.js
+++ b/web/client/reducers/context.js
@@ -34,7 +34,8 @@ import { migrateContextConfiguration } from '../utils/ContextCreatorUtils';
 export default (state = {}, action) => {
     switch (action.type) {
     case MAP_CONFIG_LOADED: {
-        return action.config?.context?.userPlugins ?? state.resource?.data?.userPlugins ? set('currentContext.userPlugins',
+        const userPlugins = action.config?.context?.userPlugins ?? state.resource?.data?.userPlugins
+        return  userPlugins ? set('currentContext.userPlugins', userPlugins, state) : state;
             action.config?.context?.userPlugins ?? state.resource?.data?.userPlugins
             , state) : state;
     }

--- a/web/client/reducers/context.js
+++ b/web/client/reducers/context.js
@@ -36,7 +36,6 @@ export default (state = {}, action) => {
     case MAP_CONFIG_LOADED: {
         const userPlugins = action.config?.context?.userPlugins ?? state.resource?.data?.userPlugins
         return  userPlugins ? set('currentContext.userPlugins', userPlugins, state) : state;
-            action.config?.context?.userPlugins ?? state.resource?.data?.userPlugins
             , state) : state;
     }
     case SET_CURRENT_CONTEXT: {

--- a/web/client/selectors/context.js
+++ b/web/client/selectors/context.js
@@ -74,12 +74,11 @@ export const pluginsSelector = state =>
  * and it has a specific plugin activated
  * @param {string} pluginName plugin name
  */
-export const isPluginInContext = pluginName => createSelector(
-    currentContextSelector,
-    pluginsSelector,
-    (currentContext, contextPlugins = {}) => !currentContext ||
-        findIndex(get(contextPlugins, 'desktop', []), plugin => plugin.name === pluginName) > -1
-);
+export const isPluginInContext = pluginName => state => {
+    const currentContext = currentContextSelector(state);
+    const contextPlugins = pluginsSelector(state);
+    return !currentContext || findIndex(get(contextPlugins, 'desktop', []), plugin => plugin.name === pluginName) > -1;
+};
 
 /*
  * Adds the current context to the monitoredState. To update on every change of it.

--- a/web/client/selectors/context.js
+++ b/web/client/selectors/context.js
@@ -78,12 +78,12 @@ export const pluginsSelector = state => {
  * and it has a specific plugin activated
  * @param {string} pluginName plugin name
  */
-export const isPluginInContext = pluginName => state => {
-    const currentContext = currentContextSelector(state);
-    const contextPlugins = pluginsSelector(state);
-    const result = !currentContext || findIndex(get(contextPlugins, 'desktop', []), plugin => plugin.name === pluginName) > -1;
-    return result;
-};
+export const isPluginInContext = pluginName => createSelector(
+    currentContextSelector,
+    pluginsSelector,
+    (currentContext, contextPlugins = {}) => !currentContext ||
+        findIndex(get(contextPlugins, 'desktop', []), plugin => plugin.name === pluginName) > -1
+);
 
 /*
  * Adds the current context to the monitoredState. To update on every change of it.

--- a/web/client/selectors/context.js
+++ b/web/client/selectors/context.js
@@ -64,10 +64,14 @@ export const templatesSelector = createSelector(
  *
  * @param {object} state the application state
  */
-export const pluginsSelector = state =>
-    isLoadingSelector(state)
-        ? loadingPluginsSelector(state)
-        : currentPluginsSelector(state) || defaultPluginsSelector(state);
+export const pluginsSelector = state => {
+    const isloading = isLoadingSelector(state);
+    const loadingPlugins = loadingPluginsSelector(state);
+    const defaultPlugins = defaultPluginsSelector(state);
+    const currentPlugins = currentPluginsSelector(state);
+    return isloading ? loadingPlugins : currentPlugins || defaultPlugins;
+};
+
 
 /**
  * Creates a selector that will return true if mapstore currently has a context active,
@@ -77,7 +81,8 @@ export const pluginsSelector = state =>
 export const isPluginInContext = pluginName => state => {
     const currentContext = currentContextSelector(state);
     const contextPlugins = pluginsSelector(state);
-    return !currentContext || findIndex(get(contextPlugins, 'desktop', []), plugin => plugin.name === pluginName) > -1;
+    const result = !currentContext || findIndex(get(contextPlugins, 'desktop', []), plugin => plugin.name === pluginName) > -1;
+    return result;
 };
 
 /*


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

I noticed that the value of isIdentifyInContext was incorrectly set to false and no longer being updated this was making the selector [isMapinfoOpen](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/selectors/mapInfo.js#L40) here  in the [mapLayout epic](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/epics/maplayout.js#L125) to be false and therefore ignored for moving away the search bar with correct style properties 


I also fixed another error in console
![image](https://github.com/user-attachments/assets/23064246-6742-43a6-a677-86cd5b6b3594)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10910 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
it works fine, also tested by closing gfi and opening catalog

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
