### PR TITLE
[Backport 2025.01.xx] Fix #11011 MapCatalog infinite scroll request all the pages (#11014)

### DIFF
--- a/web/client/components/mapcatalog/MapCatalogPanel.jsx
+++ b/web/client/components/mapcatalog/MapCatalogPanel.jsx
@@ -172,7 +172,7 @@ export default compose(
             initialStreamDebounce: 300
         },
         scrollSpyOptions: {
-            querySelector: '.map-catalog-panel > .map-catalog > .ms2-border-layout-body',
+            querySelector: '.map-catalog-panel > .map-catalog > .ms2-border-layout-body > .ms2-border-layout-content',
             pageSize: 12
         },
         hasMore: ({items = [], total = 0}) => items.length < total


### PR DESCRIPTION
## Description
<!-- Add here a few sentences describing the bug. -->

https://github.com/user-attachments/assets/ef0c14f3-a04b-4e0a-86d2-f87d9721340b

## How to reproduce
<!-- A list of steps to reproduce the bug -->
-  open a map with the MapCatalog plugin configured (e.g.: this [map](https://dev-mapstore.geosolutionsgroup.com/mapstore/#/context/all-plugins/51643))
- open the MapCatalog plugin

*Expected Result*
<!-- Describe here the expected result  -->

The panel should request the initial pages and the next one only on scroll

*Current Result*
<!-- Describe here the current behavior -->

The panel starts to request all the pages

- [x] Not browser related

<details><summary> <b>Browser info</b> </summary>
<!-- If browser related, please compile the following table -->
<!-- If your browser is not in the list please add a new row to the table with the version -->
(use this site: <a href="https://www.whatsmybrowser.org/">https://www.whatsmybrowser.org/</a> for non expert users)

| Browser Affected | Version |
|---|---|
|Internet Explorer| |
|Edge| |
|Chrome| |
|Firefox| |
|Safari| |
</details>

## Other useful information
<!-- error stack trace, screenshot, videos, or link to repository code are welcome -->
