### PR TITLE
Remove unused devDependency download-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "css-minimizer-webpack-plugin": "3.0.2",
     "denodeify": "1.2.1",
     "docma": "1.5.1",
-    "download-cli": "1.0.1",
     "dynamic-public-path-webpack-plugin": "1.0.4",
     "escope": "3.2.0",
     "eslint": "7.32.0",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
The package.json includes the download-cli devDependency which is currently not in use. 
See my issue for more information https://github.com/geosolutions-it/MapStore2/issues/11003

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
We should remove the download-cli devDependency from package.json

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
