### PR TITLE
#10936: Add resource name in the window title of the browser

### DIFF
--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -31,7 +31,8 @@ import {
     isBrowserMobile,
     isDashboardLoading,
     showConnectionsSelector,
-    isDashboardAvailable
+    isDashboardAvailable,
+    dashboardTitleSelector
 } from '../selectors/dashboard';
 import { currentLocaleLanguageSelector, currentLocaleSelector } from '../selectors/locale';
 import { isLocalizedLayerStylesEnabledSelector, localizedLayerStylesEnvSelector } from '../selectors/localizedLayerStyles';
@@ -158,13 +159,32 @@ class DashboardPlugin extends React.Component {
         cols: PropTypes.object,
         minLayoutWidth: PropTypes.number,
         widgetOpts: PropTypes.object,
-        enableZoomInTblWidget: PropTypes.bool
+        enableZoomInTblWidget: PropTypes.bool,
+        dashboardTitle: PropTypes.string
     };
     static defaultProps = {
         enabled: true,
         minLayoutWidth: 480,
         enableZoomInTblWidget: true
     };
+    componentDidMount() {
+        let isExistingDashbaordResource = this.props?.did;
+        if (isExistingDashbaordResource) {
+            this.oldDocumentTitle = document.title;
+        }
+    }
+    componentDidUpdate() {
+        let isExistingDashbaordResource = this.props?.did;
+        if (this.props.dashboardTitle && isExistingDashbaordResource) {
+            document.title = this.props.dashboardTitle;
+        }
+    }
+    componentWillUnmount() {
+        let isExistingDashbaordResource = this.props?.did;
+        if (isExistingDashbaordResource) {
+            document.title = this.oldDocumentTitle;
+        }
+    }
     render() {
         return this.props.enabled
             ? <WidgetsView
@@ -182,7 +202,7 @@ class DashboardPlugin extends React.Component {
 }
 
 export default createPlugin("Dashboard", {
-    component: withResizeDetector(DashboardPlugin),
+    component: connect((state) => ({dashboardTitle: dashboardTitleSelector(state)}))(withResizeDetector(DashboardPlugin)),
     reducers: {
         dashboard: dashboardReducers,
         widgets: widgetsReducers

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -211,7 +211,8 @@ class MapPlugin extends React.Component {
         items: PropTypes.array,
         onLoadingMapPlugins: PropTypes.func,
         onMapTypeLoaded: PropTypes.func,
-        pluginsCreator: PropTypes.func
+        pluginsCreator: PropTypes.func,
+        mapTitle: PropTypes.string
     };
 
     static defaultProps = {
@@ -253,7 +254,18 @@ class MapPlugin extends React.Component {
     };
 
     state = {};
-
+    componentDidMount() {
+        let isMapResource = this.props?.mapId;
+        if (isMapResource) {
+            this.oldDocumentTitle = document.title;
+        }
+    }
+    componentDidUpdate() {
+        let isMapResource = this.props?.mapId;
+        if (this.props.mapTitle && isMapResource) {
+            document.title = this.props.mapTitle;
+        }
+    }
     UNSAFE_componentWillMount() {
         // moved the font load of FontAwesome only to styleParseUtils (#9653)
         this.updatePlugins(this.props);
@@ -268,6 +280,10 @@ class MapPlugin extends React.Component {
 
     componentWillUnmount() {
         this._isMounted = false;
+        let isMapResource = this.props?.mapId;
+        if (isMapResource) {
+            document.title = this.oldDocumentTitle;
+        }
     }
 
     getHighlightLayer = (projection, index, env) => {

--- a/web/client/plugins/map/__tests__/selector-test.jsx
+++ b/web/client/plugins/map/__tests__/selector-test.jsx
@@ -18,6 +18,17 @@ import { registerEventListener } from '../../../actions/map';
 
 const stateMocker = createStateMocker({ map, layers, additionallayers});
 describe('Map plugin state to pros selector', () => {
+    it('test getting mapTitle from selector', () => {
+        const stateWithMapTitle = selector({map: {
+            info: {
+                attributes: {
+                    "title": "map title01"
+                }
+            }
+        }});
+        expect(stateWithMapTitle.mapTitle).toBeTruthy();
+        expect(stateWithMapTitle.mapTitle).toEqual("map title01");
+    });
     describe('elevationEnabled', () => {
         it('elevation is active when mouseposition is listening to map', () => {
             const elevationEnabledState = selector(stateMocker(registerEventListener('mousemove', 'mouseposition')));

--- a/web/client/plugins/map/selector.js
+++ b/web/client/plugins/map/selector.js
@@ -1,4 +1,4 @@
-import { mapSelector, projectionDefsSelector, isMouseMoveCoordinatesActiveSelector } from '../../selectors/map';
+import { mapSelector, projectionDefsSelector, isMouseMoveCoordinatesActiveSelector, mapNameSelector } from '../../selectors/map';
 import { mapTypeSelector } from '../../selectors/maptype';
 import { layerSelectorWithMarkers } from '../../selectors/layers';
 import { highlighedFeatures } from '../../selectors/highlight';
@@ -24,7 +24,8 @@ export default createShallowSelectorCreator(isEqual)(
     isLocalizedLayerStylesEnabledSelector,
     localizedLayerStylesNameSelector,
     currentLocaleLanguageSelector,
-    (projectionDefs, map, mapType, layers, features, loadingError, securityToken, elevationEnabled, isLocalizedLayerStylesEnabled, localizedLayerStylesName, currentLocaleLanguage) => ({
+    mapNameSelector,
+    (projectionDefs, map, mapType, layers, features, loadingError, securityToken, elevationEnabled, isLocalizedLayerStylesEnabled, localizedLayerStylesName, currentLocaleLanguage, mapTitle) => ({
         projectionDefs,
         map,
         mapType,
@@ -35,6 +36,7 @@ export default createShallowSelectorCreator(isEqual)(
         elevationEnabled,
         isLocalizedLayerStylesEnabled,
         localizedLayerStylesName,
-        currentLocaleLanguage
+        currentLocaleLanguage,
+        mapTitle
     })
 );

--- a/web/client/product/pages/Context.jsx
+++ b/web/client/product/pages/Context.jsx
@@ -94,17 +94,22 @@ class Context extends React.Component {
     componentDidUpdate(oldProps) {
         const paramsChanged = !isEqual(this.props.match.params, oldProps.match.params);
         const newParams = this.props.match.params;
+        const isMapContext = newParams?.mapId;
 
         if (paramsChanged && this.state.pluginsAreLoaded) {
             this.props.loadContext(newParams);
         }
 
-        if (this.props.windowTitle) {
+        if (this.props.windowTitle && !isMapContext) {
             document.title = this.props.windowTitle;
         }
     }
     componentWillUnmount() {
-        document.title = this.oldTitle;
+        const params = this.props.match.params;
+        const isMapContext = params?.mapId;
+        if (!isMapContext) {
+            document.title = this.oldTitle;
+        }
         this.props.reset();
     }
     render() {
@@ -120,7 +125,10 @@ class Context extends React.Component {
         if (pluginsAreLoaded && !this.state.pluginsAreLoaded) {
             this.setState({pluginsAreLoaded: true}, () => {
                 const params = this.props.match.params;
-                this.oldTitle = document.title;
+                const isMapContext = params?.mapId;
+                if (!isMapContext) {
+                    this.oldTitle = document.title;
+                }
                 this.props.loadContext(params);
             });
         }

--- a/web/client/selectors/__tests__/dashboard-test.js
+++ b/web/client/selectors/__tests__/dashboard-test.js
@@ -26,7 +26,8 @@ import {
     dashboardResourceInfoSelector,
     dashboardInfoDetailsUriFromIdSelector,
     dashboardInfoDetailsSettingsFromIdSelector,
-    canEditServiceSelector
+    canEditServiceSelector,
+    dashboardTitleSelector
 } from '../dashboard';
 
 describe('dashboard selectors', () => {
@@ -156,6 +157,13 @@ describe('dashboard selectors', () => {
                 }
             }
         }})).toBe("detailsSettings");
+    });
+    it("test dashboardTitleSelector", () => {
+        expect(dashboardTitleSelector({dashboard: {
+            resource: {
+                name: "dashbaord title1"
+            }
+        }})).toBe("dashbaord title1");
     });
     describe("canEditServiceSelector", () => {
         it('test ADMIN role ', () => {

--- a/web/client/selectors/__tests__/geostory-test.js
+++ b/web/client/selectors/__tests__/geostory-test.js
@@ -39,7 +39,8 @@ import {
     getAllCarouselContentsOfSection,
     isDrawControlEnabled,
     geoCarouselSettings,
-    getPageIndex
+    getPageIndex,
+    geostoryTitleSelector
 } from "../geostory";
 import TEST_STORY from "../../test-resources/geostory/sampleStory_1.json";
 
@@ -190,5 +191,8 @@ describe('geostory selectors', () => { // TODO: check default
         const _settings = {map: {mapInfoControl: true}};
         const settings = geoCarouselSettings({ geostory: { geoCarouselSettings: _settings }});
         expect(settings).toBe(_settings);
+    });
+    it('geostoryTitleSelector ', () => {
+        expect(geostoryTitleSelector({ geostory: { resource: { name: "geostory title1" } } })).toBe("geostory title1");
     });
 });

--- a/web/client/selectors/dashboard.js
+++ b/web/client/selectors/dashboard.js
@@ -44,4 +44,5 @@ export const canEditServiceSelector = state => {
         allowedGroups
     })(state);
 };
+export const dashboardTitleSelector = state => state?.dashboard?.resource?.name;
 

--- a/web/client/selectors/dashboard.js
+++ b/web/client/selectors/dashboard.js
@@ -44,5 +44,10 @@ export const canEditServiceSelector = state => {
         allowedGroups
     })(state);
 };
+/**
+ * Get name/title of current dashboard
+ * @param {object} state the application state
+ * @returns {string} name/title of the dashboard
+ */
 export const dashboardTitleSelector = state => state?.dashboard?.resource?.name;
 

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -73,6 +73,11 @@ export const canEditSelector = state => get(resourceSelector(state), 'canEdit', 
  */
 export const geostoryIdSelector = state => get(resourceSelector(state), 'id');
 /**
+ * Get name/title of current story
+ * @param {object} state the application state
+ */
+export const geostoryTitleSelector = state => get(resourceSelector(state), 'name');
+/**
  * Selects the edit permission of the resource
  * @param {object} state the application state
  */

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -75,6 +75,7 @@ export const geostoryIdSelector = state => get(resourceSelector(state), 'id');
 /**
  * Get name/title of current story
  * @param {object} state the application state
+ * @returns {string} name/title of the geostory
  */
 export const geostoryTitleSelector = state => get(resourceSelector(state), 'name');
 /**


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes handling edit document title in case open different stored resources: maps, dashboards, geostories to be equal the resource name and handling restore document title while leaving the resource [map, dashboard, geostory] page. This is for the stored resources with id.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10936 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

https://github.com/user-attachments/assets/ba2b0870-422e-4784-bbef-f4ce8fa22b2d



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
