### PR TITLE
Fix #10912 by making dialog opening to the left of the image button

### DIFF
--- a/web/client/plugins/ResourcesCatalog/containers/ResourceAboutEditor.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceAboutEditor.jsx
@@ -23,6 +23,7 @@ function ResourceAboutEditor({
         <Tabs>
             <Tab eventKey="content" title={'Content'}>
                 <Editor
+                    wrapperClassName="resource-about-editor"
                     editorState={editorState}
                     stripPastedStyles
                     onEditorStateChange={(newEditorState) => {

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -226,6 +226,12 @@ textarea {
     }
 }
 
+// avoid issue panel overflow https://github.com/geosolutions-it/MapStore2/issues/10912
+// works only if the editor is always present to the right or have enough space
+.rdw-image-modal {
+    left: auto !important;
+    right: 0 !important;
+}
 .mapstore-filter {
     &.form-group {
         margin: ((@square-btn-size - @square-btn-medium-size)/2) 0 0 0;

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -228,9 +228,11 @@ textarea {
 
 // avoid issue panel overflow https://github.com/geosolutions-it/MapStore2/issues/10912
 // works only if the editor is always present to the right or have enough space
-.rdw-image-modal {
-    left: auto !important;
-    right: 0 !important;
+.resource-about-editor {
+    .rdw-image-modal {
+        left: auto !important;
+        right: 0 !important;
+    }
 }
 .mapstore-filter {
     &.form-group {

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -230,8 +230,8 @@ textarea {
 // works only if the editor is always present to the right or have enough space
 .resource-about-editor {
     .rdw-image-modal {
-        left: auto !important;
-        right: 0 !important;
+        left: auto;
+        right: 0;
     }
 }
 .mapstore-filter {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This is the new behaviour 
![image](https://github.com/user-attachments/assets/c3047387-05e8-4d90-82b8-9324264613a8)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10912

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now opens to the left 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
