### PR TITLE
#10831: FIX- Improve how printing map preview is managed

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -349,13 +349,13 @@ export default {
                         printingService: getDefaultPrintingService(),
                         printMap: {}
                     };
-
-                    state = {
-                        activeAccordionPanel: 0
-                    }
-
-                    UNSAFE_componentWillMount() {
+                    constructor(props) {
+                        super(props);
+                        // Calling configurePrintMap here to replace calling in in UNSAFE_componentWillMount
                         this.configurePrintMap();
+                        this.state = {
+                            activeAccordionPanel: 0
+                        };
                     }
 
                     UNSAFE_componentWillReceiveProps(nextProps) {

--- a/web/client/plugins/print/Projection.jsx
+++ b/web/client/plugins/print/Projection.jsx
@@ -57,8 +57,7 @@ export const Projection = ({
     onChangeParameter,
     allowPreview = false,
     projections,
-    enabled = true,
-    onRefresh = () => {}
+    enabled = true
 }, context) => {
     useEffect(() => {
         if (enabled) {
@@ -67,7 +66,6 @@ export const Projection = ({
     }, [allowPreview]);
     function changeProjection(crs) {
         onChangeParameter("params.projection", crs);
-        onRefresh();
     }
     useEffect(() => {
         if (enabled) {


### PR DESCRIPTION
## Description
This PR includes:
- handle keeping the print map preview scale if user clicks on print and back to print preview
- handle keeping the print map preview scale if user changes projections from print preview screen


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10831 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

https://github.com/user-attachments/assets/e9eb110c-6372-43b2-b6d2-b7d8a05c7e15



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
