### PR TITLE
#10983: handle add new X twitter icon instead of old icon in Share-->Social

### DIFF
--- a/web/client/components/share/ShareSocials.jsx
+++ b/web/client/components/share/ShareSocials.jsx
@@ -32,7 +32,14 @@ const {
 
 // icons of the social network
 const FacebookIcon = generateShareIcon('facebook');
-const TwitterIcon = generateShareIcon('twitter');
+const TwitterXIcon = ({ color = "#000000", size = 32, round = true }) => (
+    <div style={{width: size, height: size}}>
+        <svg viewBox="0 0 64 64" fill="white" width={size} height={size} className="social-icon social-icon--twitter">
+            {round && <circle cx={size} cy={size} r="31" fill={color} />}
+            {/* X icon svg path */}
+            <path d="M 41.116 18.375 h 4.962 l -10.8405 12.39 l 12.753 16.86 H 38.005 l -7.821 -10.2255 L 21.235 47.625 H 16.27 l 11.595 -13.2525 L 15.631 18.375 H 25.87 l 7.0695 9.3465 z m -1.7415 26.28 h 2.7495 L 24.376 21.189 H 21.4255 z" fill={'white'} />
+        </svg>
+    </div>);
 const LinkedinIcon = generateShareIcon('linkedin');
 
 class ShareSocials extends React.Component {
@@ -84,7 +91,7 @@ class ShareSocials extends React.Component {
                             url={this.props.shareUrl}
                             title={title}
                             className="share-twitter">
-                            <TwitterIcon
+                            <TwitterXIcon
                                 size={32}
                                 round />
                         </TwitterShareButton>


### PR DESCRIPTION
## Description
In this PR, the new x icon of x.com is replaced the old twitter icon in share panel -> Social tab

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
