### PR TITLE
Add non root user to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ COPY ./docker/* /mapstore/docker/
 WORKDIR /mapstore
 
 FROM tomcat:9-jdk11
-
+ARG UID=1001
+ARG GID=1001
+ARG UNAME=tomcat
 # Tomcat specific options
 ENV CATALINA_BASE "$CATALINA_HOME"
 ENV MAPSTORE_WEBAPP_DST="${CATALINA_BASE}/webapps"
@@ -43,6 +45,10 @@ RUN apt-get update \
     && rm -rf /usr/share/man/* \
     && rm -rf /usr/share/doc/*
 
+RUN groupadd -g $GID $UNAME
+RUN useradd -m -u $UID -g $GID --system $UNAME
+RUN chown -R $UID:$GID ${CATALINA_BASE} ${MAPSTORE_WEBAPP_DST} ${DATA_DIR}
+USER $UNAME
 WORKDIR ${CATALINA_BASE}
 
 VOLUME [ "${DATA_DIR}" ]

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,7 +1,12 @@
 FROM postgis/postgis:12-3.1
+ARG UID=1001
+ARG GID=1001
+ARG UNAME=postgres
+RUN useradd -u $UID -g $GID -m $UNAME
 WORKDIR /code
 COPY ./01-init-user.sh /docker-entrypoint-initdb.d/
 RUN apt-get update \
     && apt-get install wget -y \
     && rm -rf /var/cache/apt/*
+USER $UNAME
 RUN wget https://raw.githubusercontent.com/geosolutions-it/geostore/master/doc/sql/002_create_schema_postgres.sql


### PR DESCRIPTION
## Description

Runs the containers as non root user by default while also giving the user the ability to configure UID, GID and username of the user. Any mounted path that will be used will also need to be chown-ed by this user.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**

Fixes https://github.com/geosolutions-it/MapStore2/issues/11027

**What is the new behavior?**

Tomcat process runs as the custom UID. (by default 1001)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
