### PR TITLE
Fix #11011 MapCatalog infinite scroll request all the pages

### DIFF
--- a/web/client/components/mapcatalog/MapCatalogPanel.jsx
+++ b/web/client/components/mapcatalog/MapCatalogPanel.jsx
@@ -172,7 +172,7 @@ export default compose(
             initialStreamDebounce: 300
         },
         scrollSpyOptions: {
-            querySelector: '.map-catalog-panel > .map-catalog > .ms2-border-layout-body',
+            querySelector: '.map-catalog-panel > .map-catalog > .ms2-border-layout-body > .ms2-border-layout-content',
             pageSize: 12
         },
         hasMore: ({items = [], total = 0}) => items.length < total


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Review the selector used for infinite scroll inside the MapCatalog plugin

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11011

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

MapCatalog is correctly loading pages

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
