### PR TITLE
#10970: Add configuration support to open resource in target from homepage

### DIFF
--- a/web/client/actions/__tests__/createnewmap-test.js
+++ b/web/client/actions/__tests__/createnewmap-test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from "expect";
+import {
+    CREATE_NEW_MAP,
+    createNewMap,
+    HAS_CONTEXTS,
+    hasContexts,
+    SET_NEW_MAP_CONTEXT,
+    setNewMapContext,
+    SHOW_NEW_MAP_DIALOG,
+    showNewMapDialog,
+    LOADING,
+    loading
+} from "../createnewmap";
+
+describe("createnewmap actions", () => {
+    it("should create an action to show the new map dialog", () => {
+        const show = true;
+        const expectedAction = {
+            type: SHOW_NEW_MAP_DIALOG,
+            show
+        };
+        expect(showNewMapDialog(show)).toEqual(expectedAction);
+    });
+
+    it("should create an action to create a new map", () => {
+        const context = { id: 1, name: "Test Context" };
+        const openInNewTab = true;
+        const expectedAction = {
+            type: CREATE_NEW_MAP,
+            context,
+            openInNewTab
+        };
+        expect(createNewMap(context, openInNewTab)).toEqual(expectedAction);
+    });
+
+    it("should create an action to set hasContexts", () => {
+        const value = true;
+        const expectedAction = {
+            type: HAS_CONTEXTS,
+            value
+        };
+        expect(hasContexts(value)).toEqual(expectedAction);
+    });
+
+    it("should create an action to set a new map context", () => {
+        const context = { id: 2, name: "Another Context" };
+        const expectedAction = {
+            type: SET_NEW_MAP_CONTEXT,
+            context
+        };
+        expect(setNewMapContext(context)).toEqual(expectedAction);
+    });
+
+    it("should create an action to set loading state", () => {
+        const value = true;
+        const name = "loading";
+        const expectedAction = {
+            type: LOADING,
+            name,
+            value
+        };
+        expect(loading(value, name)).toEqual(expectedAction);
+    });
+
+    it("should create an action to set loading state with default name", () => {
+        const value = false;
+        const expectedAction = {
+            type: LOADING,
+            name: "loading",
+            value
+        };
+        expect(loading(value)).toEqual(expectedAction);
+    });
+});

--- a/web/client/actions/createnewmap.js
+++ b/web/client/actions/createnewmap.js
@@ -17,9 +17,10 @@ export const showNewMapDialog = (show) => ({
     show
 });
 
