### PR TITLE
Backport 2025.01.xx - Fix #10912 by making dialog opening to the left of the image button (#10920)

### DIFF
--- a/web/client/plugins/ResourcesCatalog/containers/ResourceAboutEditor.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceAboutEditor.jsx
@@ -23,6 +23,7 @@ function ResourceAboutEditor({
         <Tabs>
             <Tab eventKey="content" title={'Content'}>
                 <Editor
+                    wrapperClassName="resource-about-editor"
                     editorState={editorState}
                     stripPastedStyles
                     onEditorStateChange={(newEditorState) => {

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -226,6 +226,14 @@ textarea {
     }
 }
 
+// avoid issue panel overflow https://github.com/geosolutions-it/MapStore2/issues/10912
+// works only if the editor is always present to the right or have enough space
+.resource-about-editor {
+    .rdw-image-modal {
+        left: auto;
+        right: 0;
+    }
+}
 .mapstore-filter {
     &.form-group {
         margin: ((@square-btn-size - @square-btn-medium-size)/2) 0 0 0;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Backport 2025.01.xx - Fix #10912 by making dialog opening to the left of the image button (#10920)