### PR TITLE
#10970: Add configuration support to open resource in target from homepage

### DIFF
--- a/web/client/plugins/ResourcesCatalog/EditContext.jsx
+++ b/web/client/plugins/ResourcesCatalog/EditContext.jsx
@@ -22,7 +22,8 @@ import { userSelector } from '../../selectors/security';
  */
 function EditContext({
     resource,
-    component
+    component,
+    target
 }) {
     const Component = component;
     if (resource?.canEdit && resource?.category?.name === 'CONTEXT') {
@@ -34,6 +35,7 @@ function EditContext({
                     labelId="resourcesCatalog.createMapFromContext"
                     square
                     href={`#/viewer/new/context/${resource.id}`}
+                    target={target}
                 />
                 <Component
                     glyph="pencil"
@@ -41,6 +43,7 @@ function EditContext({
                     labelId="contextManager.editContextTooltip"
                     square
                     href={`#/context-creator/${resource.id}`}
+                    target={target}
                 />
             </>
         );

--- a/web/client/plugins/ResourcesCatalog/ResourcesGrid.jsx
+++ b/web/client/plugins/ResourcesCatalog/ResourcesGrid.jsx
@@ -41,6 +41,7 @@ import { getResourceTypesInfo, getResourceStatus, getResourceId } from './utils/
  * @prop {string} cfg.navbarNodeSelector optional valid query selector for the navbar under the header, used to set the position of the panel
  * @prop {string} cfg.footerNodeSelector optional valid query selector for the footer in the page, used to set the position of the panel
  * @prop {string} cfg.targetSelector optional valid query selector for a node used to mount the plugin root component
+ * @prop {string} cfg.openInNewTab optional boolean to open the resource in a new tab. Sets the link target to `_blank` when set to `true`
  * @prop {object[]} items this property contains the items injected from the other plugins,
  * using the `containers` option in the plugin that want to inject new menu items.
  * The supported targets are:

--- a/web/client/plugins/ResourcesCatalog/components/Menu.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/Menu.jsx
@@ -19,6 +19,7 @@ import FlexBox from '../../../components/layout/FlexBox';
  * @prop {string} size button size, one of `xs`, `sm`, `md` or `xl`
  * @prop {bool} alignRight align the dropdown menu to the right
  * @prop {string} variant style for the button, one of `undefined`, `default` or `primary`
+ * @prop {string} target default link target to be used
  * @prop {any} menuItemComponent a default component to be passed as a prop to a custom `item.Component`
  */
 const Menu = forwardRef(({
@@ -28,6 +29,7 @@ const Menu = forwardRef(({
     variant,
     className,
     menuItemComponent,
+    target,
     ...props
 }, ref) => {
 
@@ -49,6 +51,7 @@ const Menu = forwardRef(({
                             item={{ ...item, id: item.id !== undefined ? item.id : idx }}
                             size={item.size || size}
                             alignRight={alignRight}
+                            target={target}
                             menuItemComponent={menuItemComponent}
                         />
                     );

--- a/web/client/plugins/ResourcesCatalog/components/MenuItem.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/MenuItem.jsx
@@ -20,9 +20,11 @@ import Button from '../../../components/layout/Button';
  * List of menu items for the `dropdown` type
  * @name DropdownMenuItems
  * @prop {object[]} items list of items
+ * @prop {string} target default link target to be used. `item.target` takes precedence
  */
 const DropdownMenuItems = ({
-    items
+    items,
+    target
 }) => {
     return <>
         {items
@@ -40,7 +42,7 @@ const DropdownMenuItems = ({
                             href={itm.href}
                             style={itm.style}
                             as={itm?.items ? 'span' : 'a' }
-                            target={itm.target}
+                            target={itm.target ?? target}
                             className={itm.className}
                         >
                             {itm.glyph ? <Icon glyph={itm.glyph} type={itm.iconType}/> : null}
@@ -49,7 +51,7 @@ const DropdownMenuItems = ({
                         </RBMenuItem>
 
                         {itm?.items && <div className="ms-nested-menu-items">
-                            <DropdownMenuItems items={itm?.items}/>
+                            <DropdownMenuItems items={itm?.items} target={target}/>
                         </div>}
                     </React.Fragment>
                 );
@@ -82,6 +84,7 @@ const DropdownMenuItems = ({
  * @prop {string} size button size, one of `xs`, `sm`, `md` or `xl`
  * @prop {bool} alignRight align the dropdown menu to the right
  * @prop {string} variant style for the button, one of `undefined`, `default` or `primary`
+ * @prop {string} target default link target to be used. `item.target` takes precedence
  * @prop {any} menuItemComponent a default component to be passed as a prop to a custom `item.Component`
  */
 const MenuItem = ({
@@ -91,6 +94,7 @@ const MenuItem = ({
     size,
     alignRight,
     variant,
+    target: defaultTarget,
     menuItemComponent
 }) => {
 
@@ -103,7 +107,7 @@ const MenuItem = ({
         href,
         style,
         Component,
-        target,
+        target: itemTarget,
         className,
         noCaret,
         glyph,
@@ -112,6 +116,8 @@ const MenuItem = ({
         tooltipId,
         src
     } = item || {};
+
+    const target = itemTarget ?? defaultTarget;
 
     if (Component) {
         return <Component variant={variant} size={size} className={className} component={menuItemComponent}/>;
@@ -146,10 +152,10 @@ const MenuItem = ({
                 </Dropdown.Toggle>
                 {containerNode
                     ? createPortal(<Dropdown.Menu>
-                        <DropdownMenuItems items={items} />
+                        <DropdownMenuItems items={items} target={defaultTarget} />
                     </Dropdown.Menu>, containerNode.parentNode)
                     : <Dropdown.Menu>
-                        <DropdownMenuItems items={items} />
+                        <DropdownMenuItems items={items} target={defaultTarget} />
                     </Dropdown.Menu>}
             </Dropdown>
         </li>);
@@ -217,6 +223,7 @@ MenuItem.propTypes = {
     size: PropTypes.string,
     alignRight: PropTypes.bool,
     variant: PropTypes.string,
+    target: PropTypes.string,
     menuItemComponent: PropTypes.any
 };
 

--- a/web/client/plugins/ResourcesCatalog/components/ResourceCard.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/ResourceCard.jsx
@@ -64,6 +64,7 @@ const ResourceCardWrapper = ({
     resource,
     active,
     interactive,
+    target,
     ...props
 }) => {
     const showViewerLink = !!(!readOnly && viewerUrl);
@@ -81,6 +82,7 @@ const ResourceCardWrapper = ({
                 <a
                     className="_absolute _fill"
                     href={viewerUrl}
+                    {...target && {target}}
                 />
             ) : null}
             {children}
@@ -205,7 +207,8 @@ const ResourceCardGridBody = ({
     statusItems,
     options,
     thumbnailUrl,
-    getResourceId
+    getResourceId,
+    target
 }) => {
 
     const headerEntry = metadata.find(entry => entry.target === 'header');
@@ -276,6 +279,7 @@ const ResourceCardGridBody = ({
                                     viewerUrl={viewerUrl}
                                     component={ResourceCardButton}
                                     readOnly={readOnly}
+                                    target={target}
                                 />
                             );
                         })}
@@ -290,6 +294,7 @@ const ResourceCardGridBody = ({
                         options={options}
                         readOnly={readOnly}
                         getResourceId={getResourceId}
+                        target={target}
                         className="_absolute _margin-sm _corner-tr"
                     />
                 )
@@ -311,7 +316,8 @@ const ResourceCardListBody = ({
     options: optionsProp,
     buttons,
     columns,
-    getResourceId
+    getResourceId,
+    target
 }) => {
     const options = [
         ...(buttons || []),
@@ -352,6 +358,7 @@ const ResourceCardListBody = ({
                             options={options}
                             readOnly={readOnly}
                             getResourceId={getResourceId}
+                            target={target}
                         />
                     )
                     : null}
@@ -382,7 +389,8 @@ const ResourceCard = forwardRef(({
     columns = [],
     getResourceTypesInfo = () => ({}),
     formatHref,
-    getResourceId
+    getResourceId,
+    target
 }, ref) => {
 
     const resource = data;
@@ -403,6 +411,7 @@ const ResourceCard = forwardRef(({
             active={active}
             interactive={!readOnly}
             className={`ms-resource-card ms-resource-card-type-${layoutCardsStyle} ms-main-colors${className ? ` ${className}` : ''}`}
+            target={target}
         >
             {CardBody ? <CardBody
                 icon={icon}
@@ -420,6 +429,7 @@ const ResourceCard = forwardRef(({
                 columns={columns}
                 thumbnailUrl={thumbnailUrl}
                 getResourceId={getResourceId}
+                target={target}
             /> : null}
         </CardComponent>
     );

--- a/web/client/plugins/ResourcesCatalog/components/ResourceCardActionButtons.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/ResourceCardActionButtons.jsx
@@ -33,6 +33,7 @@ function ResourceCardActionButtons({
     resource,
     className,
     getResourceId = () => '',
+    target,
     ...props
 }) {
 
@@ -65,7 +66,7 @@ function ResourceCardActionButtons({
                     {options.map((option) => {
                         if (option.Component) {
                             const { Component } = option;
-                            return <Component key={option.name} resource={resource} viewerUrl={viewerUrl} renderType="menuItem" component={ActionMenuItem}/>;
+                            return <Component key={option.name} resource={resource} viewerUrl={viewerUrl} renderType="menuItem" target={target} component={ActionMenuItem}/>;
                         }
                         return null;
                     })}

--- a/web/client/plugins/ResourcesCatalog/components/ResourcesContainer.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/ResourcesContainer.jsx
@@ -35,7 +35,8 @@ const ResourcesContainer = (props) => {
         getResourceStatus,
         formatHref,
         getResourceTypesInfo,
-        getResourceId
+        getResourceId,
+        target
     } = props;
     const messageId = getMainMessageId(props);
     return (
@@ -85,6 +86,7 @@ const ResourcesContainer = (props) => {
                                     query={query}
                                     columns={columns}
                                     metadata={metadata}
+                                    target={target}
                                 />
                             </li>
                         );

--- a/web/client/plugins/ResourcesCatalog/components/ResourcesMenu.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/ResourcesMenu.jsx
@@ -131,7 +131,8 @@ const ResourcesMenu = forwardRef(({
     menuItemsLeft = [],
     columns,
     setColumns,
-    metadata
+    metadata,
+    target
 }, ref) => {
 
     const {
@@ -211,6 +212,7 @@ const ResourcesMenu = forwardRef(({
                     containerClass={`ms-menu-list`}
                     size="md"
                     alignRight
+                    target={target}
                 />
                 {!hideCardLayoutButton && <Button
                     variant="default"

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/MenuItem-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/MenuItem-test.jsx
@@ -190,4 +190,38 @@ describe('MenuItem component', () => {
         expect(customComponent).toBeTruthy();
         expect(customComponent.innerText).toBe('Custom Component');
     });
+
+    it('should render default target when available', () => {
+        ReactDOM.render(<MenuItem
+            target="_blank"
+            item={{
+                type: 'link',
+                labelId: 'labelId',
+                href: '/',
+                glyph: 'heart',
+                iconType: 'glyphicon'
+            }}
+        />, document.getElementById('container'));
+        const link = document.querySelector('a');
+        expect(link).toBeTruthy();
+        expect(link.getAttribute('href')).toBe('/');
+        expect(link.getAttribute('target')).toBe('_blank');
+    });
+    it('should render item target even when defaultTarget available', () => {
+        ReactDOM.render(<MenuItem
+            target="_blank"
+            item={{
+                type: 'link',
+                labelId: 'labelId',
+                href: '/',
+                target: '_self',
+                glyph: 'heart',
+                iconType: 'glyphicon'
+            }}
+        />, document.getElementById('container'));
+        const link = document.querySelector('a');
+        expect(link).toBeTruthy();
+        expect(link.getAttribute('href')).toBe('/');
+        expect(link.getAttribute('target')).toBe('_self');
+    });
 });

--- a/web/client/plugins/ResourcesCatalog/containers/ResourcesGrid.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourcesGrid.jsx
@@ -101,7 +101,8 @@ function ResourcesGrid({
     formatHref,
     getResourceTypesInfo,
     getResourceId,
-    storedParams
+    storedParams,
+    openInNewTab
 }) {
 
     const { query } = url.parse(location.search, true);
@@ -149,7 +150,7 @@ function ResourcesGrid({
         height,
         active: !panel
     });
-
+    const defaultTarget = openInNewTab ? '_blank' : undefined;
     const parsedConfig =  useParsePluginConfigExpressions(monitoredState, {
         menuItems,
         order,
@@ -184,6 +185,7 @@ function ResourcesGrid({
                     query={query}
                     columns={columns}
                     metadata={metadata}
+                    target={defaultTarget}
                     header={
                         <ResourcesMenu
                             key={columnsId}
@@ -215,6 +217,7 @@ function ResourcesGrid({
                             formatHref={formatHref}
                             getResourceTypesInfo={getResourceTypesInfo}
                             getResourceId={getResourceId}
+                            target={defaultTarget}
                         />
                     }
                     footer={


### PR DESCRIPTION
## Description
This PR adds `openInNewTab` configuration support to ResourcesGrid plugin to allow user to open resource and new resource in new tab when set to `true`. Enabling this property set the target to `_blank`.

This enhancement does not comprehensively cover all links within the resource grid plugin but focuses specifically on those related to a resource. Further improvements can be made based on requirements

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #10970 

**What is the new behavior?**
Upon setting `openInNewTab: true`, the resource card and action button associated with opening resource (context options) and new resource menu items opens the link in new tab

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
