### PR TITLE
#10940

### DIFF
--- a/web/client/epics/__tests__/widgetsbuilder-test.js
+++ b/web/client/epics/__tests__/widgetsbuilder-test.js
@@ -192,6 +192,7 @@ describe('widgetsbuilder epic', () => {
                     expect(action.widget.charts[0].chartId).toBe(action.widget.selectedChartId);
                     expect(action.widget.charts[0].traces.length).toBe(1);
                     expect(action.widget.charts[0].traces[0].type).toBe('bar');
+                    expect(action.widget.charts[0].traces[0].layer.id).toBe('TEST2');
                     break;
                 case EDITOR_CHANGE:
                     expect(action.key).toBe('returnToFeatureGrid');
@@ -209,6 +210,31 @@ describe('widgetsbuilder epic', () => {
             controls: {
                 widgetBuilder: {
                     available: true
+                }
+            },
+            layers: {
+                flat: [
+                    {
+                        id: "TEST1"
+                    },
+                    {
+                        id: "TEST2"
+                    }]
+            },
+            featuregrid: {
+                selectedLayer: "TEST2"
+            },
+            widgets: {
+                builder: {
+                    editor: {
+                        charts: [{
+                            traces: [{
+                                layer: {
+                                    id: "TEST1"
+                                }
+                            }]
+                        }]
+                    }
                 }
             }
         });

--- a/web/client/epics/widgetsbuilder.js
+++ b/web/client/epics/widgetsbuilder.js
@@ -18,6 +18,7 @@ import {
 } from '../actions/widgets';
 
 import { closeFeatureGrid } from '../actions/featuregrid';
+import { selectedLayerSelector } from "../selectors/featuregrid";
 import { drawSupportReset } from '../actions/draw';
 import { QUERY_FORM_SEARCH, loadFilter } from '../actions/queryform';
 import { setControlProperty, TOGGLE_CONTROL } from '../actions/controls';
@@ -60,7 +61,7 @@ export const initEditorOnNewChart = (action$, {getState = () => {}} = {}) => act
     .switchMap(() => {
         const chartId = uuid();
         const state = getState();
-        const layer = getWidgetLayer(state);
+        const layer = selectedLayerSelector(state);
         return Rx.Observable.of(
             closeFeatureGrid(),
             editNewWidget({


### PR DESCRIPTION
Fix incorrect layer usage in widget opened from feature grid
- changed selector for layer when new chart created from feature grid
- Updated and added relevant tests

On behalf of DB Systel GmbH

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
The layer corresponding to the last widget opened via the TOC will be used in the widget opened from the feature grid.
<issue>

**What is the new behavior?**
The layer corresponding to the feature grid is used in the widget.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
