### PR TITLE
#10937: Unable to visualize some 3D tiles data in MapStore

### DIFF
--- a/web/client/api/catalog/CSW.js
+++ b/web/client/api/catalog/CSW.js
@@ -120,13 +120,17 @@ function getBoundingBox(record) {
 }
 function getCatalogRecord3DTiles(record, metadata) {
     const dc = record.dc;
+    // dc?.URI can be an array
+    let dcURIs = castArray(dc?.URI);
+    const firstValidURI = dcURIs?.find(uri => uri?.value?.endsWith('.json'));
+    const url = firstValidURI?.value || "";
     return {
         serviceType: '3dtiles',
         isValid: true,
         description: dc && isString(dc.abstract) && dc.abstract || '',
         title: dc && isString(dc.title) && dc.title || '',
         identifier: dc && isString(dc.identifier) && dc.identifier || '',
-        url: dc?.URI?.value || "",
+        url,
         thumbnail: null,
         bbox: getBoundingBox(record),
         format: dc && dc.format || "",

--- a/web/client/api/catalog/__tests__/CSW-test.js
+++ b/web/client/api/catalog/__tests__/CSW-test.js
@@ -462,6 +462,42 @@ describe('Test correctness of the CSW catalog APIs', () => {
         expect(catalogRecords[0].format).toEqual('3D Tiles');
         expect(catalogRecords[0].catalogType).toEqual('csw');
     });
+    it('csw with array of (DC URI) 3D Tiles', ()=>{
+        const records = [{
+            boundingBox: {
+                "extent": [
+                    43.718, 11.1, 43.84, 11.348
+                ],
+                "crs": "EPSG:4326"
+            },
+            dc: {
+                URI: [
+                    {
+                        "TYPE_NAME": "DC_1_1.URI",
+                        "protocol": "http://www.w3.org/TR/xlink/",
+                        "description": "layer01",
+                        "value": "https://hostname/3dtiles/layername/tileset.json"
+                    },
+                    {
+                        "TYPE_NAME": "DC_1_1.URI",
+                        "protocol": "image/png",
+                        "name": "attachments",
+                        "value": "https://hostname/3dtiles/layername1/attachments/GEONETWORK-PON.png"
+                    }
+                ], format: THREE_D_TILES, identifier: "test:layername", title: "3D Tiles layer for test"
+            }
+        }];
+        const catalogRecords = getCatalogRecords({records});
+        expect(catalogRecords.length).toBe(1);
+        expect(catalogRecords[0].bbox).toEqual({ bounds: {minx: 43.718, miny: 11.1, maxx: 43.84, maxy: 11.348}, crs: 'EPSG:4326' });
+        expect(catalogRecords[0].url).toEqual("https://hostname/3dtiles/layername/tileset.json");
+        expect(catalogRecords[0].identifier).toEqual("test:layername");
+        expect(catalogRecords[0].title).toEqual("3D Tiles layer for test");
+        expect(catalogRecords[0].serviceType).toEqual("3dtiles");
+        expect(catalogRecords[0].isValid).toEqual(true);
+        expect(catalogRecords[0].format).toEqual('3D Tiles');
+        expect(catalogRecords[0].catalogType).toEqual('csw');
+    });
     it('csw with DC references', () => {
         const records = getCatalogRecords({
             records: [{


### PR DESCRIPTION
## Description
This PR handles a spacial case for import csw 3dtile layer that contains URI as an array for its fetched record object by extracting the 1st valid uri ending with .json.
Previosly, it was assumed only the URI is an object so it is needed to handle this case if URI is an array.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#10937 

**What is the new behavior?**
User can add csw 3d tile layer if it has URI array in its fetched record object. The will be added normally.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
