### PR TITLE
Fix #10774 Clear all filters inside the resource search bar

### DIFF
--- a/web/client/plugins/ResourcesCatalog/ResourcesSearch.jsx
+++ b/web/client/plugins/ResourcesCatalog/ResourcesSearch.jsx
@@ -21,6 +21,7 @@ import tooltip from '../../components/misc/enhancers/tooltip';
 import Button from '../../components/layout/Button';
 import Icon from './components/Icon';
 import resourcesReducer from './reducers/resources';
+import { isEmpty } from 'lodash';
 
 const ButtonWithTooltip = tooltip(Button);
 
@@ -103,9 +104,9 @@ function ResourcesSearch({
                     debounceTime={debounceTime}
                     placeholder="maps.search"
                 />
-                {query?.q ? <ResourcesSearchTool
+                {!isEmpty(query) ? <ResourcesSearchTool
                     glyph={'1-close'}
-                    onClick={() => onSearch({ params: { q: undefined } })}
+                    onClick={() => onSearch({ clear: true })}
                 /> : null}
                 {toolbarItems.map(({ name, Component }) => {
                     return (<Component key={name} query={query} itemComponent={ResourcesSearchTool}/>);

--- a/web/client/plugins/ResourcesCatalog/__tests__/ResourcesSearch-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/__tests__/ResourcesSearch-test.jsx
@@ -51,7 +51,7 @@ describe('ResourcesSearch Plugin', () => {
         const button = document.querySelector('.square-button-md:has(.glyphicon-1-close)');
         expect(button).toBeTruthy();
         Simulate.click(button);
-        expect(store.getState().resources.search.params).toEqual({ q: undefined });
+        expect(store.getState().resources.search.clear).toBe(true);
     });
     it('should render with custom item', () => {
         const { Plugin } = getPluginForTest(ResourcesSearchPlugin, {});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Clicking on the X button inside the resource bar clears all filters

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#10774

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Clicking on the X button inside the resource bar clears all filters

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
