### PR TITLE
#10961: Fix - Styleeditor not working with only two available styles

### DIFF
--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -1701,7 +1701,6 @@ describe('Test styleeditor epics, with mock axios', () => {
                 });
                 expect(updateAdditionalLayerAction.type).toBe(UPDATE_ADDITIONAL_LAYER);
                 expect(updateSettingsParamsAction.type).toBe(UPDATE_SETTINGS_PARAMS);
-                console.log("updateSettingsParamsAction.newParams", JSON.stringify(updateSettingsParamsAction.newParams));
                 expect(updateSettingsParamsAction.newParams).toEqual({
                     availableStyles: [
                         { name: 'layerWorkspace:style_01', workspace: 'layerWorkspace' }

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -8,7 +8,7 @@
 
 import Rx from 'rxjs';
 
-import { get, head, isArray, template, uniqBy } from 'lodash';
+import { get, head, isArray, template, uniqBy, castArray } from 'lodash';
 import { success, error } from '../actions/notifications';
 import { UPDATE_NODE, updateNode, updateSettingsParams } from '../actions/layers';
 import { updateAdditionalLayer, removeAdditionalLayer, updateOptionsByOwner } from '../actions/additionallayers';
@@ -281,7 +281,7 @@ export const toggleStyleEditorEpic = (action$, store) =>
                                 LayersAPI.getLayer(baseUrl + 'rest/', layer.name)
                             )
                                 .switchMap((layerConfig) => {
-                                    const stylesConfig = layerConfig?.styles?.style || [];
+                                    const stylesConfig = castArray(layerConfig?.styles?.style ?? []);
                                     const layerConfigAvailableStyles = uniqBy([
                                         layerConfig.defaultStyle,
                                         ...stylesConfig


### PR DESCRIPTION
## Description
This PR fixes the style editor not working as expected with only two available styles

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #10961

**What is the new behavior?**
The style editor correctly fetches the availableStyles when only two styles are present on the layer (one default and one newly added)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
TESTING: Open [this](https://dev-mapstore.geosolutionsgroup.com/mapstore/#/viewer/53702) map and make sure a style is selected
