### PR TITLE
Permission row style enhancement

### DIFF
--- a/web/client/plugins/ResourcesCatalog/components/PermissionsRow.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/PermissionsRow.jsx
@@ -41,8 +41,8 @@ function PermissionsRow({
 
     return (
         <FlexBox className="ms-permissions-row" centerChildrenVertically gap="sm">
-            <FlexBox.Fill flexBox gap="sm">
-                {(!hideIcon && (type || avatar)) && <Text>
+            <FlexBox.Fill flexBox gap="sm" centerChildrenVertically>
+                {(!hideIcon && (type || avatar)) && <Text component={FlexBox} centerChildren className="ms-permission-icon">
                     {avatar
                         ? <img src={avatar}/>
                         : <Icon glyph={type} />}

--- a/web/client/themes/default/less/resources-catalog/_permissions.less
+++ b/web/client/themes/default/less/resources-catalog/_permissions.less
@@ -5,3 +5,19 @@
 .ms-permissions-column {
     width: 30%;
 }
+
+.ms-permissions-row {
+    .ms-permission-icon {
+        width: 2rem;
+        height: 2rem;
+        font-size: 1.5rem;
+
+        img {
+            border-radius: 50%;
+            height: 100%;
+            object-fit: contain;
+            position: relative;
+            width: 100%;
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR enhances permission row icon styles for users and groups

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- https://github.com/geosolutions-it/geonode-team-internal-issues/issues/126

**What is the new behavior?**
<img width="636" alt="image" src="https://github.com/user-attachments/assets/bb6592ba-9067-40a2-9e59-a7ea02ff5801" />
<img width="638" alt="image" src="https://github.com/user-attachments/assets/cfa59ecf-7b8b-43f7-b97d-584d537eb8ee" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
