### PR TITLE
Fix #10914 - Fixed WPS wrong parsing of GetExecutionStatus result

### DIFF
--- a/web/client/observables/wps/__tests__/execute-test.js
+++ b/web/client/observables/wps/__tests__/execute-test.js
@@ -88,7 +88,7 @@ const responseWithProcessAccepted = `<?xml version="1.0" encoding="UTF-8"?>
 </wps:ExecuteResponse>`;
 
 const responseWithProcessStarted = `<?xml version="1.0" encoding="UTF-8"?>
-<wps:ExecuteResponse xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" service="WPS" serviceInstance="http://testserver/geoserver/ows?" statusLocation="http://testserver/geoserver/ows?service=WPS&amp;version=1.0.0&amp;request=GetExecutionStatus&amp;executionId=0c596a4d-7ddb-4a4e-bf35-4a64b47ee0d3" version="1.0.0">
+<wps:ExecuteResponse xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" service="WPS" serviceInstance="http://testserver/geoserver/ows?"  version="1.0.0">
   <wps:Process wps:processVersion="1.0.0">
       <ows:Identifier>TestProcess</ows:Identifier>
       <ows:Title>test</ows:Title>

--- a/web/client/observables/wps/execute.js
+++ b/web/client/observables/wps/execute.js
@@ -93,7 +93,7 @@ const extractExecutionStatusFromXMLObject = (xmlObj, outputsExtractor = identity
     return {status: 'UnexpectedStatus'};
 };
 
-const handleExecuteResponseXMLObject = (xmlObj, outputsExtractor) => {
+const handleExecuteResponseXMLObject = (xmlObj, outputsExtractor, result) => {
     const statusObj = extractExecutionStatusFromXMLObject(xmlObj, outputsExtractor);
     if (statusObj.status === 'ProcessFailed') {
         throw new WPSExecuteError(statusObj.exceptionReport, 'ProcessFailed');
@@ -104,7 +104,10 @@ const handleExecuteResponseXMLObject = (xmlObj, outputsExtractor) => {
     if (statusObj.status === 'ProcessSucceeded') {
         return {succeeded: true, data: statusObj.data};
     }
-    const statusLocation = xmlObj?.ExecuteResponse?.$?.statusLocation;
+    let statusLocation = xmlObj?.ExecuteResponse?.$?.statusLocation;
+    if (!statusLocation) {
+        statusLocation = result?.config?.url;
+    }
     if (!statusLocation) {
         throw new WPSExecuteError('NoStatusLocation');
     }
@@ -251,7 +254,12 @@ export const executeProcess = (url, payload, executeOptions = {}, requestOptions
                             throw new WPSExecuteError('GetExecutionStatusXHRFailed');
                         })
                         .flatMap(result => parseXML(result.data).flatMap(newXmlObj => {
-                            const executeResponse = handleExecuteResponseXMLObject(newXmlObj, outputsExtractor);
+                            // note: handleExecuteResponseXMLObject is used to parse both status and response
+                            // this is because they are in similar format (ExecuteResponse)
+                            // Anyway this causes troubles (e.g. statusLocation is not available to extract executionId)
+                            // so we need to pass the original result to parse the original URL (this is a workaround)
+                            // We should refactor this to have a separate function to handle ExecutionStatusResponse
+                            const executeResponse = handleExecuteResponseXMLObject(newXmlObj, outputsExtractor, result);
                             if (executeResponse.succeeded) {
                                 return Observable.of(executeResponse.data);
                             }

--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -1809,7 +1809,7 @@
       },
       "wpsExecuteError": {
         "processFailed": "Download process failed! The server has returned the following exception report: \"{exceptionReport}\"",
-        "badResponse": "Download process failed! The server has returned incorrect data, error code: \"{errorCode}\"",
+        "badResponse": "Download process failed! The server has returned incorrect data, error code: \"{eCode}\"",
         "executeProcessXhrFailed": "ExecuteProcess request failed! The server might be misconfigured or it has become unreachable",
         "getExecutionStatusXhrFailed": "GetExecutionStatus request failed! The server might be misconfigured or it has become unreachable",
         "unexpectedError": "Unexpected error occurred"

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2029,7 +2029,7 @@
       },
       "wpsExecuteError": {
         "processFailed": "Download-Vorgang fehlgeschlagen! Der Server hat den folgenden Ausnahmebericht zurückgegeben: \"{exceptionReport}\"",
-        "badResponse": "Download-Vorgang fehlgeschlagen! Der Server hat falsche Daten zurückgegeben, Fehlercode: \"{errorCode}\"",
+        "badResponse": "Download-Vorgang fehlgeschlagen! Der Server hat falsche Daten zurückgegeben, Fehlercode: \"{eCode}\"",
         "executeProcessXhrFailed": "ExecuteProcess-Anforderung fehlgeschlagen! Der Server ist möglicherweise falsch konfiguriert oder nicht mehr erreichbar",
         "getExecutionStatusXhrFailed": "GetExecutionStatus-Anforderung fehlgeschlagen! Der Server ist möglicherweise falsch konfiguriert oder nicht mehr erreichbar",
         "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1990,7 +1990,7 @@
       },
       "wpsExecuteError": {
         "processFailed": "Download process failed! The server has returned the following exception report: \"{exceptionReport}\"",
-        "badResponse": "Download process failed! The server has returned incorrect data, error code: \"{errorCode}\"",
+        "badResponse": "Download process failed! The server has returned incorrect data, error code: \"{eCode}\"",
         "executeProcessXhrFailed": "ExecuteProcess request failed! The server might be misconfigured or it has become unreachable",
         "getExecutionStatusXhrFailed": "GetExecutionStatus request failed! The server might be misconfigured or it has become unreachable",
         "unexpectedError": "Unexpected error occurred"

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1990,7 +1990,7 @@
       },
       "wpsExecuteError": {
         "processFailed": "¡El proceso de descarga falló! El servidor ha devuelto el siguiente informe de excepción: \"{exceptionReport}\"",
-        "badResponse": "¡El proceso de descarga falló! El servidor ha devuelto datos incorrectos, código de error: \"{errorCode}\"",
+        "badResponse": "¡El proceso de descarga falló! El servidor ha devuelto datos incorrectos, código de error: \"{eCode}\"",
         "executeProcessXhrFailed": "¡La solicitud ExecuteProcess falló! El servidor puede estar mal configurado o no se puede acceder",
         "getExecutionStatusXhrFailed": "¡La solicitud GetExecutionStatus falló! El servidor puede estar mal configurado o no se puede acceder",
         "unexpectedError": "Ocurrió un error inesperado"

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1991,7 +1991,7 @@
       },
       "wpsExecuteError": {
         "processFailed": "Le processus de téléchargement a échoué! Le serveur a renvoyé le rapport d'exception suivant: \"{exceptionReport}\"",
-        "badResponse": "Le processus de téléchargement a échoué! Le serveur a renvoyé des données incorrectes, code d'erreur: \"{errorCode}\"",
+        "badResponse": "Le processus de téléchargement a échoué! Le serveur a renvoyé des données incorrectes, code d'erreur: \"{eCode}\"",
         "executeProcessXhrFailed": "La requête ExecuteProcess a échoué! Le serveur est peut-être mal configuré ou il est devenu inaccessible",
         "getExecutionStatusXhrFailed": "La demande GetExecutionStatus a échoué! Le serveur est peut-être mal configuré ou il est devenu inaccessible",
         "unexpectedError": "Une erreur inattendue s'est produite"

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -1842,7 +1842,7 @@
       },
       "wpsExecuteError": {
         "processFailed": "Download process failed! The server has returned the following exception report: \"{exceptionReport}\"",
-        "badResponse": "Download process failed! The server has returned incorrect data, error code: \"{errorCode}\"",
+        "badResponse": "Download process failed! The server has returned incorrect data, error code: \"{eCode}\"",
         "executeProcessXhrFailed": "ExecuteProcess request failed! The server might be misconfigured or it has become unreachable",
         "getExecutionStatusXhrFailed": "GetExecutionStatus request failed! The server might be misconfigured or it has become unreachable",
         "unexpectedError": "Unexpected error occurred"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1991,7 +1991,7 @@
       },
       "wpsExecuteError": {
         "processFailed": "Processo di download fallito! Il server ha restituito il seguente rapporto di eccezione: \"{exceptionReport}\"",
-        "badResponse": "Processo di download fallito! Il server ha restituito dati errati, codice di errore: \"{errorCode}\"",
+        "badResponse": "Processo di download fallito! Il server ha restituito dati errati, codice di errore: \"{eCode}\"",
         "executeProcessXhrFailed": "Richiesta ExecuteProcess non riuscita! Il server potrebbe essere configurato in modo errato o è diventato irraggiungibile",
         "getExecutionStatusXhrFailed": "Richiesta GetExecutionStatus non riuscita! Il server potrebbe essere configurato in modo errato o è diventato irraggiungibile",
         "unexpectedError": "Si è verificato un errore imprevisto"

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -1967,7 +1967,7 @@
       },
       "wpsExecuteError": {
         "processFailed": "Downloadproces mislukt! De server heeft het volgende uitzonderingsrapport geretourneerd: \"{exceptionReport}\"",
-        "badResponse": "Downloadproces mislukt! De server heeft onjuiste gegevens geretourneerd, foutcode: \"{errorCode}\"",
+        "badResponse": "Downloadproces mislukt! De server heeft onjuiste gegevens geretourneerd, foutcode: \"{eCode}\"",
         "executeProcessXhrFailed": "ExecuteProcess-verzoek mislukt! De server is mogelijk verkeerd geconfigureerd of is onbereikbaar geworden",
         "getExecutionStatusXhrFailed": "GetExecutionStatus-aanvraag is mislukt! De server is mogelijk verkeerd geconfigureerd of is onbereikbaar geworden",
         "unexpectedError": "Er is een onverwachte fout opgetreden"

--- a/web/client/translations/data.sk-SK.json
+++ b/web/client/translations/data.sk-SK.json
@@ -1701,7 +1701,7 @@
       },
       "wpsExecuteError": {
         "processFailed": "Proces sťahovania zlyhal! Server vrátil nasledujúcu správu o výnimke: \"{exceptionReport}\"",
-        "badResponse": "Proces sťahovania zlyhal! Server vrátil nesprávne údaje, kód chyby: \"{errorCode}\"",
+        "badResponse": "Proces sťahovania zlyhal! Server vrátil nesprávne údaje, kód chyby: \"{eCode}\"",
         "executeProcessXhrFailed": "ExecuteProcess požiadavok zlyhal! ",
         "getExecutionStatusXhrFailed": "GetExecutionStatus požiadavok zlyhal! Server môže byť nesprávne nakonfigurovaný alebo sa stal nedostupným",
         "unexpectedError": "Nastala neznáma chyba"

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -1680,7 +1680,7 @@
       },
       "wpsExecuteError": {
         "processFailed": "Nedladdningsprocessen misslyckades! Servern har returnerat följande undantagsrapport {exceptionReport} ",
-        "badResponse": "Nedladdningsprocessen misslyckades! Servern har returnerat felaktiga data, felkod: {errorCode} ",
+        "badResponse": "Nedladdningsprocessen misslyckades! Servern har returnerat felaktiga data, felkod: {eCode} ",
         "executeProcessXhrFailed": "ExecuteProcess -begäran misslyckades! Servern kan vara felkonfigurerad eller den har blivit oåtkomlig",
         "getExecutionStatusXhrFailed": "GetExecutionStatus -begäran misslyckades! Servern kan vara felkonfigurerad eller den har blivit oåtkomlig",
         "unknownError": "Ett oväntat fel inträffade"


### PR DESCRIPTION
## Description

This PR fixes #10914 by parsing the request URL instead of the status URL (missing), when requesting GetExecutionStatus.

Moreover it inserts the correct errorCode in error message (wrong translation files, the parameter is `eCode`).

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
