### PR TITLE
backport 2025.01.xx - #10940 Widgets charts get wrong layer after open it from featuregrid (#10941)

### DIFF
--- a/web/client/epics/__tests__/widgetsbuilder-test.js
+++ b/web/client/epics/__tests__/widgetsbuilder-test.js
@@ -192,6 +192,7 @@ describe('widgetsbuilder epic', () => {
                     expect(action.widget.charts[0].chartId).toBe(action.widget.selectedChartId);
                     expect(action.widget.charts[0].traces.length).toBe(1);
                     expect(action.widget.charts[0].traces[0].type).toBe('bar');
+                    expect(action.widget.charts[0].traces[0].layer.id).toBe('TEST2');
                     break;
                 case EDITOR_CHANGE:
                     expect(action.key).toBe('returnToFeatureGrid');
@@ -209,6 +210,31 @@ describe('widgetsbuilder epic', () => {
             controls: {
                 widgetBuilder: {
                     available: true
+                }
+            },
+            layers: {
+                flat: [
+                    {
+                        id: "TEST1"
+                    },
+                    {
+                        id: "TEST2"
+                    }]
+            },
+            featuregrid: {
+                selectedLayer: "TEST2"
+            },
+            widgets: {
+                builder: {
+                    editor: {
+                        charts: [{
+                            traces: [{
+                                layer: {
+                                    id: "TEST1"
+                                }
+                            }]
+                        }]
+                    }
                 }
             }
         });

--- a/web/client/epics/widgetsbuilder.js
+++ b/web/client/epics/widgetsbuilder.js
@@ -18,6 +18,7 @@ import {
 } from '../actions/widgets';
 
 import { closeFeatureGrid } from '../actions/featuregrid';
+import { selectedLayerSelector } from "../selectors/featuregrid";
 import { drawSupportReset } from '../actions/draw';
 import { QUERY_FORM_SEARCH, loadFilter } from '../actions/queryform';
 import { setControlProperty, TOGGLE_CONTROL } from '../actions/controls';
@@ -60,7 +61,7 @@ export const initEditorOnNewChart = (action$, {getState = () => {}} = {}) => act
     .switchMap(() => {
         const chartId = uuid();
         const state = getState();
-        const layer = getWidgetLayer(state);
+        const layer = selectedLayerSelector(state);
         return Rx.Observable.of(
             closeFeatureGrid(),
             editNewWidget({


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport 2025.01.xx - #10940 Widgets charts get wrong layer after open it from featuregrid (#10941)