### PR TITLE
#10986: Remove experimentalInteractiveLegend flag

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -73,9 +73,7 @@ This is the main structure:
       // Use POST requests for each WMS length URL highter than this value.
       "maxURLLength": 5000,
       // Custom path to home page
-      "homePath": '/home',
-      // If true it enables interactive legend for GeoServer WMS, WFS layers
-      "experimentalInteractiveLegend": true
+      "homePath": '/home'
   },
   // optional state initializer (it will override the one defined in appConfig.js)
   "initialState": {

--- a/docs/user-guide/layer-settings.md
+++ b/docs/user-guide/layer-settings.md
@@ -111,9 +111,6 @@ When the *Use cache options* is enabled, more controls are enabled so that it is
 !!! Note
     Any type of [Filter](filtering-layers.md#filter-types) applied to the layer remains active when the legend filter is activated on the same layer.
 
-!!!Warning
-    The *Interactive legend* is an experimental option and it is disabled by default. The flag `miscSettings.experimentalInteractiveLegend` inside [localConfig](../developer-guide/local-config.md) must be set to true to enable this functionality. The *Interactive legend* is available only for GeoServer WMS layers that support the json format for GetLegendGraphic requests.
-
 * Set the layer *Legend* with custom *Width* and *Height* options. Both of these field values if greater than the default legend's size of 12, then the custom values gets applied on the legend width and height display property
 
 * A preview of the legend is shown with the applied custom values from Legend fields above.

--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -29,7 +29,6 @@ import WMSCacheOptions from './WMSCacheOptions';
 import ThreeDTilesSettings from './ThreeDTilesSettings';
 import ModelTransformation from './ModelTransformation';
 import StyleBasedWMSJsonLegend from '../../../../plugins/TOC/components/StyleBasedWMSJsonLegend';
-import { getMiscSetting } from '../../../../utils/ConfigUtils';
 import VectorLegend from '../../../../plugins/TOC/components/VectorLegend';
 
 export default class extends React.Component {
@@ -135,8 +134,7 @@ export default class extends React.Component {
     }
     render() {
         const formatValue = this.props.element && this.props.element.format || "image/png";
-        const experimentalInteractiveLegend = getMiscSetting('experimentalInteractiveLegend', false);
-        const enableInteractiveLegend = !!(experimentalInteractiveLegend && this.props.element?.enableInteractiveLegend);
+        const enableInteractiveLegend = !!(this.props.element?.enableInteractiveLegend);
         return (
             <Grid
                 fluid
@@ -272,7 +270,7 @@ export default class extends React.Component {
                         <Col xs={12} className={"legend-label"}>
                             <label key="legend-options-title" className="control-label"><Message msgId="layerProperties.legendOptions.title" /></label>
                         </Col>
-                        { experimentalInteractiveLegend && this.props.element?.serverType !== ServerTypes.NO_VENDOR && !this.props?.hideInteractiveLegendOption &&
+                        {this.props.element?.serverType !== ServerTypes.NO_VENDOR && !this.props?.hideInteractiveLegendOption &&
                             <Col xs={12} className="first-selectize">
                                 <Checkbox
                                     data-qa="display-interactive-legend-option"
@@ -353,10 +351,10 @@ export default class extends React.Component {
                 </Row>}
                 {['wfs', 'vector'].includes(this.props.element.type) && <Row>
                     <div className={"legend-options"}>
-                        {experimentalInteractiveLegend && <Col xs={12} className={"legend-label"}>
+                        {<Col xs={12} className={"legend-label"}>
                             <label key="legend-options-title" className="control-label"><Message msgId="layerProperties.legendOptions.title" /></label>
                         </Col>}
-                        { experimentalInteractiveLegend && !this.props?.hideInteractiveLegendOption &&
+                        {!this.props?.hideInteractiveLegendOption &&
                             <Col xs={12} className="first-selectize">
                                 <Checkbox
                                     data-qa="display-interactive-legend-option"

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -14,13 +14,11 @@ import GET_CAP_RESPONSE from 'raw-loader!../../../../../test-resources/wms/GetCa
 import Display from '../Display';
 import MockAdapter from "axios-mock-adapter";
 import axios from "../../../../../libs/ajax";
-import { setConfigProp } from "../../../../../utils/ConfigUtils";
 let mockAxios;
 describe('test Layer Properties Display module component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         mockAxios = new MockAdapter(axios);
-        setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
         setTimeout(done);
     });
 
@@ -28,7 +26,6 @@ describe('test Layer Properties Display module component', () => {
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
         document.body.innerHTML = '';
         mockAxios.restore();
-        setConfigProp('miscSettings', { });
         setTimeout(done);
     });
 

--- a/web/client/components/catalog/editor/AdvancedSettings/CommonAdvancedSettings.jsx
+++ b/web/client/components/catalog/editor/AdvancedSettings/CommonAdvancedSettings.jsx
@@ -11,7 +11,6 @@ import { FormGroup, Checkbox } from "react-bootstrap";
 
 import Message from "../../../I18N/Message";
 import InfoPopover from '../../../widgets/widget/InfoPopover';
-import { getMiscSetting } from '../../../../utils/ConfigUtils';
 
 /**
  * Common Advanced settings form WMS/CSW/WMTS/WFS
@@ -26,7 +25,6 @@ export default ({
     onChangeServiceProperty = () => { },
     onToggleThumbnail = () => { }
 }) => {
-    const experimentalInteractiveLegend = getMiscSetting('experimentalInteractiveLegend', false);
     return (
         <>
             <FormGroup controlId="autoload" key="autoload">
@@ -51,7 +49,7 @@ export default ({
                     <Message msgId="catalog.fetchMetadata.label" />&nbsp;<InfoPopover text={<Message msgId="catalog.fetchMetadata.tooltip" />} />
                 </Checkbox>
             </FormGroup>}
-            {experimentalInteractiveLegend && ['wfs', 'vector'].includes(service.type) && <FormGroup className="wfs-vector-interactive-legend" controlId="enableInteractiveLegend" key="enableInteractiveLegend">
+            {['wfs', 'vector'].includes(service.type) && <FormGroup className="wfs-vector-interactive-legend" controlId="enableInteractiveLegend" key="enableInteractiveLegend">
                 <Checkbox data-qa="display-interactive-legend-option"
                     onChange={(e) => onChangeServiceProperty("layerOptions", { ...service.layerOptions, enableInteractiveLegend: e.target.checked})}
                     checked={!isNil(service.layerOptions?.enableInteractiveLegend) ? service.layerOptions?.enableInteractiveLegend : false}>

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -21,7 +21,6 @@ import WMSDomainAliases from "./WMSDomainAliases";
 import tooltip from '../../../misc/enhancers/buttonTooltip';
 import OverlayTrigger from '../../../misc/OverlayTrigger';
 import FormControl from '../../../misc/DebouncedFormControl';
-import { getMiscSetting } from '../../../../utils/ConfigUtils';
 
 const Button = tooltip(ButtonRB);
 const Select = localizedProps('noResultsText')(RS);
@@ -82,8 +81,6 @@ export default ({
         // Apply default configuration on new service
         service.isNew && onChangeServiceProperty("autoSetVisibilityLimits", props.autoSetVisibilityLimits);
     }, [props.autoSetVisibilityLimits]);
-
-    const experimentalInteractiveLegend = getMiscSetting('experimentalInteractiveLegend', false);
 
     const tileSelectOptions = getTileSizeSelectOptions(tileSizeOptions);
     const serverTypeOptions = getServerTypeOptions();
@@ -164,7 +161,7 @@ export default ({
                     }} />
             </InputGroup>
         </FormGroup>
-        {experimentalInteractiveLegend && ![ServerTypes.NO_VENDOR].includes(service.layerOptions?.serverType) && ['wms', 'csw'].includes(service.type) && <FormGroup controlId="enableInteractiveLegend" key="enableInteractiveLegend">
+        {![ServerTypes.NO_VENDOR].includes(service.layerOptions?.serverType) && ['wms', 'csw'].includes(service.type) && <FormGroup controlId="enableInteractiveLegend" key="enableInteractiveLegend">
             <Checkbox data-qa="display-interactive-legend-option"
                 onChange={(e) => onChangeServiceProperty("layerOptions", { ...service.layerOptions, enableInteractiveLegend: e.target.checked})}
                 checked={!isNil(service.layerOptions?.enableInteractiveLegend) ? service.layerOptions?.enableInteractiveLegend : false}>

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/CommonAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/CommonAdvancedSettings-test.js
@@ -10,18 +10,15 @@ import ReactDOM from "react-dom";
 import CommonAdvancedSettings from "../CommonAdvancedSettings";
 import expect from "expect";
 import TestUtils from "react-dom/test-utils";
-import { setConfigProp } from '../../../../../utils/ConfigUtils';
 
 describe('Test common advanced settings', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
-        setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
         setTimeout(done);
     });
     afterEach((done) => {
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
         document.body.innerHTML = '';
-        setConfigProp('miscSettings', { });
         setTimeout(done);
     });
     it('creates the component with defaults', () => {

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -12,18 +12,15 @@ import expect from 'expect';
 import RasterAdvancedSettings from "../RasterAdvancedSettings";
 import TestUtils from "react-dom/test-utils";
 import { waitFor } from '@testing-library/react';
-import { setConfigProp } from "../../../../../utils/ConfigUtils";
 
 describe('Test Raster advanced settings', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
-        setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
         setTimeout(done);
     });
     afterEach((done) => {
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
         document.body.innerHTML = '';
-        setConfigProp('miscSettings', { });
         setTimeout(done);
     });
     it('creates the component with defaults', () => {

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -31,7 +31,7 @@ import '../plugins/ArcGISLayer';
 import '../plugins/ModelLayer';
 
 import {setStore} from '../../../../utils/SecurityUtils';
-import ConfigUtils, { setConfigProp } from '../../../../utils/ConfigUtils';
+import ConfigUtils from '../../../../utils/ConfigUtils';
 import MockAdapter from 'axios-mock-adapter';
 import axios from '../../../../libs/ajax';
 
@@ -43,7 +43,6 @@ describe('Cesium layer', () => {
         document.body.innerHTML = '<div id="map"></div><div id="container"></div><div id="container2"></div>';
         map = new Cesium.Viewer("map");
         map.imageryLayers.removeAll();
-        setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
         setTimeout(done);
     });
 
@@ -57,7 +56,6 @@ describe('Cesium layer', () => {
         } catch(e) {}
         /* eslint-enable */
         document.body.innerHTML = '';
-        setConfigProp('miscSettings', {  });
         setTimeout(done);
     });
     it('missing layer', () => {

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -42,7 +42,6 @@ describe('Leaflet layer', () => {
     let map;
 
     beforeEach((done) => {
-        setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
         mockAxios = new MockAdapter(axios);
         document.body.innerHTML = '<div id="map"></div><div id="container"></div>';
         map = L.map('map');
@@ -50,7 +49,6 @@ describe('Leaflet layer', () => {
     });
 
     afterEach((done) => {
-        setConfigProp('miscSettings', { });
         mockAxios.restore();
         ReactDOM.unmountComponentAtNode(document.getElementById("map"));
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -30,7 +30,7 @@ import {
     setStore,
     setCredentials
 } from '../../../../utils/SecurityUtils';
-import ConfigUtils, { setConfigProp } from '../../../../utils/ConfigUtils';
+import ConfigUtils from '../../../../utils/ConfigUtils';
 import { ServerTypes } from '../../../../utils/LayersUtils';
 
 
@@ -169,7 +169,6 @@ describe('Openlayers layer', () => {
     let map;
 
     beforeEach(() => {
-        setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
         mockAxios = new MockAdapter(axios);
         document.body.innerHTML = '<div id="map" style="width:200px;height:200px;"></div><div id="container"></div>';
         map = new Map({
@@ -189,7 +188,6 @@ describe('Openlayers layer', () => {
     });
 
     afterEach(() => {
-        setConfigProp('miscSettings', { });
         mockAxios.restore();
         map.setTarget(null);
         document.body.innerHTML = '';

--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -57,7 +57,6 @@ import { testEpic } from './epicTestUtils';
 import MockAdapter from 'axios-mock-adapter';
 import axios from '../../libs/ajax';
 import { INTERACTIVE_LEGEND_ID } from '../../utils/LegendUtils';
-import { setConfigProp } from '../../utils/ConfigUtils';
 
 let mockAxios;
 
@@ -469,11 +468,9 @@ describe('Test styleeditor epics', () => {
 
     describe("tests for createStyleEpic", () => {
         beforeEach(done => {
-            setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
             setTimeout(done);
         });
         afterEach(done => {
-            setConfigProp('miscSettings', { });
             setTimeout(done);
         });
         it('test createStyleEpic', (done) => {
@@ -610,7 +607,7 @@ describe('Test styleeditor epics', () => {
                 results,
                 state);
         });
-        it('test createStyleEpic if a interactive legend filter [with enabled experimentalInteractiveLegend = true + enableInteractiveLegend = true] was applied plus another filter', (done) => {
+        it('test createStyleEpic if a interactive legend filter [with enabled enableInteractiveLegend = true] was applied plus another filter', (done) => {
             const state = {
                 layers: {
                     flat: [

--- a/web/client/plugins/TOC/components/VectorLegend.jsx
+++ b/web/client/plugins/TOC/components/VectorLegend.jsx
@@ -16,7 +16,6 @@ import { ButtonWithTooltip } from '../../../components/misc/Button';
 import RuleLegendIcon from '../../../components/styleeditor/RuleLegendIcon';
 import { INTERACTIVE_LEGEND_ID } from '../../../utils/LegendUtils';
 import { updateLayerWFSVectorLegendFilter } from '../../../utils/FilterUtils';
-import { getMiscSetting } from '../../../utils/ConfigUtils';
 
 /**
  * VectorLegend renders the legend given a valid vector style
@@ -43,8 +42,7 @@ function VectorLegend({ style, layer, interactive, onChange }) {
         const interactiveLegendFilters = get(layerFilter, 'filters', []).find(f => f.id === INTERACTIVE_LEGEND_ID);
         const legendFilters = get(interactiveLegendFilters, 'filters', []);
         const showResetWarning = !checkPreviousFiltersAreValid(rules, legendFilters) && !layerFilter.disabled;
-        const experimentalInteractiveLegend = getMiscSetting('experimentalInteractiveLegend', false);
-        const isNotInteractiveLegend = !(interactive && layer?.enableInteractiveLegend && experimentalInteractiveLegend);
+        const isNotInteractiveLegend = !(interactive && layer?.enableInteractiveLegend);
         return (<>
             {showResetWarning && !isNotInteractiveLegend ? <Alert bsStyle="warning">
                 <div><Message msgId={"layerProperties.interactiveLegend.incompatibleWFSFilterWarning"} /></div>

--- a/web/client/plugins/TOC/components/WMSLegend.jsx
+++ b/web/client/plugins/TOC/components/WMSLegend.jsx
@@ -14,7 +14,6 @@ import isEmpty from 'lodash/isEmpty';
 import isNumber from 'lodash/isNumber';
 import StyleBasedWMSJsonLegend from './StyleBasedWMSJsonLegend';
 import Legend from './Legend';
-import { getMiscSetting } from '../../../utils/ConfigUtils';
 /**
  * WMSLegend renders the wms legend image
  * @prop {object} node layer node options
@@ -73,9 +72,8 @@ class WMSLegend extends React.Component {
     }
     render() {
         let node = this.props.node || {};
-        const experimentalInteractiveLegend = getMiscSetting('experimentalInteractiveLegend', false);
         const showLegend = this.canShow(node) && node.type === "wms" && node.group !== "background";
-        const isJsonLegend = !!(experimentalInteractiveLegend && this.props.node?.enableInteractiveLegend);
+        const isJsonLegend = !!(this.props.node?.enableInteractiveLegend);
         const useOptions = showLegend && this.useLegendOptions();
         if (showLegend && !isJsonLegend) {
             return (

--- a/web/client/plugins/TOC/components/__tests__/VectorLegend-test.jsx
+++ b/web/client/plugins/TOC/components/__tests__/VectorLegend-test.jsx
@@ -11,7 +11,6 @@ import ReactDOM from 'react-dom';
 import expect from 'expect';
 import VectorLegend from '../VectorLegend';
 import { INTERACTIVE_LEGEND_ID } from '../../../../utils/LegendUtils';
-import { setConfigProp } from '../../../../utils/ConfigUtils';
 
 const rules = [
     {
@@ -153,14 +152,12 @@ const rules = [
 describe('VectorLegend module component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
-        setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
         setTimeout(done);
     });
 
     afterEach((done) => {
         ReactDOM.unmountComponentAtNode(document.getElementById('container'));
         document.body.innerHTML = '';
-        setConfigProp('miscSettings', { });
         setTimeout(done);
     });
 

--- a/web/client/plugins/TOC/components/__tests__/WMSLegend-test.jsx
+++ b/web/client/plugins/TOC/components/__tests__/WMSLegend-test.jsx
@@ -14,7 +14,6 @@ import expect from 'expect';
 import TestUtils from 'react-dom/test-utils';
 import MockAdapter from 'axios-mock-adapter';
 import axios from '../../../../libs/ajax';
-import { setConfigProp } from "../../../../utils/ConfigUtils";
 
 let mockAxios;
 
@@ -22,7 +21,6 @@ describe('test WMSLegend module component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         mockAxios = new MockAdapter(axios);
-        setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
         setTimeout(done);
     });
 
@@ -30,7 +28,6 @@ describe('test WMSLegend module component', () => {
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
         document.body.innerHTML = '';
         mockAxios.restore();
-        setConfigProp('miscSettings', { });
         setTimeout(done);
     });
 

--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -32,7 +32,6 @@ export const cqlToOgc = (cqlFilter, fOpts) => {
 import { get, isNil, isArray, find, findIndex, isString, flatten } from 'lodash';
 import { INTERACTIVE_LEGEND_ID } from './LegendUtils';
 import { geoStylerStyleFilter } from './styleparser/StyleParserUtils';
-import { getMiscSetting } from './ConfigUtils';
 let FilterUtils;
 
 const wrapValueWithWildcard = (value, condition) => {
@@ -1442,14 +1441,13 @@ export const updateLayerWFSVectorLegendFilter = (layerFilterObj, legendGeostyler
 };
 
 export function resetLayerLegendFilter(layer, reason, value) {
-    const experimentalInteractiveLegend = getMiscSetting('experimentalInteractiveLegend', false);
     const isResetForStyle = reason === 'style';      // here the reason for reset is change 'style' or change the enable/disable interactive legend config 'disableEnableInteractiveLegend'
     let needReset = false;
     if (isResetForStyle) {
         needReset = isResetForStyle && value !== layer.style;
     }
     // check if the layer has interactive legend or not, if not cancel the epic
-    const isLayerHasInterActiveLegend = experimentalInteractiveLegend && layer?.enableInteractiveLegend;
+    const isLayerHasInterActiveLegend = layer?.enableInteractiveLegend;
     let filterObj = !isFilterEmpty(layer.layerFilter) ? layer.layerFilter : undefined;
     if (!needReset || !isLayerHasInterActiveLegend || !filterObj) return false;
     // reset thte filter if legendCQLFilter is empty
@@ -1478,9 +1476,8 @@ export const createVectorFeatureFilter = (layer) => {
         // Check for interactive egend filter
         // TODO: we can add other filters here as well
         const isLayerHasInteractiveLegend = layer?.enableInteractiveLegend;
-        const experimentalInteractiveLegend = getMiscSetting('experimentalInteractiveLegend', false);
 
-        if ((isLayerHasInteractiveLegend && experimentalInteractiveLegend)) {
+        if ((isLayerHasInteractiveLegend)) {
             const isLegendFilterExist = layer?.layerFilter?.filters?.find(f => f.id === INTERACTIVE_LEGEND_ID);
             const isInteractiveLegendFiltersExist = isLegendFilterExist?.filters?.length;
             const isLayerFilterDisabled = layer?.layerFilter?.disabled;

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -36,16 +36,13 @@ import {
     createVectorFeatureFilter
 } from '../FilterUtils';
 import { INTERACTIVE_LEGEND_ID } from '../LegendUtils';
-import { setConfigProp } from '../ConfigUtils';
 
 
 describe('FilterUtils', () => {
     beforeEach((done) => {
-        setConfigProp('miscSettings', { experimentalInteractiveLegend: true });
         setTimeout(done);
     });
     afterEach((done) => {
-        setConfigProp('miscSettings', { });
         setTimeout(done);
     });
     it('Calculate OGC filter', () => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes:
- handle remove the flag 'experimentalInteractiveLegend ' and all relevant code
- remove the related docs in md files
- remove the related code in unit tests files

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10986 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The checkbox to enable interactive legend will be shown by default in catalog or layer settings without any cfg in localConfig as now no need to use flag 'experimentalInteractiveLegend'


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
