### PR TITLE
[Backport 2025.01.xx]: #10898 : removed BrandNavbar from both ResourceDetails and Language in pluginsConfig (#10978)

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -84,7 +84,6 @@ The `ManagerMenu` plugin should be removed from the `localConfig.json` configura
     +           "name": "Language",
     +           "title": "plugins.Language.title",
     +           "description": "plugins.Language.description",
-    +           "dependencies": ["BrandNavbar"],
     +        }
         ]
     }
@@ -763,9 +762,6 @@ Here below all the changes needed related the pluginsConfig.json configuration
 +           "defaultConfig": {
 +               "resourceType": "MAP"
 +           },
-+           "dependencies": [
-+               "BrandNavbar"
-+           ]
 +       }
     ]
 }

--- a/project/standard/templates/configs/pluginsConfig.json
+++ b/project/standard/templates/configs/pluginsConfig.json
@@ -565,14 +565,12 @@
       "description": "plugins.ResourceDetails.description",
       "defaultConfig": {
         "resourceType": "MAP"
-      },
-      "dependencies": ["BrandNavbar"]
+      }
     },
     {
       "name": "Language",
       "title": "plugins.Language.title",
-      "description": "plugins.Language.description",
-      "dependencies": ["BrandNavbar"]
+      "description": "plugins.Language.description"
     }
   ]
 }

--- a/web/client/configs/pluginsConfig.json
+++ b/web/client/configs/pluginsConfig.json
@@ -564,14 +564,12 @@
       "description": "plugins.ResourceDetails.description",
       "defaultConfig": {
         "resourceType": "MAP"
-      },
-      "dependencies": ["BrandNavbar"]
+      }
     },
     {
       "name": "Language",
       "title": "plugins.Language.title",
-      "description": "plugins.Language.description",
-      "dependencies": ["BrandNavbar"]
+      "description": "plugins.Language.description"
     }
   ]
 }


### PR DESCRIPTION
[Backport 2025.01.xx]: #10898 : removed BrandNavbar from both ResourceDetails and Language in pluginsConfig (#10978)