### PR TITLE
Menu divider border style

### DIFF
--- a/web/client/themes/default/less/resources-catalog/_brand-navbar.less
+++ b/web/client/themes/default/less/resources-catalog/_brand-navbar.less
@@ -18,5 +18,5 @@
 
 .ms-menu-divider {
     height: 1.2rem;
-    border: 0.5px solid;
+    border: 1px solid;
 }

--- a/web/client/themes/default/less/resources-catalog/_brand-navbar.less
+++ b/web/client/themes/default/less/resources-catalog/_brand-navbar.less
@@ -1,7 +1,22 @@
 // **************
+// Theme
+// **************
+
+#ms-components-theme(@theme-vars) {
+    .ms-menu-divider {
+        .border-color-var(@theme-vars[main-border-color]);
+    }
+}
+
+// **************
 // Layout
 // **************
 
 .ms-brand-navbar {
     min-height: 38px;
+}
+
+.ms-menu-divider {
+    height: 1.2rem;
+    border: 0.5px solid;
 }


### PR DESCRIPTION
## Description
This PR adds the menu divider border style

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- https://github.com/geosolutions-it/geonode-team-internal-issues/issues/117

**What is the new behavior?**
Menu divider has style of 1px border
<img width="190" alt="image" src="https://github.com/user-attachments/assets/1b7d2219-2e58-4fe3-9ca6-14d57ca79d15" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
