### PR TITLE
[Backport 2025.01.xx] #10961: Fix - Styleeditor not working with only two available styles (#10964)

### DIFF
--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -1625,6 +1625,101 @@ describe('Test styleeditor epics, with mock axios', () => {
             state);
 
     });
+    it('toggleStyleEditorEpic: when get layer info style response is not an array', (done) => {
+
+        mockAxios.onGet(/\/manifest/).reply(() => {
+            return [ 200, { about: { resource: [{ '@name': 'gt-css-2.16' }]} }];
+        });
+
+        mockAxios.onGet(/\/version/).reply(() => {
+            return [ 200, { about: { resource: [{ '@name': 'GeoServer', version: '2.16' }] } }];
+        });
+
+        mockAxios.onGet(/\/fonts/).reply(() => {
+            return [ 200, { fonts: ['Arial'] }];
+        });
+
+        mockAxios.onGet(/\/rest\/layers/).reply(() => {
+            return [ 200, { layer: {
+                defaultStyle: {
+                    name: 'layerWorkspace:style_01',
+                    workspace: 'layerWorkspace'
+                },
+                styles: {
+                    style: {
+                        name: 'layerWorkspace:style_01',
+                        workspace: 'layerWorkspace'
+                    }
+                }
+            }}];
+        });
+
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'layerId',
+                        name: 'layerWorkspace:layerName',
+                        url: 'protocol://style-editor/geoserver/'
+                    }
+                ],
+                selected: [
+                    'layerId'
+                ],
+                settings: {
+                    options: {
+                        opacity: 1
+                    }
+                }
+            }
+        };
+        const NUMBER_OF_ACTIONS = 5;
+
+        const results = (actions) => {
+            try {
+                const [
+                    loadingStyleAction,
+                    resetStyle,
+                    initStyleServiceAction,
+                    updateAdditionalLayerAction,
+                    updateSettingsParamsAction
+                ] = actions;
+
+                expect(resetStyle.type).toBe(RESET_STYLE_EDITOR);
+                expect(loadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(initStyleServiceAction.type).toBe(INIT_STYLE_SERVICE);
+                expect(initStyleServiceAction.service).toEqual({
+                    baseUrl: 'protocol://style-editor/geoserver/',
+                    version: '2.16',
+                    formats: [ 'css', 'sld' ],
+                    availableUrls: [],
+                    fonts: ['Arial'],
+                    classificationMethods: {
+                        vector: [ 'equalInterval', 'quantile', 'jenks' ],
+                        raster: [ 'equalInterval', 'quantile', 'jenks' ]
+                    }
+                });
+                expect(updateAdditionalLayerAction.type).toBe(UPDATE_ADDITIONAL_LAYER);
+                expect(updateSettingsParamsAction.type).toBe(UPDATE_SETTINGS_PARAMS);
+                expect(updateSettingsParamsAction.newParams).toEqual({
+                    availableStyles: [
+                        { name: 'layerWorkspace:style_01', workspace: 'layerWorkspace' }
+                    ]
+                });
+            } catch (e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            toggleStyleEditorEpic,
+            NUMBER_OF_ACTIONS,
+            toggleStyleEditor(undefined, true),
+            results,
+            state);
+
+    });
     it('test toggleStyleEditorEpic style service where layer url is array', (done) => {
         mockAxios.onGet(/\/manifest/).reply(() => {
             return [ 200, { about: { resource: [{ '@name': 'gt-css-2.16' }]} }];

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -8,7 +8,7 @@
 
 import Rx from 'rxjs';
 
-import { get, head, isArray, template, uniqBy } from 'lodash';
+import { get, head, isArray, template, uniqBy, castArray } from 'lodash';
 import { success, error } from '../actions/notifications';
 import { UPDATE_NODE, updateNode, updateSettingsParams } from '../actions/layers';
 import { updateAdditionalLayer, removeAdditionalLayer, updateOptionsByOwner } from '../actions/additionallayers';
@@ -281,7 +281,7 @@ export const toggleStyleEditorEpic = (action$, store) =>
                                 LayersAPI.getLayer(baseUrl + 'rest/', layer.name)
                             )
                                 .switchMap((layerConfig) => {
-                                    const stylesConfig = layerConfig?.styles?.style || [];
+                                    const stylesConfig = castArray(layerConfig?.styles?.style ?? []);
                                     const layerConfigAvailableStyles = uniqBy([
                                         layerConfig.defaultStyle,
                                         ...stylesConfig


### PR DESCRIPTION
#10961: Fix - Styleeditor not working with only two available styles (#10964)