-export const createNewMap = (context) => ({
+export const createNewMap = (context, openInNewTab) => ({
     type: CREATE_NEW_MAP,
-    context
+    context,
+    openInNewTab
 });
 
 export const hasContexts = (value) => ({

--- a/web/client/epics/__tests__/createnewmap-test.js
+++ b/web/client/epics/__tests__/createnewmap-test.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+import MockAdapter from 'axios-mock-adapter';
+import { CALL_HISTORY_METHOD } from 'connected-react-router';
+import expect from 'expect';
+
+import { checkContextsOnMapLoad, createNewMapEpic } from '../createnewmap';
+import { loadMaps } from '../../actions/maps';
+import { testEpic } from './epicTestUtils';
+import { createNewMap, HAS_CONTEXTS, LOADING, SHOW_NEW_MAP_DIALOG } from '../../actions/createnewmap';
+import axios from '../../libs/ajax';
+
+let mockAxios;
+
+describe('CreateNewMap Epics', () => {
+    beforeEach(done => {
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+
+    afterEach(done => {
+        mockAxios.restore();
+        setTimeout(done);
+    });
+
+    it('checkContextsOnMapLoad with context', (done) => {
+        mockAxios.onGet().reply(() => ([ 200, {
+            totalCount: 1
+        }]));
+        testEpic(checkContextsOnMapLoad, 3, loadMaps(), (actions) => {
+            expect(actions[0].type).toBe(LOADING);
+            expect(actions[0].name).toBe('newMapDialog');
+            expect(actions[0].value).toBe(true);
+            expect(actions[1].type).toBe(HAS_CONTEXTS);
+            expect(actions[1].value).toBe(true);
+            expect(actions[2].type).toBe(LOADING);
+            expect(actions[2].name).toBe('newMapDialog');
+            expect(actions[2].value).toBe(false);
+            done();
+        }, {});
+    });
+    it('checkContextsOnMapLoad with no context', (done) => {
+        mockAxios.onGet().reply(() => ([ 200, {
+            totalCount: 0
+        }]));
+        testEpic(checkContextsOnMapLoad, 3, loadMaps(), (actions) => {
+            expect(actions[0].type).toBe(LOADING);
+            expect(actions[0].name).toBe('newMapDialog');
+            expect(actions[0].value).toBe(true);
+            expect(actions[1].type).toBe(HAS_CONTEXTS);
+            expect(actions[1].value).toBe(false);
+            expect(actions[2].type).toBe(LOADING);
+            expect(actions[2].name).toBe('newMapDialog');
+            expect(actions[2].value).toBe(false);
+            done();
+        }, {});
+    });
+    it('createNewMapEpic on create new map with no context and target', (done) => {
+        testEpic(createNewMapEpic, 2, createNewMap(), (actions) => {
+            expect(actions[0].type).toBe(SHOW_NEW_MAP_DIALOG);
+            expect(actions[0].show).toBe(false);
+            expect(actions[1].type).toBe(CALL_HISTORY_METHOD);
+            expect(actions[1].payload).toBeTruthy();
+            expect(actions[1].payload.method).toBe('push');
+            expect(actions[1].payload.args).toEqual(['viewer/new']);
+            done();
+        }, {});
+    });
+    it('createNewMapEpic with no target', (done) => {
+        testEpic(createNewMapEpic, 2, createNewMap({id: "1"}), (actions) => {
+            expect(actions[0].type).toBe(SHOW_NEW_MAP_DIALOG);
+            expect(actions[0].show).toBe(false);
+            expect(actions[1].type).toBe(CALL_HISTORY_METHOD);
+            expect(actions[1].payload).toBeTruthy();
+            expect(actions[1].payload.method).toBe('push');
+            expect(actions[1].payload.args).toEqual(['viewer/new/context/1']);
+            done();
+        }, {});
+    });
+    it('createNewMapEpic with target', (done) => {
+        testEpic(createNewMapEpic, 1, createNewMap({id: "1"}, true), (actions) => {
+            expect(actions[0].type).toBe(SHOW_NEW_MAP_DIALOG);
+            expect(actions[0].show).toBe(false);
+            done();
+        }, {});
+    });
+});

--- a/web/client/epics/createnewmap.js
+++ b/web/client/epics/createnewmap.js
@@ -41,9 +41,11 @@ export const checkContextsOnMapLoad = (action$) => action$
 
 export const createNewMapEpic = (action$) => action$
     .ofType(CREATE_NEW_MAP)
-    .switchMap(({context}) => {
+    .switchMap(({context, openInNewTab}) => {
+        const url = "viewer/new" + (context ? `/context/${context.id}` : '');
+        if (openInNewTab) window.open(window.location.href + url, '_blank');
         return Rx.Observable.of(
             showNewMapDialog(false),
-            push("/viewer/new" + (context ? `/context/${context.id}` : ''))
+            ...(openInNewTab ? [] : [push(url)])
         );
     });

--- a/web/client/plugins/CreateNewMap.jsx
+++ b/web/client/plugins/CreateNewMap.jsx
@@ -152,6 +152,7 @@ class CreateNewMap extends React.Component {
  * @prop {boolean} cfg.showNewGeostory show/hide th create new geostory button.
  * @prop {boolean} cfg.showNewContext show/hide the create new context button.
  * @prop {string[]} cfg.allowedRoles array of users roles allowed to create maps and/or dashboards. default: `["ADMIN", "USER"]`. Users that don't have these roles will never see the buttons.
+ * @prop {boolean} cfg.openInNewTab if true, the new map/map context will be opened in a new tab. default: `false`
  */
 export default {
     CreateNewMapPlugin: connect((state) => ({

--- a/web/client/plugins/CreateNewMap.jsx
+++ b/web/client/plugins/CreateNewMap.jsx
@@ -44,6 +44,7 @@ class CreateNewMap extends React.Component {
         fluid: PropTypes.bool,
         hasContexts: PropTypes.bool,
         showNewMapDialog: PropTypes.bool,
+        openInNewTab: PropTypes.bool,
         onShowNewMapDialog: PropTypes.func,
         onNewMap: PropTypes.func
     };
@@ -72,6 +73,20 @@ class CreateNewMap extends React.Component {
         onNewMap: () => {}
     };
 
+    onClick = (type) => {
+        let resourceUrl = "viewer/new";
+        if (type === "dashboard") {
+            resourceUrl = "dashboard";
+        } else if (type === "geostory") {
+            resourceUrl = "geostory/newgeostory/";
+        }
+        if (this.props.openInNewTab) {
+            window.open(window.location.href + resourceUrl, '_blank');
+        } else {
+            this.context.router.history.push(resourceUrl);
+        }
+    };
+
     render() {
         const display = this.isAllowed() ? null : "none";
         return (
@@ -86,8 +101,8 @@ class CreateNewMap extends React.Component {
                                     className="square-button"
                                     bsStyle="primary"
                                     title={<Glyphicon glyph="add-map" />}
-                                    onClick={() => this.createNewEmptyMap()}>
-                                    <MenuItem onClick={() => this.createNewEmptyMap()}>
+                                    onClick={() => this.onClick()}>
+                                    <MenuItem onClick={() => this.onClick()}>
                                         <Message msgId="newMapEmpty"/>
                                     </MenuItem>
                                     <MenuItem onClick={() => this.props.onShowNewMapDialog(true)}>
@@ -100,17 +115,17 @@ class CreateNewMap extends React.Component {
                                     tooltipId="newMap"
                                     className="square-button"
                                     bsStyle="primary"
-                                    onClick={() => this.createNewEmptyMap()}>
+                                    onClick={() => this.onClick()}>
                                     <Glyphicon glyph="add-map"/>
                                 </Button>
                             }
                             {this.props.showNewDashboard ?
-                                <Button tooltipId="resources.dashboards.newDashboard" className="square-button" bsStyle="primary" onClick={() => { this.context.router.history.push("/dashboard"); }}>
+                                <Button tooltipId="resources.dashboards.newDashboard" className="square-button" bsStyle="primary" onClick={() => this.onClick("dashboard")}>
                                     <Glyphicon glyph="add-dashboard" />
                                 </Button>
                                 : null}
                             {this.props.showNewGeostory ?
-                                <Button tooltipId="resources.geostories.newGeostory" className="square-button" bsStyle="primary" onClick={() => { this.context.router.history.push("/geostory/newgeostory/"); }}>
+                                <Button tooltipId="resources.geostories.newGeostory" className="square-button" bsStyle="primary" onClick={() => this.onClick("geostory") }>
                                     <Glyphicon glyph="add-geostory" />
                                 </Button>
                                 : null}
@@ -120,14 +135,10 @@ class CreateNewMap extends React.Component {
                 <NewMapDialog
                     show={this.props.showNewMapDialog}
                     onClose={() => this.props.onShowNewMapDialog(false)}
-                    onSelect={this.props.onNewMap}/>
+                    onSelect={(...args) => this.props.onNewMap(...args, this.props.openInNewTab)}/>
             </div>
         );
     }
-
-    createNewEmptyMap = () => {
-        this.context.router.history.push("/viewer/new");
-    };
 
     isAllowed = () => this.props.isLoggedIn && this.props.allowedRoles.indexOf(this.props.user && this.props.user.role) >= 0;
 }

--- a/web/client/plugins/Dashboards.jsx
+++ b/web/client/plugins/Dashboards.jsx
@@ -55,7 +55,8 @@ class Dashboards extends React.Component {
         fluid: PropTypes.bool,
         shareOptions: PropTypes.object,
         shareToolEnabled: PropTypes.bool,
-        emptyView: PropTypes.object
+        emptyView: PropTypes.object,
+        openInNewTab: PropTypes.bool
     };
 
     static contextTypes = {
@@ -91,7 +92,14 @@ class Dashboards extends React.Component {
             fluid={this.props.fluid}
             title={this.props.title}
             colProps={this.props.colProps}
-            viewerUrl={(dashboard) => {this.context.router.history.push(`dashboard/${dashboard.id}`); }}
+            viewerUrl={(dashboard) => {
+                const resourceUrl = `dashboard/${dashboard.id}`;
+                if (this.props.openInNewTab) {
+                    window.open(window.location.href + resourceUrl, '_blank');
+                } else {
+                    this.context.router.history.push(resourceUrl);
+                }
+            }}
             getShareUrl={dashboard => `dashboard/${dashboard.id}`}
             shareOptions={this.props.shareOptions}
             shareToolEnabled={this.props.shareToolEnabled}

--- a/web/client/plugins/Dashboards.jsx
+++ b/web/client/plugins/Dashboards.jsx
@@ -42,6 +42,7 @@ const dashboardsCountSelector = createSelector(
  * @prop {object} cfg.shareOptions configuration applied to share panel
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
  * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
+ * @prop {boolean} cfg.openInNewTab Flag to open the dashboard resource in a new tab. By default `false`, will open resource in the same tab
  */
 class Dashboards extends React.Component {
     static propTypes = {

--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -53,6 +53,7 @@ class FeaturedMaps extends React.Component {
         showAPIShare: PropTypes.bool,
         shareOptions: PropTypes.object,
         shareToolEnabled: PropTypes.bool,
+        openInNewTab: PropTypes.bool,
         onEditData: PropTypes.func
     };
 
@@ -108,7 +109,14 @@ class FeaturedMaps extends React.Component {
                 resources={items}
                 colProps={this.props.colProps}
                 version={this.props.version}
-                viewerUrl={(res) => this.context.router.history.push('/' + this.makeShareUrl(res).url)}
+                viewerUrl={(res) => {
+                    const resourceUrl = this.makeShareUrl(res).url;
+                    if (this.props.openInNewTab) {
+                        window.open(window.location.href + resourceUrl, '_blank');
+                    } else {
+                        this.context.router.history.push(resourceUrl);
+                    }
+                }}
                 getShareUrl={this.makeShareUrl}
                 shareOptions={this.getShareOptions} // TODO: share options depending on the content type
                 shareToolEnabled={this.props.shareToolEnabled}

--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -196,6 +196,7 @@ const updateFeaturedMapsStream = mapPropsStream(props$ =>
  * @prop {string} cfg.pageSize change the page size (only desktop)
  * @prop {object} cfg.shareOptions configuration applied to share panel grouped by category name
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
+ * @prop {boolean} cfg.openInNewTab Flag to open the featured resource in a new tab. By default `false`, will open resource in the same tab
  * @memberof plugins
  * @class
  * @example

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -54,7 +54,8 @@ class Geostories extends React.Component {
         fluid: PropTypes.bool,
         shareOptions: PropTypes.object,
         shareToolEnabled: PropTypes.bool,
-        emptyView: PropTypes.object
+        emptyView: PropTypes.object,
+        openInNewTab: PropTypes.bool
     };
 
     static contextTypes = {
@@ -90,7 +91,14 @@ class Geostories extends React.Component {
             fluid={this.props.fluid}
             title={this.props.title}
             colProps={this.props.colProps}
-            viewerUrl={(geostory) => {this.context.router.history.push(`geostory/${geostory.id}`); }}
+            viewerUrl={(geostory) => {
+                const resourceUrl = `geostory/${geostory.id}`;
+                if (this.props.openInNewTab) {
+                    window.open(window.location.href + resourceUrl, '_blank');
+                } else {
+                    this.context.router.history.push(resourceUrl);
+                }
+            }}
             getShareUrl={(geostory) => `geostory/${geostory.id}`}
             shareOptions={this.props.shareOptions}
             shareToolEnabled={this.props.shareToolEnabled}

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -41,6 +41,7 @@ const geostoriesCountSelector = createSelector(
  * @prop {object} cfg.shareOptions configuration applied to share panel
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
  * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
+ * @prop {boolean} cfg.openInNewTab Flag to open the geostory resource in a new tab. By default `false`, will open resource in the same tab
  */
 class Geostories extends React.Component {
     static propTypes = {

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -78,7 +78,8 @@ class Maps extends React.Component {
         fluid: PropTypes.bool,
         showAPIShare: PropTypes.bool,
         shareToolEnabled: PropTypes.bool,
-        emptyView: PropTypes.object
+        emptyView: PropTypes.object,
+        openInNewTab: PropTypes.bool
     };
 
     static contextTypes = {
@@ -111,10 +112,14 @@ class Maps extends React.Component {
             title={this.props.title}
             colProps={this.props.colProps}
             viewerUrl={(map = {}) => {
+                let resourceUrl = `viewer/${map.id}`;
                 if (map.contextName) {
-                    this.context.router.history.push("/context/" + map.contextName + "/" + map.id);
+                    resourceUrl = "context/" + map.contextName + "/" + map.id;
+                }
+                if (this.props.openInNewTab) {
+                    window.open(window.location.href + resourceUrl, '_blank');
                 } else {
-                    this.context.router.history.push("/viewer/" + map.id);
+                    this.context.router.history.push(resourceUrl);
                 }
             }}
             getShareUrl={(map) => map.contextName ? `context/${map.contextName}/${map.id}` : `viewer/${map.id}`}

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -173,6 +173,7 @@ const MapsPlugin = compose(
  * @prop {boolean} cfg.showCreateButton default true. Flag to show/hide the button "create a new one" when there is no dashboard yet.
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
  * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
+ * @prop {boolean} cfg.openInNewTab Flag to open the map resource in a new tab. By default `false`, will open resource in the same tab
  */
 export default {
     MapsPlugin: assign(MapsPlugin, {


### PR DESCRIPTION
## Description
This PR adds `openInNewTab` configuration support for `Dashboards`, `Geostories`, `CreateNewMap`, `FeaturedMaps`, `Maps` plugins allowing user to open resource in a new tab from homepage when set to `true`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #10970

**What is the new behavior?**
When configured, the user can open the resources from homepage in a new tab. Supports included all resource types and add new resource buttons

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
