### PR TITLE
#11021: Implement an option to have static WMS legends

### DIFF
--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -135,7 +135,8 @@ export default class extends React.Component {
     render() {
         const formatValue = this.props.element && this.props.element.format || "image/png";
         const enableInteractiveLegend = !!this.props.element?.enableInteractiveLegend;
-        const enableLegendFilterByViewport = !!this.props.element?.enableLegendFilterByViewport;
+        const enableDynamicLegend = !!this.props.element?.enableDynamicLegend;
+        const hideDynamicLegend = this.props?.hideInteractiveLegendOption && enableInteractiveLegend;
         return (
             <Grid
                 fluid
@@ -271,8 +272,9 @@ export default class extends React.Component {
                         <Col xs={12} className={"legend-label"}>
                             <label key="legend-options-title" className="control-label"><Message msgId="layerProperties.legendOptions.title" /></label>
                         </Col>
-                        {this.props.element?.serverType !== ServerTypes.NO_VENDOR && !this.props?.hideInteractiveLegendOption &&
-                            <Col xs={12} className="first-selectize">
+                        <Col xs={12} className="first-selectize">
+                            <FormGroup>
+                                {this.props.element?.serverType !== ServerTypes.NO_VENDOR && !this.props?.hideInteractiveLegendOption &&
                                 <Checkbox
                                     data-qa="display-interactive-legend-option"
                                     value="enableInteractiveLegend"
@@ -282,6 +284,8 @@ export default class extends React.Component {
                                         if (!checked) {
                                             const newLayerFilter = updateLayerLegendFilter(this.props.element.layerFilter);
                                             this.props.onChange("layerFilter", newLayerFilter);
+                                        } else {
+                                            this.props.onChange("enableDynamicLegend", checked);
                                         }
                                         this.props.onChange("enableInteractiveLegend", checked);
                                     }}
@@ -289,19 +293,20 @@ export default class extends React.Component {
                                     <Message msgId="layerProperties.enableInteractiveLegendInfo.label"/>
                                     &nbsp;<InfoPopover text={<Message msgId="layerProperties.enableInteractiveLegendInfo.info" />} />
                                 </Checkbox>
-                            </Col>
-                        }
-                        <Col xs={12} className="first-selectize">
-                            <Checkbox
-                                data-qa="display-legend-filter-viewport"
-                                value="enableLegendFilterByViewport"
-                                key="enableLegendFilterByViewport"
-                                onChange={(e) => {
-                                    this.props.onChange("enableLegendFilterByViewport", e.target.checked);
-                                }}
-                                checked={enableLegendFilterByViewport} >
-                                <Message msgId="layerProperties.legendByViewportFilter"/>
-                            </Checkbox>
+                                }
+                                {!hideDynamicLegend && <Checkbox
+                                    data-qa="display-dynamic-legend-filter"
+                                    value="enableDynamicLegend"
+                                    key="enableDynamicLegend"
+                                    disabled={enableInteractiveLegend}
+                                    onChange={(e) => {
+                                        this.props.onChange("enableDynamicLegend", e.target.checked);
+                                    }}
+                                    checked={enableDynamicLegend || enableInteractiveLegend} >
+                                    <Message msgId="layerProperties.enableDynamicLegend.label"/>
+                                &nbsp;<InfoPopover text={<Message msgId="layerProperties.enableDynamicLegend.info" />} />
+                                </Checkbox>}
+                            </FormGroup>
                         </Col>
                         {!enableInteractiveLegend && <><Col xs={12} sm={6} className="first-selectize">
                             <FormGroup validationState={this.getValidationState("legendWidth")}>

--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -134,7 +134,8 @@ export default class extends React.Component {
     }
     render() {
         const formatValue = this.props.element && this.props.element.format || "image/png";
-        const enableInteractiveLegend = !!(this.props.element?.enableInteractiveLegend);
+        const enableInteractiveLegend = !!this.props.element?.enableInteractiveLegend;
+        const enableLegendFilterByViewport = !!this.props.element?.enableLegendFilterByViewport;
         return (
             <Grid
                 fluid
@@ -277,11 +278,12 @@ export default class extends React.Component {
                                     value="enableInteractiveLegend"
                                     key="enableInteractiveLegend"
                                     onChange={(e) => {
-                                        if (!e.target.checked) {
+                                        const checked = e.target.checked;
+                                        if (!checked) {
                                             const newLayerFilter = updateLayerLegendFilter(this.props.element.layerFilter);
-                                            this.props.onChange("layerFilter", newLayerFilter );
+                                            this.props.onChange("layerFilter", newLayerFilter);
                                         }
-                                        this.props.onChange("enableInteractiveLegend", e.target.checked);
+                                        this.props.onChange("enableInteractiveLegend", checked);
                                     }}
                                     checked={enableInteractiveLegend} >
                                     <Message msgId="layerProperties.enableInteractiveLegendInfo.label"/>
@@ -289,6 +291,18 @@ export default class extends React.Component {
                                 </Checkbox>
                             </Col>
                         }
+                        <Col xs={12} className="first-selectize">
+                            <Checkbox
+                                data-qa="display-legend-filter-viewport"
+                                value="enableLegendFilterByViewport"
+                                key="enableLegendFilterByViewport"
+                                onChange={(e) => {
+                                    this.props.onChange("enableLegendFilterByViewport", e.target.checked);
+                                }}
+                                checked={enableLegendFilterByViewport} >
+                                <Message msgId="layerProperties.legendByViewportFilter"/>
+                            </Checkbox>
+                        </Col>
                         {!enableInteractiveLegend && <><Col xs={12} sm={6} className="first-selectize">
                             <FormGroup validationState={this.getValidationState("legendWidth")}>
                                 <ControlLabel><Message msgId="layerProperties.legendOptions.legendWidth" /></ControlLabel>

--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -284,8 +284,6 @@ export default class extends React.Component {
                                         if (!checked) {
                                             const newLayerFilter = updateLayerLegendFilter(this.props.element.layerFilter);
                                             this.props.onChange("layerFilter", newLayerFilter);
-                                        } else {
-                                            this.props.onChange("enableDynamicLegend", checked);
                                         }
                                         this.props.onChange("enableInteractiveLegend", checked);
                                     }}

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -74,7 +74,7 @@ describe('test Layer Properties Display module component', () => {
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toBeTruthy();
-        expect(inputs.length).toBe(13);
+        expect(inputs.length).toBe(14);
         ReactTestUtils.Simulate.focus(inputs[2]);
         expect(inputs[2].value).toBe('70');
         inputs[8].click();
@@ -102,7 +102,7 @@ describe('test Layer Properties Display module component', () => {
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toBeTruthy();
-        expect(inputs.length).toBe(12);
+        expect(inputs.length).toBe(13);
         ReactTestUtils.Simulate.focus(inputs[2]);
         expect(inputs[2].value).toBe('70');
         inputs[8].click();
@@ -216,8 +216,8 @@ describe('test Layer Properties Display module component', () => {
         expect(comp).toBeTruthy();
         const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "control-label" );
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
-        const legendWidth = inputs[11];
-        const legendHeight = inputs[12];
+        const legendWidth = inputs[12];
+        const legendHeight = inputs[13];
         // Default legend values
         expect(legendWidth.value).toBe('12');
         expect(legendHeight.value).toBe('12');
@@ -246,8 +246,8 @@ describe('test Layer Properties Display module component', () => {
         expect(comp).toBeTruthy();
         const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "control-label" );
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
-        const legendWidth = inputs[10];
-        const legendHeight = inputs[11];
+        const legendWidth = inputs[11];
+        const legendHeight = inputs[12];
         // Default legend values
         expect(legendWidth.value).toBe('12');
         expect(legendHeight.value).toBe('12');
@@ -286,10 +286,10 @@ describe('test Layer Properties Display module component', () => {
         const legendPreview = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "legend-preview" );
         expect(legendPreview).toBeTruthy();
         expect(inputs).toBeTruthy();
-        expect(inputs.length).toBe(13);
+        expect(inputs.length).toBe(14);
         let interactiveLegendConfig = inputs[10];
-        let legendWidth = inputs[11];
-        let legendHeight = inputs[12];
+        let legendWidth = inputs[12];
+        let legendHeight = inputs[13];
         const img = ReactTestUtils.scryRenderedDOMComponentsWithTag(comp, 'img');
 
         // Check value in img src
@@ -336,8 +336,6 @@ describe('test Layer Properties Display module component', () => {
         expect(spy).toHaveBeenCalled();
         expect(spy.calls[4].arguments[0]).toEqual("enableInteractiveLegend");
         expect(spy.calls[4].arguments[1]).toEqual(true);
-
-
     });
 
     it("tests Layer Properties Legend component with values from layers", () => {
@@ -362,9 +360,9 @@ describe('test Layer Properties Display module component', () => {
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toBeTruthy();
-        expect(inputs.length).toBe(13);
-        expect(inputs[11].value).toBe("20");
-        expect(inputs[12].value).toBe("40");
+        expect(inputs.length).toBe(14);
+        expect(inputs[12].value).toBe("20");
+        expect(inputs[13].value).toBe("40");
     });
     it('tests wfs Layer Properties Legend component events', () => {
         const l = {
@@ -442,5 +440,66 @@ describe('test Layer Properties Display module component', () => {
         expect(spy.calls[0].arguments[0]).toEqual("enableInteractiveLegend");
         expect(spy.calls[0].arguments[1]).toEqual(true);
     });
-
+    it('tests default legend filter by viewport field with interactive legend active', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl',
+            legendOptions: {
+                legendWidth: 15,
+                legendHeight: 15
+            },
+            enableInteractiveLegend: true
+        };
+        const settings = {
+            options: {
+                opacity: 1
+            }
+        };
+        const handlers = {
+            onChange() {}
+        };
+        const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        expect(comp).toBeTruthy();
+        let enableLegendFilterByViewport = document.querySelector(".legend-options input[data-qa='display-legend-filter-viewport']");
+        expect(enableLegendFilterByViewport).toBeTruthy();
+        expect(enableLegendFilterByViewport.checked).toBeFalsy();
+    });
+    it('tests legend filter by viewport field', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl',
+            legendOptions: {
+                legendWidth: 15,
+                legendHeight: 15
+            },
+            enableInteractiveLegend: false
+        };
+        const settings = {
+            options: {
+                opacity: 1
+            }
+        };
+        const handlers = {
+            onChange() {}
+        };
+        let spy = expect.spyOn(handlers, "onChange");
+        const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        expect(comp).toBeTruthy();
+        let enableLegendFilterByViewport = document.querySelector(".legend-options input[data-qa='display-legend-filter-viewport']");
+        expect(enableLegendFilterByViewport).toBeTruthy();
+        expect(enableLegendFilterByViewport.checked).toBeFalsy();
+        enableLegendFilterByViewport.checked = true;
+        ReactTestUtils.Simulate.change(enableLegendFilterByViewport);
+        expect(spy).toHaveBeenCalled();
+        expect(spy.calls[0].arguments[0]).toEqual("enableLegendFilterByViewport");
+        expect(spy.calls[0].arguments[1]).toEqual(true);
+    });
 });

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -334,10 +334,8 @@ describe('test Layer Properties Display module component', () => {
         interactiveLegendConfig.checked = true;
         ReactTestUtils.Simulate.change(interactiveLegendConfig);
         expect(spy).toHaveBeenCalled();
-        expect(spy.calls[4].arguments[0]).toEqual("enableDynamicLegend");
-        expect(spy.calls[5].arguments[0]).toEqual("enableInteractiveLegend");
+        expect(spy.calls[4].arguments[0]).toEqual("enableInteractiveLegend");
         expect(spy.calls[4].arguments[1]).toEqual(true);
-        expect(spy.calls[5].arguments[1]).toEqual(true);
     });
 
     it("tests Layer Properties Legend component with values from layers", () => {

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -334,8 +334,10 @@ describe('test Layer Properties Display module component', () => {
         interactiveLegendConfig.checked = true;
         ReactTestUtils.Simulate.change(interactiveLegendConfig);
         expect(spy).toHaveBeenCalled();
-        expect(spy.calls[4].arguments[0]).toEqual("enableInteractiveLegend");
+        expect(spy.calls[4].arguments[0]).toEqual("enableDynamicLegend");
+        expect(spy.calls[5].arguments[0]).toEqual("enableInteractiveLegend");
         expect(spy.calls[4].arguments[1]).toEqual(true);
+        expect(spy.calls[5].arguments[1]).toEqual(true);
     });
 
     it("tests Layer Properties Legend component with values from layers", () => {
@@ -440,7 +442,7 @@ describe('test Layer Properties Display module component', () => {
         expect(spy.calls[0].arguments[0]).toEqual("enableInteractiveLegend");
         expect(spy.calls[0].arguments[1]).toEqual(true);
     });
-    it('tests default legend filter by viewport field with interactive legend active', () => {
+    it('tests default dynamic legend filter field with interactive legend active', () => {
         const l = {
             name: 'layer00',
             title: 'Layer',
@@ -464,9 +466,38 @@ describe('test Layer Properties Display module component', () => {
         };
         const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
-        let enableLegendFilterByViewport = document.querySelector(".legend-options input[data-qa='display-legend-filter-viewport']");
-        expect(enableLegendFilterByViewport).toBeTruthy();
-        expect(enableLegendFilterByViewport.checked).toBeFalsy();
+        let enableDynamicLegend = document.querySelector(".legend-options input[data-qa='display-dynamic-legend-filter']");
+        expect(enableDynamicLegend).toBeTruthy();
+        expect(enableDynamicLegend.checked).toBeTruthy();
+    });
+    it('tests hide dynamic legend filter field with interactive legend and hide interactive option', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl',
+            legendOptions: {
+                legendWidth: 15,
+                legendHeight: 15
+            },
+            enableInteractiveLegend: true
+        };
+        const settings = {
+            options: {
+                opacity: 1
+            }
+        };
+        const handlers = {
+            onChange() {}
+        };
+        const comp = ReactDOM.render(<Display hideInteractiveLegendOption element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        expect(comp).toBeTruthy();
+        let enableDynamicLegend = document.querySelector(".legend-options input[data-qa='display-dynamic-legend-filter']");
+        let enableInteractiveLegend = document.querySelector(".legend-options input[data-qa='display-interactive-legend-option']");
+        expect(enableDynamicLegend).toBeFalsy();
+        expect(enableInteractiveLegend).toBeFalsy();
     });
     it('tests legend filter by viewport field', () => {
         const l = {
@@ -493,13 +524,13 @@ describe('test Layer Properties Display module component', () => {
         let spy = expect.spyOn(handlers, "onChange");
         const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
-        let enableLegendFilterByViewport = document.querySelector(".legend-options input[data-qa='display-legend-filter-viewport']");
-        expect(enableLegendFilterByViewport).toBeTruthy();
-        expect(enableLegendFilterByViewport.checked).toBeFalsy();
-        enableLegendFilterByViewport.checked = true;
-        ReactTestUtils.Simulate.change(enableLegendFilterByViewport);
+        let enableDynamicLegend = document.querySelector(".legend-options input[data-qa='display-dynamic-legend-filter']");
+        expect(enableDynamicLegend).toBeTruthy();
+        expect(enableDynamicLegend.checked).toBeFalsy();
+        enableDynamicLegend.checked = true;
+        ReactTestUtils.Simulate.change(enableDynamicLegend);
         expect(spy).toHaveBeenCalled();
-        expect(spy.calls[0].arguments[0]).toEqual("enableLegendFilterByViewport");
+        expect(spy.calls[0].arguments[0]).toEqual("enableDynamicLegend");
         expect(spy.calls[0].arguments[1]).toEqual(true);
     });
 });

--- a/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
+++ b/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
@@ -84,7 +84,7 @@ class StyleBasedWMSJsonLegend extends React.Component {
         if (!isEqual(prevLayerStyle, currentLayerStyle)
             || !isEqual(prevLayerStyleVersion, currLayerStyleVersion)
             || !isEqual(prevFilter, currFilter)
-            || !isEqual(currEnableDynamicLegend, prevEnableDynamicLegend)
+            || !isEqual(prevEnableDynamicLegend, currEnableDynamicLegend)
             || !isEqual(prevProps.mapBbox, this.props.mapBbox)
         ) {
             this.getLegendData();

--- a/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
+++ b/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
@@ -74,8 +74,8 @@ class StyleBasedWMSJsonLegend extends React.Component {
         const prevLayerStyleVersion = prevProps?.layer?.styleVersion;
         const currLayerStyleVersion = this.props?.layer?.styleVersion;
 
-        const currEnableLegendFilterByViewport = this.props?.layer?.enableLegendFilterByViewport;
-        const prevEnableLegendFilterByViewport = prevProps?.layer?.enableLegendFilterByViewport;
+        const currEnableDynamicLegend = this.props?.layer?.enableDynamicLegend;
+        const prevEnableDynamicLegend = prevProps?.layer?.enableDynamicLegend;
 
         const [prevFilter, currFilter] = [prevProps?.layer, this.props?.layer]
             .map(_layer => getLayerFilterByLegendFormat(_layer, LEGEND_FORMAT.JSON));
@@ -84,7 +84,7 @@ class StyleBasedWMSJsonLegend extends React.Component {
         if (!isEqual(prevLayerStyle, currentLayerStyle)
             || !isEqual(prevLayerStyleVersion, currLayerStyleVersion)
             || !isEqual(prevFilter, currFilter)
-            || !isEqual(currEnableLegendFilterByViewport, prevEnableLegendFilterByViewport)
+            || !isEqual(currEnableDynamicLegend, prevEnableDynamicLegend)
             || !isEqual(prevProps.mapBbox, this.props.mapBbox)
         ) {
             this.getLegendData();

--- a/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
+++ b/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
@@ -74,6 +74,9 @@ class StyleBasedWMSJsonLegend extends React.Component {
         const prevLayerStyleVersion = prevProps?.layer?.styleVersion;
         const currLayerStyleVersion = this.props?.layer?.styleVersion;
 
+        const currEnableLegendFilterByViewport = this.props?.layer?.enableLegendFilterByViewport;
+        const prevEnableLegendFilterByViewport = prevProps?.layer?.enableLegendFilterByViewport;
+
         const [prevFilter, currFilter] = [prevProps?.layer, this.props?.layer]
             .map(_layer => getLayerFilterByLegendFormat(_layer, LEGEND_FORMAT.JSON));
 
@@ -81,6 +84,7 @@ class StyleBasedWMSJsonLegend extends React.Component {
         if (!isEqual(prevLayerStyle, currentLayerStyle)
             || !isEqual(prevLayerStyleVersion, currLayerStyleVersion)
             || !isEqual(prevFilter, currFilter)
+            || !isEqual(currEnableLegendFilterByViewport, prevEnableLegendFilterByViewport)
             || !isEqual(prevProps.mapBbox, this.props.mapBbox)
         ) {
             this.getLegendData();

--- a/web/client/plugins/TOC/components/WMSLegend.jsx
+++ b/web/client/plugins/TOC/components/WMSLegend.jsx
@@ -67,11 +67,6 @@ class WMSLegend extends React.Component {
         const containerWidth = this.containerRef.current && this.containerRef.current.clientWidth;
         this.setState({ containerWidth, ...this.state }); // eslint-disable-line -- TODO: need to be fixed
     }
-    componentDidUpdate(prevProps) {
-        if (prevProps.node?.enableLegendFilterByViewport !== this.props.node?.enableLegendFilterByViewport) {
-            this.forceUpdate();
-        }
-    }
     getLegendProps = () => {
         return pick(this.props, ['currentZoomLvl', 'scales', 'scaleDependent', 'language', 'projection', 'mapSize', 'mapBbox']);
     }

--- a/web/client/plugins/TOC/components/WMSLegend.jsx
+++ b/web/client/plugins/TOC/components/WMSLegend.jsx
@@ -67,6 +67,11 @@ class WMSLegend extends React.Component {
         const containerWidth = this.containerRef.current && this.containerRef.current.clientWidth;
         this.setState({ containerWidth, ...this.state }); // eslint-disable-line -- TODO: need to be fixed
     }
+    componentDidUpdate(prevProps) {
+        if (prevProps.node?.enableLegendFilterByViewport !== this.props.node?.enableLegendFilterByViewport) {
+            this.forceUpdate();
+        }
+    }
     getLegendProps = () => {
         return pick(this.props, ['currentZoomLvl', 'scales', 'scaleDependent', 'language', 'projection', 'mapSize', 'mapBbox']);
     }

--- a/web/client/plugins/TOC/components/__tests__/WMSLegend-test.jsx
+++ b/web/client/plugins/TOC/components/__tests__/WMSLegend-test.jsx
@@ -85,7 +85,7 @@ describe('test WMSLegend module component', () => {
         const params = new URLSearchParams(image[0].src);
         expect(params.get("width")).toBe('12');
         expect(params.get("height")).toBe('12');
-        expect(params.get("LEGEND_OPTIONS")).toBe('hideEmptyRules:true;forceLabels:on');
+        expect(params.get("LEGEND_OPTIONS")).toBe('forceLabels:on');
     });
 
     it('tests WMSLegend component legendOptions with one or all values missing', () => {
@@ -109,7 +109,7 @@ describe('test WMSLegend module component', () => {
         const params = new URLSearchParams(image[0].src);
         expect(params.get("width")).toBe('12');
         expect(params.get("height")).toBe('12');
-        expect(params.get("LEGEND_OPTIONS")).toBe('hideEmptyRules:true;forceLabels:on');
+        expect(params.get("LEGEND_OPTIONS")).toBe('forceLabels:on');
     });
 
     it('tests WMSLegend component legendOptions with values', () => {
@@ -120,6 +120,30 @@ describe('test WMSLegend module component', () => {
             storeIndex: 9,
             type: 'wms',
             url: 'fakeurl',
+            legendOptions: {legendWidth: 20, legendHeight: 40}
+        };
+        const comp = ReactDOM.render(<WMSLegend node={l} />, document.getElementById("container"));
+
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+
+        const image = domNode.getElementsByTagName('img');
+        expect(image).toExist();
+        expect(image.length).toBe(1);
+        const params = new URLSearchParams(image[0].src);
+        expect(params.get("width")).toBe('20');
+        expect(params.get("height")).toBe('40');
+        expect(params.get("LEGEND_OPTIONS")).toBe('forceLabels:on');
+    });
+    it('tests WMSLegend component legendOptions with dynamic legend enabled', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl',
+            enableDynamicLegend: true,
             legendOptions: {legendWidth: 20, legendHeight: 40}
         };
         const comp = ReactDOM.render(<WMSLegend node={l} />, document.getElementById("container"));
@@ -156,7 +180,7 @@ describe('test WMSLegend module component', () => {
         const params = new URLSearchParams(image[0].src);
         expect(params.get("width")).toBe('20');
         expect(params.get("height")).toBe('40');
-        expect(params.get("LEGEND_OPTIONS")).toBe('hideEmptyRules:true;forceLabels:on');
+        expect(params.get("LEGEND_OPTIONS")).toBe('forceLabels:on');
     });
 
     it('tests WMSLegend component language property with value', () => {

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -114,14 +114,14 @@ const SettingsButton = connect(() => ({}), {
  * @memberof plugins
  * @static
  *
- * @prop cfg.dock {bool} true shows dock panel, false shows modal
- * @prop cfg.width {number} width of panel
- * @prop cfg.showFeatureInfoTab {bool} enable/disbale feature info settings
- * @prop cfg.enableIFrameModule {bool} enable iframe in template editor of feature info, default true
- * @prop cfg.hideTitleTranslations {bool} if true hide the title translations tool
- * @prop cfg.showTooltipOptions {bool} if true, it shows tooltip section
- * @prop cfg.initialActiveTab {string} tab that will be enabled initially when the settings are opened. Possible values:
- * @prop cfg.hideInteractiveLegendOption {bool} if true, it hide the checkbox of enable interactive legend in display tab
+ * @prop {boolean} cfg.dock true shows dock panel, false shows modal
+ * @prop {number} cfg.width width of panel
+ * @prop {boolean} cfg.showFeatureInfoTab enable/disbale feature info settings
+ * @prop {boolean} cfg.enableIFrameModule enable iframe in template editor of feature info, default true
+ * @prop {boolean} cfg.hideTitleTranslations if true hide the title translations tool
+ * @prop {boolean} cfg.showTooltipOptions if true, it shows tooltip section
+ * @prop {string} cfg.initialActiveTab tab that will be enabled initially when the settings are opened. Possible values:
+ * @prop {boolean} cfg.hideInteractiveLegendOption (deprecated) if true, it hide the checkbox of enable interactive legend in display tab
  * 'general' (General tab), 'display' (Display tab), 'style' (Style tab), 'feature' (Feature info tab).
  * @example
  * {

--- a/web/client/plugins/__tests__/TOCItemsSettings-test.jsx
+++ b/web/client/plugins/__tests__/TOCItemsSettings-test.jsx
@@ -85,7 +85,7 @@ describe('TOCItemsSettings Plugin', () => {
         const tabIndexes = document.querySelectorAll(TAB_INDEX_SELECTOR);
         expect(tabIndexes.length).toBe(4);
         expect(tabIndexes[1].className).toBe("active");
-        expect(document.querySelectorAll(`${TAB_CONTENT_SELECTOR} div.form-group`).length).toBe(7);
+        expect(document.querySelectorAll(`${TAB_CONTENT_SELECTOR} div.form-group`).length).toBe(8);
     });
     it('default style selector', done => {
         mockAxios.onGet().reply(() => {

--- a/web/client/translations/data.ca-ES.json
+++ b/web/client/translations/data.ca-ES.json
@@ -205,11 +205,14 @@
       },
       "enableInteractiveLegendInfo": {
         "label": "Activa la llegenda interactiva",
-        "info": "Si aquesta opci\u00f3 est\u00e0 habilitada,es pot aplicar filtre per llegenda fent clic als elements de llegenda d'aquesta capa des del TOC. Nota: aquest par\u00e0metre requereix configuracions espec\u00edfiques a Geoserver",
+        "info": "Si aquesta opci\u00f3 est\u00e0 habilitada, es pot aplicar un filtre per llegenda fent clic als elements de llegenda d'aquesta capa des del TOC. A m\u00e9s, aix\u00f2 tamb\u00e9 activa la llegenda din\u00e0mica. Nota: Aquest par\u00e0metre requereix configuracions espec\u00edfiques a GeoServer",
         "infoWithoutGSNote": "Si aquesta opci\u00f3 est\u00e0 habilitada,es pot aplicar filtre per llegenda fent clic als elements de llegenda d'aquesta capa des del TOC.",
         "fetchError": "No s'ha pogut recuperar la informaci\u00f3 de la llegenda del servei"
       },
-      "legendByViewportFilter": "Filtre de llegenda per vista del mapa",
+      "enableDynamicLegend": {
+        "label": "Activa la llegenda din\u00e0mica",
+        "info": "Si aquesta opci\u00f3 est\u00e0 habilitada, la llegenda s'actualitzar\u00e0 en funci\u00f3 de la vista del mapa i els filtres de capa"
+      },
       "enableLocalizedLayerStyles": {
         "label": "Activa l\u2019estil localitzat",
         "tooltip": "Nota: aquest par\u00e0metre requereix configuracions espec\u00edfiques a Geoserver"

--- a/web/client/translations/data.ca-ES.json
+++ b/web/client/translations/data.ca-ES.json
@@ -209,6 +209,7 @@
         "infoWithoutGSNote": "Si aquesta opci\u00f3 est\u00e0 habilitada,es pot aplicar filtre per llegenda fent clic als elements de llegenda d'aquesta capa des del TOC.",
         "fetchError": "No s'ha pogut recuperar la informaci\u00f3 de la llegenda del servei"
       },
+      "legendByViewportFilter": "Filtre de llegenda per vista del mapa",
       "enableLocalizedLayerStyles": {
         "label": "Activa l\u2019estil localitzat",
         "tooltip": "Nota: aquest par\u00e0metre requereix configuracions espec\u00edfiques a Geoserver"

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -208,6 +208,7 @@
         "infoWithoutGSNote": "Wenn diese Option aktiviert ist, kann der Filter nach Legende angewendet werden, indem im Inhaltsverzeichnis auf Legendenelemente dieser Ebene geklickt wird.",
         "fetchError": "Die Legenden Informationen konnten nicht vom Dienst abgerufen werden"
       },
+      "legendByViewportFilter": "Legendenfilter nach Ansicht",
       "enableLocalizedLayerStyles": {
         "label": "Lokalisierten Stil aktivieren",
         "tooltip": "Hinweis: Diese Einstellung benötigt spezifische Konfigurationen im GeoServer"

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -204,11 +204,14 @@
       },
       "enableInteractiveLegendInfo": {
         "label": "Aktivieren Sie die interaktive Legende",
-        "info": "Wenn diese Option aktiviert ist, kann der Filter nach Legende angewendet werden, indem im Inhaltsverzeichnis auf Legendenelemente dieser Ebene geklickt wird. Hinweis: Diese Einstellung benötigt spezifische Konfigurationen im GeoServer",
+        "info": "Wenn diese Option aktiviert ist, kann der Filter nach Legende angewendet werden, indem im Inhaltsverzeichnis auf Legendenelemente dieser Ebene geklickt wird. Zusätzlich wird auch die dynamische Legende aktiviert. Hinweis: Dieser Parameter erfordert spezifische Konfigurationen im GeoServer",
         "infoWithoutGSNote": "Wenn diese Option aktiviert ist, kann der Filter nach Legende angewendet werden, indem im Inhaltsverzeichnis auf Legendenelemente dieser Ebene geklickt wird.",
         "fetchError": "Die Legenden Informationen konnten nicht vom Dienst abgerufen werden"
       },
-      "legendByViewportFilter": "Legendenfilter nach Ansicht",
+      "enableDynamicLegend": {
+        "label": "Dynamische Legende aktivieren",
+        "info": "Wenn diese Option aktiviert ist, wird die Legende basierend auf dem Kartenansichtsfenster und den Ebenenfiltern aktualisiert"
+      },
       "enableLocalizedLayerStyles": {
         "label": "Lokalisierten Stil aktivieren",
         "tooltip": "Hinweis: Diese Einstellung benötigt spezifische Konfigurationen im GeoServer"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -208,6 +208,7 @@
         "infoWithoutGSNote": "If this option is enabled, filter by legend can be applied by clicking on legend items of this layer from the TOC.",
         "fetchError": "Failed to retrieve the legend info from the service"
       },
+      "legendByViewportFilter": "Legend filter by viewport",
       "enableLocalizedLayerStyles": {
         "label": "Enable localized style",
         "tooltip": "Note: This parameter requires specific configurations on GeoServer"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -204,11 +204,14 @@
       },
       "enableInteractiveLegendInfo": {
         "label": "Enable interactive legend",
-        "info": "If this option is enabled, filter by legend can be applied by clicking on legend items of this layer from the TOC. Note: This parameter requires specific configurations on GeoServer",
+        "info": "If this option is enabled, filter by legend can be applied by clicking on legend items of this layer from the TOC. Additionally, this also enables the dynamic legend. Note: This parameter requires specific configurations on GeoServer",
         "infoWithoutGSNote": "If this option is enabled, filter by legend can be applied by clicking on legend items of this layer from the TOC.",
         "fetchError": "Failed to retrieve the legend info from the service"
       },
-      "legendByViewportFilter": "Legend filter by viewport",
+      "enableDynamicLegend": {
+        "label": "Enable dynamic legend",
+        "info": "If this option is enabled, the legend will be updated based on the map viewport and layer filters"
+      },
       "enableLocalizedLayerStyles": {
         "label": "Enable localized style",
         "tooltip": "Note: This parameter requires specific configurations on GeoServer"

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -205,6 +205,7 @@
         "infoWithoutGSNote": "Si esta opción está habilitada, se puede aplicar el filtro por leyenda haciendo clic en los elementos de leyenda de esta capa desde el TOC.",
         "fetchError": "No se pudo obtener la información de la leyenda del servicio"
       },
+      "legendByViewportFilter": "Filtro de leyenda por ventana gráfica",
       "templateFormatInfoAlertExample": "La identificación de la característica es <span style='white-space:nowrap'>${ properties.datos }</span> ora <span style='white-space:nowrap'>${ properties['datos-valor'] }</span>",
       "templateError": "Hubo un error al aplicar la plantilla a la información devuelta por el servidor, verifique la plantilla",
       "templatePreview": "Vista previa de la plantilla",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -201,11 +201,14 @@
       },
       "enableInteractiveLegendInfo": {
         "label": "Habilitar una leyenda interactiva",
-        "info": "Si esta opción está habilitada, se puede aplicar el filtro por leyenda haciendo clic en los elementos de leyenda de esta capa desde el TOC. Nota: este parámetro requiere configuraciones específicas en GeoServer",
+        "info": "Si esta opción está habilitada, se puede aplicar el filtro por leyenda haciendo clic en los elementos de leyenda de esta capa desde el TOC. Además, esto también habilita la leyenda dinámica. Nota: Este parámetro requiere configuraciones específicas en GeoServer",
         "infoWithoutGSNote": "Si esta opción está habilitada, se puede aplicar el filtro por leyenda haciendo clic en los elementos de leyenda de esta capa desde el TOC.",
         "fetchError": "No se pudo obtener la información de la leyenda del servicio"
       },
-      "legendByViewportFilter": "Filtro de leyenda por ventana gráfica",
+      "enableDynamicLegend": {
+        "label": "Habilitar leyenda dinámica",
+        "info": "Si esta opción está habilitada, la leyenda se actualizará en función de la ventana del mapa y los filtros de capa"
+      },
       "templateFormatInfoAlertExample": "La identificación de la característica es <span style='white-space:nowrap'>${ properties.datos }</span> ora <span style='white-space:nowrap'>${ properties['datos-valor'] }</span>",
       "templateError": "Hubo un error al aplicar la plantilla a la información devuelta por el servidor, verifique la plantilla",
       "templatePreview": "Vista previa de la plantilla",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -208,6 +208,7 @@
         "infoWithoutGSNote": "Si cette option est activée, le filtre par légende peut être appliqué en cliquant sur les éléments de légende de cette couche depuis la table des matières.",
         "fetchError": "Impossible d'obtenir les informations de légende du service"
       },
+      "legendByViewportFilter": "Filtre de légende par fenêtre",
       "enableLocalizedLayerStyles": {
         "label": "Activer le style localisé",
         "tooltip": "Remarque: ce paramètre nécessite des configurations spécifiques sur GeoServer"

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -204,11 +204,14 @@
       },
       "enableInteractiveLegendInfo": {
         "label": "Activer la légende interactive",
-        "info": "Si cette option est activée, le filtre par légende peut être appliqué en cliquant sur les éléments de légende de cette couche depuis la table des matières. Remarque: ce paramètre nécessite des configurations spécifiques sur GeoServer",
+        "info": "Si cette option est activée, le filtre par légende peut être appliqué en cliquant sur les éléments de légende de cette couche depuis la table des matières. De plus, cela active également la légende dynamique. Remarque : Ce paramètre nécessite des configurations spécifiques sur GeoServer",
         "infoWithoutGSNote": "Si cette option est activée, le filtre par légende peut être appliqué en cliquant sur les éléments de légende de cette couche depuis la table des matières.",
         "fetchError": "Impossible d'obtenir les informations de légende du service"
       },
-      "legendByViewportFilter": "Filtre de légende par fenêtre",
+      "enableDynamicLegend": {
+        "label": "Activer la légende dynamique",
+        "info": "Si cette option est activée, la légende sera mise à jour en fonction de la fenêtre de la carte et des filtres de couche"
+      },
       "enableLocalizedLayerStyles": {
         "label": "Activer le style localisé",
         "tooltip": "Remarque: ce paramètre nécessite des configurations spécifiques sur GeoServer"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -204,11 +204,14 @@
       },
       "enableInteractiveLegendInfo": {
         "label": "Abilita leggenda interattiva",
-        "info": "Se questa opzione è abilitata, è possibile applicare il filtro per legenda facendo clic sugli elementi della legenda di questo layer dal sommario. Nota: questo parametro richiede configurazioni specifiche su GeoServer",
+        "info": "Se questa opzione è abilitata, è possibile applicare il filtro per legenda facendo clic sugli elementi della legenda di questo layer dal sommario. Inoltre, questo abilita anche la legenda dinamica. Nota: Questo parametro richiede configurazioni specifiche su GeoServer",
         "infoWithoutGSNote": "Se questa opzione è abilitata, è possibile applicare il filtro per legenda facendo clic sugli elementi della legenda di questo layer dal sommario.",
         "fetchError": "Impossibile ottenere le informazioni sulla leggenda dal servizio"
       },
-      "legendByViewportFilter": "Filtro legenda per viewport",
+      "enableDynamicLegend": {
+        "label": "Abilita legenda dinamica",
+        "info": "Se questa opzione è abilitata, la legenda verrà aggiornata in base alla vista della mappa e ai filtri del livello"
+      },
       "enableLocalizedLayerStyles": {
         "label": "Abilita stile localizzato",
         "tooltip": "Nota: questo parametro richiede configurazioni specifiche su GeoServer"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -208,6 +208,7 @@
         "infoWithoutGSNote": "Se questa opzione è abilitata, è possibile applicare il filtro per legenda facendo clic sugli elementi della legenda di questo layer dal sommario.",
         "fetchError": "Impossibile ottenere le informazioni sulla leggenda dal servizio"
       },
+      "legendByViewportFilter": "Filtro legenda per viewport",
       "enableLocalizedLayerStyles": {
         "label": "Abilita stile localizzato",
         "tooltip": "Nota: questo parametro richiede configurazioni specifiche su GeoServer"

--- a/web/client/utils/LegendUtils.js
+++ b/web/client/utils/LegendUtils.js
@@ -56,19 +56,20 @@ export const getWMSLegendConfig = ({
         SLD_VERSION: "1.1.0",
         LEGEND_OPTIONS: legendOptions
     };
-
     if (layer.serverType !== ServerTypes.NO_VENDOR) {
-        const filterViewport = layer.enableLegendFilterByViewport;
+        const addContentDependantParams = layer.enableDynamicLegend || layer.enableInteractiveLegend;
         return {
             ...baseParams,
-            // hideEmptyRules is applied for all layers except background layers
-            LEGEND_OPTIONS: `hideEmptyRules:${layer.group !== "background"};${legendOptions}`,
-            SRCWIDTH: mapSize?.width ?? 512,
-            SRCHEIGHT: mapSize?.height ?? 512,
-            SRS: projection,
-            CRS: projection,
-            ...optionsToVendorParams({ ...layer, layerFilter: getLayerFilterByLegendFormat(layer, format) }),
-            ...(filterViewport && mapBbox?.bounds && {BBOX: getExtentFromViewport(mapBbox, projection)?.join(',')})
+            ...(addContentDependantParams && {
+                // hideEmptyRules is applied for all layers except background layers
+                LEGEND_OPTIONS: `hideEmptyRules:${layer.group !== "background"};${legendOptions}`,
+                SRCWIDTH: mapSize?.width ?? 512,
+                SRCHEIGHT: mapSize?.height ?? 512,
+                SRS: projection,
+                CRS: projection,
+                ...optionsToVendorParams({ ...layer, layerFilter: getLayerFilterByLegendFormat(layer, format) }),
+                ...(mapBbox?.bounds && {BBOX: getExtentFromViewport(mapBbox, projection)?.join(',')})
+            })
         };
     }
 

--- a/web/client/utils/LegendUtils.js
+++ b/web/client/utils/LegendUtils.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { isEmpty } from "lodash";
+import isEmpty from "lodash/isEmpty";
 import { getExtentFromViewport } from "./CoordinatesUtils";
 import { ServerTypes } from "./LayersUtils";
 import { optionsToVendorParams } from "./VendorParamsUtils";
@@ -58,6 +58,7 @@ export const getWMSLegendConfig = ({
     };
 
     if (layer.serverType !== ServerTypes.NO_VENDOR) {
+        const filterViewport = layer.enableLegendFilterByViewport;
         return {
             ...baseParams,
             // hideEmptyRules is applied for all layers except background layers
@@ -66,8 +67,8 @@ export const getWMSLegendConfig = ({
             SRCHEIGHT: mapSize?.height ?? 512,
             SRS: projection,
             CRS: projection,
-            ...(mapBbox?.bounds && {BBOX: getExtentFromViewport(mapBbox, projection)?.join(',')}),
-            ...optionsToVendorParams({ ...layer, layerFilter: getLayerFilterByLegendFormat(layer, format) })
+            ...optionsToVendorParams({ ...layer, layerFilter: getLayerFilterByLegendFormat(layer, format) }),
+            ...(filterViewport && mapBbox?.bounds && {BBOX: getExtentFromViewport(mapBbox, projection)?.join(',')})
         };
     }
 

--- a/web/client/utils/__tests__/LegendUtils-test.js
+++ b/web/client/utils/__tests__/LegendUtils-test.js
@@ -117,11 +117,7 @@ describe('LegendUtils', () => {
                 style: null,
                 version: '1.3.0',
                 SLD_VERSION: '1.1.0',
-                LEGEND_OPTIONS: 'hideEmptyRules:true;fontSize:10',
-                SRCWIDTH: 800,
-                SRCHEIGHT: 600,
-                SRS: 'EPSG:4326',
-                CRS: 'EPSG:4326'
+                LEGEND_OPTIONS: 'fontSize:10'
             });
         });
         it('should return correct WMS legend config for vendor server type with background group', () => {
@@ -157,7 +153,8 @@ describe('LegendUtils', () => {
                 SRCWIDTH: 800,
                 SRCHEIGHT: 600,
                 SRS: 'EPSG:4326',
-                CRS: 'EPSG:4326'
+                CRS: 'EPSG:4326',
+                BBOX: '-30,20,50,60'
             });
         });
         it('should add bbox when legend viewport filter is enabled', () => {
@@ -197,14 +194,13 @@ describe('LegendUtils', () => {
                 BBOX: '-30,20,50,60'
             });
         });
-        it('should skip bbox when legend viewport filter is not enabled', () => {
+        it('should skip content dependent param when dynamic legend is not enabled', () => {
             const layer = {
                 name: 'testLayer',
                 type: 'wms',
                 url: 'http://example.com',
                 serverType: 'VENDOR',
-                enableInteractiveLegend: true,
-                enableLegendFilterByViewport: false
+                enableDynamicLegend: false
             };
             const config = getWMSLegendConfig({
                 format: LEGEND_FORMAT.IMAGE,
@@ -226,21 +222,47 @@ describe('LegendUtils', () => {
                 style: null,
                 version: '1.3.0',
                 SLD_VERSION: '1.1.0',
-                LEGEND_OPTIONS: 'hideEmptyRules:true;fontSize:10',
-                SRCWIDTH: 800,
-                SRCHEIGHT: 600,
-                SRS: 'EPSG:4326',
-                CRS: 'EPSG:4326'
+                LEGEND_OPTIONS: 'fontSize:10'
             });
         });
-        it('should skip bbox when legend viewport filter is undefined', () => {
+        it('should skip bbox when interactive legend is not enabled', () => {
             const layer = {
                 name: 'testLayer',
                 type: 'wms',
                 url: 'http://example.com',
                 serverType: 'VENDOR',
-                enableInteractiveLegend: false,
-                enableLegendFilterByViewport: undefined
+                enableInteractiveLegend: false
+            };
+            const config = getWMSLegendConfig({
+                format: LEGEND_FORMAT.IMAGE,
+                legendHeight: 20,
+                legendWidth: 20,
+                layer,
+                mapSize: { width: 800, height: 600 },
+                projection: 'EPSG:4326',
+                mapBbox: { bounds: { minx: -30, miny: 20, maxx: 50, maxy: 60 }, crs: "EPSG:4326" },
+                legendOptions: 'fontSize:10'
+            });
+            expect(config).toEqual({
+                service: 'WMS',
+                request: 'GetLegendGraphic',
+                format: LEGEND_FORMAT.IMAGE,
+                height: 20,
+                width: 20,
+                layer: 'testLayer',
+                style: null,
+                version: '1.3.0',
+                SLD_VERSION: '1.1.0',
+                LEGEND_OPTIONS: 'fontSize:10'
+            });
+        });
+        it('should add content dependent params when dynamic legend is enabled', () => {
+            const layer = {
+                name: 'testLayer',
+                type: 'wms',
+                url: 'http://example.com',
+                serverType: 'VENDOR',
+                enableDynamicLegend: true
             };
             const config = getWMSLegendConfig({
                 format: LEGEND_FORMAT.IMAGE,
@@ -266,7 +288,8 @@ describe('LegendUtils', () => {
                 SRCWIDTH: 800,
                 SRCHEIGHT: 600,
                 SRS: 'EPSG:4326',
-                CRS: 'EPSG:4326'
+                CRS: 'EPSG:4326',
+                BBOX: '-30,20,50,60'
             });
         });
     });

--- a/web/client/utils/__tests__/LegendUtils-test.js
+++ b/web/client/utils/__tests__/LegendUtils-test.js
@@ -121,8 +121,7 @@ describe('LegendUtils', () => {
                 SRCWIDTH: 800,
                 SRCHEIGHT: 600,
                 SRS: 'EPSG:4326',
-                CRS: 'EPSG:4326',
-                BBOX: '-30,20,50,60'
+                CRS: 'EPSG:4326'
             });
         });
         it('should return correct WMS legend config for vendor server type with background group', () => {
@@ -131,7 +130,8 @@ describe('LegendUtils', () => {
                 type: 'wms',
                 url: 'http://example.com',
                 serverType: 'VENDOR',
-                group: 'background'
+                group: 'background',
+                enableInteractiveLegend: true
             };
             const config = getWMSLegendConfig({
                 format: LEGEND_FORMAT.IMAGE,
@@ -157,8 +157,116 @@ describe('LegendUtils', () => {
                 SRCWIDTH: 800,
                 SRCHEIGHT: 600,
                 SRS: 'EPSG:4326',
+                CRS: 'EPSG:4326'
+            });
+        });
+        it('should add bbox when legend viewport filter is enabled', () => {
+            const layer = {
+                name: 'testLayer',
+                type: 'wms',
+                url: 'http://example.com',
+                serverType: 'VENDOR',
+                enableInteractiveLegend: true,
+                enableLegendFilterByViewport: true
+            };
+            const config = getWMSLegendConfig({
+                format: LEGEND_FORMAT.IMAGE,
+                legendHeight: 20,
+                legendWidth: 20,
+                layer,
+                mapSize: { width: 800, height: 600 },
+                projection: 'EPSG:4326',
+                mapBbox: { bounds: { minx: -30, miny: 20, maxx: 50, maxy: 60 }, crs: "EPSG:4326" },
+                legendOptions: 'fontSize:10'
+            });
+            expect(config).toEqual({
+                service: 'WMS',
+                request: 'GetLegendGraphic',
+                format: LEGEND_FORMAT.IMAGE,
+                height: 20,
+                width: 20,
+                layer: 'testLayer',
+                style: null,
+                version: '1.3.0',
+                SLD_VERSION: '1.1.0',
+                LEGEND_OPTIONS: 'hideEmptyRules:true;fontSize:10',
+                SRCWIDTH: 800,
+                SRCHEIGHT: 600,
+                SRS: 'EPSG:4326',
                 CRS: 'EPSG:4326',
                 BBOX: '-30,20,50,60'
+            });
+        });
+        it('should skip bbox when legend viewport filter is not enabled', () => {
+            const layer = {
+                name: 'testLayer',
+                type: 'wms',
+                url: 'http://example.com',
+                serverType: 'VENDOR',
+                enableInteractiveLegend: true,
+                enableLegendFilterByViewport: false
+            };
+            const config = getWMSLegendConfig({
+                format: LEGEND_FORMAT.IMAGE,
+                legendHeight: 20,
+                legendWidth: 20,
+                layer,
+                mapSize: { width: 800, height: 600 },
+                projection: 'EPSG:4326',
+                mapBbox: { bounds: { minx: -30, miny: 20, maxx: 50, maxy: 60 }, crs: "EPSG:4326" },
+                legendOptions: 'fontSize:10'
+            });
+            expect(config).toEqual({
+                service: 'WMS',
+                request: 'GetLegendGraphic',
+                format: LEGEND_FORMAT.IMAGE,
+                height: 20,
+                width: 20,
+                layer: 'testLayer',
+                style: null,
+                version: '1.3.0',
+                SLD_VERSION: '1.1.0',
+                LEGEND_OPTIONS: 'hideEmptyRules:true;fontSize:10',
+                SRCWIDTH: 800,
+                SRCHEIGHT: 600,
+                SRS: 'EPSG:4326',
+                CRS: 'EPSG:4326'
+            });
+        });
+        it('should skip bbox when legend viewport filter is undefined', () => {
+            const layer = {
+                name: 'testLayer',
+                type: 'wms',
+                url: 'http://example.com',
+                serverType: 'VENDOR',
+                enableInteractiveLegend: false,
+                enableLegendFilterByViewport: undefined
+            };
+            const config = getWMSLegendConfig({
+                format: LEGEND_FORMAT.IMAGE,
+                legendHeight: 20,
+                legendWidth: 20,
+                layer,
+                mapSize: { width: 800, height: 600 },
+                projection: 'EPSG:4326',
+                mapBbox: { bounds: { minx: -30, miny: 20, maxx: 50, maxy: 60 }, crs: "EPSG:4326" },
+                legendOptions: 'fontSize:10'
+            });
+            expect(config).toEqual({
+                service: 'WMS',
+                request: 'GetLegendGraphic',
+                format: LEGEND_FORMAT.IMAGE,
+                height: 20,
+                width: 20,
+                layer: 'testLayer',
+                style: null,
+                version: '1.3.0',
+                SLD_VERSION: '1.1.0',
+                LEGEND_OPTIONS: 'hideEmptyRules:true;fontSize:10',
+                SRCWIDTH: 800,
+                SRCHEIGHT: 600,
+                SRS: 'EPSG:4326',
+                CRS: 'EPSG:4326'
             });
         });
     });


### PR DESCRIPTION
## Description
This PR adds the ability to opt in or out of legend filtering by viewport. The field is available in Display tab of the layer setting. By default this option is not active. The feature also applies to print tool

<img width="400" alt="image" src="https://github.com/user-attachments/assets/18229166-2b9a-476d-bf54-5b3047679eda" />

**Tooltips**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4c05f1ac-47f5-4671-b85b-8ec956070821" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8f729155-20ff-4ef3-9937-dd9d64694539" />



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #11021 

**What is the new behavior?**
- User can view legend by filtering based on map viewport or static legend
- Same applies to print tool

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
