### PR TITLE
#10918: Fix issue with measure tool in Cesium map

### DIFF
--- a/web/client/components/map/cesium/DrawGeometrySupport.jsx
+++ b/web/client/components/map/cesium/DrawGeometrySupport.jsx
@@ -74,7 +74,7 @@ function DrawGeometrySupport({
                 draw.current = null;
             }
         };
-    }, [map, active, geometryType, sampleTerrain, coordinatesLength, geodesic, onDrawEnd]);
+    }, [map, active, geometryType, sampleTerrain, coordinatesLength, geodesic]);
 
     return null;
 }

--- a/web/client/components/map/openlayers/DrawGeometrySupport.jsx
+++ b/web/client/components/map/openlayers/DrawGeometrySupport.jsx
@@ -60,7 +60,7 @@ function DrawGeometrySupport({
                 draw.current = null;
             }
         };
-    }, [map, active, geometryType, coordinatesLength, geodesic, onDrawEnd]);
+    }, [map, active, geometryType, coordinatesLength, geodesic]);
     return null;
 }
 

--- a/web/client/plugins/Annotations/containers/AnnotationsMapInteractionsSupport.jsx
+++ b/web/client/plugins/Annotations/containers/AnnotationsMapInteractionsSupport.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { lazy, Suspense } from 'react';
+import React, { lazy, Suspense, useEffect, useRef } from 'react';
 import { MapLibraries } from '../../../utils/MapTypeUtils';
 import { validateFeature } from '../utils/AnnotationsUtils';
 
@@ -45,6 +45,13 @@ function AnnotationsMapInteractionsSupport({
     const selectedAnnotationType = getGeometryType(feature);
     const drawGeometryType = getDrawGeometryType(feature);
     const isGeodesic = !!geodesic[selectedAnnotationType];
+
+    const featureRef = useRef(feature);
+    useEffect(() => {
+        // to avoid stale closure in the callback
+        featureRef.current = feature;
+    }, [feature]);
+
     return (
         <Suspense fallback={null}>
             <>
@@ -57,9 +64,9 @@ function AnnotationsMapInteractionsSupport({
                     getObjectsToExcludeOnPick={() => []}
                     onDrawEnd={({ feature: newFeature }) => {
                         onChange({
-                            ...feature,
+                            ...featureRef.current,
                             properties: {
-                                ...feature?.properties,
+                                ...featureRef.current?.properties,
                                 geodesic: isGeodesic,
                                 ...(newFeature?.properties?.radius !== undefined && {
                                     radius: newFeature?.properties?.radius


### PR DESCRIPTION
## Description
This PR fixes the issue with the measure tool in the Cesium map by removing the `onDrawEnd` dependency and addressing the stale closure differently, limiting the code change to Annotation.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10918 

**What is the new behavior?**
- Circle annotation works as is
- Measure tool on Cesium and OL map works as expected

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
