### PR TITLE
Remove object assign pollyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,6 @@
     "md5": "2.3.0",
     "moment": "2.29.4",
     "node-geo-distance": "1.2.0",
-    "object-assign": "4.1.1",
     "object-fit-images": "3.2.4",
     "ol": "7.4.0",
     "pdfmake": "0.2.7",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "babel-loader": "8.0.5",
     "babel-plugin-add-module-exports": "0.1.4",
     "babel-plugin-istanbul": "6.0.0",
-    "babel-plugin-object-assign": "1.2.1",
     "babel-plugin-react-transform": "2.0.2",
     "babel-plugin-transform-imports": "2.0.0",
     "copy-webpack-plugin": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     "earcut": "2.2.4",
     "element-closest": "2.0.2",
     "embed-video": "2.0.4",
-    "es6-object-assign": "1.1.0",
     "es6-promise": "2.3.0",
     "esri-leaflet": "3.0.12",
     "eventlistener": "0.0.1",

--- a/utility/projects/projectLib.js
+++ b/utility/projects/projectLib.js
@@ -1,4 +1,3 @@
-const assign = require('object-assign');
 const denodeify = require('denodeify');
 const fs = require('fs');
 const mkdirp = denodeify(require('mkdirp'));
@@ -12,7 +11,7 @@ const ncp = denodeify(require('ncp').ncp);
 const createPackageJSON = (options, outFolder) => {
     process.stdout.write('Creating package.json...\n');
 
-    const packageJSON = assign({}, require('../../package.json'), options);
+    const packageJSON = Object.assign({}, require('../../package.json'), options);
     return writeFile(outFolder + '/package.json', JSON.stringify(packageJSON, null, 4));
 };
 

--- a/web/client/actions/__tests__/usergroups-test.js
+++ b/web/client/actions/__tests__/usergroups-test.js
@@ -8,8 +8,6 @@
 
 import expect from 'expect';
 
-import assign from 'object-assign';
-
 import {
     editGroup,
     EDITGROUP,
@@ -40,7 +38,7 @@ let oldAddBaseUri = GeoStoreDAO.addBaseUrl;
 describe('Test correctness of the usergroups actions', () => {
     beforeEach(() => {
         GeoStoreDAO.addBaseUrl = (options) => {
-            return assign(options, {baseURL: 'base/web/client/test-resources/geostore/'});
+            return Object.assign(options, {baseURL: 'base/web/client/test-resources/geostore/'});
         };
     });
 
@@ -177,7 +175,7 @@ describe('Test correctness of the usergroups actions', () => {
     });
     it('create usergroup', (done) => {
         GeoStoreDAO.addBaseUrl = (options) => {
-            return assign(options, {baseURL: 'base/web/client/test-resources/geostore/usergroups/newGroup.txt#'});
+            return Object.assign(options, {baseURL: 'base/web/client/test-resources/geostore/usergroups/newGroup.txt#'});
         };
         const retFun = saveGroup({groupName: "TEST"});
         expect(retFun).toExist();
@@ -201,7 +199,7 @@ describe('Test correctness of the usergroups actions', () => {
     });
     it('create usergroup with groups', (done) => {
         GeoStoreDAO.addBaseUrl = (options) => {
-            return assign(options, {baseURL: 'base/web/client/test-resources/geostore/usergroups/newGroup.txt#'});
+            return Object.assign(options, {baseURL: 'base/web/client/test-resources/geostore/usergroups/newGroup.txt#'});
         };
         const retFun = saveGroup({groupName: "TEST", newUsers: [{id: 100, name: "name1"}]});
         expect(retFun).toExist();

--- a/web/client/actions/__tests__/users-test.js
+++ b/web/client/actions/__tests__/users-test.js
@@ -8,7 +8,6 @@
 
 import expect from 'expect';
 
-import assign from 'object-assign';
 
 import {
     editUser,
@@ -37,7 +36,7 @@ let oldAddBaseUri = GeoStoreDAO.addBaseUrl;
 describe('Test correctness of the users actions', () => {
     beforeEach(() => {
         GeoStoreDAO.addBaseUrl = (options) => {
-            return assign(options, {baseURL: 'base/web/client/test-resources/geostore/'});
+            return Object.assign(options, {baseURL: 'base/web/client/test-resources/geostore/'});
         };
     });
 
@@ -164,7 +163,7 @@ describe('Test correctness of the users actions', () => {
     });
     it('saveUser create', (done) => {
         GeoStoreDAO.addBaseUrl = (options) => {
-            return assign(options, {baseURL: 'base/web/client/test-resources/geostore/users/newUser.txt#'});
+            return Object.assign(options, {baseURL: 'base/web/client/test-resources/geostore/users/newUser.txt#'});
         };
         const retFun = saveUser({name: "test", role: "USER", password: "password"});
         expect(retFun).toExist();
@@ -182,7 +181,7 @@ describe('Test correctness of the users actions', () => {
     });
     it('saveUser create with groups', (done) => {
         GeoStoreDAO.addBaseUrl = (options) => {
-            return assign(options, {baseURL: 'base/web/client/test-resources/geostore/users/newUser.txt#'});
+            return Object.assign(options, {baseURL: 'base/web/client/test-resources/geostore/users/newUser.txt#'});
         };
         const retFun = saveUser({name: "test", groups: [{groupName: "everyone"}, {groupName: "testers"}], role: "USER", password: "password"});
         expect(retFun).toExist();

--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -9,7 +9,6 @@
 import urlUtil from 'url';
 
 import { get, head, last, template, isNil, castArray, isEmpty } from 'lodash';
-import assign from 'object-assign';
 import xml2js from 'xml2js';
 import axios from '../libs/ajax';
 import { cleanDuplicatedQuestionMarks } from '../utils/ConfigUtils';
@@ -20,8 +19,8 @@ import { getDefaultUrl } from '../utils/URLUtils';
 
 export const parseUrl = (url) => {
     const parsed = urlUtil.parse(getDefaultUrl(url), true);
-    return urlUtil.format(assign({}, parsed, { search: null }, {
-        query: assign({
+    return urlUtil.format(Object.assign({}, parsed, { search: null }, {
+        query: Object.assign({
             service: "CSW",
             version: "2.0.2"
         }, parsed.query, { request: undefined })

--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -7,7 +7,6 @@
 */
 import { castArray, findIndex, get, has, isArray, merge, omit, pick } from 'lodash';
 
-import assign from 'object-assign';
 import uuidv1 from 'uuid/v1';
 import xml2js from 'xml2js';
 const xmlBuilder = new xml2js.Builder();
@@ -94,7 +93,7 @@ const Api = {
      * @return {object} options with baseURL
      */
     addBaseUrl: function(options) {
-        return assign({}, options, {baseURL: options && options.baseURL || ConfigUtils.getDefaults().geoStoreUrl});
+        return Object.assign({}, options, {baseURL: options && options.baseURL || ConfigUtils.getDefaults().geoStoreUrl});
     },
     getData: function(id, options) {
         const url = "data/" + id;
@@ -401,7 +400,7 @@ const Api = {
     },
     updateUser: function(id, user, options) {
         const url = "users/user/" + id;
-        const postUser = assign({}, user);
+        const postUser = Object.assign({}, user);
         if (postUser.newPassword === "") {
             delete postUser.newPassword;
         }
@@ -560,7 +559,7 @@ const Api = {
          * @return {object}      The user object adapted for creation (newPassword, UUID)
          */
         initUser: (user) => {
-            const postUser = assign({}, user);
+            const postUser = Object.assign({}, user);
             if (postUser.newPassword) {
                 postUser.password = postUser.newPassword;
             }

--- a/web/client/api/Nominatim.js
+++ b/web/client/api/Nominatim.js
@@ -8,7 +8,6 @@
 import axios from '../libs/ajax';
 
 import urlUtil from 'url';
-import assign from 'object-assign';
 const DEFAULT_URL = 'nominatim.openstreetmap.org';
 const DEFAULT_REVERSE_URL = 'nominatim.openstreetmap.org/reverse';
 const defaultOptions = {
@@ -22,7 +21,7 @@ const defaultOptions = {
  */
 const Api = {
     geocode: function(text, options) {
-        var params = assign({q: text}, defaultOptions, options || {});
+        var params = Object.assign({q: text}, defaultOptions, options || {});
         var url = urlUtil.format({
             protocol: "https",
             host: DEFAULT_URL,
@@ -31,7 +30,7 @@ const Api = {
         return axios.get(url); // TODO the jsonp method returns .promise and .cancel method,the last can be called when user cancel the query
     },
     reverseGeocode: function(coords, options) {
-        const params = assign({lat: coords.lat, lon: coords.lng}, options || {}, defaultOptions);
+        const params = Object.assign({lat: coords.lat, lon: coords.lng}, options || {}, defaultOptions);
         const url = urlUtil.format({
             protocol: "https",
             host: DEFAULT_REVERSE_URL,

--- a/web/client/api/SLDService.js
+++ b/web/client/api/SLDService.js
@@ -10,7 +10,6 @@ import { urlParts } from '../utils/URLUtils';
 
 import url from 'url';
 import { sortBy, head, castArray, isNumber, isString } from 'lodash';
-import assign from 'object-assign';
 import chroma from 'chroma-js';
 import { getLayerUrl } from '../utils/LayersUtils';
 import { standardClassificationScales as standardColors } from '../utils/ClassificationUtils';
@@ -67,16 +66,16 @@ const mapParams = (layer, params) => {
     const otherParams = layer.thematic && layer.thematic.fieldAsParam && ['field'] || [];
     return Object.keys(params).reduce((previous, key) => {
         if (isViewParam(key, [...configParams, ...otherParams])) {
-            return assign(previous, addViewParam(previous.viewparams, key, params[key]));
+            return Object.assign(previous, addViewParam(previous.viewparams, key, params[key]));
         }
         if (key === 'ramp') {
-            return assign(previous, getColor(layer, params[key], params.intervals || 5));
+            return Object.assign(previous, getColor(layer, params[key], params.intervals || 5));
         }
         if (key === 'classification') {
-            return assign(previous, getCustomClassification(params[key]));
+            return Object.assign(previous, getCustomClassification(params[key]));
         }
         if (key === 'attribute') {
-            return assign(previous, {
+            return Object.assign(previous, {
                 attribute: layer.thematic && layer.thematic.fieldAsParam ? params[key] : params.field
             });
         }
@@ -84,21 +83,21 @@ const mapParams = (layer, params) => {
             return previous;
         }
         if (key === 'strokeWeight' && !params.strokeOn) {
-            return assign(previous, {
+            return Object.assign(previous, {
                 [key]: -1
             });
         }
         if (key === 'strokeOn') {
             return previous;
         }
-        return assign(previous, {
+        return Object.assign(previous, {
             [key]: params[key]
         });
     }, {});
 };
 
 const getUrl = (parts) => {
-    return assign({
+    return Object.assign({
         protocol: parts.protocol,
         hostname: parts.domain
     }, parts.port ? {
@@ -178,14 +177,14 @@ const API = {
      */
     getStyleService: (layer, params) => {
         const parts = urlParts(getLayerUrl(layer));
-        return url.format(assign(getUrl(parts), {
+        return url.format(Object.assign(getUrl(parts), {
             pathname: parts.applicationRootPath + "/rest/sldservice/" + layer.name + "/classify.xml",
-            query: assign({}, mapParams(layer, params), { fullSLD: true })
+            query: Object.assign({}, mapParams(layer, params), { fullSLD: true })
         }));
     },
     getCapabilitiesUrl: (layer) => {
         const parts = urlParts(getLayerUrl(layer));
-        return url.format(assign(getUrl(parts), {
+        return url.format(Object.assign(getUrl(parts), {
             pathname: parts.applicationRootPath + "/rest/sldservice/capabilities.json"
         }));
     },
@@ -203,7 +202,7 @@ const API = {
     getStyleMetadataService: (layer, params, styleService) => {
         const { baseUrl = '', isStatic = false } = styleService || {};
         const parts = urlParts(isStatic ? baseUrl : getLayerUrl(layer));
-        return url.format(assign(getUrl(parts), {
+        return url.format(Object.assign(getUrl(parts), {
             pathname: parts.applicationRootPath + "/rest/sldservice/" + layer.name + "/classify.json",
             query: params
         }));
@@ -251,7 +250,7 @@ const API = {
     getFieldsService: (layer) => {
         const parts = urlParts(getLayerUrl(layer));
         const table = layer.thematic && layer.thematic.datatable || layer.name;
-        return url.format(assign(getUrl(parts), {
+        return url.format(Object.assign(getUrl(parts), {
             pathname: parts.applicationRootPath + "/rest/sldservice/" + table + "/attributes.json"
         }));
     },
@@ -357,7 +356,7 @@ const API = {
      * @returns {array} list of actual parameters configuration (standard params are inlined)
      */
     getThematicParameters: (params) => {
-        return params.map((param) => param.type && API.standardParams[param.type] && assign({}, API.standardParams[param.type], param) || param);
+        return params.map((param) => param.type && API.standardParams[param.type] && Object.assign({}, API.standardParams[param.type], param) || param);
     },
     /**
      * Supported known parameters: some parameters have a special behaviour (preconfigured and localized labels and values):
@@ -434,7 +433,7 @@ const API = {
      */
     removeThematicStyle: (params) => {
         const {SLD, viewparams, ...other} = params;
-        return assign({}, other, {
+        return Object.assign({}, other, {
             SLD: null,
             viewparams: null
         });

--- a/web/client/api/WCS.js
+++ b/web/client/api/WCS.js
@@ -7,14 +7,13 @@
  */
 import axios from '../libs/ajax';
 import urlUtil from 'url';
-import assign from 'object-assign';
 import xml2js from 'xml2js';
 import { getDefaultUrl } from '../utils/URLUtils';
 
 export const describeCoverage = function(url, typeName) {
     const parsed = urlUtil.parse(getDefaultUrl(url), true);
-    const describeLayerUrl = urlUtil.format(assign({}, parsed, {
-        query: assign({
+    const describeLayerUrl = urlUtil.format(Object.assign({}, parsed, {
+        query: Object.assign({
             service: "WCS",
             version: "1.1.0",
             identifiers: typeName,

--- a/web/client/api/WFS.js
+++ b/web/client/api/WFS.js
@@ -7,7 +7,6 @@
  */
 import axios from '../libs/ajax';
 import urlUtil from 'url';
-import assign from 'object-assign';
 import xml2js from 'xml2js';
 import ConfigUtils from '../utils/ConfigUtils';
 import requestBuilder from '../utils/ogc/WFS/RequestBuilder';
@@ -40,7 +39,7 @@ export const toDescribeURL = (url, typeName) => {
  */
 export const getFeatureSimple = function(baseUrl, params) {
     return axios.get(baseUrl + '?service=WFS&version=1.1.0&request=GetFeature', {
-        params: assign({
+        params: Object.assign({
             outputFormat: "application/json"
         }, params)
     }).then((response) => {
@@ -53,9 +52,9 @@ export const getFeatureSimple = function(baseUrl, params) {
 
 export const getCapabilitiesURL = (url, {version = "1.1.0"} = {}) => {
     const parsed = urlUtil.parse(getDefaultUrl(url), true);
-    return urlUtil.format(assign({}, parsed, {
+    return urlUtil.format(Object.assign({}, parsed, {
         search: undefined, // this allows to merge parameters correctly
-        query: assign({
+        query: Object.assign({
             version,
             ...parsed.query,
             service: "WFS",
@@ -66,9 +65,9 @@ export const getCapabilitiesURL = (url, {version = "1.1.0"} = {}) => {
 
 export const getFeatureURL = (url, typeName, { version = "1.1.0", ...params } = {}) => {
     const parsed = urlUtil.parse(getDefaultUrl(url), true);
-    return urlUtil.format(assign({}, parsed, {
+    return urlUtil.format(Object.assign({}, parsed, {
         search: undefined, // this allows to merge parameters correctly
-        query: assign({
+        query: Object.assign({
             typeName,
             version,
             ...parsed.query,

--- a/web/client/api/WMTS.js
+++ b/web/client/api/WMTS.js
@@ -9,7 +9,6 @@ import axios from '../libs/ajax';
 
 import { getConfigProp } from '../utils/ConfigUtils';
 import urlUtil from 'url';
-import assign from 'object-assign';
 import xml2js from 'xml2js';
 
 const capabilitiesCache = {};
@@ -28,8 +27,8 @@ import {
 
 export const parseUrl = (url) => {
     const parsed = urlUtil.parse(getDefaultUrl(url), true);
-    return urlUtil.format(assign({}, parsed, {search: null}, {
-        query: assign({
+    return urlUtil.format(Object.assign({}, parsed, {search: null}, {
+        query: Object.assign({
             SERVICE: "WMTS",
             VERSION: "1.0.0",
             REQUEST: "GetCapabilities"
@@ -57,7 +56,7 @@ const searchAndPaginate = (json, startPosition, maxRecords, text, url) => {
         nextRecord: startPosition + Math.min(maxRecords, filteredLayers.length) + 1,
         records: filteredLayers
             .filter((layer, index) => index >= startPosition - 1 && index < startPosition - 1 + maxRecords)
-            .map((layer) => assign({}, layer, {
+            .map((layer) => Object.assign({}, layer, {
                 SRS: SRSList,
                 TileMatrixSet,
                 // Only KVP is supported by MapInfo, for the moment. TODO: Support single layer's InfoFormat

--- a/web/client/api/catalog/WMS.js
+++ b/web/client/api/catalog/WMS.js
@@ -7,7 +7,6 @@
  */
 
 import { isArray, castArray, filter, isEmpty, isNil } from 'lodash';
-import assign from 'object-assign';
 import { getResolutionObject } from "../../utils/MapUtils";
 import { Observable } from 'rxjs';
 import { getConfigProp, cleanDuplicatedQuestionMarks } from '../../utils/ConfigUtils';
@@ -177,7 +176,7 @@ export const getCatalogRecords = (records, options) => {
                 title: getLayerTitleTranslations(record) || record.Name,
                 getMapFormats: record.getMapFormats,
                 getFeatureInfoFormats: record.getFeatureInfoFormats,
-                dimensions: (record.Dimension && castArray(record.Dimension) || []).map((dim) => assign({}, {
+                dimensions: (record.Dimension && castArray(record.Dimension) || []).map((dim) => Object.assign({}, {
                     values: dim._ && dim._.split(',') || []
                 }, dim.$ || {}))
                 // TODO: re-enable when support to inline values is full (now timeline miss snap, auto-select and forward-backward buttons enabled/disabled for this kind of values)

--- a/web/client/api/geoserver/GeoFence.js
+++ b/web/client/api/geoserver/GeoFence.js
@@ -7,7 +7,6 @@
  */
 
 import { castArray, get } from 'lodash';
-import assign from 'object-assign';
 
 import axios from '../../libs/ajax';
 import ConfigUtils from '../../utils/ConfigUtils';
@@ -162,12 +161,12 @@ var Api = {
     getUserServiceName: () => ConfigUtils.getDefaults().geoserverUserServiceName,
 
     addBaseUrl: function(options = {}) {
-        return assign(options, {
+        return Object.assign(options, {
             baseURL: ConfigUtils.getDefaults().geoFenceUrl + ( ConfigUtils.getDefaults().geoFencePath || 'geofence/rest' )});
     },
     addBaseUrlGS: function(options = {}) {
         const {url: baseURL} = ConfigUtils.getDefaults().geoFenceGeoServerInstance || {};
-        return assign(options, {baseURL});
+        return Object.assign(options, {baseURL});
     }
 };
 

--- a/web/client/api/geoserver/Styles.js
+++ b/web/client/api/geoserver/Styles.js
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 import axios from '../../libs/ajax';
-import assign from 'object-assign';
 import { getVersion } from './About';
 import head from 'lodash/head';
 import castArray from 'lodash/castArray';
@@ -103,8 +102,8 @@ const updateStyleMetadata = ({ baseUrl: geoserverBaseUrl, styleName, metadata })
 */
 export const saveStyle = (geoserverBaseUrl, styleName, body, options) => {
     let url = geoserverBaseUrl + "styles/" + encodeURI(styleName);
-    let opts = assign({}, options);
-    opts.headers = assign({}, opts.headers, {"Content-Type": "application/vnd.ogc.sld+xml"});
+    let opts = Object.assign({}, options);
+    opts.headers = Object.assign({}, opts.headers, {"Content-Type": "application/vnd.ogc.sld+xml"});
     return axios.put(url, body, opts);
 };
 /**
@@ -226,7 +225,7 @@ export const getStylesInfo = ({baseUrl: geoserverBaseUrl, styles = []}) => {
             styles.forEach(({ name, href }, idx) =>
                 axios.get(href || getStyleBaseUrl({...getNameParts(name), geoserverBaseUrl}))
                     .then(({data}) => {
-                        responses[idx] = assign({}, styles[idx], data && data.style && {
+                        responses[idx] = Object.assign({}, styles[idx], data && data.style && {
                             ...data.style,
                             ...(data.style.metadata && { metadata: parseStyleMetadata(data.style.metadata) }),
                             name: stringifyNameParts(data.style)
@@ -235,7 +234,7 @@ export const getStylesInfo = ({baseUrl: geoserverBaseUrl, styles = []}) => {
                         if (count === 0) resolve(responses.filter(val => val));
                     })
                     .catch(() => {
-                        responses[idx] = assign({}, styles[idx]);
+                        responses[idx] = Object.assign({}, styles[idx]);
                         count--;
                         if (count === 0) resolve(responses.filter(val => val));
                     })

--- a/web/client/api/searchText.js
+++ b/web/client/api/searchText.js
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
-
 import { nominatimToGeoJson } from '../utils/GeoCodeUtils';
 import { generateTemplateString } from '../utils/TemplateUtils';
 import * as WFS from './WFS';
@@ -44,7 +42,7 @@ let Services = {
     wfs: (searchText, {url, typeName, queriableAttributes = [], outputFormat = "application/json", predicate = "ILIKE", staticFilter = "", blacklist = [], item, fromTextToFilter = defaultFromTextToFilter, returnFullData = false, ...params }) => {
         const filter = fromTextToFilter({searchText, staticFilter, blacklist, item, queriableAttributes, predicate});
         return WFS
-            .getFeatureSimple(url, assign({
+            .getFeatureSimple(url, Object.assign({
                 maxFeatures: 10,
                 typeName,
                 outputFormat,

--- a/web/client/components/app/appPolyfill.js
+++ b/web/client/components/app/appPolyfill.js
@@ -8,6 +8,3 @@
 
 // issue #3147 Element.closest is not supported in ie11
 import 'element-closest';
-
-// issue #3153  Embedded doesn't work on ie11
-require('es6-object-assign').polyfill();

--- a/web/client/components/background/BackgroundDialog.jsx
+++ b/web/client/components/background/BackgroundDialog.jsx
@@ -16,7 +16,6 @@ import htmlToDraft from 'html-to-draftjs';
 import localizedProps from '../misc/enhancers/localizedProps';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
-import assign from 'object-assign';
 import uuidv1 from 'uuid/v1';
 import {pick, omit, get, keys, isNumber, isBoolean} from 'lodash';
 import Message from '../I18N/Message';
@@ -119,7 +118,7 @@ export default class BackgroundDialog extends React.Component {
         const contentBlock = htmlToDraft(creditsTitleHtml);
         const contentState = ContentState.createFromBlockArray(contentBlock.contentBlocks);
         const editorState = EditorState.createWithContent(contentState);
-        const newState = assign({}, pickedProps, {additionalParameters: this.assignParameters(this.props.additionalParameters), editorState});
+        const newState = Object.assign({}, pickedProps, {additionalParameters: this.assignParameters(this.props.additionalParameters), editorState});
         this.state = newState;
     }
 
@@ -300,10 +299,10 @@ export default class BackgroundDialog extends React.Component {
                         const format = this.state.format || this.props.defaultFormat;
                         const creditsTitle = draftToHtml(convertToRaw(this.state.editorState.getCurrentContent()));
                         this.props.updateThumbnail(this.state.thumbnail.data, backgroundId);
-                        this.props.onSave(assign({}, this.props.layer, omit(this.state, 'thumbnail'), this.props.editing ? {} : {id: backgroundId},
+                        this.props.onSave(Object.assign({}, this.props.layer, omit(this.state, 'thumbnail'), this.props.editing ? {} : {id: backgroundId},
                             {
                                 params: omit(
-                                    this.state.additionalParameters.reduce((accum, p) => assign(accum, {[p.param]: p.val}), {}),
+                                    this.state.additionalParameters.reduce((accum, p) => Object.assign(accum, {[p.param]: p.val}), {}),
                                     ['source', 'title']
                                 ),
                                 format,
@@ -383,7 +382,7 @@ export default class BackgroundDialog extends React.Component {
                     } else {
                         modifiedKey = event;
                     }
-                    return assign({}, v, {[key]: modifiedKey, type});
+                    return Object.assign({}, v, {[key]: modifiedKey, type});
                 }
                 return v;
             })

--- a/web/client/components/buttons/ImageButton.jsx
+++ b/web/client/components/buttons/ImageButton.jsx
@@ -9,8 +9,6 @@ import PropTypes from 'prop-types';
  */
 import React from 'react';
 
-import assign from 'object-assign';
-
 class ImageButton extends React.Component {
     static propTypes = {
         id: PropTypes.string,
@@ -37,11 +35,11 @@ class ImageButton extends React.Component {
             display: "inline-block"
         };
         if (this.props.image) {
-            assign(finalStyle, {
+            Object.assign(finalStyle, {
                 overflow: "hidden"
             });
         } else {
-            assign(finalStyle, {
+            Object.assign(finalStyle, {
                 height: "48px",
                 width: "48px",
                 border: "1px solid grey",
@@ -49,7 +47,7 @@ class ImageButton extends React.Component {
                 backgroundColor: "rgb(250, 250, 250)"
             });
         }
-        assign(finalStyle, this.props.style);
+        Object.assign(finalStyle, this.props.style);
         return finalStyle;
     };
 

--- a/web/client/components/catalog/__tests__/RecordItem-test.jsx
+++ b/web/client/components/catalog/__tests__/RecordItem-test.jsx
@@ -7,7 +7,6 @@
  */
 
 import expect from 'expect';
-import assign from 'object-assign';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
@@ -108,7 +107,7 @@ const sampleRecord3 = {
     }
 };
 
-const getCapRecord = assign({}, sampleRecord, {references: [{
+const getCapRecord = Object.assign({}, sampleRecord, {references: [{
     type: "OGC:WMS",
     url: "http://wms.sample.service:80/geoserver/wms?SERVICE=WMS&",
     params: {name: "workspace:layername"}
@@ -754,7 +753,7 @@ describe('This test for RecordItem', () => {
         }]
     };
 
-    const localizedRecord = assign({}, noTitleRecord,
+    const localizedRecord = Object.assign({}, noTitleRecord,
         {
             title: {
                 "default": "deftitle",

--- a/web/client/components/manager/users/GroupDialog.jsx
+++ b/web/client/components/manager/users/GroupDialog.jsx
@@ -11,7 +11,6 @@
 import React from 'react';
 import { Alert, Tabs, Tab, Glyphicon, FormControl, FormGroup, ControlLabel } from 'react-bootstrap';
 import PropTypes from 'prop-types';
-import assign from 'object-assign';
 import Spinner from 'react-spinkit';
 import { findIndex, castArray } from 'lodash';
 
@@ -259,7 +258,7 @@ class GroupDialog extends React.Component {
             maskLoading={this.props.group && (this.props.group.status === "loading" || this.props.group.status === "saving")}
             id="mapstore-group-dialog"
             className="group-edit-dialog"
-            style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}
+            style={Object.assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}
             draggable={false}
         >
             <span role="header">

--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -8,7 +8,6 @@
 import React from 'react';
 
 import Layers from '../../../utils/cesium/Layers';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import { round, isNil, castArray } from 'lodash';
 import { getResolutions } from '../../../utils/MapUtils';
@@ -285,7 +284,7 @@ class CesiumLayer extends React.Component {
             if (this.props.options.refresh && this.layer.updateParams) {
                 let counter = 0;
                 this.refreshTimer = setInterval(() => {
-                    const newLayer = this.layer.updateParams(assign({}, this.props.options.params, {_refreshCounter: counter++}));
+                    const newLayer = this.layer.updateParams(Object.assign({}, this.props.options.params, {_refreshCounter: counter++}));
                     this.removeLayer();
                     this.layer = newLayer;
                     this.addLayerInternal(newProps);

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -24,7 +24,6 @@ import {
     getResolutions
 } from '../../../utils/MapUtils';
 import { reprojectBbox } from '../../../utils/CoordinatesUtils';
-import assign from 'object-assign';
 import { throttle, isEqual } from 'lodash';
 
 class CesiumMap extends React.Component {
@@ -97,7 +96,7 @@ class CesiumMap extends React.Component {
 
     componentDidMount() {
         const creditContainer = document.querySelector(this.props.mapOptions?.attribution?.container || '#footer-attribution-container');
-        let map = new Cesium.Viewer(this.getDocument().getElementById(this.props.id), assign({
+        let map = new Cesium.Viewer(this.getDocument().getElementById(this.props.id), Object.assign({
             imageryProvider: new Cesium.OpenStreetMapImageryProvider(), // redefining to avoid to use default bing (that queries the bing API without any reason, because baseLayerPicker is false, anyway)
             baseLayerPicker: false,
             animation: false,
@@ -349,7 +348,7 @@ class CesiumMap extends React.Component {
                 break;
             }
         }
-        return assign({}, rawOptions, overrides);
+        return Object.assign({}, rawOptions, overrides);
     };
 
     getCenter = () => {

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -11,7 +11,6 @@ import CesiumLayer from '../Layer';
 import expect from 'expect';
 import * as Cesium from 'cesium';
 import { waitFor } from '@testing-library/react';
-import assign from 'object-assign';
 
 import '../../../../utils/cesium/Layers';
 import '../plugins/OSMLayer';
@@ -563,7 +562,7 @@ describe('Cesium layer', () => {
             expect(layer.provider.alpha).toBe(1.0);
             layer = ReactDOM.render(
                 <CesiumLayer type="wms"
-                    options={assign({}, options, {opacity: 0.5})} position={0} map={map}/>, document.getElementById("container"));
+                    options={Object.assign({}, options, {opacity: 0.5})} position={0} map={map}/>, document.getElementById("container"));
             expect(layer.provider.alpha).toBe(0.5);
             done();
         }).catch(done);

--- a/web/client/components/map/cesium/plugins/WMTSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMTSLayer.js
@@ -14,7 +14,6 @@ import {
 } from '../../../../utils/ProxyUtils';
 import * as WMTSUtils from '../../../../utils/WMTSUtils';
 import { creditsToAttribution, getAuthenticationParam, getURLs } from '../../../../utils/LayersUtils';
-import assign from 'object-assign';
 import { isObject, isArray, slice, get, head} from 'lodash';
 import urlParser from 'url';
 import { isVectorFormat } from '../../../../utils/VectorTileUtils';
@@ -115,7 +114,7 @@ function wmtsToCesiumOptions(_options) {
     const queryParametersString = urlParser.format({ query: {...getAuthenticationParam(options)}});
     const cr = options.credits;
     const credit = cr ? new Cesium.Credit(creditsToAttribution(cr)) : '';
-    return assign({
+    return Object.assign({
         // TODO: multi-domain support, if use {s} switches to RESTFul mode
         url: new Cesium.Resource({
             url: head(getURLs(isArray(options.url) ? options.url : [options.url], queryParametersString)),
@@ -149,8 +148,8 @@ const createLayer = options => {
     const orig = layer.requestImage;
     layer.requestImage = (x, y, level) => cesiumOptions.isValid(x, y, level) ? orig.bind(layer)( x, y, level) : new Promise( () => undefined);
     layer.updateParams = (params) => {
-        const newOptions = assign({}, options, {
-            params: assign({}, options.params || {}, params)
+        const newOptions = Object.assign({}, options, {
+            params: Object.assign({}, options.params || {}, params)
         });
         return createLayer(newOptions);
     };

--- a/web/client/components/map/leaflet/DrawSupport.jsx
+++ b/web/client/components/map/leaflet/DrawSupport.jsx
@@ -30,7 +30,6 @@ L.Draw.Polygon.prototype._calculateFinishDistance = function(t) {
 
 import {isSimpleGeomType, getSimpleGeomType} from '../../../utils/MapUtils';
 import {boundsToOLExtent} from '../../../utils/leaflet/DrawSupportUtils';
-const assign = require('object-assign');
 
 const {reproject, reprojectBbox, calculateCircleCoordinates, reprojectGeoJson} = require('../../../utils/CoordinatesUtils');
 
@@ -496,7 +495,7 @@ class DrawSupport extends React.Component {
             }
         });
 
-        const props = assign({}, newProps, {features: newFeatures.length >  0 ? newFeatures : [{}]});
+        const props = Object.assign({}, newProps, {features: newFeatures.length >  0 ? newFeatures : [{}]});
         if (!this.drawLayer) {
             /* Reprojection is needed to implement circle initial visualization after querypanel geometry reload (on reload the 100 points polygon is shown)
              *
@@ -528,7 +527,7 @@ class DrawSupport extends React.Component {
         this.addGeojsonLayer({
             features: newProps.features,
             projection: newProps.options && newProps.options.featureProjection || "EPSG:4326",
-            style: assign({}, newProps.style, {
+            style: Object.assign({}, newProps.style, {
                 poly: {
                     icon: new L.DivIcon({
                         iconSize: new L.Point(8, 8),
@@ -703,7 +702,7 @@ class DrawSupport extends React.Component {
         } else {
             geom = featureEdited.toGeoJSON().geometry;
         }
-        return assign({}, featureEdited.toGeoJSON(), {geometry: geom});
+        return Object.assign({}, featureEdited.toGeoJSON(), {geometry: geom});
     };
 }
 

--- a/web/client/components/map/leaflet/MeasurementSupport.jsx
+++ b/web/client/components/map/leaflet/MeasurementSupport.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import assign from 'object-assign';
 import L from 'leaflet';
 import {
     isNil,
@@ -249,8 +248,8 @@ class MeasurementSupport extends React.Component {
 
         let feature = this.lastLayer && this.lastLayer.toGeoJSON() || {};
         if (this.props.measurement.geomType === 'LineString') {
-            feature = assign({}, feature, {
-                geometry: assign({}, feature.geometry, {
+            feature = Object.assign({}, feature, {
+                geometry: Object.assign({}, feature.geometry, {
                     coordinates: transformLineToArcs(feature.geometry.coordinates)
                 })
             });
@@ -262,13 +261,13 @@ class MeasurementSupport extends React.Component {
                 y: pos.lat,
                 srs: 'EPSG:4326'
             };
-            let newMeasureState = assign({}, this.props.measurement, {
+            let newMeasureState = Object.assign({}, this.props.measurement, {
                 point: point,
                 feature
             });
             this.props.changeMeasurementState(newMeasureState);
         } else {
-            let newMeasureState = assign({}, this.props.measurement, {
+            let newMeasureState = Object.assign({}, this.props.measurement, {
                 feature
             });
             this.props.changeMeasurementState(newMeasureState);
@@ -314,8 +313,8 @@ class MeasurementSupport extends React.Component {
     addArcsToMap = (features) => {
         this.removeLastLayer();
         let newFeatures = features.map(f => {
-            return assign({}, f, {
-                geometry: assign({}, f.geometry, {
+            return Object.assign({}, f, {
+                geometry: Object.assign({}, f.geometry, {
                     coordinates: transformLineToArcs(f.geometry.coordinates)
                 })
             });
@@ -362,7 +361,7 @@ class MeasurementSupport extends React.Component {
             bearing = this.calculateBearing();
         }
         // let drawn geom stay on the map
-        let newMeasureState = assign({}, this.props.measurement, {
+        let newMeasureState = Object.assign({}, this.props.measurement, {
             point: null, // Point is set in onDraw.created
             len: distance,
             area: area,

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -16,8 +16,6 @@ import LeafLetLayer from '../Layer.jsx';
 import Feature from '../Feature.jsx';
 import expect from 'expect';
 
-import assign from 'object-assign';
-
 import '../../../../utils/leaflet/Layers';
 import '../plugins/OSMLayer';
 import '../plugins/GraticuleLayer';
@@ -838,7 +836,7 @@ describe('Leaflet layer', () => {
 
         layer = ReactDOM.render(
             <LeafLetLayer type="wms"
-                options={assign({}, options, {opacity: 0.5})} map={map}/>, document.getElementById("container"));
+                options={Object.assign({}, options, {opacity: 0.5})} map={map}/>, document.getElementById("container"));
         expect(layer.layer.options.opacity).toBe(0.5);
     });
 
@@ -1212,7 +1210,7 @@ describe('Leaflet layer', () => {
 
         expect(layer).toExist();
 
-        const newOptions = assign({}, options, {
+        const newOptions = Object.assign({}, options, {
             singleTile: true
         });
         layer = ReactDOM.render(

--- a/web/client/components/map/leaflet/plugins/BingLayer.js
+++ b/web/client/components/map/leaflet/plugins/BingLayer.js
@@ -8,7 +8,6 @@
 import L from 'leaflet';
 import Layers from '../../../../utils/leaflet/Layers';
 import 'leaflet-plugins/layer/tile/Bing';
-import assign from 'object-assign';
 
 L.BingLayer.prototype.loadMetadata = function() {
     if (this.metaRequested) {
@@ -60,7 +59,7 @@ Layers.registerType('bing', {
             maxZoom: options.maxZoom || 23
         };
         if (options.zoomOffset) {
-            layerOptions = assign({}, layerOptions, {
+            layerOptions = Object.assign({}, layerOptions, {
                 zoomOffset: options.zoomOffset
             });
         }

--- a/web/client/components/map/leaflet/plugins/ElevationLayer.js
+++ b/web/client/components/map/leaflet/plugins/ElevationLayer.js
@@ -8,7 +8,6 @@
 
 import Layers from '../../../../utils/leaflet/Layers';
 import L from 'leaflet';
-import objectAssign from 'object-assign';
 import { isArray } from 'lodash';
 import { addAuthenticationParameter } from '../../../../utils/SecurityUtils';
 import { loadTile, getElevation, getElevationKey } from '../../../../utils/ElevationUtils';
@@ -46,7 +45,7 @@ L.TileLayer.ElevationWMS = L.TileLayer.MultipleUrlWMS.extend({
     },
     _getTileFromCoords: function(latLng) {
         const layerPoint = this._map.project(latLng).divideBy(256).floor();
-        return objectAssign(layerPoint, {z: this._tileZoom});
+        return Object.assign(layerPoint, {z: this._tileZoom});
     },
     _getTileRelativePixel: function(tilePoint, containerPoint) {
         const x = Math.floor(containerPoint.x - this._getTilePos(tilePoint).x - this._map._getMapPanePos().x);

--- a/web/client/components/map/leaflet/plugins/GraticuleLayer.js
+++ b/web/client/components/map/leaflet/plugins/GraticuleLayer.js
@@ -8,13 +8,12 @@
 
 import Layers from '../../../../utils/leaflet/Layers';
 import SimpleGraticule from 'leaflet-simple-graticule/L.SimpleGraticule';
-import assign from 'object-assign';
 
 require('leaflet-simple-graticule/L.SimpleGraticule.css');
 
 Layers.registerType('graticule', {
     create: (options) => {
-        const graticuleOptions = assign({
+        const graticuleOptions = Object.assign({
             interval: 20,
             showOriginLabel: true,
             redraw: 'move'

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -10,7 +10,6 @@ import Layers from '../../../../utils/leaflet/Layers';
 
 import { filterWMSParamOptions, getWMSURLs, wmsToLeafletOptions, removeNulls } from '../../../../utils/leaflet/WMSUtils';
 import L from 'leaflet';
-import objectAssign from 'object-assign';
 import { isArray } from 'lodash';
 import {addAuthenticationToSLD, addAuthenticationParameter} from '../../../../utils/SecurityUtils';
 
@@ -79,9 +78,9 @@ Layers.registerType('wms', {
             return newLayer;
         }
         // find the options that make a parameter change
-        let oldqueryParameters = objectAssign({}, filterWMSParamOptions(wmsToLeafletOptions(oldOptions)),
+        let oldqueryParameters = Object.assign({}, filterWMSParamOptions(wmsToLeafletOptions(oldOptions)),
             addAuthenticationToSLD(oldOptions.params || {}, oldOptions));
-        let newQueryParameters = objectAssign({}, filterWMSParamOptions(wmsToLeafletOptions(newOptions)),
+        let newQueryParameters = Object.assign({}, filterWMSParamOptions(wmsToLeafletOptions(newOptions)),
             addAuthenticationToSLD(newOptions.params || {}, newOptions));
         let newParameters = Object.keys(newQueryParameters).filter((key) => {return newQueryParameters[key] !== oldqueryParameters[key]; });
         let removeParams = Object.keys(oldqueryParameters).filter((key) => { return oldqueryParameters[key] !== newQueryParameters[key]; });
@@ -91,10 +90,10 @@ Layers.registerType('wms', {
         }
         if ( newParameters.length > 0 ) {
             newParams = newParameters.reduce( (accumulator, currentValue) => {
-                return objectAssign({}, accumulator, {[currentValue]: newQueryParameters[currentValue] });
+                return Object.assign({}, accumulator, {[currentValue]: newQueryParameters[currentValue] });
             }, newParams);
             // set new options as parameters, merged with params
-            layer.setParams(removeNulls(objectAssign(newParams, newParams.params, addAuthenticationToSLD(newOptions.params || {}, newOptions))));
+            layer.setParams(removeNulls(Object.assign(newParams, newParams.params, addAuthenticationToSLD(newOptions.params || {}, newOptions))));
         }/* else if (!isEqual(newOptions.params, oldOptions.params)) {
             layer.setParams(newOptions.params);
         }*/

--- a/web/client/components/map/leaflet/plugins/WMTSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMTSLayer.js
@@ -9,7 +9,6 @@
 import Layers from '../../../../utils/leaflet/Layers';
 import {normalizeSRS} from '../../../../utils/CoordinatesUtils';
 import L from 'leaflet';
-import assign from 'object-assign';
 import {addAuthenticationParameter} from '../../../../utils/SecurityUtils';
 import { creditsToAttribution } from '../../../../utils/LayersUtils';
 import * as WMTSUtils from '../../../../utils/WMTSUtils';
@@ -25,7 +24,7 @@ function wmtsToLeafletOptions(options) {
     const srs = normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS);
     const attribution = options.credits && creditsToAttribution(options.credits) || '';
     const tileMatrixSet = WMTSUtils.getTileMatrixSet(options.tileMatrixSet, srs, options.allowedSRS, options.matrixIds);
-    return assign({
+    return Object.assign({
         requestEncoding: options.requestEncoding,
         layer: options.name,
         style: options.style || "",

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -19,7 +19,6 @@ import isNil from 'lodash/isNil';
 import castArray from 'lodash/castArray';
 
 import PropTypes from 'prop-types';
-import assign from 'object-assign';
 import uuid from 'uuid';
 import axios from '../../../libs/ajax';
 import {isSimpleGeomType, getSimpleGeomType} from '../../../utils/MapUtils';
@@ -303,7 +302,7 @@ export default class DrawSupport extends React.Component {
         if (newFeature && newFeature.features && newFeature.features.length) {
             // filtering invalid circles features or keep all when drawing is disabled
             const featuresFiltered = newFeature.features.filter(f => !f.properties.isCircle || f.properties.isCircle && !f.properties.canEdit || !newProps.options.drawEnabled);
-            return this.addFeatures(assign({}, newProps, {features: [{...newFeature, features: featuresFiltered }]}));
+            return this.addFeatures(Object.assign({}, newProps, {features: [{...newFeature, features: featuresFiltered }]}));
         }
         return this.addFeatures(newProps);
 
@@ -704,13 +703,13 @@ export default class DrawSupport extends React.Component {
                 }
                 let properties = this.props.features[0].properties;
                 if (drawMethod === "Text") {
-                    properties = assign({}, this.props.features[0].properties, {
+                    properties = Object.assign({}, this.props.features[0].properties, {
                         textValues: (this.props.features[0].properties.textValues || []).concat(["."]),
                         textGeometriesIndexes: (this.props.features[0].properties.textGeometriesIndexes || []).concat([sketchFeature.getGeometry().getGeometries().length - 1])
                     });
                 }
                 if (drawMethod === "Circle") {
-                    properties = assign({}, properties, {
+                    properties = Object.assign({}, properties, {
                         circles: (this.props.features[0].properties.circles || []).concat([sketchFeature.getGeometry().getGeometries().length - 1])
                     });
                 }
@@ -750,7 +749,7 @@ export default class DrawSupport extends React.Component {
                 } else {
                     this.props.onChangeDrawingStatus('replace', this.props.drawMethod, this.props.drawOwner,
                         newFeatures.map((f) => reprojectGeoJson(f, "EPSG:4326", this.getMapCrs())),
-                        assign({}, this.props.options, { featureProjection: this.getMapCrs()}));
+                        Object.assign({}, this.props.options, { featureProjection: this.getMapCrs()}));
                 }
                 if (this.selectInteraction) {
                     // TODO update also the selected features
@@ -795,7 +794,7 @@ export default class DrawSupport extends React.Component {
             } else {
                 this.props.onChangeDrawingStatus('replace', this.props.drawMethod, this.props.drawOwner,
                     features.map((f) => reprojectGeoJson(f, "EPSG:4326", this.getMapCrs())),
-                    assign({}, this.props.options, { featureProjection: this.getMapCrs()}));
+                    Object.assign({}, this.props.options, { featureProjection: this.getMapCrs()}));
             }
             // restore select interaction if it was disabled
             if (this.selectInteraction) {
@@ -901,7 +900,7 @@ export default class DrawSupport extends React.Component {
         }
         default: return {};
         }
-        return assign({}, drawBaseProps, roiProps);
+        return Object.assign({}, drawBaseProps, roiProps);
     };
 
     setDoubleClickZoomEnabled = (enabled) => {
@@ -919,7 +918,7 @@ export default class DrawSupport extends React.Component {
         const movedFeatures = event.features.getArray();
         const updatedFeatures = this.props.features.map((f) => {
             const moved = head(movedFeatures.filter((mf) => this.fromOLFeature(mf).id === f.id));
-            return moved ? assign({}, f, {
+            return moved ? Object.assign({}, f, {
                 geometry: moved.geometry,
                 center: moved.center,
                 extent: moved.extent,
@@ -1106,10 +1105,10 @@ export default class DrawSupport extends React.Component {
         });
 
         if (allHaveFeatures) {
-            props = assign({}, newProps, {features: newFeatures});
+            props = Object.assign({}, newProps, {features: newFeatures});
         } else {
             if (allHaveCircleProperty) {
-                props = assign({}, newProps, {features: []});
+                props = Object.assign({}, newProps, {features: []});
             } else {
                 const fts = newFeatures.reduce((pre, curr) => {
                     if (curr.geometry) {
@@ -1117,7 +1116,7 @@ export default class DrawSupport extends React.Component {
                     }
                     return pre;
                 }, []);
-                props = assign({}, newProps, {features: fts});
+                props = Object.assign({}, newProps, {features: fts});
             }
         }
 
@@ -1201,7 +1200,7 @@ export default class DrawSupport extends React.Component {
                     selected = selectedFeatures.reduce((previous, current) => {
                         return current.get('id') === f.id ? true : previous;
                     }, false);
-                    return assign({}, f, { selected: selected, selectedFeature: evt.selected });
+                    return Object.assign({}, f, { selected: selected, selectedFeature: evt.selected });
                 });
                 this.props.onSelectFeatures(featuresSelected);
             }
@@ -1332,7 +1331,7 @@ export default class DrawSupport extends React.Component {
                     radius = this.calculateRadius(center, coordinates);
                 }
             }
-            return assign({}, {
+            return Object.assign({}, {
                 id: feature.get('id'),
                 type,
                 extent,
@@ -1365,7 +1364,7 @@ export default class DrawSupport extends React.Component {
             } else {
                 radius = 0;
             }
-            return assign({}, {
+            return Object.assign({}, {
                 id: feature.get('id'),
                 type: g.getType(),
                 extent,
@@ -1376,7 +1375,7 @@ export default class DrawSupport extends React.Component {
                 projection: this.getMapCrs()
             });
         });
-        return assign({}, {
+        return Object.assign({}, {
             type: "Feature",
             id: feature.get('id'),
             style: this.fromOlStyle(feature.getStyle()),

--- a/web/client/components/map/openlayers/LegacyVectorStyle.js
+++ b/web/client/components/map/openlayers/LegacyVectorStyle.js
@@ -8,8 +8,6 @@ import isString from 'lodash/isString';
 import isArray from 'lodash/isArray';
 import isNil from 'lodash/isNil';
 
-import assign from 'object-assign';
-
 import {colorToRgbaStr} from '../../../utils/ColorUtils';
 import {set} from '../../../utils/ImmutableUtils';
 
@@ -216,24 +214,24 @@ const defaultOLStyles = {
     'Point': () => [new Style({
         image: image
     })],
-    'LineString': options => [new Style(assign({},
+    'LineString': options => [new Style(Object.assign({},
         strokeStyle(options, {color: 'blue', width: 3})
     ))],
-    'MultiLineString': options => [new Style(assign({},
+    'MultiLineString': options => [new Style(Object.assign({},
         strokeStyle(options, {color: 'blue', width: 3})
     ))],
     'MultiPoint': () => [new Style({
         image: image
     })],
-    'MultiPolygon': options => [new Style(assign({},
+    'MultiPolygon': options => [new Style(Object.assign({},
         strokeStyle(options),
         fillStyle(options)
     ))],
-    'Polygon': options => [new Style(assign({},
+    'Polygon': options => [new Style(Object.assign({},
         strokeStyle(options),
         fillStyle(options)
     ))],
-    'GeometryCollection': options => [new Style(assign({},
+    'GeometryCollection': options => [new Style(Object.assign({},
         strokeStyle(options),
         fillStyle(options),
         {image: new Circle({
@@ -462,7 +460,7 @@ export function getStyle(options, isDrawing = false, textValues = []) {
 
         if (geomType === "Point" || geomType === "MultiPoint") {
             style = {
-                image: new Circle(assign({}, style, {radius: options.style.radius || 5}))
+                image: new Circle(Object.assign({}, style, {radius: options.style.radius || 5}))
             };
         }
         if (options.style.iconUrl || options.style.iconGlyph) {

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -18,7 +18,6 @@ import proj4 from 'proj4';
 import { register } from 'ol/proj/proj4.js';
 import PropTypes from 'prop-types';
 import React from 'react';
-import assign from 'object-assign';
 
 import {reproject, reprojectBbox, normalizeLng, normalizeSRS } from '../../../utils/CoordinatesUtils';
 import { getProjection as msGetProjection }  from '../../../utils/ProjectionUtils';
@@ -113,7 +112,7 @@ class OpenlayersMap extends React.Component {
         register(proj4);
         // interactive flag is used only for initializations,
         // TODO manage it also when it changes status (ComponentWillReceiveProps)
-        let interactionsOptions = assign(
+        let interactionsOptions = Object.assign(
             this.props.interactive ?
                 {} :
                 {
@@ -128,7 +127,7 @@ class OpenlayersMap extends React.Component {
                 },
             this.props.mapOptions.interactions);
 
-        let interactions = defaults(assign({
+        let interactions = defaults(Object.assign({
             dragPan: false,
             mouseWheelZoom: false
         }, interactionsOptions, {}));
@@ -144,9 +143,9 @@ class OpenlayersMap extends React.Component {
                 this.mouseWheelInteraction
             ]);
         }
-        let controls = defaultControls(assign({
+        let controls = defaultControls(Object.assign({
             zoom: this.props.zoomControl,
-            attributionOptions: assign({
+            attributionOptions: Object.assign({
                 collapsible: false
             }, this.props.mapOptions.attribution && this.props.mapOptions.attribution.container ? {
                 target: this.getDocument().querySelector(this.props.mapOptions.attribution.container)
@@ -515,12 +514,12 @@ class OpenlayersMap extends React.Component {
     createView = (center, zoom, projection, options, limits = {}) => {
         // limit has a crs defined
         const extent = limits.restrictedExtent && limits.crs && reprojectBbox(limits.restrictedExtent, limits.crs, normalizeSRS(projection));
-        const newOptions = !options || (options && !options.view) ? assign({}, options, { extent }) : assign({}, options);
+        const newOptions = !options || (options && !options.view) ? Object.assign({}, options, { extent }) : Object.assign({}, options);
         /*
         * setting the zoom level in the localConfig file is co-related to the projection extent(size)
         * it is recommended to use projections with the same coverage area (extent). If you want to have the same restricted zoom level (minZoom)
         */
-        const viewOptions = assign({}, {
+        const viewOptions = Object.assign({}, {
             projection: normalizeSRS(projection),
             center: [center.x, center.y],
             zoom: zoom,

--- a/web/client/components/map/openlayers/Overview.jsx
+++ b/web/client/components/map/openlayers/Overview.jsx
@@ -8,7 +8,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Layers from '../../../utils/openlayers/Layers';
-import assign from 'object-assign';
 import isFinite from 'lodash/isFinite';
 
 import OverviewMap from 'ol/control/OverviewMap';
@@ -44,7 +43,7 @@ export default class Overview extends React.Component {
         this.props.layers.forEach((layerOpt) => {
             olLayers.push(Layers.createLayer(layerOpt.type, layerOpt.options || {}));
         });
-        let opt = assign({}, defaultOpt, this.props.overviewOpt, {layers: olLayers});
+        let opt = Object.assign({}, defaultOpt, this.props.overviewOpt, {layers: olLayers});
         this.overview = new OverviewMap(opt);
         if (this.props.map) {
             this.overview.setMap(this.props.map);

--- a/web/client/components/map/openlayers/ScaleBar.jsx
+++ b/web/client/components/map/openlayers/ScaleBar.jsx
@@ -8,7 +8,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import assign from 'object-assign';
 import ScaleLine from 'ol/control/ScaleLine';
 
 export default class ScaleBar extends React.Component {
@@ -28,7 +27,7 @@ export default class ScaleBar extends React.Component {
     };
 
     componentDidMount() {
-        this.scalebar = new ScaleLine(assign({}, this.props, this.props.container ? {
+        this.scalebar = new ScaleLine(Object.assign({}, this.props, this.props.container ? {
             target: document.querySelector(this.props.container)
         } : {}));
         if (this.props.map) {

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import expect from 'expect';
-import assign from 'object-assign';
 import DrawSupport from '../DrawSupport';
 import {DEFAULT_ANNOTATIONS_STYLES} from '../../../../plugins/Annotations/utils/AnnotationsUtils';
 import {circle, geomCollFeature} from '../../../../test-resources/drawsupport/features';
@@ -1573,7 +1572,7 @@ describe('Test DrawSupport', () => {
         };
         ReactDOM.render(<DrawSupport {...properties}/>, document.getElementById("container"));
 
-        let newProps = assign({}, properties, {
+        let newProps = Object.assign({}, properties, {
             features: [{
                 center: {x: -11271098, y: 7748880},
                 coordinates: [-11271098, 7748880],

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -10,7 +10,6 @@ import ReactDOM from 'react-dom';
 import expect from 'expect';
 import OpenlayersLayer from '../Layer';
 import { waitFor } from '@testing-library/react';
-import assign from 'object-assign';
 import Layers from '../../../../utils/openlayers/Layers';
 import '../plugins/OSMLayer';
 import '../plugins/WMSLayer';
@@ -702,7 +701,7 @@ describe('Openlayers layer', () => {
                 width = parseInt(src.match(/WIDTH=([0-9]+)/i)[1], 10);
                 layer = ReactDOM.render(
                     <OpenlayersLayer type="wms"
-                        options={assign({}, options, {
+                        options={Object.assign({}, options, {
                             ratio: 2
                         })} map={map} />, document.getElementById("container"));
                 map.getLayers().item(0).getSource().setImageLoadFunction(loadFun);
@@ -1600,7 +1599,7 @@ describe('Openlayers layer', () => {
         expect(div).toBeTruthy();
 
         // if only one layer for google exists, the div will be hidden
-        let newOpts = assign({}, options, {visibility: false});
+        let newOpts = Object.assign({}, options, {visibility: false});
         layer = ReactDOM.render(
             <OpenlayersLayer type="google" options={newOpts} map={map} mapId="map"/>, document.getElementById("container"));
         expect(div.style.visibility).toBe('hidden');
@@ -1748,7 +1747,7 @@ describe('Openlayers layer', () => {
 
         layer = ReactDOM.render(
             <OpenlayersLayer type="wms"
-                options={assign({}, options, {opacity: 0.5})} map={map}/>, document.getElementById("container"));
+                options={Object.assign({}, options, {opacity: 0.5})} map={map}/>, document.getElementById("container"));
 
         expect(layer.layer.getOpacity()).toBe(0.5);
     });
@@ -1808,7 +1807,7 @@ describe('Openlayers layer', () => {
 
         layer = ReactDOM.render(
             <OpenlayersLayer type="wms" observables={["cql_filter"]}
-                options={assign({}, options, {params: {cql_filter: "EXCLUDE"}})} map={map}/>, document.getElementById("container"));
+                options={Object.assign({}, options, {params: {cql_filter: "EXCLUDE"}})} map={map}/>, document.getElementById("container"));
         expect(layer.layer.getSource().getParams().cql_filter).toBe("EXCLUDE");
     });
     it('changes wms params causes cache drop', () => {
@@ -1841,7 +1840,7 @@ describe('Openlayers layer', () => {
 
         layer = ReactDOM.render(
             <OpenlayersLayer type="wms" observables={["cql_filter"]}
-                options={assign({}, options, { params: { cql_filter: "EXCLUDE" } })} map={map} />, document.getElementById("container"));
+                options={Object.assign({}, options, { params: { cql_filter: "EXCLUDE" } })} map={map} />, document.getElementById("container"));
         expect(source.getParams().cql_filter).toBe("EXCLUDE");
 
         // this prevents old cache to be rendered while loading
@@ -1877,7 +1876,7 @@ describe('Openlayers layer', () => {
 
         layer = ReactDOM.render(
             <OpenlayersLayer type="wms" observables={["cql_filter"]}
-                options={assign({}, options, { params: { time: "2019-01-01T00:00:00Z", ...options.params } })} map={map} />, document.getElementById("container"));
+                options={Object.assign({}, options, { params: { time: "2019-01-01T00:00:00Z", ...options.params } })} map={map} />, document.getElementById("container"));
 
         expect(spy).toHaveBeenCalled();
         expect(source.getParams().time).toBe("2019-01-01T00:00:00Z");
@@ -1910,7 +1909,7 @@ describe('Openlayers layer', () => {
 
         layer = ReactDOM.render(
             <OpenlayersLayer type="wms"
-                options={assign({}, options, { format: "image/jpeg" })} map={map} />, document.getElementById("container"));
+                options={Object.assign({}, options, { format: "image/jpeg" })} map={map} />, document.getElementById("container"));
 
         expect(layer.layer.getSource().getParams().STYLES).toBe("");
     });

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -13,8 +13,6 @@ import OpenlayersLayer from '../Layer';
 import OpenlayersMap from '../Map';
 import { DEFAULT_INTERACTION_OPTIONS } from '../../../../utils/openlayers/DrawUtils';
 
-import assign from 'object-assign';
-
 import proj from 'proj4';
 import MapUtils from '../../../../utils/MapUtils';
 
@@ -663,10 +661,10 @@ describe('OpenlayersMap', () => {
             />
             , document.getElementById("map"));
 
-        let origProps = assign({}, map.props);
+        let origProps = Object.assign({}, map.props);
         function testProps(newProps) {
             // update original props with newProps
-            return assign({}, origProps, newProps);
+            return Object.assign({}, origProps, newProps);
         }
 
         map = ReactDOM.render(
@@ -740,10 +738,10 @@ describe('OpenlayersMap', () => {
             />
             , document.getElementById("map"));
 
-        let origProps = assign({}, map.props);
+        let origProps = Object.assign({}, map.props);
         function testProps(newProps) {
             // update original props with newProps
-            return assign({}, origProps, newProps);
+            return Object.assign({}, origProps, newProps);
         }
 
         map = ReactDOM.render(

--- a/web/client/components/map/openlayers/plugins/MarkerLayer.js
+++ b/web/client/components/map/openlayers/plugins/MarkerLayer.js
@@ -7,7 +7,6 @@
  */
 
 import Layers from '../../../../utils/openlayers/Layers';
-import assign from 'object-assign';
 import defaultIcon from '../img/marker-icon.png';
 import {Style, Icon} from 'ol/style';
 
@@ -31,7 +30,7 @@ const defaultStyles = {
  */
 Layers.registerType('marker', {
     create: (options, map, mapId) => {
-        return Layers.createLayer('vector', assign(options, {style: () => { return defaultStyles.Point; }}), map, mapId);
+        return Layers.createLayer('vector', Object.assign(options, {style: () => { return defaultStyles.Point; }}), map, mapId);
 
     }
 });

--- a/web/client/components/map/openlayers/plugins/TileProviderLayer.js
+++ b/web/client/components/map/openlayers/plugins/TileProviderLayer.js
@@ -5,7 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import assign from 'object-assign';
 import Layers from '../../../../utils/openlayers/Layers';
 import TileProvider from '../../../../utils/TileConfigProvider';
 import CoordinatesUtils from '../../../../utils/CoordinatesUtils';
@@ -19,14 +18,14 @@ function lBoundsToOlExtent(bounds, destPrj) {
 }
 function tileXYZToOpenlayersOptions(options) {
     let urls = options.url.match(/(\{s\})/) ? getUrls(options) : [template(options.url, options)];
-    let sourceOpt = assign({}, {
+    let sourceOpt = Object.assign({}, {
         urls: urls,
         attributions: options.attribution ? [options.attribution] : [],
         maxZoom: options.maxZoom ? options.maxZoom : 18,
         minZoom: options.minZoom ? options.minZoom : 0 // dosen't affect ol layer rendering UNSUPPORTED
     });
     let source = new XYZ(sourceOpt);
-    let olOpt = assign({}, {
+    let olOpt = Object.assign({}, {
         msId: options.id,
         opacity: options.opacity !== undefined ? options.opacity : 1,
         visible: options.visibility !== false,

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -11,7 +11,6 @@ import isNil from 'lodash/isNil';
 import isEqual from 'lodash/isEqual';
 import union from 'lodash/union';
 import isArray from 'lodash/isArray';
-import assign from 'object-assign';
 import axios from '../../../../libs/ajax';
 import CoordinatesUtils from '../../../../utils/CoordinatesUtils';
 import { getProjection } from '../../../../utils/ProjectionUtils';
@@ -273,10 +272,10 @@ Layers.registerType('wms', {
             }
 
             if (changed) {
-                const params = assign(newParams, addAuthenticationToSLD(optionsToVendorParams(newOptions) || {}, newOptions));
+                const params = Object.assign(newParams, addAuthenticationToSLD(optionsToVendorParams(newOptions) || {}, newOptions));
 
-                wmsSource.updateParams(assign(params, Object.keys(oldParams || {}).reduce((previous, key) => {
-                    return !isNil(params[key]) ? previous : assign(previous, {
+                wmsSource.updateParams(Object.assign(params, Object.keys(oldParams || {}).reduce((previous, key) => {
+                    return !isNil(params[key]) ? previous : Object.assign(previous, {
                         [key]: undefined
                     });
                 }, {})));

--- a/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
+++ b/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
 */
 import expect from 'expect';
-import assign from 'object-assign';
 import React from 'react';
 import {DragDropContext as dragDropContext} from 'react-dnd';
 import testBackend from 'react-dnd-test-backend';
@@ -208,17 +207,17 @@ describe("test the MeasureComponent", () => {
         expect(bearingSpan.innerHTML).toBe("N 45° 0' 0'' E");
 
         cmp = ReactDOM.render(
-            <MeasureComponent measurement={assign({}, measurement, {bearing: 135})} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
+            <MeasureComponent measurement={Object.assign({}, measurement, {bearing: 135})} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
         );
         expect(bearingSpan.innerHTML).toBe("S 45° 0' 0'' E");
 
         cmp = ReactDOM.render(
-            <MeasureComponent measurement={assign({}, measurement, {bearing: 225})} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
+            <MeasureComponent measurement={Object.assign({}, measurement, {bearing: 225})} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
         );
         expect(bearingSpan.innerHTML).toBe("S 45° 0' 0'' W");
 
         cmp = ReactDOM.render(
-            <MeasureComponent measurement={assign({}, measurement, {bearing: 315})} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
+            <MeasureComponent measurement={Object.assign({}, measurement, {bearing: 315})} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
         );
         expect(bearingSpan.innerHTML).toBe("N 45° 0' 0'' W");
     });
@@ -264,7 +263,7 @@ describe("test the MeasureComponent", () => {
         expect(bearingSpan.innerHTML).toBe("225.83°");
 
         cmp = ReactDOM.render(
-            <MeasureComponent measurement={assign({}, measurement, {bearing: 315})} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
+            <MeasureComponent measurement={Object.assign({}, measurement, {bearing: 315})} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
         );
         expect(bearingSpan.innerHTML).toBe("315°");
     });
@@ -307,7 +306,7 @@ describe("test the MeasureComponent", () => {
                     length: {unit: 'km', label: 'km'},
                     area: {unit: 'sqkm', label: 'km²'}
                 }}
-                measurement={assign({}, measurement, {len: 10000})}/>, document.getElementById("container")
+                measurement={Object.assign({}, measurement, {len: 10000})}/>, document.getElementById("container")
         );
         expect(lenSpan.firstChild.innerHTML).toBe("10");
 
@@ -318,7 +317,7 @@ describe("test the MeasureComponent", () => {
                 uom={{
                     length: {unit: 'km', label: 'km'},
                     area: {unit: 'sqkm', label: 'km²'}
-                }} measurement={assign({}, measurement, {geomType: 'Polygon', area: 1000000})}/>, document.getElementById("container")
+                }} measurement={Object.assign({}, measurement, {geomType: 'Polygon', area: 1000000})}/>, document.getElementById("container")
         );
         const areaSpan = document.getElementById('measure-area-res');
         expect(areaSpan).toExist();

--- a/web/client/components/resources/modals/fragments/PermissionEditor.jsx
+++ b/web/client/components/resources/modals/fragments/PermissionEditor.jsx
@@ -7,7 +7,6 @@
 */
 
 import {find, findIndex, head} from 'lodash';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Glyphicon, Table } from 'react-bootstrap';
@@ -81,9 +80,9 @@ class PermissionEditor extends React.Component {
                 (rule) => {
                     if (rule.group && rule.group.groupName === this.props.newGroup.groupName) {
                         if (this.props.newPermission === "canWrite") {
-                            return assign({}, rule, { canRead: true, canWrite: true });
+                            return Object.assign({}, rule, { canRead: true, canWrite: true });
                         }
-                        return assign({}, rule, { canRead: true, canWrite: false });
+                        return Object.assign({}, rule, { canRead: true, canWrite: false });
                     }
                     return rule;
                 }, this
@@ -107,11 +106,11 @@ class PermissionEditor extends React.Component {
                 (rule) => {
                     if (rule.group && rule.group.groupName === groupName) {
                         if (input === "canWrite") {
-                            return assign({}, rule, { canRead: true, canWrite: true });
+                            return Object.assign({}, rule, { canRead: true, canWrite: true });
                         } else if (input === "canRead") {
-                            return assign({}, rule, { canRead: true, canWrite: false });
+                            return Object.assign({}, rule, { canRead: true, canWrite: false });
                         }
-                        return assign({}, rule, { canRead: false, canWrite: false });
+                        return Object.assign({}, rule, { canRead: false, canWrite: false });
                     }
                     return rule;
                 }

--- a/web/client/components/style/ThemaClassesEditor.jsx
+++ b/web/client/components/style/ThemaClassesEditor.jsx
@@ -16,7 +16,6 @@ import isNil from 'lodash/isNil';
 import numberLocalizer from 'react-widgets/lib/localizers/simple-number';
 numberLocalizer();
 import { NumberPicker } from 'react-widgets';
-import assign from 'object-assign';
 import Message from "../../components/I18N/Message";
 import { createPagedUniqueAutompleteStream } from '../../observables/autocomplete';
 import { AutocompleteCombobox } from '../../components/misc/AutocompleteCombobox';
@@ -167,7 +166,7 @@ class ThemaClassesEditor extends React.Component {
     updateColor = (classIndex, color) => {
         if (color) {
             const newClassification = this.props.classification.map((classItem, index) => {
-                return index === classIndex ? assign({}, classItem, {
+                return index === classIndex ? Object.assign({}, classItem, {
                     color
                 }) : classItem;
             });
@@ -178,7 +177,7 @@ class ThemaClassesEditor extends React.Component {
     updateUnique = (classIndex, unique, type = 'text') => {
         const newClassification = this.props.classification.map((classItem, index) => {
             if (index === classIndex) {
-                return assign({}, classItem, {
+                return Object.assign({}, classItem, {
                     unique: isNil(unique) ? type === 'number' ? 0 : '' : unique
                 });
             }
@@ -191,7 +190,7 @@ class ThemaClassesEditor extends React.Component {
         const fieldProp = type === 'number' ? 'quantity' : 'label';
         const newClassification = this.props.classification.map((classItem, index) => {
             if (index === classIndex) {
-                return assign({}, classItem, {
+                return Object.assign({}, classItem, {
                     [fieldProp]: value
                 });
             }
@@ -204,7 +203,7 @@ class ThemaClassesEditor extends React.Component {
         if (!isNaN(min)) {
             const newClassification = this.props.classification.map((classItem, index) => {
                 if (index === classIndex) {
-                    return assign({}, classItem, {
+                    return Object.assign({}, classItem, {
                         min
                     });
                 }
@@ -218,12 +217,12 @@ class ThemaClassesEditor extends React.Component {
         if (!isNaN(max)) {
             const newClassification = this.props.classification.map((classItem, index) => {
                 if (index === classIndex) {
-                    return assign({}, classItem, {
+                    return Object.assign({}, classItem, {
                         max
                     });
                 }
                 if (index === (classIndex + 1)) {
-                    return assign({}, classItem, {
+                    return Object.assign({}, classItem, {
                         min: max
                     });
                 }
@@ -276,7 +275,7 @@ class ThemaClassesEditor extends React.Component {
     updateCustomLabel = (classIndex, value) => {
         if (value !== undefined) {
             const newClassification = this.props.classification.map((classItem, index) => {
-                return index === classIndex ? assign({}, classItem, {
+                return index === classIndex ? Object.assign({}, classItem, {
                     title: value
                 }) : classItem;
             });

--- a/web/client/components/tutorial/Tutorial.jsx
+++ b/web/client/components/tutorial/Tutorial.jsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Joyride from 'react-joyride';
 import I18N from '../I18N/I18N';
-import assign from 'object-assign';
 import { head } from 'lodash';
 import Portal from '../misc/Portal';
 import 'react-joyride/lib/react-joyride-compiled.css';
@@ -131,7 +130,7 @@ class Tutorial extends React.Component {
     componentDidMount() {
         let defaultSteps = this.props.presetList[this.props.preset] || [];
         let checkbox = this.props.showCheckbox ? <div id="tutorial-intro-checkbox-container"><input type="checkbox" id="tutorial-intro-checkbox" className="tutorial-tooltip-intro-checkbox" onChange={this.props.actions.onDisable}/><span><I18N.Message msgId={"tutorial.checkbox"}/></span></div> : <div id="tutorial-intro-checkbox-container"/>;
-        this.props.actions.onSetup('default', defaultSteps, this.props.introStyle, checkbox, this.props.defaultStep, assign({}, this.props.presetList, {default_tutorial: defaultSteps}));
+        this.props.actions.onSetup('default', defaultSteps, this.props.introStyle, checkbox, this.props.defaultStep, Object.assign({}, this.props.presetList, {default_tutorial: defaultSteps}));
     }
 
     UNSAFE_componentWillUpdate(newProps, newState) {

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -8,7 +8,6 @@
 
 import expect from 'expect';
 
-import assign from 'object-assign';
 import { set } from '../../utils/ImmutableUtils';
 import CoordinatesUtils from '../../utils/CoordinatesUtils';
 import {
@@ -694,7 +693,7 @@ describe('featuregrid Epics', () => {
         };
         CoordinatesUtils.getProjUrl = () => "base/web/client/test-resources/wms/projDef_3044.txt";
 
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
         testEpic(startSyncWmsFilter, 1, toggleSyncWms(), actions => {
             expect(actions.length).toBe(1);
             actions.map((action) => {
@@ -801,7 +800,7 @@ describe('featuregrid Epics', () => {
             }
         };
 
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
         const epicResult = actions => {
             try {
                 expect(actions.length).toBe(1);
@@ -866,7 +865,7 @@ describe('featuregrid Epics', () => {
             editEnabled: true,
             drawEnabled: false };
 
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
         const epicResult = actions => {
             try {
                 expect(actions.length).toBe(1);
@@ -904,7 +903,7 @@ describe('featuregrid Epics', () => {
             }
         };
 
-        const newState = assign({}, stateWithGmlGeometry, stateFeaturegrid);
+        const newState = Object.assign({}, stateWithGmlGeometry, stateFeaturegrid);
 
         testEpic(addTimeoutEpic(triggerDrawSupportOnSelectionChange, 50), 1, toggleEditMode(), actions => {
             expect(actions.length).toBe(1);
@@ -1269,7 +1268,7 @@ describe('featuregrid Epics', () => {
                 changes: []
             }
         };
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
         testEpic(handleDrawFeature, 1, startDrawingFeature(), actions => {
             expect(actions.length).toBe(1);
             actions.map((action) => {
@@ -1299,7 +1298,7 @@ describe('featuregrid Epics', () => {
                 changes: []
             }
         };
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
         testEpic(handleEditFeature, 1, startEditingFeature(), actions => {
             expect(actions.length).toBe(1);
             actions.map((action) => {
@@ -1328,7 +1327,7 @@ describe('featuregrid Epics', () => {
                 changes: []
             }
         };
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
 
         testEpic(resetEditingOnFeatureGridClose, 1, [openFeatureGrid(), toggleEditMode(), closeFeatureGrid()], actions => {
             expect(actions.length).toBe(1);
@@ -1359,7 +1358,7 @@ describe('featuregrid Epics', () => {
                 changes: []
             }
         };
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
 
         testEpic(onFeatureGridGeometryEditing, 1, [geometryChanged([{id: 'polygons.1', geometry: { type: 'Polygon', coordinates: [[[-180, 90], [180, 90], [180, -90], [-180, 90]]]}, geometry_name: 'geometry' }], 'featureGrid', '')], actions => {
             expect(actions.length).toBe(1);
@@ -1393,7 +1392,7 @@ describe('featuregrid Epics', () => {
                 changes: []
             }
         };
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
 
         testEpic(onFeatureGridGeometryEditing, 2, [geometryChanged([{id: 'polygons.1', geometry: { type: 'Polygon', coordinates: [[[-180, 90], [180, 90], [180, -90], [-180, 90]]]}, geometry_name: 'geometry' }], 'featureGrid', 'enterEditMode')], actions => {
             expect(actions.length).toBe(2);
@@ -1449,7 +1448,7 @@ describe('featuregrid Epics', () => {
                 filterObj: {}
             }
         };
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
 
         testEpic(addTimeoutEpic(syncMapWmsFilter), 1, [{type: UPDATE_QUERY}, {type: START_SYNC_WMS}], actions => {
             expect(actions.length).toBe(1);
@@ -1492,7 +1491,7 @@ describe('featuregrid Epics', () => {
                 syncWmsFilter: true
             }
         };
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
         testEpic(startSyncWmsFilter, 1, toggleSyncWms(), actions => {
             expect(actions.length).toBe(1);
             actions.map((action) => {
@@ -1538,7 +1537,7 @@ describe('featuregrid Epics', () => {
             }
         };
 
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
         testEpic(onOpenAdvancedSearch, 4, [openAdvancedSearch(), toggleControl('queryPanel', 'enabled')], actions => {
             expect(actions.length).toBe(4);
             actions.map((action) => {
@@ -1579,7 +1578,7 @@ describe('featuregrid Epics', () => {
             }
         };
 
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
         testEpic(virtualScrollLoadFeatures, 1, [moreFeatures({startPage: 0, endPage: 2})], actions => {
 
             expect(actions.length).toBe(1);
@@ -1622,7 +1621,7 @@ describe('featuregrid Epics', () => {
             }
         };
 
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
         testEpic(virtualScrollLoadFeatures, 1, [moreFeatures({ startPage: 0, endPage: 2 })], actions => {
 
             expect(actions.length).toBe(1);
@@ -1656,7 +1655,7 @@ describe('featuregrid Epics', () => {
                 features: []
             }
         };
-        const newState = assign({}, state, stateFeaturegrid);
+        const newState = Object.assign({}, state, stateFeaturegrid);
         testEpic(virtualScrollLoadFeatures, 2, [moreFeatures({startPage: 0, endPage: 2}), querySearchResponse({features: Array(30)}, " ", {pagination: {startIndex: 0, maxFeatures: 30}})], actions => {
             expect(actions.length).toBe(2);
             actions.map((action) => {

--- a/web/client/epics/__tests__/localconfig-test.js
+++ b/web/client/epics/__tests__/localconfig-test.js
@@ -10,14 +10,13 @@ import { SUPPORTED_LOCALES_REGISTERED, localConfigLoaded } from '../../actions/l
 
 import {getSupportedLocales} from '../../utils/LocaleUtils';
 import expect from 'expect';
-import assign from 'object-assign';
 import { testEpic } from './epicTestUtils';
 import { setSupportedLocales } from '../localconfig';
 
 describe('localconfig Epics', () => {
 
     it('test load of supported locales with no locales', (done) => {
-        const newState = assign({});
+        const newState = Object.assign({});
 
         testEpic(setSupportedLocales, 1, localConfigLoaded(newState), actions => {
             expect(actions.length).toBe(1);
@@ -41,7 +40,7 @@ describe('localconfig Epics', () => {
                 description: "Italiano"
             }
         };
-        const newState = assign({
+        const newState = Object.assign({
             initialState: {
                 defaultState: {
                     locales: {

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -13,7 +13,6 @@ import axios from '../libs/ajax';
 import bbox from '@turf/bbox';
 import { createChangesTransaction, getDefaultFeatureProjection, getPagesToLoad, gridUpdateToQueryUpdate, updatePages  } from '../utils/FeatureGridUtils';
 
-import assign from 'object-assign';
 import {
     changeDrawingStatus,
     GEOMETRY_CHANGED,
@@ -180,7 +179,7 @@ const setupDrawSupport = (state, original) => {
     };
 
     let features = selectedFeaturesSelector(state).map(ft => {
-        let feature = assign({}, ft, {type: "Feature"});
+        let feature = Object.assign({}, ft, {type: "Feature"});
         if (!isEmpty(feature)) {
 
             // TODO check this WITH APPLY CHANGES
@@ -760,7 +759,7 @@ export const handleEditFeature = (action$, store) => action$.ofType(START_EDITIN
             editEnabled: true,
             drawEnabled: false
         };
-        let feature = assign({}, selectedFeatureSelector(state), {type: "Feature"});
+        let feature = Object.assign({}, selectedFeatureSelector(state), {type: "Feature"});
         let changes = changesMapSelector(state);
         if (changes[feature.id] && changes[feature.id] && changes[feature.id].geometry) {
             feature.geometry = changes[feature.id].geometry;
@@ -777,7 +776,7 @@ export const handleDrawFeature = (action$, store) => action$.ofType(START_DRAWIN
         const describe = describeSelector(state);
         const defaultFeatureProj = getDefaultFeatureProjection();
         const geomType = findGeometryProperty(describe).localType;
-        let feature = assign({}, selectedFeatureSelector(state), {type: "Feature"});
+        let feature = Object.assign({}, selectedFeatureSelector(state), {type: "Feature"});
         let changes = changesMapSelector(state);
         if (changes[feature.id] && (changes[feature.id].geometry || changes[feature.id].geometry === null)) {
             feature.geometry = changes[feature.id].geometry;
@@ -853,11 +852,11 @@ export const onFeatureGridGeometryEditing = (action$, store) => action$.ofType(G
         };
 
         let changedFeatures = a.features.map((ft, index) => {
-            return assign({}, ft, {id: selectedFeaturesSelector(state)[index].id, _new: selectedFeaturesSelector(state)[index]._new, type: "Feature"});
+            return Object.assign({}, ft, {id: selectedFeaturesSelector(state)[index].id, _new: selectedFeaturesSelector(state)[index]._new, type: "Feature"});
         });
 
         // use one of the features to get drawing method i.e. feature.geometry.type
-        let feature = assign({}, head(a.features), {id: selectedFeatureSelector(state).id, _new: selectedFeatureSelector(state)._new, type: "Feature"});
+        let feature = Object.assign({}, head(a.features), {id: selectedFeatureSelector(state).id, _new: selectedFeatureSelector(state)._new, type: "Feature"});
         let enableEdit = a.enableEdit === "enterEditMode" ? Rx.Observable.of(changeDrawingStatus("drawOrEdit", feature.geometry.type, "featureGrid", changedFeatures, drawOptions)) : Rx.Observable.empty();
 
         return Rx.Observable.of(geometryChanged(changedFeatures)).concat(enableEdit);
@@ -1037,7 +1036,7 @@ export const onOpenAdvancedSearch = (action$, store) =>
                     // merge advanced filter with columns filters
                         return Rx.Observable.of(
                             createQuery(action.searchUrl, action.filterObj),
-                            storeAdvancedSearchFilter(assign({}, queryFormUiStateSelector(store.getState()), action.filterObj)),
+                            storeAdvancedSearchFilter(Object.assign({}, queryFormUiStateSelector(store.getState()), action.filterObj)),
                             setControlProperty('queryPanel', "enabled", false),
                             openFeatureGrid(),
                             isSyncWmsActive(store.getState()) ? startSyncWMS() : Rx.Observable.empty()          // to keep sync icon active if it is previously active before opening advanced search

--- a/web/client/epics/layers.js
+++ b/web/client/epics/layers.js
@@ -25,12 +25,11 @@ import {
 import { getLayersWithDimension, layerSettingSelector, getLayerFromId } from '../selectors/layers';
 import { basicError } from '../utils/NotificationUtils';
 import { getCapabilitiesUrl, getLayerTitleTranslations, removeWorkspace } from '../utils/LayersUtils';
-import assign from 'object-assign';
 import { isArray, head } from 'lodash';
 
 export const getUpdates = (updates, options) => {
     return Object.keys(options).filter((opt) => options[opt]).reduce((previous, current) => {
-        return assign(previous, {
+        return Object.assign(previous, {
             [current]: updates[current]
         });
     }, {});
@@ -74,7 +73,7 @@ export const refresh = action$ =>
                         if (caps.error) {
                             return Rx.Observable.of(caps.error && caps);
                         }
-                        return Rx.Observable.of(assign({layer: layer.id, title: getLayerTitleTranslations(caps), bbox: Api.getBBox(caps, true), dimensions: Api.getDimensions(caps)}, (describe && !describe.error) ? {search: describe} : {}));
+                        return Rx.Observable.of(Object.assign({layer: layer.id, title: getLayerTitleTranslations(caps), bbox: Api.getBBox(caps, true), dimensions: Api.getDimensions(caps)}, (describe && !describe.error) ? {search: describe} : {}));
                     })
                 )
             )

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -9,7 +9,6 @@
 import * as Rx from 'rxjs';
 import toBbox from 'turf-bbox';
 import pointOnSurface from '@turf/point-on-surface';
-import assign from 'object-assign';
 import {isNil, sortBy} from 'lodash';
 import uuid from 'uuid';
 
@@ -133,8 +132,8 @@ export const searchItemSelected = (action$) =>
                         let staticFilter = generateTemplateString(item.__SERVICE__.geomService.options.staticFilter || "")(item);
                         // retrieve geometry from geomService or pass the item directly
                         return Rx.Observable.fromPromise(
-                            API.Utils.getService(item.__SERVICE__.geomService.type)("", assign({}, item.__SERVICE__.geomService.options, { staticFilter }))
-                                .then(res => assign({}, item, { geometry: CoordinatesUtils.mergeToPolyGeom(res) }))
+                            API.Utils.getService(item.__SERVICE__.geomService.type)("", Object.assign({}, item.__SERVICE__.geomService.options, { staticFilter }))
+                                .then(res => Object.assign({}, item, { geometry: CoordinatesUtils.mergeToPolyGeom(res) }))
                         );
                     }
                     return Rx.Observable.of(action.item);

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -35,7 +35,6 @@ import { authkeyParamNameSelector } from '../selectors/catalog';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
 import { addTimeParameter } from '../utils/WFSTimeUtils';
 import ConfigUtils from '../utils/ConfigUtils';
-import assign from 'object-assign';
 
 import {
     spatialFieldMethodSelector,
@@ -222,7 +221,7 @@ export const viewportSelectedEpic = (action$, store) =>
             || action.type === CHANGE_MAP_VIEW && spatialFieldMethodSelector(store.getState()) === "Viewport")
             && map.bbox && map.bbox.bounds && map.bbox.crs) {
                 const bounds = Object.keys(map.bbox.bounds).reduce((p, c) => {
-                    return assign({}, p, {[c]: parseFloat(map.bbox.bounds[c])});
+                    return Object.assign({}, p, {[c]: parseFloat(map.bbox.bounds[c])});
                 }, {});
                 return Rx.Observable.of(updateGeometrySpatialField(CoordinatesUtils.getViewportGeometry(bounds, map.bbox.crs)));
             }

--- a/web/client/jsapi/MapStore2.js
+++ b/web/client/jsapi/MapStore2.js
@@ -9,7 +9,6 @@
 import url from 'url';
 
 import { merge, partialRight } from 'lodash';
-import assign from 'object-assign';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
@@ -205,7 +204,7 @@ const MapStore2 = {
         });
         const initialActions = [...getInitialActions(options), loadVersion.bind(null, options.versionURL)];
         const appConfig = {
-            storeOpts: assign({}, storeOpts, {notify: true, noRouter: true}),
+            storeOpts: Object.assign({}, storeOpts, {notify: true, noRouter: true}),
             appStore,
             pluginsDef,
             initialActions,
@@ -225,7 +224,7 @@ const MapStore2 = {
             prefixContainer: '#' + container
         };
 
-        const themeCfg = options.theme && assign({}, defaultThemeCfg, options.theme) || defaultThemeCfg;
+        const themeCfg = options.theme && Object.assign({}, defaultThemeCfg, options.theme) || defaultThemeCfg;
         const onStoreInit = (store) => {
             store.addActionListener((action) => {
                 const act = action.type === "PERFORM_ACTION" && action.action || action; // Needed to works also in debug
@@ -329,7 +328,7 @@ const MapStore2 = {
      * MapStore2.withPlugins({...});
      */
     withPlugins: (plugins, options) => {
-        return assign({}, MapStore2, {create: partialRight(MapStore2.create, partialRight.placeholder, partialRight.placeholder, plugins), defaultOptions: options || {}});
+        return Object.assign({}, MapStore2, {create: partialRight(MapStore2.create, partialRight.placeholder, partialRight.placeholder, plugins), defaultOptions: options || {}});
     },
     /**
      * Triggers an action

--- a/web/client/libs/__tests__/ajax-test.js
+++ b/web/client/libs/__tests__/ajax-test.js
@@ -8,7 +8,6 @@
 
 import expect from 'expect';
 import axios from '../ajax';
-import assign from 'object-assign';
 import urlUtil from 'url';
 
 import ConfigUtils from "../../utils/ConfigUtils";
@@ -39,7 +38,7 @@ const securityInfoA = {
     user: userA
 };
 
-const userB = assign({}, userA, {
+const userB = Object.assign({}, userA, {
     name: "adminB",
     attribute: [{
         name: "UUID",

--- a/web/client/libs/ajax.js
+++ b/web/client/libs/ajax.js
@@ -16,7 +16,6 @@ import {
     getBasicAuthHeader
 } from '../utils/SecurityUtils';
 
-import assign from 'object-assign';
 import isObject from 'lodash/isObject';
 import omitBy from 'lodash/omitBy';
 import isNil from 'lodash/isNil';
@@ -28,7 +27,7 @@ import { getProxyCacheByUrl, setProxyCacheByUrl } from '../utils/ProxyUtils';
  */
 function addParameterToAxiosConfig(axiosConfig, parameterName, parameterValue) {
     // FIXME: the parameters can also be a URLSearchParams
-    axiosConfig.params = assign({}, axiosConfig.params, {[parameterName]: parameterValue});
+    axiosConfig.params = Object.assign({}, axiosConfig.params, {[parameterName]: parameterValue});
     // remove from URL auth parameters if any, to avoid possible duplication
     axiosConfig.url = axiosConfig.url ? ConfigUtils.getUrlWithoutParameters(axiosConfig.url, [parameterName]) : axiosConfig.url;
 }
@@ -37,7 +36,7 @@ function addParameterToAxiosConfig(axiosConfig, parameterName, parameterValue) {
  * Internal helper that adds or overrides an http header in a axios configuration.
  */
 function addHeaderToAxiosConfig(axiosConfig, headerName, headerValue) {
-    axiosConfig.headers = assign({}, axiosConfig.headers, {[headerName]: headerValue});
+    axiosConfig.headers = Object.assign({}, axiosConfig.headers, {[headerName]: headerValue});
 }
 
 /**
@@ -137,9 +136,9 @@ axios.interceptors.request.use(config => {
                 const params = omitBy(config.params, isNil);
                 config.url = proxyUrl + encodeURIComponent(
                     urlUtil.format(
-                        assign({}, parsedUri, {
+                        Object.assign({}, parsedUri, {
                             search: null,
-                            query: assign({}, parsedUri.query, params)
+                            query: Object.assign({}, parsedUri.query, params)
                         })
                     )
                 );

--- a/web/client/observables/__tests__/autocomplete-test.js
+++ b/web/client/observables/__tests__/autocomplete-test.js
@@ -11,7 +11,6 @@ import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { isEmpty } from 'lodash';
-import assign from 'object-assign';
 
 import {
     createPagedUniqueAutompleteStream,
@@ -58,7 +57,7 @@ describe('\nAutocomplete Observables', () => {
                 }
             })
         )(AutocompleteEditor);
-        const item = ReactDOM.render(<ReactItem {...assign({}, props)}/>, document.getElementById("container"));
+        const item = ReactDOM.render(<ReactItem {...Object.assign({}, props)}/>, document.getElementById("container"));
         expect(item).toExist();
     });
 
@@ -74,7 +73,7 @@ describe('\nAutocomplete Observables', () => {
                 }
             })
         )(AutocompleteEditor);
-        const item = ReactDOM.render(<ReactItem {...assign({}, props, {performFetch: true})}/>, document.getElementById("container"));
+        const item = ReactDOM.render(<ReactItem {...Object.assign({}, props, {performFetch: true})}/>, document.getElementById("container"));
         expect(item).toExist();
     });
 
@@ -89,7 +88,7 @@ describe('\nAutocomplete Observables', () => {
                 }
             })
         )(AutocompleteEditor);
-        const item = ReactDOM.render(<ReactItem {...assign({}, props, {performFetch: true, url: "wrong"})}/>, document.getElementById("container"));
+        const item = ReactDOM.render(<ReactItem {...Object.assign({}, props, {performFetch: true, url: "wrong"})}/>, document.getElementById("container"));
         expect(item).toExist();
     });
 
@@ -106,7 +105,7 @@ describe('\nAutocomplete Observables', () => {
                 }
             })
         )(() => <AutocompleteWFSCombobox autocompleteStreamFactory={createWFSFetchStream}/>);
-        const item = ReactDOM.render(<ReactItem {...assign({}, {
+        const item = ReactDOM.render(<ReactItem {...Object.assign({}, {
             url: "base/web/client/test-resources/wps/pageUniqueResponse.jsonwfs",
             "filterProps": {
                 "blacklist": [],
@@ -133,7 +132,7 @@ describe('\nAutocomplete Observables', () => {
                 }
             })
         )(() => <AutocompleteWFSCombobox autocompleteStreamFactory={createWFSFetchStream}/>);
-        const item = ReactDOM.render(<ReactItem {...assign({}, {
+        const item = ReactDOM.render(<ReactItem {...Object.assign({}, {
             url: "base/web/client/test-resources/wps/pageUniqueResponse.jsonwfs",
             "filterProps": {
                 "blacklist": [],

--- a/web/client/observables/autocomplete.js
+++ b/web/client/observables/autocomplete.js
@@ -15,7 +15,6 @@
 import url from 'url';
 
 import { endsWith, head, isNil } from 'lodash';
-import assign from 'object-assign';
 import Rx from 'rxjs';
 
 import {API} from '../api/searchText';
@@ -79,8 +78,8 @@ export const createWFSFetchStream = (props$) =>
                 if ( !!parsed.query && !!parsed.query.service) {
                     delete parsed.query.service;
                 }
-                const urlParsed = url.format(assign({}, parsed, {search: null, pathname: newPathname }));
-                let serviceOptions = assign({}, {
+                const urlParsed = url.format(Object.assign({}, parsed, {search: null, pathname: newPathname }));
+                let serviceOptions = Object.assign({}, {
                     url: urlParsed,
                     typeName: p.filterProps && p.filterProps.typeName || "",
                     predicate: p.filterProps && p.filterProps.predicate || "ILIKE",

--- a/web/client/plugins/BurgerMenu.jsx
+++ b/web/client/plugins/BurgerMenu.jsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import assign from 'object-assign';
 import { DropdownButton, Glyphicon, MenuItem } from 'react-bootstrap';
 
 import tooltip from "../components/misc/enhancers/tooltip";
@@ -120,7 +119,7 @@ class BurgerMenu extends React.Component {
 
     getPanels = items => {
         return items.filter((item) => item.panel)
-            .map((item) => assign({}, item, {panel: item.panel === true ? item.plugin : item.panel})).concat(
+            .map((item) => Object.assign({}, item, {panel: item.panel === true ? item.plugin : item.panel})).concat(
                 items.filter((item) => item.tools).reduce((previous, current) => {
                     return previous.concat(
                         current.tools.map((tool, index) => ({

--- a/web/client/plugins/CRSSelector.jsx
+++ b/web/client/plugins/CRSSelector.jsx
@@ -7,7 +7,6 @@
  */
 
 import { has, includes, indexOf } from 'lodash';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Dropdown, Glyphicon, ListGroupItem } from 'react-bootstrap';
@@ -191,7 +190,7 @@ const crsSelector = connect(
   * }
 */
 export default {
-    CRSSelectorPlugin: assign(crsSelector, {
+    CRSSelectorPlugin: Object.assign(crsSelector, {
         disablePluginIf: "{state('mapType') === 'leaflet'}",
         MapFooter: {
             name: "crsSelector",

--- a/web/client/plugins/DrawerMenu.jsx
+++ b/web/client/plugins/DrawerMenu.jsx
@@ -9,7 +9,6 @@
 import './drawer/drawer.css';
 
 import { partialRight } from 'lodash';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Glyphicon, Panel } from 'react-bootstrap';
@@ -131,7 +130,7 @@ class DrawerMenu extends React.Component {
 
     getTools = () => {
         const unsorted = this.props.items
-            .map((item, index) => assign({}, item, {position: item.position || index}));
+            .map((item, index) => Object.assign({}, item, {position: item.position || index}));
         return unsorted.sort((a, b) => a.position - b.position);
     };
 
@@ -179,7 +178,7 @@ const DrawerMenuPlugin = connect((state) => ({
 })(DrawerMenu);
 
 export default {
-    DrawerMenuPlugin: assign(DrawerMenuPlugin, {
+    DrawerMenuPlugin: Object.assign(DrawerMenuPlugin, {
         disablePluginIf: "{state('featuregridmode') === 'EDIT'}",
         FloatingLegend: {
             priority: 1,

--- a/web/client/plugins/Expander.jsx
+++ b/web/client/plugins/Expander.jsx
@@ -8,7 +8,6 @@
 import React from 'react';
 
 import { Glyphicon } from 'react-bootstrap';
-import assign from 'object-assign';
 import ExpanderPlugin from '../components/buttons/ToggleButton';
 
 /**
@@ -18,7 +17,7 @@ import ExpanderPlugin from '../components/buttons/ToggleButton';
  * @memberof plugins
  */
 export default {
-    ExpanderPlugin: assign(ExpanderPlugin, {
+    ExpanderPlugin: Object.assign(ExpanderPlugin, {
         Toolbar: {
             name: 'expand',
             position: 10000,

--- a/web/client/plugins/FullScreen.jsx
+++ b/web/client/plugins/FullScreen.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 
 import { toggleFullscreen } from '../actions/fullscreen';
 import { toggleFullscreenEpic } from '../epics/fullscreen';
-import assign from 'object-assign';
 import FullScreenButton from '../components/buttons/FullScreenButton';
 
 /**
@@ -32,7 +31,7 @@ const FullScreen = connect( ({controls = {}} = {}) => ({
 // http://caniuse.com/#feat=fullscreen
 
 export default {
-    FullScreenPlugin: assign(FullScreen, {
+    FullScreenPlugin: Object.assign(FullScreen, {
         disablePluginIf: "{state('browser') && state('browser').safari}",
         Toolbar: {
             name: 'fullscreen',

--- a/web/client/plugins/GoFull.jsx
+++ b/web/client/plugins/GoFull.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import { connect } from 'react-redux';
 
 import GoFullButton from '../components/buttons/GoFullButton';
@@ -24,7 +23,7 @@ const GoFullPlugin = connect(() => ({}))(GoFullButton);
  * @class GoFull
  */
 export default {
-    GoFullPlugin: assign(GoFullPlugin, {
+    GoFullPlugin: Object.assign(GoFullPlugin, {
         Toolbar: {
             name: 'gofull',
             position: 1,

--- a/web/client/plugins/Help.jsx
+++ b/web/client/plugins/Help.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import React from 'react';
 import { Glyphicon } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -24,7 +23,7 @@ const HelpTextPanel = connect((state) => ({
 })(HelpTextPanelComp);
 
 export default {
-    HelpPlugin: assign(HelpTextPanel, {
+    HelpPlugin: Object.assign(HelpTextPanel, {
         Toolbar: {
             name: 'help',
             position: 1000,

--- a/web/client/plugins/History.jsx
+++ b/web/client/plugins/History.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import React from 'react';
 import { Glyphicon } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -50,7 +49,7 @@ const RedoButton = connect((state) => {
 })(RedoButtonComp);
 
 export default {
-    UndoPlugin: assign(UndoButton, {
+    UndoPlugin: Object.assign(UndoButton, {
         Toolbar: {
             name: 'undo',
             position: 5,
@@ -61,7 +60,7 @@ export default {
             priority: 1
         }
     }),
-    RedoPlugin: assign(RedoButton, {
+    RedoPlugin: Object.assign(RedoButton, {
         Toolbar: {
             name: 'redo',
             position: 6,

--- a/web/client/plugins/Home.jsx
+++ b/web/client/plugins/Home.jsx
@@ -8,7 +8,6 @@
 
 import React from 'react';
 
-import assign from 'object-assign';
 import { goToHomePage } from '../actions/router';
 import { comparePendingChanges } from '../epics/pendingChanges';
 import Message from './locale/Message';
@@ -41,7 +40,7 @@ import {burgerMenuSelector} from '../selectors/controls';
  * @memberof plugins
  */
 export default {
-    HomePlugin: assign(Home, {
+    HomePlugin: Object.assign(Home, {
         Toolbar: {
             name: 'home',
             position: 1,

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -9,7 +9,6 @@
 import './identify/identify.css';
 
 import { isUndefined } from 'lodash';
-import assign from 'object-assign';
 import React from 'react';
 import { Glyphicon } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -291,7 +290,7 @@ const FeatureInfoTriggerSelector = connect((state) => ({
 })(FeatureInfoTriggerSelectorComp);
 
 export default {
-    IdentifyPlugin: assign(IdentifyPlugin, {
+    IdentifyPlugin: Object.assign(IdentifyPlugin, {
         Toolbar: {
             name: 'info',
             position: 6,

--- a/web/client/plugins/Language.jsx
+++ b/web/client/plugins/Language.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import { connect } from 'react-redux';
 
 import { loadLocale } from '../actions/locale';
@@ -26,7 +25,7 @@ const LangBar = connect((state) => ({
  * @memberof plugins
  */
 export default {
-    LanguagePlugin: assign(LangBar, {
+    LanguagePlugin: Object.assign(LangBar, {
         OmniBar: {
             name: 'language',
             position: 5,

--- a/web/client/plugins/MapImport.jsx
+++ b/web/client/plugins/MapImport.jsx
@@ -28,7 +28,6 @@ import { addLayer } from '../actions/layers';
 import { loadAnnotations } from '../plugins/Annotations/actions/annotations';
 import { annotationsLayerSelector } from '../plugins/Annotations/selectors/annotations';
 import { toggleControl } from '../actions/controls';
-import assign from 'object-assign';
 import { Glyphicon } from 'react-bootstrap';
 import { mapTypeSelector } from '../selectors/maptype';
 import { DEFAULT_VECTOR_FILE_MAX_SIZE_IN_MB } from '../utils/FileUtils';
@@ -50,7 +49,7 @@ import { DEFAULT_VECTOR_FILE_MAX_SIZE_IN_MB } from '../utils/FileUtils';
  * @prop {number} cfg.importedVectorFileMaxSizeInMB it is the max allowable file size for import vectir layers in mega bytes
  */
 export default {
-    MapImportPlugin: assign({loadPlugin: (resolve) => {
+    MapImportPlugin: Object.assign({loadPlugin: (resolve) => {
         import('./import/Import').then((importMod) => {
             const Import = importMod.default;
 

--- a/web/client/plugins/MapLoading.jsx
+++ b/web/client/plugins/MapLoading.jsx
@@ -9,7 +9,6 @@
 
 import './maploading/maploading.css';
 
-import assign from 'object-assign';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
@@ -30,7 +29,7 @@ const MapLoadingPlugin = connect(selector)(GlobalSpinner);
  * @memberof plugins
  */
 export default {
-    MapLoadingPlugin: assign(MapLoadingPlugin, {
+    MapLoadingPlugin: Object.assign(MapLoadingPlugin, {
         Toolbar: {
             name: 'maploading',
             position: 1,

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -8,7 +8,6 @@
 
 import './metadataexplorer/css/style.css';
 
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Glyphicon, Panel } from 'react-bootstrap';
@@ -343,7 +342,7 @@ const AddLayerButton = connect(() => ({}), {
  * @prop {number} [delayAutoSearch] time in ms passed after a search is triggered by filter changes, default 1000
  */
 export default {
-    MetadataExplorerPlugin: assign(MetadataExplorerPlugin, {
+    MetadataExplorerPlugin: Object.assign(MetadataExplorerPlugin, {
         BurgerMenu: {
             name: 'metadataexplorer',
             position: 5,

--- a/web/client/plugins/MousePosition.jsx
+++ b/web/client/plugins/MousePosition.jsx
@@ -7,7 +7,6 @@
  */
 
 import { get } from 'lodash';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Tooltip } from 'react-bootstrap';
@@ -143,7 +142,7 @@ const MousePositionPlugin = connect(selector, {
 })(MousePosition);
 
 export default {
-    MousePositionPlugin: assign(MousePositionPlugin, {
+    MousePositionPlugin: Object.assign(MousePositionPlugin, {
         MapFooter: {
             name: 'mousePosition',
             position: 2,

--- a/web/client/plugins/Playback.jsx
+++ b/web/client/plugins/Playback.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import React from 'react';
 import { connect } from 'react-redux';
 import { compose, defaultProps } from 'recompose';
@@ -66,7 +65,7 @@ class PlaybackPlugin extends React.Component {
 }
 
 export default {
-    PlaybackPlugin: assign(PlaybackPlugin, {
+    PlaybackPlugin: Object.assign(PlaybackPlugin, {
         noRoot: true,
         disablePluginIf: "{state('featuregridmode') === 'EDIT'}",
         Timeline: {

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -11,7 +11,6 @@ import './print/print.css';
 import head from 'lodash/head';
 import castArray from "lodash/castArray";
 import isNil from "lodash/isNil";
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { PanelGroup, Col, Glyphicon, Grid, Panel, Row } from 'react-bootstrap';
@@ -236,7 +235,7 @@ function filterLayer(layer = {}) {
 }
 
 export default {
-    PrintPlugin: assign({
+    PrintPlugin: Object.assign({
         loadPlugin: (resolve) => {
             Promise.all([
                 import('./print/index'),

--- a/web/client/plugins/Redirect.jsx
+++ b/web/client/plugins/Redirect.jsx
@@ -9,7 +9,6 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
-import assign from 'object-assign';
 import { connect } from 'react-redux';
 
 class RedirectComponent extends React.Component {
@@ -51,5 +50,5 @@ const Redirect = connect((state) => ({
  * @memberof plugins
  */
 export default {
-    RedirectPlugin: assign(Redirect, {}
+    RedirectPlugin: Object.assign(Redirect, {}
     )};

--- a/web/client/plugins/ScaleBox.jsx
+++ b/web/client/plugins/ScaleBox.jsx
@@ -16,7 +16,6 @@ import HelpWrapper from './help/HelpWrapper';
 import Message from './locale/Message';
 import ScaleBox from '../components/mapcontrols/scale/ScaleBox';
 import { getScales } from '../utils/MapUtils';
-import assign from 'object-assign';
 
 const selector = createSelector([mapSelector, minZoomSelector], (map, minZoom) => ({
     minZoom,
@@ -56,7 +55,7 @@ const ScaleBoxPlugin = connect(selector, {
 })(ScaleBoxTool);
 
 export default {
-    ScaleBoxPlugin: assign(ScaleBoxPlugin, {
+    ScaleBoxPlugin: Object.assign(ScaleBoxPlugin, {
         disablePluginIf: "{state('mapType') === 'cesium'}"
     }, {
         MapFooter: {

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -7,7 +7,6 @@
 */
 
 import { get } from 'lodash';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -353,7 +352,7 @@ const SearchPlugin = connect((state) => ({
     getSearchOptions = () => {
         const { searchOptions, textSearchConfig } = this.props;
         if (textSearchConfig && textSearchConfig.services && textSearchConfig.services.length > 0) {
-            return textSearchConfig.override ? assign({}, searchOptions, {services: textSearchConfig.services}) : assign({}, searchOptions, {services: searchOptions.services.concat(textSearchConfig.services)});
+            return textSearchConfig.override ? Object.assign({}, searchOptions, {services: textSearchConfig.services}) : Object.assign({}, searchOptions, {services: searchOptions.services.concat(textSearchConfig.services)});
         }
         return searchOptions;
     };
@@ -361,7 +360,7 @@ const SearchPlugin = connect((state) => ({
     getCurrentServices = () => {
         const {selectedServices} = this.props;
         const searchOptions = this.getSearchOptions();
-        return selectedServices && selectedServices.length > 0 ? assign({}, searchOptions, {services: selectedServices}) : searchOptions;
+        return selectedServices && selectedServices.length > 0 ? Object.assign({}, searchOptions, {services: selectedServices}) : searchOptions;
     };
 
     searchFitToTheScreen = () => {
@@ -409,7 +408,7 @@ const SearchPlugin = connect((state) => ({
     });
 
 export default {
-    SearchPlugin: assign(
+    SearchPlugin: Object.assign(
         connect(createStructuredSelector({
             style: state => mapLayoutValuesSelector(state, { right: true }),
             offsets: state => mapLayoutValuesSelector(state, { right: true, left: true }),

--- a/web/client/plugins/Settings.jsx
+++ b/web/client/plugins/Settings.jsx
@@ -8,7 +8,6 @@
 
 import './settings/css/settings.css';
 
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React, { cloneElement } from 'react';
 import { castArray } from 'lodash';
@@ -158,7 +157,7 @@ class SettingsButton extends React.Component {
     }
 
     isEnabled = (setting) => {
-        const settings = assign({}, this.props.settings, this.props.overrideSettings);
+        const settings = Object.assign({}, this.props.settings, this.props.overrideSettings);
         return settings[setting];
     };
 }
@@ -186,7 +185,7 @@ const SettingsPlugin = connect((state) => ({
  * @memberof plugins
  */
 export default {
-    SettingsPlugin: assign(SettingsPlugin, {
+    SettingsPlugin: Object.assign(SettingsPlugin, {
         Toolbar: {
             name: 'settings',
             position: 100,

--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -7,7 +7,6 @@
  */
 
 import React, {useEffect} from 'react';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { branch, compose, lifecycle, toClass } from 'recompose';
@@ -232,7 +231,7 @@ const StyleEditorPlugin = compose(
 )(StyleEditorPanel);
 
 export default {
-    StyleEditorPlugin: assign(StyleEditorPlugin, {
+    StyleEditorPlugin: Object.assign(StyleEditorPlugin, {
         TOC: {
             priority: 1,
             container: 'TOCItemSettings'

--- a/web/client/plugins/ThematicLayer.jsx
+++ b/web/client/plugins/ThematicLayer.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
 */
 import React, {Suspense} from 'react';
-import assign from 'object-assign';
 import { connect, createPlugin } from '../utils/PluginsUtils';
 import LoadingView from '../components/misc/LoadingView';
 
@@ -42,7 +41,7 @@ const enhancer = connect((state) => {
             error: state?.thematic?.errorClassification || null
         },
         canEditThematic: isAdminUserSelector(state),
-        initialParams: assign(API.defaultParams, customColors ? {
+        initialParams: Object.assign(API.defaultParams, customColors ? {
             ramp: customColors[0].name
         } : {}),
         methods: API.methods,

--- a/web/client/plugins/ThemeSwitcher.jsx
+++ b/web/client/plugins/ThemeSwitcher.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-import assign from 'object-assign';
 import { connect } from 'react-redux';
 
 import { selectTheme } from '../actions/theme';
@@ -22,7 +21,7 @@ const ThemeSwitcherPlugin = connect((s) => ({
 })(ThemeSwitcher);
 
 export default {
-    ThemeSwitcherPlugin: assign(ThemeSwitcherPlugin, {
+    ThemeSwitcherPlugin: Object.assign(ThemeSwitcherPlugin, {
         GridContainer: {
             id: 'themeSwitcher',
             name: 'themeSwitcher',

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -8,7 +8,6 @@
 
 import { head, isString } from 'lodash';
 import moment from 'moment';
-import assign from 'object-assign';
 import React, { useEffect } from 'react';
 import { Glyphicon } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -381,7 +380,7 @@ const TimelinePlugin = compose(
 );
 
 export default {
-    TimelinePlugin: assign(TimelinePlugin, {
+    TimelinePlugin: Object.assign(TimelinePlugin, {
         disablePluginIf: "{state('mapType') === 'cesium'}",
         WidgetsTray: {
             tool: <TimelineToggle />,

--- a/web/client/plugins/Toolbar.jsx
+++ b/web/client/plugins/Toolbar.jsx
@@ -14,7 +14,6 @@ import { CSSTransitionGroup } from 'react-transition-group';
 import { isFeatureGridOpen } from '../selectors/featuregrid';
 import { mapLayoutValuesSelector } from '../selectors/maplayout';
 import { createSelector } from 'reselect';
-import assign from 'object-assign';
 import ToolsContainer from './containers/ToolsContainer';
 
 class AnimatedContainer extends React.Component {
@@ -105,7 +104,7 @@ class Toolbar extends React.Component {
                 || hidableItems.length === 1 // if the item is only one, the expander will not show, instead we have only the item
                 || this.props.allVisible) // expanded state, all items are visible, no filtering.
             .filter(item => item.showWhen ? item.showWhen(this.props) : true) // optional display option (used by expander, that depends on other)
-            .map((item, index) => assign({}, item, {position: item.position || index}));
+            .map((item, index) => Object.assign({}, item, {position: item.position || index}));
         return unsorted.sort((a, b) => a.position - b.position);
     };
 

--- a/web/client/plugins/Tutorial.jsx
+++ b/web/client/plugins/Tutorial.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import React from 'react';
 import { Glyphicon } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -161,7 +160,7 @@ const Tutorial = connect(tutorialPluginSelector, (dispatch) => {
 }))(TutorialComp);
 
 export default {
-    TutorialPlugin: assign(Tutorial, {
+    TutorialPlugin: Object.assign(Tutorial, {
         BurgerMenu: {
             name: 'tutorial',
             position: 1200,

--- a/web/client/plugins/ZoomAll.jsx
+++ b/web/client/plugins/ZoomAll.jsx
@@ -8,7 +8,6 @@
 
 import './zoomall/zoomall.css';
 
-import assign from 'object-assign';
 import React from 'react';
 import { Glyphicon } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -41,7 +40,7 @@ class ZoomAllPlugin extends React.Component {
  * @memberof plugins
  */
 export default {
-    ZoomAllPlugin: assign(ZoomAllPlugin, {
+    ZoomAllPlugin: Object.assign(ZoomAllPlugin, {
         Toolbar: {
             name: "ZoomAll",
             position: 7,

--- a/web/client/plugins/ZoomIn.jsx
+++ b/web/client/plugins/ZoomIn.jsx
@@ -8,7 +8,6 @@
 
 import './zoom/zoom.css';
 
-import assign from 'object-assign';
 import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -36,7 +35,7 @@ const ZoomInButton = connect(selector, {
 })(ZoomButtonComp);
 
 export default {
-    ZoomInPlugin: assign(ZoomInButton, {
+    ZoomInPlugin: Object.assign(ZoomInButton, {
         disablePluginIf: "{state('mapType') === 'cesium'}",
         Toolbar: {
             name: "ZoomIn",

--- a/web/client/plugins/ZoomOut.jsx
+++ b/web/client/plugins/ZoomOut.jsx
@@ -1,6 +1,5 @@
 import './zoom/zoom.css';
 
-import assign from 'object-assign';
 /*
  * Copyright 2016, GeoSolutions Sas.
  * All rights reserved.
@@ -41,7 +40,7 @@ const ZoomOutButton = connect(
 
 
 export default {
-    ZoomOutPlugin: assign(ZoomOutButton, {
+    ZoomOutPlugin: Object.assign(ZoomOutButton, {
         disablePluginIf: "{state('mapType') === 'cesium'}",
         Toolbar: {
             name: "ZoomOut",

--- a/web/client/plugins/containers/ToolsContainer.jsx
+++ b/web/client/plugins/containers/ToolsContainer.jsx
@@ -7,7 +7,6 @@
  */
 
 import { partial } from 'lodash';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Collapse, Glyphicon, Panel, Tooltip } from 'react-bootstrap';
@@ -196,7 +195,7 @@ class ToolsContainer extends React.Component {
 
     mergeHandlers = (props, handlers) => {
         return Object.keys(handlers).reduce((previous, event) => {
-            return assign(previous, {[event]: props[event] ? compose(props[event], handlers[event]) : handlers[event]});
+            return Object.assign(previous, {[event]: props[event] ? compose(props[event], handlers[event]) : handlers[event]});
         }, props);
     };
 

--- a/web/client/plugins/map/index.js
+++ b/web/client/plugins/map/index.js
@@ -30,7 +30,6 @@ import {
 import { updateHighlighted } from '../../actions/highlight';
 import { warning } from '../../actions/notifications';
 import { connect } from 'react-redux';
-import assign from 'object-assign';
 import { projectionDefsSelector, isMouseMoveActiveSelector } from '../../selectors/map';
 import {
     snappingLayerSelector
@@ -51,7 +50,7 @@ const pluginsCreator = (mapType, actions) => {
         const LMap = connect((state) => ({
             projectionDefs: projectionDefsSelector(state),
             mousePosition: isMouseMoveActiveSelector(state)
-        }), assign({}, {
+        }), Object.assign({}, {
             onMapViewChanges: changeMapView,
             onClick: clickOnMap,
             onMouseMove: mouseMove,
@@ -61,7 +60,7 @@ const pluginsCreator = (mapType, actions) => {
             onWarning: warning,
             onMouseOut: mouseOut
         }, actions), (stateProps, dispatchProps, ownProps) => {
-            return assign({}, ownProps, stateProps, assign({}, dispatchProps, {
+            return Object.assign({}, ownProps, stateProps, Object.assign({}, dispatchProps, {
                 onMouseMove: stateProps.mousePosition ? dispatchProps.onMouseMove : () => {}
             }));
         })(components.LMap);

--- a/web/client/product/__tests__/main-test.jsx
+++ b/web/client/product/__tests__/main-test.jsx
@@ -8,7 +8,6 @@
 
 import expect from 'expect';
 import {includes} from 'lodash';
-import assign from 'object-assign';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -41,7 +40,7 @@ describe('standard application runner', () => {
 
     it('allows overriding appConfig', (done) => {
         const overrideCfg = (config) => {
-            return assign({}, config, {
+            return Object.assign({}, config, {
                 appComponent: AppComponent
             });
         };
@@ -54,7 +53,7 @@ describe('standard application runner', () => {
 
     it('check printingEnabled set to false', (done) => {
         const overrideCfg = (config) => {
-            return assign({}, config, {
+            return Object.assign({}, config, {
                 onStoreInit: () => {
                     setTimeout(() => {
                         expect(config.printingEnabled).toBe(false);

--- a/web/client/product/plugins/About.jsx
+++ b/web/client/product/plugins/About.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import React from 'react';
 import { Glyphicon } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -64,7 +63,7 @@ const AboutNavBarButton = connect(() => ({}), { onClick: toggleControl.bind(null
  * }
  */
 export default {
-    AboutPlugin: assign(About,
+    AboutPlugin: Object.assign(About,
         {
             BurgerMenu: {
                 name: 'about',

--- a/web/client/product/plugins/MapType.jsx
+++ b/web/client/product/plugins/MapType.jsx
@@ -14,7 +14,6 @@ import { compose } from 'redux';
 import { changeMapType } from '../../actions/maptype';
 import { mapTypeSelector } from '../../selectors/maptype';
 import { connect } from 'react-redux';
-import assign from 'object-assign';
 import { MapLibraries } from '../../utils/MapTypeUtils';
 
 class MapType extends React.Component {
@@ -57,7 +56,7 @@ const MapTypePlugin = connect((state) => ({
 })(MapType);
 
 export default {
-    MapTypePlugin: assign(MapTypePlugin, {
+    MapTypePlugin: Object.assign(MapTypePlugin, {
         OmniBar: {
             name: 'MapType',
             tool: true,

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -7,7 +7,6 @@
  */
 
 import expect from 'expect';
-import assign from 'object-assign';
 import 'babel-polyfill';
 
 import mapInfo from '../mapInfo';
@@ -56,11 +55,11 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(0);
 
-        state = mapInfo(assign({}, appState, {responses: []}), testAction);
+        state = mapInfo(Object.assign({}, appState, {responses: []}), testAction);
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(0);
 
-        state = mapInfo(assign({}, appState, {responses: ["test"]}), {...testAction, reqId: 11});
+        state = mapInfo(Object.assign({}, appState, {responses: ["test"]}), {...testAction, reqId: 11});
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(1);
         expect(state.responses[0]).toBe("test");
@@ -80,11 +79,11 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses).toBeTruthy();
         expect(state.responses.length).toBe(0);
 
-        state = mapInfo(assign({}, appState, {responses: []}), testAction);
+        state = mapInfo(Object.assign({}, appState, {responses: []}), testAction);
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(0);
 
-        state = mapInfo(assign({}, appState, {responses: ["test"]}), {...testAction, reqId: 11});
+        state = mapInfo(Object.assign({}, appState, {responses: ["test"]}), {...testAction, reqId: 11});
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(1);
         expect(state.responses[0]).toBe("test");
@@ -108,7 +107,7 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[0].layerMetadata).toBe("meta");
         expect(state.index).toBe(0);
 
-        state = mapInfo(assign({}, appState, {responses: []}), testAction);
+        state = mapInfo(Object.assign({}, appState, {responses: []}), testAction);
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(1);
         expect(state.responses[0].response).toBe("data");
@@ -116,7 +115,7 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[0].layerMetadata).toBe("meta");
         expect(state.index).toBe(0);
 
-        state = mapInfo(assign({}, appState, {responses: ["test"]}), {...testAction, reqId: 11});
+        state = mapInfo(Object.assign({}, appState, {responses: ["test"]}), {...testAction, reqId: 11});
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(2);
         expect(state.responses[0]).toBeTruthy();
@@ -195,12 +194,12 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[0].layerMetadata).toBe("meta");
         expect(state.index).toBe(0);
 
-        state = mapInfo(assign({}, appState, {responses: [], showInMapPopup: true}), testAction);
+        state = mapInfo(Object.assign({}, appState, {responses: [], showInMapPopup: true}), testAction);
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(1);
         expect(state.index).toBe(0);
 
-        state = mapInfo(assign({}, appState, {responses: ["test"], showInMapPopup: true}), {...testAction, reqId: 11});
+        state = mapInfo(Object.assign({}, appState, {responses: ["test"], showInMapPopup: true}), {...testAction, reqId: 11});
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(2);
         expect(state.responses[0]).toBeTruthy();
@@ -224,7 +223,7 @@ describe('Test the mapInfo reducer', () => {
         expect(state.index).toBe(undefined);
         expect(state.loaded).toBe(undefined);
 
-        state = mapInfo(assign({}, appState, {responses: ["test"]}), {...testAction, reqId: 11});
+        state = mapInfo(Object.assign({}, appState, {responses: ["test"]}), {...testAction, reqId: 11});
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(2);
         expect(state.responses[0]).toBeTruthy();
@@ -232,7 +231,7 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[1].queryParams).toBe("params");
         expect(state.responses[1].layerMetadata).toBe("meta");
 
-        state = mapInfo(assign({}, appState, {responses: [{response: "test"}, {response: "test"}]}), {...testAction, layerMetadata: "meta3", reqId: 3});
+        state = mapInfo(Object.assign({}, appState, {responses: [{response: "test"}, {response: "test"}]}), {...testAction, layerMetadata: "meta3", reqId: 3});
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(3);
         expect(state.responses[0]).toBeTruthy();
@@ -269,13 +268,13 @@ describe('Test the mapInfo reducer', () => {
         expect(state.requests).toExist();
         expect(state.requests.length).toBe(0);
 
-        state = mapInfo(assign({}, appState, {responses: []}), {type: 'PURGE_MAPINFO_RESULTS'});
+        state = mapInfo(Object.assign({}, appState, {responses: []}), {type: 'PURGE_MAPINFO_RESULTS'});
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(0);
         expect(state.requests).toExist();
         expect(state.requests.length).toBe(0);
 
-        state = mapInfo(assign({}, appState, {responses: ["test"]}), {type: 'PURGE_MAPINFO_RESULTS'});
+        state = mapInfo(Object.assign({}, appState, {responses: ["test"]}), {type: 'PURGE_MAPINFO_RESULTS'});
         expect(state.responses).toExist();
         expect(state.responses.length).toBe(0);
         expect(state.requests).toExist();

--- a/web/client/reducers/backgroundselector.js
+++ b/web/client/reducers/backgroundselector.js
@@ -20,27 +20,26 @@ import {
 } from '../actions/backgroundselector';
 
 import { RESET_CATALOG } from '../actions/catalog';
-import assign from 'object-assign';
 
 function backgroundselector(state = null, action) {
     switch (action.type) {
     case ADD_BACKGROUND: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             source: action.source
         });
     }
     case RESET_CATALOG: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             source: 'metadataExplorer'
         });
     }
     case SET_BACKGROUND_MODAL_PARAMS: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             modalParams: action.modalParams
         });
     }
     case BACKGROUNDS_CLEAR: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             backgrounds: [],
             removedBackgroundsThumbIds: [],
             modalParams: {},
@@ -54,22 +53,22 @@ function backgroundselector(state = null, action) {
             const newBackgrounds = doesNotHaveBackground ? backgrounds.concat({id: action.id}) : backgrounds;
             const updatedBackgrounds = newBackgrounds.map(background => {
                 if (background.id === action.id) {
-                    return assign({}, background, {
+                    return Object.assign({}, background, {
                         id: action.id,
                         thumbnail: action.thumbnailData
                     });
                 }
-                return assign({}, background);
+                return Object.assign({}, background);
             });
 
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 backgrounds: updatedBackgrounds
             });
         }
         return state;
     }
     case CLEAR_MODAL_PARAMETERS : {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             modalParams: undefined
         });
     }
@@ -82,17 +81,17 @@ function backgroundselector(state = null, action) {
                 .filter(background => background.id === action.backgroundId && !!background.thumbId)
                 .map(background => background.thumbId);
 
-        return assign({}, state, {
+        return Object.assign({}, state, {
             backgrounds: updatedBackgrounds,
             removedBackgroundsThumbIds: removedBackgroundsThumbIds.concat(newRemovedBackgroundsThumbIds),
             lastRemovedId: action.backgroundId
         });
     }
     case CREATE_BACKGROUNDS_LIST: {
-        return assign({}, state, {backgrounds: action.backgrounds});
+        return Object.assign({}, state, {backgrounds: action.backgrounds});
     }
     case CONFIRM_DELETE_BACKGROUND_MODAL: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             confirmDeleteBackgroundModal: {
                 show: action.show,
                 layerTitle: action.layerTitle,
@@ -101,10 +100,10 @@ function backgroundselector(state = null, action) {
         });
     }
     case ALLOW_BACKGROUNDS_DELETION: {
-        return assign({}, state, {allowDeletion: action.allow || false});
+        return Object.assign({}, state, {allowDeletion: action.allow || false});
     }
     case STASH_SELECTED_SERVICE : {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             stashedService: action.service
         });
     }

--- a/web/client/reducers/box.js
+++ b/web/client/reducers/box.js
@@ -5,7 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
 */
-import assign from 'object-assign';
 
 import { CHANGE_BOX_SELECTION_STATUS } from '../actions/box';
 
@@ -16,7 +15,7 @@ const initialState = {
 function box(state = initialState, action) {
     switch (action.type) {
     case CHANGE_BOX_SELECTION_STATUS:
-        return assign({}, state, {status: action.status});
+        return Object.assign({}, state, {status: action.status});
     default:
         return state;
     }

--- a/web/client/reducers/browser.js
+++ b/web/client/reducers/browser.js
@@ -8,12 +8,10 @@
 
 import { CHANGE_BROWSER_PROPERTIES } from '../actions/browser';
 
-import assign from 'object-assign';
-
 function browser(state = null, action) {
     switch (action.type) {
     case CHANGE_BROWSER_PROPERTIES: {
-        return assign({}, state,
+        return Object.assign({}, state,
             action.newProperties
         );
     }

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -40,7 +40,6 @@ import {
 import { MAP_CONFIG_LOADED } from '../actions/config';
 import { set } from '../utils/ImmutableUtils';
 import { isNil } from 'lodash';
-import assign from 'object-assign';
 import uuid from 'uuid';
 
 export const emptyService = {
@@ -82,7 +81,7 @@ function catalog(state = {
             saving: action.status
         };
     case RECORD_LIST_LOADED:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             result: action.result,
             searchOptions: action.searchOptions,
             loadingError: null,
@@ -90,7 +89,7 @@ function catalog(state = {
             loading: false
         });
     case RESET_CATALOG:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             result: null,
             loadingError: null,
             searchOptions: null/*
@@ -101,7 +100,7 @@ function catalog(state = {
                 layerError: null*/
         });
     case RECORD_LIST_LOAD_ERROR:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             result: null,
             searchOptions: null,
             loadingError: action.error,
@@ -109,17 +108,17 @@ function catalog(state = {
             layerError: null
         });
     case CHANGE_CATALOG_FORMAT:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             result: null,
             loadingError: null,
             format: action.format,
             layerError: null
         });
     case ADD_LAYER_ERROR:
-        return assign({}, state, {layerError: action.error});
+        return Object.assign({}, state, {layerError: action.error});
     case CHANGE_CATALOG_MODE:
-        return assign({}, state, {
-            newService: action.isNew ? emptyService : assign({}, state.services && state.services[state.selectedService || ""] || {}, {oldService: state.selectedService || ""}),
+        return Object.assign({}, state, {
+            newService: action.isNew ? emptyService : Object.assign({}, state.services && state.services[state.selectedService || ""] || {}, {oldService: state.selectedService || ""}),
             mode: action.mode,
             result: null,
             showFormatError: false,
@@ -128,9 +127,9 @@ function catalog(state = {
     case MAP_CONFIG_LOADED: {
         if (state && !isNil(state.default)) {
             if (action.config && !isNil(action.config.catalogServices)) {
-                return assign({}, state, {services: action.config.catalogServices.services, selectedService: action.config.catalogServices.selectedService });
+                return Object.assign({}, state, {services: action.config.catalogServices.services, selectedService: action.config.catalogServices.selectedService });
             }
-            return assign({}, state, {services: state.default.services, selectedService: state.default.selectedService });
+            return Object.assign({}, state, {services: state.default.services, selectedService: state.default.selectedService });
         }
         return state;
     }
@@ -154,19 +153,19 @@ function catalog(state = {
             // reset the template options
             templateOptions = {showTemplate: false, metadataTemplate: ""};
         }
-        return assign({}, state, {newService: assign({}, state.newService, {type, ...templateOptions})});
+        return Object.assign({}, state, {newService: Object.assign({}, state.newService, {type, ...templateOptions})});
     }
     case ADD_CATALOG_SERVICE: {
         const { isNew, ...service } = action.service;
         const selectedService = isNew ? service.title + uuid() : state.selectedService;
-        const newServices = assign({}, state.services, { [selectedService]: service});
-        return assign({}, state, {
+        const newServices = Object.assign({}, state.services, { [selectedService]: service});
+        return Object.assign({}, state, {
             services: newServices,
             selectedService,
             mode: "view",
             result: null,
             loadingError: null,
-            searchOptions: assign({}, state.searchOptions, {
+            searchOptions: Object.assign({}, state.searchOptions, {
                 text: ""
             }),
             layerError: null
@@ -179,7 +178,7 @@ function catalog(state = {
     }
     case CHANGE_SELECTED_SERVICE: {
         if (action.service !== state.selectedService) {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 selectedService: action.service,
                 result: null,
                 loadingError: null,
@@ -191,12 +190,12 @@ function catalog(state = {
     case DELETE_CATALOG_SERVICE: {
         let newServices;
         let selectedService = "";
-        newServices = assign({}, state.services);
+        newServices = Object.assign({}, state.services);
         delete newServices[action.service];
         if (Object.keys(newServices).length) {
             selectedService = newServices[Object.keys(newServices)[0]].title;
         }
-        return assign({}, state, {
+        return Object.assign({}, state, {
             services: newServices,
             selectedService,
             mode: "view",

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -20,7 +20,6 @@ import {
 
 import { DETAILS_LOADED } from '../actions/details';
 import { MAP_TYPE_CHANGED, VISUALIZATION_MODE_CHANGED } from '../actions/maptype';
-import assign from 'object-assign';
 import ConfigUtils from '../utils/ConfigUtils';
 import { set, unset } from '../utils/ImmutableUtils';
 import { normalizeLayer } from '../utils/LayersUtils';
@@ -65,9 +64,9 @@ function mapConfig(state = null, action) {
         // if map is loaded from an already saved map keep the same id
         let mapId = state?.map?.mapId || state?.map?.present?.mapId;
         mapId = action.config?.fileName && mapId ? mapId : action.mapId;
-        newMapState.map = assign({}, newMapState.map, {mapId, size, bbox, version: hasVersion ? action.config.version : 1});
+        newMapState.map = Object.assign({}, newMapState.map, {mapId, size, bbox, version: hasVersion ? action.config.version : 1});
         // we store the map initial state for future usage
-        return assign({}, newMapState, {mapInitialConfig: {...newMapState.map, mapId: action.mapId}});
+        return Object.assign({}, newMapState, {mapInitialConfig: {...newMapState.map, mapId: action.mapId}});
     case MAP_CONFIG_LOAD_ERROR:
         return {
             loadingError: {...action.error, mapId: action.mapId}
@@ -75,26 +74,26 @@ function mapConfig(state = null, action) {
     case MAP_INFO_LOAD_START:
         map = state && state.map && state.map.present ? state.map.present : state && state.map;
         if (map && map.mapId === action.mapId) {
-            map = assign({}, map, {loadingInfo: true});
-            return assign({}, state, {map: map});
+            map = Object.assign({}, map, {loadingInfo: true});
+            return Object.assign({}, state, {map: map});
         }
         return state;
     case MAP_INFO_LOAD_ERROR: {
         map = state && state.map && state.map.present ? state.map.present : state && state.map;
         if (map && map.mapId === action.mapId) {
-            map = assign({}, map, {loadingInfoError: action.error, loadingInfo: false});
-            return assign({}, state, {map: map});
+            map = Object.assign({}, map, {loadingInfoError: action.error, loadingInfo: false});
+            return Object.assign({}, state, {map: map});
         }
         return state;
     }
     case MAP_INFO_LOADED:
         map = state && state.map && state.map.present ? state.map.present : state && state.map;
         if (map && (`${map.mapId}` === `${action.mapId}` || !map.mapId && !action.mapId)) {
-            map = assign({}, map, {info: action.merge ? {
+            map = Object.assign({}, map, {info: action.merge ? {
                 ...map.info,
                 ...action.info
             } : action.info, loadingInfo: false});
-            return assign({}, state, {map: map});
+            return Object.assign({}, state, {map: map});
         }
         return state;
     case DETAILS_LOADED:
@@ -112,16 +111,16 @@ function mapConfig(state = null, action) {
                     }
                 }
             };
-            return assign({}, state, {map: map});
+            return Object.assign({}, state, {map: map});
         } else if (dashboardResource && dashboardResource.id?.toString() === action.id.toString()) {
-            dashboardResource = assign({}, dashboardResource, {
+            dashboardResource = Object.assign({}, dashboardResource, {
                 attributes:
-                    assign({}, dashboardResource.attributes, {
+                    Object.assign({}, dashboardResource.attributes, {
                         details: action.detailsUri,
                         detailsSettings: action.detailsSettings
                     })
             });
-            return assign({}, state, {dashboard: {
+            return Object.assign({}, state, {dashboard: {
                 ...state.dashboard, resource: dashboardResource
             }});
         }
@@ -129,11 +128,11 @@ function mapConfig(state = null, action) {
     case MAP_SAVE_ERROR:
         map = state && state.map && state.map.present ? state.map.present : state && state.map;
         map = set('mapSaveErrors', castArray(action.error), map);
-        return assign({}, state, {map: map});
+        return Object.assign({}, state, {map: map});
     case MAP_SAVED:
         map = state && state.map && state.map.present ? state.map.present : state && state.map;
         map = unset('mapSaveErrors', map);
-        return assign({}, state, {map: map});
+        return Object.assign({}, state, {map: map});
     case RESET_MAP_SAVE_ERROR:
         map = state?.map?.present || state?.map;
         map = unset('mapSaveErrors', map);

--- a/web/client/reducers/controls.js
+++ b/web/client/reducers/controls.js
@@ -13,7 +13,6 @@ import {
     RESET_CONTROLS
 } from '../actions/controls';
 
-import assign from 'object-assign';
 import {IDENTIFY_IS_MOUNTED} from "../actions/mapInfo";
 
 /**
@@ -56,39 +55,39 @@ function controls(state = {}, action) {
     switch (action.type) {
     case TOGGLE_CONTROL:
         const property = action.property || 'enabled';
-        return assign({}, state, {
-            [action.control]: assign({}, state[action.control], {
+        return Object.assign({}, state, {
+            [action.control]: Object.assign({}, state[action.control], {
                 [property]: !(state[action.control] || {})[property]
             })
         });
     case SET_CONTROL_PROPERTY:
         if (action.toggle === true && state[action.control] && state[action.control][action.property] === action.value) {
-            return assign({}, state, {
-                [action.control]: assign({}, state[action.control], {
+            return Object.assign({}, state, {
+                [action.control]: Object.assign({}, state[action.control], {
                     [action.property]: undefined
                 })
             });
         }
-        return assign({}, state, {
-            [action.control]: assign({}, state[action.control], {
+        return Object.assign({}, state, {
+            [action.control]: Object.assign({}, state[action.control], {
                 [action.property]: action.value
             })
         });
     case SET_CONTROL_PROPERTIES: {
-        return assign({}, state, {
-            [action.control]: assign({}, state[action.control], action.properties)
+        return Object.assign({}, state, {
+            [action.control]: Object.assign({}, state[action.control], action.properties)
         });
     }
     case RESET_CONTROLS: {
         const newControls = Object.keys(state).filter(c => (action.skip || []).indexOf(c) === -1);
         const resetted = newControls.reduce((previous, controlName) => {
-            return assign(previous, {
-                [controlName]: assign({}, state[controlName], state[controlName].enabled === true ? {
+            return Object.assign(previous, {
+                [controlName]: Object.assign({}, state[controlName], state[controlName].enabled === true ? {
                     enabled: false
                 } : {})
             });
         }, {});
-        return assign({}, state, resetted);
+        return Object.assign({}, state, resetted);
     }
     case IDENTIFY_IS_MOUNTED: {
         return {

--- a/web/client/reducers/cookie.js
+++ b/web/client/reducers/cookie.js
@@ -12,20 +12,18 @@ import {
     SET_DETAILS_COOKIE_HTML
 } from '../actions/cookie';
 
-import assign from 'object-assign';
-
 function cookie(state = {
     html: {}
 }, action) {
     switch (action.type) {
     case SET_COOKIE_VISIBILITY: {
-        return assign({}, state, {showCookiePanel: action.status});
+        return Object.assign({}, state, {showCookiePanel: action.status});
     }
     case SET_MORE_DETAILS_VISIBILITY: {
-        return assign({}, state, {seeMore: action.status});
+        return Object.assign({}, state, {seeMore: action.status});
     }
     case SET_DETAILS_COOKIE_HTML: {
-        return assign({}, state, {html: { ...state.html, [action.lang]: action.html}});
+        return Object.assign({}, state, {html: { ...state.html, [action.lang]: action.html}});
     }
     default:
         return state;

--- a/web/client/reducers/crsselector.js
+++ b/web/client/reducers/crsselector.js
@@ -1,9 +1,8 @@
 import { CHANGE_CRS_INPUT_VALUE } from '../actions/crsselector';
-import assign from 'object-assign';
 function crsselector(state = {projections: []}, action) {
     switch (action.type) {
     case CHANGE_CRS_INPUT_VALUE:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             value: action.value
         });
     default:

--- a/web/client/reducers/draw.js
+++ b/web/client/reducers/draw.js
@@ -17,8 +17,6 @@ import {
     SET_SNAPPING_CONFIG
 } from '../actions/draw';
 
-import assign from 'object-assign';
-
 const initialState = {
     drawStatus: null,
     drawOwner: null,
@@ -36,7 +34,7 @@ export const defaultSnappingConfig = { edge: true, vertex: true, pixelTolerance:
 function draw(state = initialState, action) {
     switch (action.type) {
     case CHANGE_DRAWING_STATUS:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             drawStatus: action.status,
             drawOwner: action.owner,
             drawMethod: action.method,
@@ -45,13 +43,13 @@ function draw(state = initialState, action) {
             style: action.style
         });
     case SET_CURRENT_STYLE:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             currentStyle: action.currentStyle
         });
     case GEOMETRY_CHANGED:
-        return assign({}, state, {tempFeatures: action.features});
+        return Object.assign({}, state, {tempFeatures: action.features});
     case DRAW_SUPPORT_STOPPED:
-        return assign({}, state, {tempFeatures: []});
+        return Object.assign({}, state, {tempFeatures: []});
     case TOGGLE_SNAPPING:
         return {
             ...state,

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -5,7 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
 */
-import assign from 'object-assign';
 
 import { head, get, uniqBy, isArray } from 'lodash';
 
@@ -152,7 +151,7 @@ const applyNewChanges = (features, changedFeatures, updates, updatesGeom) =>
 function featuregrid(state = emptyResultsState, action) {
     switch (action.type) {
     case INIT_PLUGIN: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             editingAllowedRoles: action.options.editingAllowedRoles || state.editingAllowedRoles || ["ADMIN"],
             editingAllowedGroups: action.options.editingAllowedGroups || state.editingAllowedGroups || [],
             virtualScroll: !!action.options.virtualScroll,
@@ -161,7 +160,7 @@ function featuregrid(state = emptyResultsState, action) {
     }
     case LOAD_MORE_FEATURES:
     case CHANGE_PAGE: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             pagination: {
                 page: action.page !== undefined ? action.page : state.pagination.page,
                 size: action.size !== undefined ? action.size : state.pagination.size
@@ -180,41 +179,41 @@ function featuregrid(state = emptyResultsState, action) {
     case SELECT_FEATURES: {
         const features = action.features.filter(f => f.id !== 'empty_row');
         if (state.multiselect && action.append) {
-            return assign({}, state, {select: action.append ? uniqBy([...state.select, ...features], "id") : features});
+            return Object.assign({}, state, {select: action.append ? uniqBy([...state.select, ...features], "id") : features});
         }
         if (features && state.select && state.select[0] && features[0] && state.select.length === 1 && isSameFeature(features[0], state.select[0])) {
             return state;
         }
-        return assign({}, state, {select: (features || [])});
+        return Object.assign({}, state, {select: (features || [])});
     }
     case TOGGLE_FEATURES_SELECTION:
         let keepValues = state.select.filter( f => !isPresent(f, action.features));
         // let removeValues = state.select.filter( f => isPresent(f, action.features));
         let newValues = action.features.filter( f => !isPresent(f, state.select));
         let res = keepValues.concat( (newValues || []));
-        return assign({}, state, {select: res});
+        return Object.assign({}, state, {select: res});
     case DESELECT_FEATURES:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             select: state.select.filter(f1 => !isPresent(f1, action.features))
         });
     case SET_SELECTION_OPTIONS: {
-        return assign({}, state, {multiselect: action.multiselect ?? state.multiselect, showCheckbox: action.showCheckbox ?? state.showCheckbox});
+        return Object.assign({}, state, {multiselect: action.multiselect ?? state.multiselect, showCheckbox: action.showCheckbox ?? state.showCheckbox});
     }
     case UPDATE_EDITORS_OPTIONS:
-        return assign({}, state, { customEditorsOptions: action.payload });
+        return Object.assign({}, state, { customEditorsOptions: action.payload });
     case SET_UP: {
-        return assign({}, state, action.options || {});
+        return Object.assign({}, state, action.options || {});
     }
     case CLEAR_SELECTION:
-        return assign({}, state, {select: [], changes: []});
+        return Object.assign({}, state, {select: [], changes: []});
     case SET_FEATURES:
-        return assign({}, state, {features: action.features});
+        return Object.assign({}, state, {features: action.features});
     case DOCK_SIZE_FEATURES:
-        return assign({}, state, {dockSize: action.dockSize});
+        return Object.assign({}, state, {dockSize: action.dockSize});
     case SET_LAYER:
-        return assign({}, state, {selectedLayer: action.id});
+        return Object.assign({}, state, {selectedLayer: action.id});
     case TOGGLE_TOOL:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             tools: {
                 ...state.tools,
                 [action.tool]: action.value === undefined ? !(state.tools && state.tools[action.tool]) : action.value
@@ -222,7 +221,7 @@ function featuregrid(state = emptyResultsState, action) {
 
         });
     case CUSTOMIZE_ATTRIBUTE:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             attributes: {
                 ...state.attributes,
                 [action.name]: {
@@ -232,7 +231,7 @@ function featuregrid(state = emptyResultsState, action) {
             }
         });
     case TOGGLE_MODE: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             tools: action.mode === MODES.EDIT ? {} : state.tools,
             mode: action.mode,
             multiselect: action.mode === MODES.EDIT,
@@ -241,7 +240,7 @@ function featuregrid(state = emptyResultsState, action) {
     }
     case FEATURES_MODIFIED: {
         const newFeaturesChanges = action.features.filter(f => f._new) || [];
-        return assign({}, state, {
+        return Object.assign({}, state, {
             newFeatures: newFeaturesChanges.length > 0 ? applyNewChanges(state.newFeatures, newFeaturesChanges, action.updated, null) : state.newFeatures,
             changes: [...(state && state.changes || []), ...(action.features.filter(f => !f._new).map(f => ({
                 id: f.id,
@@ -250,13 +249,13 @@ function featuregrid(state = emptyResultsState, action) {
         });
     }
     case SAVING: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             saving: true,
             loading: true
         });
     }
     case SAVE_SUCCESS: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             deleteConfirm: false,
             saved: true,
             saving: false,
@@ -265,7 +264,7 @@ function featuregrid(state = emptyResultsState, action) {
         });
     }
     case CLEAR_CHANGES: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             saved: false,
             deleteConfirm: false,
             drawing: false,
@@ -275,7 +274,7 @@ function featuregrid(state = emptyResultsState, action) {
     }
     case CREATE_NEW_FEATURE: {
         let id = uuid.v1();
-        return assign({}, state, {
+        return Object.assign({}, state, {
             newFeatures: action.features.map(f => ({...f, _new: true, id: f.id ? f.id : id, type: "Feature",
                 geometry: f.geometry ? f.geometry : null
             })),
@@ -285,7 +284,7 @@ function featuregrid(state = emptyResultsState, action) {
         });
     }
     case SAVE_ERROR: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             deleteConfirm: false,
             saving: false,
             loading: false,
@@ -294,7 +293,7 @@ function featuregrid(state = emptyResultsState, action) {
     }
     case GEOMETRY_CHANGED: {
         const newFeaturesChanges = action.features.filter(f => f._new) || [];
-        return assign({}, state, {
+        return Object.assign({}, state, {
             newFeatures: newFeaturesChanges.length > 0 ? applyNewChanges(state.newFeatures, newFeaturesChanges, null, {geometry: {...head(newFeaturesChanges).geometry} }) : state.newFeatures,
             changes: action.features.filter(f => !f._new).map((f, index) => ({
                 id: f.id,
@@ -305,7 +304,7 @@ function featuregrid(state = emptyResultsState, action) {
     }
     case DELETE_GEOMETRY_FEATURE: {
         const newFeaturesChanges = action.features.filter(f => f._new) || [];
-        return assign({}, state, {
+        return Object.assign({}, state, {
             newFeatures: newFeaturesChanges.length > 0 ? applyNewChanges(state.newFeatures, newFeaturesChanges, null, {geometry: null}) : state.newFeatures,
             changes: [...(state && state.changes || []), ...(action.features.filter(f => !f._new).map(f => ({
                 id: f.id,
@@ -314,23 +313,23 @@ function featuregrid(state = emptyResultsState, action) {
         });
     }
     case FEATURE_TYPE_LOADED: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             localType: get(action, "featureType.original.featureTypes[0].properties[1].localType")
         });
     }
     case START_DRAWING_FEATURE: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             drawing: !state.drawing
         });
     }
     case OPEN_FEATURE_GRID: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             open: true,
             closer: null
         });
     }
     case CLOSE_FEATURE_GRID: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             open: false,
             pagination: {
                 page: 0,
@@ -347,18 +346,18 @@ function featuregrid(state = emptyResultsState, action) {
         });
     }
     case DISABLE_TOOLBAR: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             disableToolbar: action.disabled
         });
     }
     case SET_PERMISSION: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             canEdit: action.permission.canEdit
         });
     }
     case CHANGE_DRAWING_STATUS: {
         if (action.status === "clean") {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 drawing: false
             });
         }
@@ -378,7 +377,7 @@ function featuregrid(state = emptyResultsState, action) {
             }
 
             const newValue = [...oldVal, action.update.value];
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 filters: {
                     [attribute]: {
                         attribute: attribute,
@@ -391,7 +390,7 @@ function featuregrid(state = emptyResultsState, action) {
             });
         }
         if (attribute) {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 filters: {
                     ...state.filters,
                     [attribute]: action.update
@@ -401,7 +400,7 @@ function featuregrid(state = emptyResultsState, action) {
         return state;
     }
     case QUERY_CREATE : {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             filters: {
             }
         });
@@ -419,24 +418,24 @@ function featuregrid(state = emptyResultsState, action) {
         || maxDockSize && maxDockSize < action.size && maxDockSize
         || minDockSize && minDockSize > action.size && minDockSize
         || action.size;
-        return assign({}, state, {
+        return Object.assign({}, state, {
             dockSize: size
         });
     }
     case STORE_ADVANCED_SEARCH_FILTER : {
-        return assign({}, state, {advancedFilters: assign({}, state.advancedFilters, {[state.selectedLayer]: action.filterObj})});
+        return Object.assign({}, state, {advancedFilters: Object.assign({}, state.advancedFilters, {[state.selectedLayer]: action.filterObj})});
     }
     case GRID_QUERY_RESULT: {
-        return assign({}, state, {features: action.features || [], pages: action.pages || []});
+        return Object.assign({}, state, {features: action.features || [], pages: action.pages || []});
     }
     case TOGGLE_SHOW_AGAIN_FLAG: {
-        return assign({}, state, {showAgain: !state.showAgain});
+        return Object.assign({}, state, {showAgain: !state.showAgain});
     }
     case SET_TIME_SYNC: {
-        return assign({}, state, {timeSync: action.value});
+        return Object.assign({}, state, {timeSync: action.value});
     }
     case SET_VIEWPORT_FILTER: {
-        return assign({}, state, {viewportFilter: action.value});
+        return Object.assign({}, state, {viewportFilter: action.value});
     }
     case MAP_CONFIG_LOADED: {
         return {...state, ...get(action, 'config.featureGrid', {})};

--- a/web/client/reducers/help.js
+++ b/web/client/reducers/help.js
@@ -8,21 +8,19 @@
 
 import { CHANGE_HELP_STATE, CHANGE_HELP_TEXT, CHANGE_HELPWIN_VIZ } from '../actions/help';
 
-import assign from 'object-assign';
-
 function help(state = null, action) {
     switch (action.type) {
     case CHANGE_HELP_STATE:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             enabled: action.enabled
         });
     case CHANGE_HELP_TEXT: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             helpText: action.helpText
         });
     }
     case CHANGE_HELPWIN_VIZ: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             helpwinViz: action.helpwinViz
         });
     }

--- a/web/client/reducers/highlight.js
+++ b/web/client/reducers/highlight.js
@@ -8,8 +8,6 @@
 
 import { HIGHLIGHT_STATUS, UPDATE_HIGHLIGHTED, SET_HIGHLIGHT_FEATURES_PATH } from '../actions/highlight';
 
-import assign from 'object-assign';
-
 const initialState = {
     status: 'disabled',
     layer: 'featureselector',
@@ -22,7 +20,7 @@ const initialState = {
 function highlight(state = initialState, action) {
     switch (action.type) {
     case SET_HIGHLIGHT_FEATURES_PATH: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             featuresPath: action.featuresPath || "highlight.emptyFeatures"
         });
     }

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -36,7 +36,6 @@ import {
 } from '../actions/layers';
 
 import { TOGGLE_CONTROL } from '../actions/controls';
-import assign from 'object-assign';
 import uuidv1 from 'uuid/v1';
 import { isString, includes, castArray } from 'lodash';
 import {
@@ -72,35 +71,35 @@ function layers(state = { flat: [] }, action) {
     switch (action.type) {
     case TOGGLE_CONTROL: {
         if (action.control === 'RefreshLayers') {
-            return assign({}, state, {refreshError: []});
+            return Object.assign({}, state, {refreshError: []});
         }
         return state;
     }
     case LAYER_LOADING: {
         const newLayers = (state.flat || []).map((layer) => {
-            return layer.id === action.layerId ? assign({}, layer, {loading: true}) : layer;
+            return layer.id === action.layerId ? Object.assign({}, layer, {loading: true}) : layer;
         });
-        return assign({}, state, {flat: newLayers});
+        return Object.assign({}, state, {flat: newLayers});
     }
     case LAYER_LOAD: {
         const newLayers = (state.flat || []).map((layer) => {
-            return layer.id === action.layerId ? assign({}, layer, {
+            return layer.id === action.layerId ? Object.assign({}, layer, {
                 loading: false, previousLoadingError: layer.loadingError, loadingError: action.error ? "Error" : false
             }) : layer;
         });
-        return assign({}, state, {flat: newLayers});
+        return Object.assign({}, state, {flat: newLayers});
     }
     case LAYER_ERROR: {
         const isError = action.tilesCount === action.tilesErrorCount;
         const newLayers = (state.flat || []).map((layer) => {
-            return layer.id === action.layerId ? assign({}, layer, {
+            return layer.id === action.layerId ? Object.assign({}, layer, {
                 previousLoadingError: layer.loadingError, loadingError: isError ? 'Error' : 'Warning'
             }) : layer;
         });
-        return assign({}, state, {flat: newLayers});
+        return Object.assign({}, state, {flat: newLayers});
     }
     case REFRESH_LAYERS: {
-        return assign({}, state, {refreshing: action.layers, refreshError: []});
+        return Object.assign({}, state, {refreshing: action.layers, refreshError: []});
     }
     case LAYERS_REFRESH_ERROR: {
         const newLayers = (state.refreshing || []).filter((layer) => {
@@ -110,13 +109,13 @@ function layers(state = { flat: [] }, action) {
             layer: err.fullLayer.title,
             error: action.error
         }));
-        return assign({}, state, {refreshing: newLayers, refreshError: [...(state.refreshError || []), ...errors]});
+        return Object.assign({}, state, {refreshing: newLayers, refreshError: [...(state.refreshError || []), ...errors]});
     }
     case LAYERS_REFRESHED: {
         const newLayers = (state.refreshing || []).filter((layer) => {
             return action.layers.filter((l) => l.layer === layer.id).length === 0;
         });
-        return assign({}, state, {refreshing: newLayers});
+        return Object.assign({}, state, {refreshing: newLayers});
     }
     case CHANGE_LAYER_PARAMS:
     case CHANGE_LAYER_PROPERTIES: {
@@ -126,32 +125,32 @@ function layers(state = { flat: [] }, action) {
             false);
         const newLayers = flatLayers.map((layer) => {
             if ( includes(castArray(action.layer), layer.id )) {
-                return assign(
+                return Object.assign(
                     {},
                     layer,
                     action.newProperties,
                     action.params
                         ? {
-                            params: assign({}, layer.params, action.params)
+                            params: Object.assign({}, layer.params, action.params)
                         }
                         : {});
             } else if (layer.group === 'background' && isBackground && action.newProperties && action.newProperties.visibility) {
                 // TODO remove
-                return assign({}, layer, {visibility: false});
+                return Object.assign({}, layer, {visibility: false});
             }
-            return assign({}, layer);
+            return Object.assign({}, layer);
         });
-        return assign({}, state, {flat: newLayers});
+        return Object.assign({}, state, {flat: newLayers});
     }
     case CHANGE_GROUP_PROPERTIES: {
         let newLayers = state.flat.map((layer) => {
             const layerGroup = layer.group || DEFAULT_GROUP_ID;
             if (layerGroup === action.group || layerGroup.indexOf(`${action.group}.`) === 0) {
-                return assign({}, layer, action.newProperties);
+                return Object.assign({}, layer, action.newProperties);
             }
-            return assign({}, layer);
+            return Object.assign({}, layer);
         });
-        return assign({}, state, {
+        return Object.assign({}, state, {
             flat: newLayers
         });
     }
@@ -159,7 +158,7 @@ function layers(state = { flat: [] }, action) {
         let nodeSelector = action.nodeType === 'layers' ? 'flat' : 'groups';
         let nodes = state[nodeSelector] || [];
         const newNodes = deepChange(nodes, action.node, 'expanded', action.status);
-        return assign({}, state, {[nodeSelector]: newNodes});
+        return Object.assign({}, state, {[nodeSelector]: newNodes});
     }
     case SORT_NODE: {
         let node = getNode(state.groups || [], action.node);
@@ -171,7 +170,7 @@ function layers(state = { flat: [] }, action) {
             const newNodes = action.node === ROOT_GROUP_ID ? reorderedNodes :
                 deepChange(state.groups, action.node, 'nodes', reorderedNodes);
             let newLayers = action.sortLayers ? action.sortLayers(newNodes, state.flat) : state.flat;
-            return assign({}, state, {groups: newNodes, flat: newLayers});
+            return Object.assign({}, state, {groups: newNodes, flat: newLayers});
         }
         return state;
     }
@@ -231,7 +230,7 @@ function layers(state = { flat: [] }, action) {
                 removeEmptyGroups(deepRemove(state.groups, action.node)) :
                 deepRemove(state.groups, action.node);
             const newLayers = state.flat.filter((layer) => layer.id !== action.node);
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 flat: newLayers,
                 groups: newGroups,
                 selected: (state?.selected || []).filter((selectedId) => selectedId !== action.node)
@@ -243,14 +242,14 @@ function layers(state = { flat: [] }, action) {
         const layer = normalizeLayer(action.layer);
         let newLayers = (state.flat || []).concat();
         let newGroups = (state.groups || []).concat();
-        const newLayer = (layer.id) ? layer : assign({}, layer, {id: getLayerId(layer)});
+        const newLayer = (layer.id) ? layer : Object.assign({}, layer, {id: getLayerId(layer)});
         newLayers.push(newLayer);
         const groupId = newLayer.group || DEFAULT_GROUP_ID;
         if (groupId !== "background") {
             newGroups = moveNode(newGroups, newLayer.id, groupId, newLayers, action.foreground);
         }
         let orderedNewLayers = sortLayers ? sortLayers(newGroups, newLayers) : newLayers;
-        return assign({}, state, {
+        return Object.assign({}, state, {
             flat: orderedNewLayers,
             groups: newGroups
         });
@@ -258,7 +257,7 @@ function layers(state = { flat: [] }, action) {
     case REMOVE_LAYER: {
         const newGroups = deepRemove(state.groups, action.layerId);
         const newLayers = state.flat.filter((layer) => layer.id !== action.layerId);
-        return assign({}, state, {
+        return Object.assign({}, state, {
             flat: newLayers,
             groups: newGroups
         });
@@ -291,18 +290,18 @@ function layers(state = { flat: [] }, action) {
             parent,
             action.asFirst
         );
-        return assign({}, state, {
+        return Object.assign({}, state, {
             groups: newGroups
         });
     }
     case SHOW_SETTINGS: {
-        let settings = assign({}, state.settings, {
+        let settings = Object.assign({}, state.settings, {
             expanded: true,
             node: action.node,
             nodeType: action.nodeType,
             options: action.options
         });
-        return assign({}, state, {
+        return Object.assign({}, state, {
             settings: settings,
             editLayerName: false,
             layerNameIsBeingChecked: false,
@@ -310,13 +309,13 @@ function layers(state = { flat: [] }, action) {
         });
     }
     case HIDE_SETTINGS: {
-        let settings = assign({}, state.settings, {
+        let settings = Object.assign({}, state.settings, {
             expanded: false,
             node: null,
             nodeType: null,
             options: {}
         });
-        return assign({}, state, {
+        return Object.assign({}, state, {
             settings: settings,
             editLayerName: false,
             layerNameIsBeingChecked: false,
@@ -325,17 +324,17 @@ function layers(state = { flat: [] }, action) {
     }
 
     case UPDATE_SETTINGS: {
-        const options = assign({},
+        const options = Object.assign({},
             state.settings && state.settings.options,
             action.options
         );
-        const settings = assign({}, state.settings, {options: options});
-        return assign({}, state, {
+        const settings = Object.assign({}, state.settings, {options: options});
+        return Object.assign({}, state, {
             settings: settings
         });
     }
     case CLEAR_LAYERS: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             flat: [],
             groups: [],
             selected: []
@@ -359,26 +358,26 @@ function layers(state = { flat: [] }, action) {
         };
     }
     case FILTER_LAYERS: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             filter: action.text || ''
         });
     }
     case SHOW_LAYER_METADATA: {
-        let layerMetadata = assign({}, state.layerMetadata, {
+        let layerMetadata = Object.assign({}, state.layerMetadata, {
             metadataRecord: action.metadataRecord,
             expanded: true,
             maskLoading: action.maskLoading
         });
-        return assign({}, state, {
+        return Object.assign({}, state, {
             layerMetadata
         });
     }
     case HIDE_LAYER_METADATA: {
-        let layerMetadata = assign({}, state.layerMetadata, {
+        let layerMetadata = Object.assign({}, state.layerMetadata, {
             metadataRecord: {},
             expanded: false
         });
-        return assign({}, state, {
+        return Object.assign({}, state, {
             layerMetadata
         });
     }

--- a/web/client/reducers/localConfig.js
+++ b/web/client/reducers/localConfig.js
@@ -8,13 +8,12 @@
 
 import { LOCAL_CONFIG_LOADED } from '../actions/localConfig';
 
-import assign from 'object-assign';
 import ConfigUtils from '../utils/ConfigUtils';
 const initialState = ConfigUtils.getDefaults();
 function controls(state = initialState, action) {
     switch (action.type) {
     case LOCAL_CONFIG_LOADED:
-        return assign({}, state, action.config);
+        return Object.assign({}, state, action.config);
     default:
         return state;
     }

--- a/web/client/reducers/locate.js
+++ b/web/client/reducers/locate.js
@@ -8,16 +8,15 @@
 
 import { CHANGE_LOCATE_STATE, LOCATE_ERROR } from '../actions/locate';
 
-import assign from 'object-assign';
 
 function locate(state = {state: "DISABLED"}, action) {
     switch (action.type) {
     case CHANGE_LOCATE_STATE:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             state: action.state
         });
     case LOCATE_ERROR:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             error: action.error
         });
     default:

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -28,7 +28,6 @@ import {
 } from '../actions/map';
 import { LOCATION_CHANGE } from 'connected-react-router';
 
-import assign from 'object-assign';
 import MapUtils from '../utils/MapUtils';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
 
@@ -37,23 +36,23 @@ function mapConfig(state = {eventListeners: {}}, action) {
     case CHANGE_MAP_VIEW:
         const {type, ...params} = action;
         params.zoom = isNaN(params.zoom) ? 1 : params.zoom;
-        return assign({}, state, params);
+        return Object.assign({}, state, params);
     case CHANGE_MOUSE_POINTER:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             mousePointer: action.pointer
         });
     case LOCATION_CHANGE:
         if (action?.payload?.action === 'REPLACE') {
             return state;
         }
-        return assign({}, {eventListeners: {}});
+        return Object.assign({}, {eventListeners: {}});
     case CHANGE_ZOOM_LVL:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             zoom: action.zoom,
             mapStateSource: action.mapStateSource
         });
     case CHANGE_MAP_LIMITS:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             limits: {
                 restrictedExtent: action.restrictedExtent,
                 crs: action.crs,
@@ -61,7 +60,7 @@ function mapConfig(state = {eventListeners: {}}, action) {
             }
         });
     case CHANGE_MAP_CRS:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             projection: action.crs
         });
     case CHANGE_MAP_SCALES:
@@ -69,10 +68,10 @@ function mapConfig(state = {eventListeners: {}}, action) {
             const dpi = state && state.mapOptions && state.mapOptions.view && state.mapOptions.view.DPI || null;
             const resolutions = MapUtils.getResolutionsForScales(action.scales, state && state.projection || "EPSG:4326", dpi);
             // add or update mapOptions.view.resolutions
-            return assign({}, state, {
-                mapOptions: assign({}, state && state.mapOptions,
+            return Object.assign({}, state, {
+                mapOptions: Object.assign({}, state && state.mapOptions,
                     {
-                        view: assign({}, state && state.mapOptions && state.mapOptions.view, {
+                        view: Object.assign({}, state && state.mapOptions && state.mapOptions.view, {
                             resolutions: resolutions,
                             scales: action.scales
                         })
@@ -81,9 +80,9 @@ function mapConfig(state = {eventListeners: {}}, action) {
         } else if (state && state.mapOptions && state.mapOptions.view && state.mapOptions.view && state.mapOptions.view.resolutions) {
             // TODO: this block is removing empty objects from the state, check if it really needed
             // deeper clone
-            let newState = assign({}, state);
-            newState.mapOptions = assign({}, newState.mapOptions);
-            newState.mapOptions.view = assign({}, newState.mapOptions.view);
+            let newState = Object.assign({}, state);
+            newState.mapOptions = Object.assign({}, newState.mapOptions);
+            newState.mapOptions.view = Object.assign({}, newState.mapOptions.view);
             // remove resolutions
             delete newState.mapOptions.view.resolutions;
             // cleanup state
@@ -97,12 +96,12 @@ function mapConfig(state = {eventListeners: {}}, action) {
         }
         return state;
     case SET_MAP_RESOLUTIONS: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             resolutions: action.resolutions
         });
     }
     case ZOOM_TO_POINT: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             center: CoordinatesUtils.reproject(action.pos, action.crs, 'EPSG:4326'),
             zoom: action.zoom,
             mapStateSource: null
@@ -114,35 +113,35 @@ function mapConfig(state = {eventListeners: {}}, action) {
             action.center,
             action.center.crs || 'EPSG:4326',
             'EPSG:4326');
-        return assign({}, state, {
+        return Object.assign({}, state, {
             center,
             mapStateSource: null
         });
     }
     case CHANGE_MAP_STYLE: {
-        return assign({}, state, {mapStateSource: action.mapStateSource, style: action.style, resize: state.resize ? state.resize + 1 : 1});
+        return Object.assign({}, state, {mapStateSource: action.mapStateSource, style: action.style, resize: state.resize ? state.resize + 1 : 1});
     }
     case RESIZE_MAP: {
-        return assign({}, state, {resize: state.resize ? state.resize + 1 : 1});
+        return Object.assign({}, state, {resize: state.resize ? state.resize + 1 : 1});
     }
     case CHANGE_ROTATION: {
-        let newBbox = assign({}, state.bbox, {rotation: action.rotation});
-        return assign({}, state, {bbox: newBbox, mapStateSource: action.mapStateSource});
+        let newBbox = Object.assign({}, state.bbox, {rotation: action.rotation});
+        return Object.assign({}, state, {bbox: newBbox, mapStateSource: action.mapStateSource});
     }
     case UPDATE_VERSION: {
-        return assign({}, state, {version: action.version});
+        return Object.assign({}, state, {version: action.version});
     }
     case REGISTER_EVENT_LISTENER: {
-        return assign({}, state,
-            {eventListeners: assign({}, state.eventListeners || {},
+        return Object.assign({}, state,
+            {eventListeners: Object.assign({}, state.eventListeners || {},
                 {[action.eventName]: [...(state.eventListeners && state.eventListeners[action.eventName] || []), action.toolName]})});
     }
     case UNREGISTER_EVENT_LISTENER: {
         let data = state;
         if (state?.eventListeners) {
             const filteredEventNameTools = (state.eventListeners && state.eventListeners[action.eventName] || []).filter(tool => tool !== action.toolName) || [];
-            data = assign({}, state,
-                {eventListeners: assign({}, state.eventListeners,
+            data = Object.assign({}, state,
+                {eventListeners: Object.assign({}, state.eventListeners,
                     {[action.eventName]: filteredEventNameTools})});
         }
         return data;
@@ -156,7 +155,7 @@ function mapConfig(state = {eventListeners: {}}, action) {
             const heading = action.orientation.heading;
             const pitch = action.orientation.pitch;
             const roll = action.orientation.roll;
-            return assign({}, state, {orientate: {x, y, z, heading, pitch, roll}});
+            return Object.assign({}, state, {orientate: {x, y, z, heading, pitch, roll}});
         }
         return null;
     }

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -5,7 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import assign from 'object-assign';
 import { findIndex, isUndefined, isEmpty } from 'lodash';
 
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -116,7 +115,7 @@ function receiveResponse(state, action, type) {
             indexObj = {loaded: true};
         }
         // Set responses and index as first response is received
-        return assign({}, state, {
+        return Object.assign({}, state, {
             ...(isVector && {requests}),
             ...(!isUndefined(indexObj) && indexObj),
             responses: [...responses]}
@@ -244,35 +243,35 @@ const initState = {
 function mapInfo(state = initState, action) {
     switch (action.type) {
     case NO_QUERYABLE_LAYERS:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             warning: 'NO_QUERYABLE_LAYERS'
         });
     case CLEAR_WARNING:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             warning: null
         });
     case CHANGE_MAPINFO_STATE:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             enabled: action.enabled
         });
     case TOGGLE_MAPINFO_STATE:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             enabled: !state.enabled
         });
     case CHANGE_PAGE: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             index: action.index
         });
     }
     case TOGGLE_HIGHLIGHT_FEATURE: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             highlight: action.enabled
         });
     }
     case NEW_MAPINFO_REQUEST: {
         const {reqId, request} = action;
         const requests = state.requests || [];
-        return assign({}, state, {
+        return Object.assign({}, state, {
             requests: [...requests, {request, reqId}]
         });
     }
@@ -289,7 +288,7 @@ function mapInfo(state = initState, action) {
         return receiveResponse(state, action, 'error');
     }
     case FEATURE_INFO_CLICK: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             clickPoint: action.point,
             clickLayer: action.layer || null,
             itemId: action.itemId || null,
@@ -306,29 +305,29 @@ function mapInfo(state = initState, action) {
         };
     }
     case SHOW_MAPINFO_MARKER: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             showMarker: true
         });
     }
     case HIDE_MAPINFO_MARKER: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             showMarker: false
         });
     }
     case SHOW_REVERSE_GEOCODE: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             showModalReverse: true,
             reverseGeocodeData: action.reverseGeocodeData
         });
     }
     case HIDE_REVERSE_GEOCODE: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             showModalReverse: false,
             reverseGeocodeData: undefined
         });
     }
     case RESET_CONTROLS: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             showMarker: false,
             responses: [],
             requests: [],
@@ -339,7 +338,7 @@ function mapInfo(state = initState, action) {
         });
     }
     case UPDATE_CENTER_TO_MARKER: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             centerToMarker: action.status
         });
     }

--- a/web/client/reducers/mapimport.js
+++ b/web/client/reducers/mapimport.js
@@ -20,7 +20,6 @@ import {
 
 import { uniqWith } from 'lodash';
 import { TOGGLE_CONTROL } from '../actions/controls';
-import assign from 'object-assign';
 
 const initialState = {
     layers: null,
@@ -33,15 +32,15 @@ const initialState = {
 function mapimport(state = initialState, action) {
     switch (action.type) {
     case ON_SHAPE_ERROR: {
-        return assign({}, state, {error: action.message, success: null});
+        return Object.assign({}, state, {error: action.message, success: null});
     }
     case SET_LAYERS: {
         let selected = action.layers && action.layers[0] ? action.layers[0] : null;
         const errors = action.layers ? action.errors : null;
-        return assign({}, state, {layers: action.layers, selected: selected, bbox: [190, 190, -190, -190], errors}, selected ? {} : {success: null});
+        return Object.assign({}, state, {layers: action.layers, selected: selected, bbox: [190, 190, -190, -190], errors}, selected ? {} : {success: null});
     }
     case ON_ERROR: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             // remove duplicates
             errors: uniqWith(
                 [...(state.errors || []), action.error],
@@ -50,28 +49,28 @@ function mapimport(state = initialState, action) {
             ), success: null});
     }
     case LOADING: {
-        return assign({}, state, {loading: action.status});
+        return Object.assign({}, state, {loading: action.status});
     }
     case ON_SELECT_LAYER: {
-        return assign({}, state, {selected: action.layer});
+        return Object.assign({}, state, {selected: action.layer});
     }
     case ON_LAYER_ADDED: {
         let newLayers = state.layers.filter((l) => {
             return action.layer.name !== l.name;
         }, this);
         let selected = newLayers && newLayers[0] ? newLayers[0] : null;
-        return assign({}, state, {layers: newLayers, selected: selected}, !selected ? {bbox: [190, 190, -190, -190]} : {});
+        return Object.assign({}, state, {layers: newLayers, selected: selected}, !selected ? {bbox: [190, 190, -190, -190]} : {});
     }
     case UPDATE_BBOX: {
-        return assign({}, state, {bbox: action.bbox});
+        return Object.assign({}, state, {bbox: action.bbox});
     }
     case ON_SUCCESS: {
-        return assign({}, state, {success: action.message, errors: null, error: null});
+        return Object.assign({}, state, {success: action.message, errors: null, error: null});
     }
     case TOGGLE_CONTROL: {
         // TODO check this. if it must remain
         if (action.control === 'shapefile') {
-            return assign({}, state, {errors: null, success: null});
+            return Object.assign({}, state, {errors: null, success: null});
         }
         return state;
     }
@@ -80,7 +79,7 @@ function mapimport(state = initialState, action) {
             return action.layer.name !== l.name;
         }, this);
         const selected = newLayers && newLayers[0] ? newLayers[0] : null;
-        return assign({}, state, {layers: newLayers, selected, success: null});
+        return Object.assign({}, state, {layers: newLayers, selected, success: null});
     }
     default:
         return state;

--- a/web/client/reducers/maplayout.js
+++ b/web/client/reducers/maplayout.js
@@ -8,7 +8,6 @@
 
 import {UPDATE_DOCK_PANELS, UPDATE_MAP_LAYOUT} from '../actions/maplayout';
 
-import assign from 'object-assign';
 const DEFAULT_RIGHT_DOCK_PANELS = ['mapCatalog', 'mapTemplates', 'metadataexplorer', 'userExtensions', 'details', 'GeoProcessing'];
 const DEFAULT_LEFT_DOCK_PANELS = [];
 
@@ -23,7 +22,7 @@ function mapLayout(state = { layout: {}, boundingMapRect: {}, boundingSidebarRec
     switch (action.type) {
     case UPDATE_MAP_LAYOUT: {
         const {boundingMapRect = {}, boundingSidebarRect = {}, ...layout} = action.layout;
-        return assign({}, state, {layout: assign({}, layout, layout), boundingMapRect: {...boundingMapRect}, boundingSidebarRect: {...boundingSidebarRect}});
+        return Object.assign({}, state, {layout: Object.assign({}, layout, layout), boundingMapRect: {...boundingMapRect}, boundingSidebarRect: {...boundingSidebarRect}});
     }
     case UPDATE_DOCK_PANELS: {
         const {name, action: operation, location} = action;

--- a/web/client/reducers/measurement.js
+++ b/web/client/reducers/measurement.js
@@ -28,7 +28,7 @@ import { getGeomTypeSelected } from '../utils/MeasurementUtils';
 import { validateCoord, defaultUnitOfMeasure } from '../utils/MeasureUtils';
 import { isPolygon } from '../utils/openlayers/DrawUtils';
 import { dropRight, isEmpty, findIndex, isNumber } from 'lodash';
-import assign from 'object-assign';
+
 const defaultState = {
     lineMeasureEnabled: true,
     geomType: "LineString",
@@ -55,7 +55,7 @@ function measurement(state = defaultState, action) {
     switch (action.type) {
     case CHANGE_MEASUREMENT_TOOL: {
         const currentFeatureIndex = action.geomType !== null && findIndex(state.features, (f)=> ((f.properties?.values?.[0] || {}).type === 'bearing' ? 'Bearing' : f.geometry.type) === action.geomType);
-        return assign({}, state, {
+        return Object.assign({}, state, {
             lineMeasureEnabled: action.geomType !== state.geomType && action.geomType === 'LineString',
             areaMeasureEnabled: action.geomType !== state.geomType && action.geomType === 'Polygon',
             bearingMeasureEnabled: action.geomType !== state.geomType && action.geomType === 'Bearing',
@@ -81,7 +81,7 @@ function measurement(state = defaultState, action) {
              */
             feature = set("geometry.coordinates[0]", dropRight(feature.geometry.coordinates[0]), feature);
         }
-        return assign({}, state, {
+        return Object.assign({}, state, {
             lineMeasureEnabled: action.lineMeasureEnabled,
             areaMeasureEnabled: action.areaMeasureEnabled,
             bearingMeasureEnabled: action.bearingMeasureEnabled,
@@ -117,9 +117,9 @@ function measurement(state = defaultState, action) {
     case CHANGE_UOM: {
         const prop = action.uom === "length" ? "lenUnit" : "lenArea";
         const {value, label} = action.value;
-        return assign({}, state, {
+        return Object.assign({}, state, {
             ...((action.uom === "length" || action.uom === "area") && { [prop]: value }),
-            uom: assign({}, action.previousUom || state.uom, {
+            uom: Object.assign({}, action.previousUom || state.uom, {
                 [action.uom]: {
                     unit: value,
                     label

--- a/web/client/reducers/mousePosition.js
+++ b/web/client/reducers/mousePosition.js
@@ -13,27 +13,26 @@ import {
 } from '../actions/mousePosition';
 
 import { MOUSE_MOVE, MOUSE_OUT } from '../actions/map';
-import assign from 'object-assign';
 
 function mousePosition(state = {enabled: true, position: null, crs: null}, action) {
     switch (action.type) {
     case CHANGE_MOUSE_POSITION_STATE:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             enabled: action.enabled
         });
     case CHANGE_MOUSE_POSITION:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             position: action.position
         });
     case CHANGE_MOUSE_POSITION_CRS:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             crs: action.crs
         });
     case MOUSE_MOVE: {
-        return assign({}, state, {position: action.position, mouseOut: false});
+        return Object.assign({}, state, {position: action.position, mouseOut: false});
     }
     case MOUSE_OUT: {
-        return assign({}, state, {mouseOut: true});
+        return Object.assign({}, state, {mouseOut: true});
     }
     default:
         return state;

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -22,7 +22,6 @@ import {
 
 import { TOGGLE_CONTROL } from '../actions/controls';
 import { isObject, get } from 'lodash';
-import assign from 'object-assign';
 
 import set from "lodash/set";
 
@@ -50,7 +49,7 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
     switch (action.type) {
     case TOGGLE_CONTROL: {
         if (action.control === 'print') {
-            return assign({}, state, {pdfUrl: null, isLoading: false, error: null});
+            return Object.assign({}, state, {pdfUrl: null, isLoading: false, error: null});
         }
         return state;
     }
@@ -58,9 +57,9 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
         const layouts = get(action, 'capabilities.layouts', [{name: 'A4'}]);
         const sheetName = layouts.filter(l => getSheetName(l.name) === state.spec.sheet).length ?
             state.spec.sheet : getSheetName(layouts[0].name);
-        return assign({}, state, {
+        return Object.assign({}, state, {
             capabilities: action.capabilities,
-            spec: assign({}, state.spec || {}, {
+            spec: Object.assign({}, state.spec || {}, {
                 sheet: sheetName,
                 resolution: action.capabilities
                         && action.capabilities.dpis
@@ -82,14 +81,14 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
     case CONFIGURE_PRINT_MAP: {
 
         const layers = action.layers.map((layer) => {
-            return layer.title ? assign({}, layer, {
+            return layer.title ? Object.assign({}, layer, {
                 title: isObject(layer.title) && action.currentLocale && layer.title[action.currentLocale]
                 || isObject(layer.title) && layer.title.default
                 || layer.title
             }) : layer;
         });
 
-        return assign({}, state, {
+        return Object.assign({}, state, {
             map: {
                 center: action.center,
                 zoom: action.zoom,
@@ -106,8 +105,8 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
     }
     case CHANGE_PRINT_ZOOM_LEVEL: {
         const diff = action.zoom - state.map.scaleZoom;
-        return assign({}, state, {
-            map: assign({}, state.map, {
+        return Object.assign({}, state, {
+            map: Object.assign({}, state.map, {
                 scaleZoom: action.zoom,
                 zoom: state.map.zoom + diff >= 0 ? state.map.zoom + diff : 0,
                 scale: action.scale
@@ -116,8 +115,8 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
         );
     }
     case CHANGE_MAP_PRINT_PREVIEW: {
-        return assign({}, state, {
-            map: assign({}, state.map, {
+        return Object.assign({}, state, {
+            map: Object.assign({}, state.map, {
                 size: action.size,
                 zoom: action.zoom,
                 scaleZoom: action.zoom,
@@ -128,19 +127,19 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
         );
     }
     case PRINT_SUBMITTING: {
-        return assign({}, state, {isLoading: true, pdfUrl: null, error: null});
+        return Object.assign({}, state, {isLoading: true, pdfUrl: null, error: null});
     }
     case PRINT_CREATED: {
-        return assign({}, state, {isLoading: false, pdfUrl: action.url, error: null});
+        return Object.assign({}, state, {isLoading: false, pdfUrl: action.url, error: null});
     }
     case PRINT_ERROR: {
-        return assign({}, state, {isLoading: false, pdfUrl: null, error: action.error});
+        return Object.assign({}, state, {isLoading: false, pdfUrl: null, error: action.error});
     }
     case PRINT_CAPABILITIES_ERROR: {
-        return assign({}, state, {isLoading: false, pdfUrl: null, error: action.error});
+        return Object.assign({}, state, {isLoading: false, pdfUrl: null, error: action.error});
     }
     case PRINT_CANCEL: {
-        return assign({}, state, {isLoading: false, pdfUrl: null, error: null});
+        return Object.assign({}, state, {isLoading: false, pdfUrl: null, error: null});
     }
     default:
         return state;

--- a/web/client/reducers/query.js
+++ b/web/client/reducers/query.js
@@ -24,7 +24,6 @@ import {
 import { SET_SYNC_TOOL } from '../actions/featuregrid';
 import { QUERY_FORM_RESET } from '../actions/queryform';
 import { RESET_CONTROLS } from '../actions/controls';
-import assign from 'object-assign';
 
 const extractData = (feature) => {
     return ['STATE_NAME', 'STATE_ABBR', 'SUB_REGION', 'STATE_FIPS' ].map((attribute) => ({
@@ -36,7 +35,7 @@ const extractData = (feature) => {
             return previous;
         }, [])
     })).reduce((previous, current) => {
-        return assign(previous, {
+        return Object.assign(previous, {
             [current.attribute]: current.values.map((value) => ({
                 id: value,
                 name: value
@@ -57,52 +56,52 @@ const initialState = {
 function query(state = initialState, action) {
     switch (action.type) {
     case FEATURE_TYPE_SELECTED: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             typeName: action.typeName,
             url: action.url
         });
     }
     case FEATURE_TYPE_LOADED: {
-        return assign({}, state, {
-            featureTypes: assign({}, state.featureTypes, {[action.typeName]: action.featureType})
+        return Object.assign({}, state, {
+            featureTypes: Object.assign({}, state.featureTypes, {[action.typeName]: action.featureType})
         });
     }
     case FEATURE_TYPE_ERROR: {
-        return assign({}, state, {
-            featureTypes: assign({}, state.featureTypes, {[action.typeName]: {error: action.error}})
+        return Object.assign({}, state, {
+            featureTypes: Object.assign({}, state.featureTypes, {[action.typeName]: {error: action.error}})
         });
     }
     case FEATURE_LOADING: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             featureLoading: action.isLoading
         });
     }
     case FEATURE_LOADED: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             featureLoading: false,
-            data: assign({}, state.data, {[action.typeName]: extractData(action.feature)})
+            data: Object.assign({}, state.data, {[action.typeName]: extractData(action.feature)})
         });
     }
     case FEATURE_ERROR: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             featureLoading: false,
-            featureTypes: assign({}, state.data, {[action.typeName]: {error: action.error}})
+            featureTypes: Object.assign({}, state.data, {[action.typeName]: {error: action.error}})
         });
     }
     case QUERY_CREATE: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             isNew: true,
             searchUrl: action.searchUrl,
             filterObj: action.filterObj
         });
     }
     case UPDATE_QUERY: {
-        return assign({}, state, {
-            filterObj: assign({}, state.filterObj, action.updates)
+        return Object.assign({}, state, {
+            filterObj: Object.assign({}, state.filterObj, action.updates)
         });
     }
     case QUERY_RESULT: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             isNew: false,
             result: action.result,
             searchUrl: action.searchUrl,
@@ -111,7 +110,7 @@ function query(state = initialState, action) {
         });
     }
     case QUERY_ERROR: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             isNew: false,
             result: null,
             resultError: action.error
@@ -122,7 +121,7 @@ function query(state = initialState, action) {
         if (action.skip && action.skip.indexOf("query") >= 0) {
             return state;
         }
-        return assign({}, state, {
+        return Object.assign({}, state, {
             isNew: false,
             result: null,
             filterObj: null,
@@ -130,17 +129,17 @@ function query(state = initialState, action) {
             filters: null
         });
     case RESET_QUERY: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             result: null,
             resultError: null
         });
     }
     case TOGGLE_SYNC_WMS:
-        return assign({}, state, {syncWmsFilter: !state.syncWmsFilter});
+        return Object.assign({}, state, {syncWmsFilter: !state.syncWmsFilter});
     case SET_SYNC_TOOL:
-        return assign({}, state, {syncWmsFilter: action.syncWmsFilter});
+        return Object.assign({}, state, {syncWmsFilter: action.syncWmsFilter});
     case TOGGLE_LAYER_FILTER:
-        return assign({}, state, {isLayerFilter: !state.isLayerFilter});
+        return Object.assign({}, state, {isLayerFilter: !state.isLayerFilter});
     default:
         return state;
     }

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -55,7 +55,6 @@ import {
 } from '../actions/queryform';
 
 import { END_DRAWING, CHANGE_DRAWING_STATUS } from '../actions/draw';
-import assign from 'object-assign';
 import union from 'turf-union';
 import bbox from 'turf-bbox';
 import { get } from 'lodash';
@@ -92,7 +91,7 @@ const initialState = {
 };
 
 const updateFilterField = (field = {}, action = {}) => {
-    let f = assign({}, field, {[action.fieldName]: action.fieldValue, type: action.fieldType}, {fieldOptions: assign({}, {...field.fieldOptions}, {currentPage: action.fieldOptions.currentPage === undefined ? 1 : action.fieldOptions.currentPage})});
+    let f = Object.assign({}, field, {[action.fieldName]: action.fieldValue, type: action.fieldType}, {fieldOptions: Object.assign({}, {...field.fieldOptions}, {currentPage: action.fieldOptions.currentPage === undefined ? 1 : action.fieldOptions.currentPage})});
     if (action.fieldName === "attribute") {
         f.value = action.fieldType === "string" ? '' : null;
         f.operator = "=";
@@ -135,13 +134,13 @@ function queryform(state = initialState, action) {
             exception: null
         };
 
-        return assign({}, state, {filterFields: (state.filterFields ? [...state.filterFields, newFilterField] : [newFilterField])});
+        return Object.assign({}, state, {filterFields: (state.filterFields ? [...state.filterFields, newFilterField] : [newFilterField])});
     }
     case REMOVE_FILTER_FIELD: {
-        return assign({}, state, {filterFields: state.filterFields.filter((field) => field.rowId !== action.rowId)});
+        return Object.assign({}, state, {filterFields: state.filterFields.filter((field) => field.rowId !== action.rowId)});
     }
     case UPDATE_FILTER_FIELD: {
-        return assign({}, state, {filterFields: state.filterFields.map((field) => {
+        return Object.assign({}, state, {filterFields: state.filterFields.map((field) => {
             if (field.rowId === action.rowId) {
                 return updateFilterField(field, action);
             }
@@ -149,18 +148,18 @@ function queryform(state = initialState, action) {
         })});
     }
     case UPDATE_FILTER_FIELD_OPTIONS: {
-        return assign({}, state, {filterFields: state.filterFields.map((field) => {
+        return Object.assign({}, state, {filterFields: state.filterFields.map((field) => {
             if (field.rowId === action.filterField.rowId) {
-                return assign({}, field, {options: assign({}, {...field.options}, {[field.attribute]: action.options} )}, {fieldOptions: assign({}, {...field.fieldOptions}, {valuesCount: action.valuesCount})});
+                return Object.assign({}, field, {options: Object.assign({}, {...field.options}, {[field.attribute]: action.options} )}, {fieldOptions: Object.assign({}, {...field.fieldOptions}, {valuesCount: action.valuesCount})});
             }
             return field;
         })});
     }
     case TOGGLE_AUTOCOMPLETE_MENU: {
         if (action.layerFilterType === "filterField") {
-            return assign({}, state, {filterFields: state.filterFields.map((field) => {
+            return Object.assign({}, state, {filterFields: state.filterFields.map((field) => {
                 if (field.rowId === action.rowId) {
-                    return assign({}, field, {openAutocompleteMenu: action.status} );
+                    return Object.assign({}, field, {openAutocompleteMenu: action.status} );
                 }
                 return field;
             })});
@@ -180,13 +179,13 @@ function queryform(state = initialState, action) {
             , state);
     }
     case SET_AUTOCOMPLETE_MODE: {
-        return assign({}, state, {autocompleteEnabled: action.status});
+        return Object.assign({}, state, {autocompleteEnabled: action.status});
     }
     case LOADING_FILTER_FIELD_OPTIONS: {
         if (action.layerFilterType === "filterField") {
-            return assign({}, state, {filterFields: state.filterFields.map((field) => {
+            return Object.assign({}, state, {filterFields: state.filterFields.map((field) => {
                 if (field.rowId === action.filterField.rowId) {
-                    return assign({}, field, {loading: action.status});
+                    return Object.assign({}, field, {loading: action.status});
                 }
                 return field;
             })});
@@ -205,9 +204,9 @@ function queryform(state = initialState, action) {
             , state);
     }
     case UPDATE_EXCEPTION_FIELD: {
-        return assign({}, state, {filterFields: state.filterFields.map((field) => {
+        return Object.assign({}, state, {filterFields: state.filterFields.map((field) => {
             if (field.rowId === action.rowId) {
-                return assign({}, field, {exception: action.exceptionMessage});
+                return Object.assign({}, field, {exception: action.exceptionMessage});
             }
             return field;
         })});
@@ -219,49 +218,49 @@ function queryform(state = initialState, action) {
             groupId: action.groupId,
             index: action.index + 1
         };
-        return assign({}, state, {groupFields: (state.groupFields ? [...state.groupFields, newGroupField] : [newGroupField])});
+        return Object.assign({}, state, {groupFields: (state.groupFields ? [...state.groupFields, newGroupField] : [newGroupField])});
     }
     case UPDATE_LOGIC_COMBO: {
-        return assign({}, state, {groupFields: state.groupFields.map((field) => {
+        return Object.assign({}, state, {groupFields: state.groupFields.map((field) => {
             if (field.id === action.groupId) {
-                return assign({}, field, {logic: action.logic});
+                return Object.assign({}, field, {logic: action.logic});
             }
             return field;
         })});
     }
     case REMOVE_GROUP_FIELD: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             filterFields: state.filterFields.filter((field) => field.groupId !== action.groupId),
             groupFields: state.groupFields.filter((group) => group.id !== action.groupId)
         });
     }
     case CHANGE_CASCADING_VALUE: {
-        return assign({}, state, {filterFields: state.filterFields.map((field) => {
+        return Object.assign({}, state, {filterFields: state.filterFields.map((field) => {
             for (let i = 0; i < action.attributes.length; i++) {
                 if (field.attribute === action.attributes[i].id) {
-                    return assign({}, field, {value: null});
+                    return Object.assign({}, field, {value: null});
                 }
             }
             return field;
         })});
     }
     case EXPAND_ATTRIBUTE_PANEL: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             attributePanelExpanded: action.expand
         });
     }
     case EXPAND_SPATIAL_PANEL: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             spatialPanelExpanded: action.expand
         });
     }
     case EXPAND_CROSS_LAYER: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             crossLayerExpanded: action.expand
         });
     }
     case SET_CROSS_LAYER_PARAMETER: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             crossLayerFilter: set(action.key, action.value, state.crossLayerFilter)
         });
     }
@@ -300,7 +299,7 @@ function queryform(state = initialState, action) {
         }, state);
     }
     case RESET_CROSS_LAYER_FILTER: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             crossLayerFilter: {
                 attribute: state.crossLayerFilter && state.crossLayerFilter.attribute
             }
@@ -329,29 +328,29 @@ function queryform(state = initialState, action) {
             , state);
     }
     case SELECT_SPATIAL_METHOD: {
-        return assign({}, state, {spatialField: assign({}, state.spatialField, {[action.fieldName]: action.method, geometry: null})});
+        return Object.assign({}, state, {spatialField: Object.assign({}, state.spatialField, {[action.fieldName]: action.method, geometry: null})});
     }
     case UPDATE_GEOMETRY: {
-        return assign({}, state, {spatialField: assign({}, state.spatialField, {geometry: action.geometry})}, {toolbarEnabled: true});
+        return Object.assign({}, state, {spatialField: Object.assign({}, state.spatialField, {geometry: action.geometry})}, {toolbarEnabled: true});
     }
     case SELECT_SPATIAL_OPERATION: {
-        return assign({}, state, {spatialField: assign({}, state.spatialField, {[action.fieldName]: action.operation})});
+        return Object.assign({}, state, {spatialField: Object.assign({}, state.spatialField, {[action.fieldName]: action.operation})});
     }
     case CHANGE_SPATIAL_ATTRIBUTE: {
-        return assign({}, state, {
-            spatialField: assign({}, state.spatialField, {attribute: action.attribute}),
-            crossLayerFilter: assign({}, state.crossLayerFilter, {attribute: action.attribute})
+        return Object.assign({}, state, {
+            spatialField: Object.assign({}, state.spatialField, {attribute: action.attribute}),
+            crossLayerFilter: Object.assign({}, state.crossLayerFilter, {attribute: action.attribute})
         });
     }
     case CHANGE_DRAWING_STATUS: {
         if (action.owner === "queryform" && action.status === "start") {
-            return assign({}, state, {toolbarEnabled: false});
+            return Object.assign({}, state, {toolbarEnabled: false});
         }
 
         return state;
     }
     case CHANGE_SPATIAL_FILTER_VALUE: {
-        return assign({}, state, {toolbarEnabled: true, spatialField: assign({}, state.spatialField, {
+        return Object.assign({}, state, {toolbarEnabled: true, spatialField: Object.assign({}, state.spatialField, {
             value: action.value,
             collectGeometries: action.collectGeometries,
             geometry: action.srsName ? {...action.geometry, projection: action.srsName} : action.geometry
@@ -360,7 +359,7 @@ function queryform(state = initialState, action) {
     case END_DRAWING: {
         let newState;
         if (action.owner === "queryform") {
-            newState = assign({}, state, {toolbarEnabled: true, spatialField: assign({}, state.spatialField, {
+            newState = Object.assign({}, state, {toolbarEnabled: true, spatialField: Object.assign({}, state.spatialField, {
                 collectGeometries: action.collectGeometries,
                 geometry: action.geometry
             })});
@@ -371,16 +370,16 @@ function queryform(state = initialState, action) {
         return newState;
     }
     case REMOVE_SPATIAL_SELECT: {
-        let spatialField = assign({}, initialState.spatialField, { attribute: state.spatialField.attribute, value: undefined });
-        return assign({}, state, {spatialField: assign({}, state.spatialField, spatialField)});
+        let spatialField = Object.assign({}, initialState.spatialField, { attribute: state.spatialField.attribute, value: undefined });
+        return Object.assign({}, state, {spatialField: Object.assign({}, state.spatialField, spatialField)});
     }
     case SHOW_SPATIAL_DETAILS: {
-        return assign({}, state, {showDetailsPanel: action.show});
+        return Object.assign({}, state, {showDetailsPanel: action.show});
     }
     case QUERY_FORM_RESET: {
-        let spatialField = assign({}, initialState.spatialField, { attribute: state.spatialField.attribute, value: undefined });
+        let spatialField = Object.assign({}, initialState.spatialField, { attribute: state.spatialField.attribute, value: undefined });
         let crossLayerFilter = { attribute: state.crossLayerFilter && state.crossLayerFilter.attribute };
-        return assign({}, state, initialState, {
+        return Object.assign({}, state, initialState, {
             spatialField,
             crossLayerFilter,
             filters: [],
@@ -388,15 +387,15 @@ function queryform(state = initialState, action) {
         });
     }
     case SHOW_GENERATED_FILTER: {
-        return assign({}, state, {showGeneratedFilter: action.data});
+        return Object.assign({}, state, {showGeneratedFilter: action.data});
     }
     case CHANGE_DWITHIN_VALUE: {
-        return assign({}, state, {spatialField: assign({}, state.spatialField, {geometry: assign({}, state.spatialField.geometry, {distance: action.distance})})});
+        return Object.assign({}, state, {spatialField: Object.assign({}, state.spatialField, {geometry: Object.assign({}, state.spatialField.geometry, {distance: action.distance})})});
     }
     case ZONE_FILTER: {
-        return assign({}, state, {spatialField: assign({}, state.spatialField, {zoneFields: state.spatialField.zoneFields.map((field) => {
+        return Object.assign({}, state, {spatialField: Object.assign({}, state.spatialField, {zoneFields: state.spatialField.zoneFields.map((field) => {
             if (field.id === action.id && action.data.features && action.data.features.length > 0) {
-                return assign({}, field, {
+                return Object.assign({}, field, {
                     values: action.data.features,
                     open: true,
                     error: null
@@ -406,9 +405,9 @@ function queryform(state = initialState, action) {
         })})});
     }
     case ZONE_SEARCH: {
-        return assign({}, state, {spatialField: assign({}, state.spatialField, {zoneFields: state.spatialField.zoneFields.map((field) => {
+        return Object.assign({}, state, {spatialField: Object.assign({}, state.spatialField, {zoneFields: state.spatialField.zoneFields.map((field) => {
             if (field.id === action.id) {
-                return assign({}, field, {
+                return Object.assign({}, field, {
                     busy: action.active
                 });
             }
@@ -438,7 +437,7 @@ function queryform(state = initialState, action) {
                     }
                 }
 
-                return assign({}, field, {
+                return Object.assign({}, field, {
                     value: value,
                     open: false,
                     geometryName: geometry ? geometry.geometryName : null
@@ -446,12 +445,12 @@ function queryform(state = initialState, action) {
             }
 
             if (field.dependson && action.id === field.dependson.id) {
-                return assign({}, field, {
+                return Object.assign({}, field, {
                     disabled: false,
                     values: null,
                     value: null,
                     open: false,
-                    dependson: assign({}, field.dependson, {value: value})
+                    dependson: Object.assign({}, field.dependson, {value: value})
                 });
             }
 
@@ -463,7 +462,7 @@ function queryform(state = initialState, action) {
             features: action.value.feature
         });
 
-        return assign({}, state, {spatialField: assign({}, state.spatialField, {
+        return Object.assign({}, state, {spatialField: Object.assign({}, state.spatialField, {
             zoneFields: zoneFields,
             geometry: extent && geometry ? {
                 extent: extent,
@@ -473,9 +472,9 @@ function queryform(state = initialState, action) {
         })});
     }
     case ZONES_RESET: {
-        return assign({}, state, {spatialField: assign({}, state.spatialField, {
+        return Object.assign({}, state, {spatialField: Object.assign({}, state.spatialField, {
             zoneFields: state.spatialField.zoneFields.map((field) => {
-                let f = assign({}, field, {
+                let f = Object.assign({}, field, {
                     values: null,
                     value: null,
                     open: false,
@@ -483,11 +482,11 @@ function queryform(state = initialState, action) {
                 });
 
                 if (field.dependson) {
-                    return assign({}, f, {
+                    return Object.assign({}, f, {
                         disabled: true,
                         open: false,
                         value: null,
-                        dependson: assign({}, field.dependson, {value: null})
+                        dependson: Object.assign({}, field.dependson, {value: null})
                     });
                 }
 
@@ -498,7 +497,7 @@ function queryform(state = initialState, action) {
     }
     case ZONE_SEARCH_ERROR: {
         let error;
-        return assign({}, state, {spatialField: assign({}, state.spatialField, {zoneFields: state.spatialField.zoneFields.map((field) => {
+        return Object.assign({}, state, {spatialField: Object.assign({}, state.spatialField, {zoneFields: state.spatialField.zoneFields.map((field) => {
             if (field.id === action.id) {
                 if (typeof action.error !== "object") {
                     if (action.error.status && action.error.statusText && action.error.data) {
@@ -515,7 +514,7 @@ function queryform(state = initialState, action) {
                 } else {
                     error = action.error;
                 }
-                return assign({}, field, {
+                return Object.assign({}, field, {
                     error: error,
                     busy: false
                 });
@@ -589,7 +588,7 @@ function queryform(state = initialState, action) {
     }
     case LOAD_FILTER:
         const {attribute, ...other} = initialState.spatialField;
-        const cleanInitialState = assign({}, initialState, {spatialField: {...other}});
+        const cleanInitialState = Object.assign({}, initialState, {spatialField: {...other}});
         const {spatialField, filterFields, groupFields, crossLayerFilter, attributePanelExpanded, spatialPanelExpanded, filters} = (action.filter || cleanInitialState);
         return {...state,
             ...{

--- a/web/client/reducers/rulesmanager.js
+++ b/web/client/reducers/rulesmanager.js
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
-
 import wk from 'wellknown';
 import { isEmpty, head, uniq, concat } from 'lodash';
 
@@ -72,7 +70,7 @@ function rulesmanager(state = defaultState, action) {
     switch (action.type) {
     case RULES_SELECTED: {
         if (!action.merge) {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 selectedRules: action.rules,
                 targetPosition: action.targetPosition
             });
@@ -80,22 +78,22 @@ function rulesmanager(state = defaultState, action) {
         const newRules = action.rules || [];
         const existingRules = state.selectedRules || [];
         if (action.unselect) {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 selectedRules: existingRules.filter(
                     rule => !head(newRules.filter(unselected => unselected.id === rule.id)))
             });
         }
-        return assign({}, state, { selectedRules: uniq(concat(existingRules, newRules), rule => rule.id)});
+        return Object.assign({}, state, { selectedRules: uniq(concat(existingRules, newRules), rule => rule.id)});
     }
     case UPDATE_FILTERS_VALUES: {
         const filtersValues = state.filtersValues || {};
-        return assign({}, state, {
-            filtersValues: assign({}, filtersValues, action.filtersValues)
+        return Object.assign({}, state, {
+            filtersValues: Object.assign({}, filtersValues, action.filtersValues)
         });
     }
     case OPTIONS_LOADED: {
-        return assign({}, state, {
-            options: assign({}, state.options, {
+        return Object.assign({}, state, {
+            options: Object.assign({}, state.options, {
                 [action.name]: action.values || [],
                 [action.name + "Page"]: action.page,
                 [action.name + "Count"]: action.valuesCount
@@ -103,47 +101,47 @@ function rulesmanager(state = defaultState, action) {
         });
     }
     case LOADING:
-        return assign({}, state, {loading: action.loading});
+        return Object.assign({}, state, {loading: action.loading});
     case SET_FILTER: {
         const {key, value, isResetField} = action;
         if (isResetField) {
             if (key === "rolename") {
-                return assign({}, state, {filters: {...state.filters, [key]: value, ['roleAny']: undefined}});
+                return Object.assign({}, state, {filters: {...state.filters, [key]: value, ['roleAny']: undefined}});
             } else if (key === "username") {
-                return assign({}, state, {filters: {...state.filters, [key]: value, ['userAny']: undefined}});
+                return Object.assign({}, state, {filters: {...state.filters, [key]: value, ['userAny']: undefined}});
             }
-            return assign({}, state, {filters: {...state.filters, [key]: value, [key + 'Any']: undefined}});
+            return Object.assign({}, state, {filters: {...state.filters, [key]: value, [key + 'Any']: undefined}});
         }
         if (value || key?.includes('Any')) {
-            return assign({}, state, {filters: {...state.filters, [key]: value}});
+            return Object.assign({}, state, {filters: {...state.filters, [key]: value}});
         }
         const {[key]: omit, ...newFilters} = state.filters || {};
-        return assign({}, state, {filters: newFilters});
+        return Object.assign({}, state, {filters: newFilters});
     }
     case EDIT_RULE: {
         const {createNew, targetPriority} = action;
         if (createNew) {
-            return assign({}, state, {activeRule: {grant: state.grantDefault, position: {value: getPosition(state, targetPriority), position: "offsetFromTop"}}});
+            return Object.assign({}, state, {activeRule: {grant: state.grantDefault, position: {value: getPosition(state, targetPriority), position: "offsetFromTop"}}});
         }
         const activeRule = state.selectedRules[0] || {};
         const geometryState = activeRule.constraints && activeRule.constraints.restrictedAreaWkt && {
             wkt: activeRule.constraints.restrictedAreaWkt,
             geometry: wk.parse(activeRule.constraints.restrictedAreaWkt)} || {};
-        return assign({}, state, {activeRule,
+        return Object.assign({}, state, {activeRule,
             position: {value: state.targetPosition.offsetFromTop, position: "offsetFromTop"},
             geometryState});
     }
     case RULE_SAVED: {
-        return assign({}, state, {triggerLoad: (state.triggerLoad || 0) + 1, geometryState: undefined, activeRule: undefined, selectedRules: [], targetPosition: undefined });
+        return Object.assign({}, state, {triggerLoad: (state.triggerLoad || 0) + 1, geometryState: undefined, activeRule: undefined, selectedRules: [], targetPosition: undefined });
     }
     case CLEAN_EDITING: {
-        return assign({}, state, {activeRule: undefined, geometryState: undefined});
+        return Object.assign({}, state, {activeRule: undefined, geometryState: undefined});
     }
     case CHANGE_DRAWING_STATUS: {
         let newState;
         if (action.owner === "rulesmanager" && (action.status === "stop" || action.status === "start" || action.status === "clean")) {
             const geometry = fixGeometry(((action.features || [])[0] || {}), action.method);
-            newState = assign({}, state, {geometryState: assign({}, {
+            newState = Object.assign({}, state, {geometryState: Object.assign({}, {
                 geometry,
                 wkt: !isEmpty(geometry) && wk.stringify(geometry) || undefined
             })});

--- a/web/client/reducers/search.js
+++ b/web/client/reducers/search.js
@@ -27,7 +27,6 @@ import {
 
 import { RESET_CONTROLS } from '../actions/controls';
 import { generateTemplateString } from '../utils/TemplateUtils';
-import assign from 'object-assign';
 /**
  * Manages the state of the map search with it's results
  * The properties represent the shape of the state
@@ -97,43 +96,43 @@ function search(state = null, action) {
         return {...state, searchText: displayName || state.searchText || '' };
     }
     case TEXT_SEARCH_LOADING: {
-        return assign({}, state, {loading: action.loading});
+        return Object.assign({}, state, {loading: action.loading});
     }
     case TEXT_SEARCH_ERROR: {
-        return assign({}, state, {error: action.error});
+        return Object.assign({}, state, {error: action.error});
     }
     case TEXT_SEARCH_TEXT_CHANGE:
-        return assign({}, state, { searchText: action.searchText, error: null });
+        return Object.assign({}, state, { searchText: action.searchText, error: null });
     case TEXT_SEARCH_RESULTS_LOADED:
         let results = action.results;
         if (action.append === true && state && state.results) {
             results = [...state.results, ...action.results];
         }
-        return assign({}, state, { results: results, error: null });
+        return Object.assign({}, state, { results: results, error: null });
     case TEXT_SEARCH_RESULTS_PURGE:
-        return assign({}, state, { results: null, error: null});
+        return Object.assign({}, state, { results: null, error: null});
     case TEXT_SEARCH_ADD_MARKER:
         const latlng = action.markerPosition.latlng ? {latlng: action.markerPosition.latlng, lat: action.markerPosition.latlng.lat,  lng: action.markerPosition.latlng.lng} : action.markerPosition;
-        return assign({}, state, { markerPosition: latlng, markerLabel: action.markerLabel });
+        return Object.assign({}, state, { markerPosition: latlng, markerLabel: action.markerLabel });
     case TEXT_SEARCH_SET_HIGHLIGHTED_FEATURE:
-        return assign({}, state, {highlightedFeature: action.highlightedFeature});
+        return Object.assign({}, state, {highlightedFeature: action.highlightedFeature});
     case TEXT_SEARCH_RESET:
         return { style: state.style || {} };
     case RESET_CONTROLS:
         return null;
     case TEXT_SEARCH_NESTED_SERVICES_SELECTED:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             selectedServices: action.services,
             searchText: action.searchText,
             selectedItems: (state.selectedItems || []).concat(action.items)
         });
     case TEXT_SEARCH_CANCEL_ITEM:
-        return state ? assign({}, {
+        return state ? Object.assign({}, {
             selectedItems: state.selectedItems && state.selectedItems.filter(item => item !== action.item),
             searchText: state.searchText === "" && action.item && action.item.text ? action.item.text.substring(0, action.item.text.length) : state.searchText
         }) : state;
     case UPDATE_RESULTS_STYLE:
-        return assign({}, state, {style: action.style});
+        return Object.assign({}, state, {style: action.style});
     case CHANGE_SEARCH_TOOL:
         return {...state, activeSearchTool: action.activeSearchTool};
     case CHANGE_FORMAT:
@@ -141,7 +140,7 @@ function search(state = null, action) {
     case CHANGE_COORD:
         return {...state, coordinate: {...state.coordinate, [action.coord]: action.val}};
     case HIDE_MARKER:
-        return assign({}, state, {markerPosition: state?.markerPosition?.latlng ? {} : state?.markerPosition});
+        return Object.assign({}, state, {markerPosition: state?.markerPosition?.latlng ? {} : state?.markerPosition});
     default:
         return state;
     }

--- a/web/client/reducers/searchconfig.js
+++ b/web/client/reducers/searchconfig.js
@@ -9,32 +9,31 @@ import { SET_SEARCH_CONFIG_PROP, RESET_SEARCH_CONFIG, UPDATE_SERVICE } from '../
 
 import { RESET_CONTROLS } from '../actions/controls';
 import { MAP_CONFIG_LOADED } from '../actions/config';
-import assign from 'object-assign';
 
 function searchconfig(state = null, action) {
     switch (action.type) {
     case SET_SEARCH_CONFIG_PROP:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             [action.property]: action.value
         });
     case MAP_CONFIG_LOADED: {
         const textSearchConfig = action.config.map.text_search_config || action.config.map.text_serch_config;
-        return assign({}, state, {textSearchConfig});
+        return Object.assign({}, state, {textSearchConfig});
     }
     case RESET_CONTROLS:
     case RESET_SEARCH_CONFIG: {
-        return assign({}, state, {service: undefined, page: action.page, init_service_values: undefined, editIdx: undefined});
+        return Object.assign({}, state, {service: undefined, page: action.page, init_service_values: undefined, editIdx: undefined});
     }
     case UPDATE_SERVICE: {
         let newServices = (state.textSearchConfig && state.textSearchConfig.services || []).slice();
         // Convert priority to int
-        const newService = assign({}, action.service, {priority: parseInt(action.service.priority, 10)});
+        const newService = Object.assign({}, action.service, {priority: parseInt(action.service.priority, 10)});
         if (action.idx !== -1) {
             newServices[action.idx] = newService;
         } else {
             newServices.push(newService);
         }
-        return assign({}, state, {service: undefined, page: 0, init_service_values: undefined, editIdx: undefined, textSearchConfig: {services: newServices, override: state.textSearchConfig && state.textSearchConfig.override || false}});
+        return Object.assign({}, state, {service: undefined, page: 0, init_service_values: undefined, editIdx: undefined, textSearchConfig: {services: newServices, override: state.textSearchConfig && state.textSearchConfig.override || false}});
     }
     default:
         return state;

--- a/web/client/reducers/security.js
+++ b/web/client/reducers/security.js
@@ -21,21 +21,20 @@ import {
 import { SET_CONTROL_PROPERTY } from '../actions/controls';
 import { USERMANAGER_UPDATE_USER } from '../actions/users';
 import {getUserAttributes} from '../utils/SecurityUtils';
-import assign from 'object-assign';
 import { cloneDeep, head } from 'lodash';
 
 function security(state = {user: null, errorCause: null}, action) {
     switch (action.type) {
     case USERMANAGER_UPDATE_USER:
         if (state.user && action.user && state.user.id === action.user.id) {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 user: cloneDeep(action.user)
             });
         }
         return state;
     case SET_CONTROL_PROPERTY:
         if (action.control === 'ResetPassword' && action.property === 'enabled') {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 passwordChanged: false,
                 passwordError: null
             });
@@ -46,7 +45,7 @@ function security(state = {user: null, errorCause: null}, action) {
         const userAttributes = getUserAttributes(action.userDetails.User);
         const userUuid = head(userAttributes.filter(attribute => attribute.name.toLowerCase() === 'uuid'));
         const timestamp = new Date() / 1000 | 0;
-        return assign({}, state, {
+        return Object.assign({}, state, {
             user: action.userDetails.User,
             token: (action.userDetails && action.userDetails.access_token) || (userUuid && userUuid.value),
             refresh_token: (action.userDetails && action.userDetails.refresh_token),
@@ -59,22 +58,22 @@ function security(state = {user: null, errorCause: null}, action) {
     case REFRESH_SUCCESS:
     {
         const timestamp = new Date() / 1000 | 0;
-        return assign({}, state, {
+        return Object.assign({}, state, {
             token: (action.userDetails && action.userDetails.access_token),
             refresh_token: (action.userDetails && action.userDetails.refresh_token),
             expires: (action.userDetails && action.userDetails.expires) ? timestamp + action.userDetails.expires : timestamp + 48 * 60 * 60
         });
     }
     case LOGIN_FAIL:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             loginError: action.error
         });
     case RESET_ERROR:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             loginError: null
         });
     case LOGOUT:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             user: null,
             token: null,
             refresh_token: null,
@@ -84,20 +83,20 @@ function security(state = {user: null, errorCause: null}, action) {
             loginError: null
         });
     case CHANGE_PASSWORD:
-        return  assign({}, state, {
+        return  Object.assign({}, state, {
             passwordError: null,
             changePasswordLoading: true
         });
     case CHANGE_PASSWORD_SUCCESS:
-        return assign({}, state, {
-            user: assign({}, state.user, assign({}, action.user, {date: new Date().getTime()})),
+        return Object.assign({}, state, {
+            user: Object.assign({}, state.user, Object.assign({}, action.user, {date: new Date().getTime()})),
             authHeader: action.authHeader,
             passwordChanged: true,
             passwordError: null,
             changePasswordLoading: false
         });
     case CHANGE_PASSWORD_FAIL:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             passwordError: action.error,
             passwordChanged: false,
             changePasswordLoading: false
@@ -105,7 +104,7 @@ function security(state = {user: null, errorCause: null}, action) {
         });
     case SESSION_VALID:
     {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             user: action.userDetails.User,
             loginError: null
         });

--- a/web/client/reducers/selection.js
+++ b/web/client/reducers/selection.js
@@ -8,14 +8,13 @@
 
 import { CHANGE_SELECTION_STATE } from '../actions/selection';
 
-import assign from 'object-assign';
 
 function selection(state = {
     geomType: null
 }, action) {
     switch (action.type) {
     case CHANGE_SELECTION_STATE:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             geomType: action.geomType,
             point: action.point,
             line: action.line,

--- a/web/client/reducers/snapshot.js
+++ b/web/client/reducers/snapshot.js
@@ -14,17 +14,15 @@ import {
     SNAPSHOT_REMOVE_QUEUE
 } from '../actions/snapshot';
 
-import assign from 'object-assign';
-
 function snapshot(state = null, action) {
     switch (action.type) {
     case CHANGE_SNAPSHOT_STATE:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             state: action.state,
             tainted: action.tainted
         });
     case SNAPSHOT_READY:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             img: {
                 data: action.imgData,
                 width: action.width,
@@ -33,7 +31,7 @@ function snapshot(state = null, action) {
             }
         });
     case SNAPSHOT_ERROR:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             error: action.error
         });
     case SNAPSHOT_ADD_QUEUE: {
@@ -43,7 +41,7 @@ function snapshot(state = null, action) {
         } else {
             queue = [action.options];
         }
-        return assign({}, state, {
+        return Object.assign({}, state, {
             queue: queue
         });
     }
@@ -55,7 +53,7 @@ function snapshot(state = null, action) {
             }
             return true;
         });
-        return assign({}, state, {
+        return Object.assign({}, state, {
             queue: queue
         });
     }

--- a/web/client/reducers/style.js
+++ b/web/client/reducers/style.js
@@ -8,8 +8,6 @@
 
 import { SET_STYLE_PARAMETER } from '../actions/style';
 
-import assign from 'object-assign';
-
 const initialSpec = {
     color: { r: 0, g: 0, b: 255, a: 1 },
     width: 3,
@@ -21,7 +19,7 @@ const initialSpec = {
 function style(state = initialSpec, action) {
     switch (action.type) {
     case SET_STYLE_PARAMETER: {
-        return assign({}, state, {[action.name]: action.value});
+        return Object.assign({}, state, {[action.name]: action.value});
     }
     default:
         return state;

--- a/web/client/reducers/thematic.js
+++ b/web/client/reducers/thematic.js
@@ -19,7 +19,6 @@ import {
 } from '../actions/thematic';
 
 import { HIDE_SETTINGS } from '../actions/layers';
-import assign from 'object-assign';
 
 const initialState = {
     loadingFields: false,
@@ -39,46 +38,46 @@ const initialState = {
 function thematic(state = initialState, action) {
     switch (action.type) {
     case HIDE_SETTINGS:
-        return assign({}, initialState);
+        return Object.assign({}, initialState);
     case LOAD_FIELDS:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             fields: null,
             loadingFields: true,
             errorFields: null
         });
     case FIELDS_LOADED:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             fields: action.fields,
             loadingFields: false,
             errorFields: null
         });
     case FIELDS_ERROR:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             fields: null,
             loadingFields: false,
             errorFields: action.error
         });
     case LOAD_CLASSIFICATION:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             loadingClassification: true,
             errorClassification: null
         });
     case CLASSIFICATION_LOADED:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             classification: action.classification,
             loadingClassification: false,
             errorClassification: null,
             customClassification: false
         });
     case CLASSIFICATION_ERROR:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             classification: null,
             loadingClassification: false,
             errorClassification: action.error,
             customClassification: false
         });
     case CHANGE_CONFIGURATION:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             adminCfg: {
                 open: action.editEnabled,
                 current: action.current,
@@ -86,19 +85,19 @@ function thematic(state = initialState, action) {
             }
         });
     case CHANGE_DIRTY:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             dirty: action.dirty
         });
     case CHANGE_INPUT_VALIDITY:
         if (action.valid) {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 invalidInputs: Object.keys(state.invalidInputs).reduce((previous, current) => {
                     return current === action.input ? previous : [...previous, current];
                 }, {})
             });
         }
-        return assign({}, state, {
-            invalidInputs: assign({}, state.invalidInputs, {
+        return Object.assign({}, state, {
+            invalidInputs: Object.assign({}, state.invalidInputs, {
                 [action.input]: {
                     message: action.message,
                     params: action.params || {}

--- a/web/client/reducers/tutorial.js
+++ b/web/client/reducers/tutorial.js
@@ -17,7 +17,6 @@ import {
     TOGGLE_TUTORIAL
 } from '../actions/tutorial';
 
-import assign from 'object-assign';
 import React from 'react';
 import I18N from '../components/I18N/I18N';
 
@@ -38,13 +37,13 @@ import { getApi } from '../api/userPersistedStorage';
 function tutorial(state = initialState, action) {
     switch (action.type) {
     case START_TUTORIAL:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             run: true,
             start: true,
             status: 'run'
         });
     case INIT_TUTORIAL:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             style: action.style,
             defaultStep: action.defaultStep,
             checkbox: action.checkbox,
@@ -54,9 +53,9 @@ function tutorial(state = initialState, action) {
         let setup = {};
         setup.steps = [].concat(action.steps);
         setup.id = action.id;
-        setup.checkbox = action.checkbox ? action.checkbox : assign({}, state.checkbox);
-        setup.style = action.style ? action.style : assign({}, state.style);
-        setup.defaultStep = action.defaultStep ? action.defaultStep : assign({}, state.defaultStep);
+        setup.checkbox = action.checkbox ? action.checkbox : Object.assign({}, state.checkbox);
+        setup.style = action.style ? action.style : Object.assign({}, state.style);
+        setup.defaultStep = action.defaultStep ? action.defaultStep : Object.assign({}, state.defaultStep);
         setup.disabled = false;
         setup.presetGroup = action.presetGroup;
         let isActuallyDisabled = false;
@@ -78,8 +77,8 @@ function tutorial(state = initialState, action) {
             text = (step.selector === '#intro-tutorial') && !isActuallyDisabled ? <div><div>{text}</div>{setup.checkbox}</div> : text;
             let style = (step.selector === '#intro-tutorial') ? setup.style : {};
             let isFixed = (step.selector === '#intro-tutorial') ? true : step.isFixed || false;
-            assign(style, step.style);
-            return assign({}, setup.defaultStep, step, {
+            Object.assign(style, step.style);
+            return Object.assign({}, setup.defaultStep, step, {
                 index,
                 title,
                 text,
@@ -104,7 +103,7 @@ function tutorial(state = initialState, action) {
             setup.steps = setup.steps.filter((step) => {
                 return step.selector !== '#intro-tutorial';
             }).map((step, index) => {
-                return assign({}, step, {index});
+                return Object.assign({}, step, {index});
             });
 
             setup.run = false;
@@ -112,7 +111,7 @@ function tutorial(state = initialState, action) {
             setup.status = 'close';
         }
 
-        return assign({}, state, setup);
+        return Object.assign({}, state, setup);
     case UPDATE_TUTORIAL:
         let update = {};
         update.steps = [].concat(action.steps);
@@ -130,7 +129,7 @@ function tutorial(state = initialState, action) {
                 update.steps = update.steps.filter((step) => {
                     return step.selector !== '#intro-tutorial';
                 }).map((step, index) => {
-                    return assign({}, step, {index});
+                    return Object.assign({}, step, {index});
                 });
             } else if (action.tour.type === 'error:target_not_found') {
                 update.status = 'error';
@@ -138,7 +137,7 @@ function tutorial(state = initialState, action) {
                 update.tourAction = action.tour.action;
             }
         }
-        return assign({}, state, update);
+        return Object.assign({}, state, update);
     case DISABLE_TUTORIAL:
         let disabled = !state.disabled;
         const presetGroup = state.presetGroup || [state.id];
@@ -151,11 +150,11 @@ function tutorial(state = initialState, action) {
             }
         });
 
-        return assign({}, state, {
+        return Object.assign({}, state, {
             disabled
         });
     case RESET_TUTORIAL:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             steps: [],
             run: false,
             start: false,
@@ -163,14 +162,14 @@ function tutorial(state = initialState, action) {
             enabled: false
         });
     case CLOSE_TUTORIAL:
-        return assign({}, state, {
+        return Object.assign({}, state, {
             run: false,
             start: false,
             status: 'close',
             enabled: false
         });
     case TOGGLE_TUTORIAL:
-        return assign({}, state, { enabled: !state.enabled });
+        return Object.assign({}, state, { enabled: !state.enabled });
     default:
         return state;
     }

--- a/web/client/reducers/usergroups.js
+++ b/web/client/reducers/usergroups.js
@@ -21,8 +21,6 @@ import {
     RESET_SEARCH_USER_GROUPS
 } from '../actions/usergroups';
 
-import assign from 'object-assign';
-
 function usergroups(state = {}, action) {
     switch (action.type) {
     case UPDATE_USER_GROUPS: {
@@ -96,15 +94,15 @@ function usergroups(state = {}, action) {
             ...action.group
         } : action.group;
         if (state.currentGroup && action.group && state.currentGroup.id === action.group.id ) {
-            return assign({}, state, {
-                currentGroup: assign({}, state.currentGroup, {
+            return Object.assign({}, state, {
+                currentGroup: Object.assign({}, state.currentGroup, {
                     status: action.status,
                     ...action.group
                 })}
             );
             // this to catch user loaded but window already closed
         } else if (action.status === "loading" || action.status === "new" || !action.status) {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 currentGroup: newGroup
             });
         }
@@ -114,16 +112,16 @@ function usergroups(state = {}, action) {
     case EDITGROUPDATA: {
         let k = action.key;
         let currentGroup = state.currentGroup;
-        currentGroup = assign({}, currentGroup, {[k]: action.newValue} );
-        return assign({}, state, {
-            currentGroup: assign({}, {...currentGroup, status: "modified"})
+        currentGroup = Object.assign({}, currentGroup, {[k]: action.newValue} );
+        return Object.assign({}, state, {
+            currentGroup: Object.assign({}, {...currentGroup, status: "modified"})
         });
     }
     case UPDATEGROUP: {
         let currentGroup = state.currentGroup;
 
-        return assign({}, state, {
-            currentGroup: assign({}, {
+        return Object.assign({}, state, {
+            currentGroup: Object.assign({}, {
                 ...currentGroup,
                 ...action.group,
                 status: action.status,
@@ -134,11 +132,11 @@ function usergroups(state = {}, action) {
 
     case DELETEGROUP: {
         if (action.status === "deleted" || action.status === "cancelled") {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 deletingGroup: null
             });
         }
-        return assign({}, state, {
+        return Object.assign({}, state, {
             deletingGroup: {
                 id: action.id,
                 status: action.status,
@@ -149,13 +147,13 @@ function usergroups(state = {}, action) {
     case SEARCHUSERS: {
         switch (action.status) {
         case "loading": {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 availableUsersError: null,
                 availableUsersLoading: true
             });
         }
         case "success": {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 availableUsersError: null,
                 availableUsersLoading: false,
                 availableUsers: action.users,
@@ -163,7 +161,7 @@ function usergroups(state = {}, action) {
             });
         }
         case "error": {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 availableUsersError: action.error,
                 availableUsersLoading: false
             });

--- a/web/client/reducers/users.js
+++ b/web/client/reducers/users.js
@@ -23,8 +23,6 @@ import {
 
 import { UPDATEGROUP, STATUS_CREATED, DELETEGROUP, STATUS_DELETED } from '../actions/usergroups';
 
-import assign from 'object-assign';
-
 function users(state = {}, action) {
     switch (action.type) {
     case UPDATE_USERS: {
@@ -98,15 +96,15 @@ function users(state = {}, action) {
             ...action.user
         } : action.user;
         if (state.currentUser && action.user && state.currentUser.id === action.user.id ) {
-            return assign({}, state, {
-                currentUser: assign({}, state.currentUser, {
+            return Object.assign({}, state, {
+                currentUser: Object.assign({}, state.currentUser, {
                     status: action.status,
                     ...action.user
                 })}
             );
             // this to catch user loaded but window already closed
         } else if (action.status === "loading" || action.status === "new" || !action.status) {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 currentUser: newUser
             });
         }
@@ -116,16 +114,16 @@ function users(state = {}, action) {
     case USERMANAGER_EDIT_USER_DATA: {
         let k = action.key;
         let currentUser = state.currentUser;
-        currentUser = assign({}, currentUser, {[k]: action.newValue} );
-        return assign({}, state, {
-            currentUser: assign({}, {...currentUser, status: "modified"})
+        currentUser = Object.assign({}, currentUser, {[k]: action.newValue} );
+        return Object.assign({}, state, {
+            currentUser: Object.assign({}, {...currentUser, status: "modified"})
         });
     }
     case USERMANAGER_UPDATE_USER: {
         let currentUser = state.currentUser;
 
-        return assign({}, state, {
-            currentUser: assign({}, {
+        return Object.assign({}, state, {
+            currentUser: Object.assign({}, {
                 ...currentUser,
                 ...action.user,
                 status: action.status,
@@ -135,11 +133,11 @@ function users(state = {}, action) {
     }
     case USERMANAGER_DELETE_USER: {
         if (action.status === "deleted" || action.status === "cancelled") {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 deletingUser: null
             });
         }
-        return assign({}, state, {
+        return Object.assign({}, state, {
             deletingUser: {
                 id: action.id,
                 status: action.status,
@@ -148,7 +146,7 @@ function users(state = {}, action) {
         });
     }
     case USERMANAGER_GETGROUPS: {
-        return assign({}, state, {
+        return Object.assign({}, state, {
             groups: action.groups,
             groupsStatus: action.status,
             groupsError: action.error
@@ -156,7 +154,7 @@ function users(state = {}, action) {
     }
     case UPDATEGROUP: {
         if (action.status === STATUS_CREATED) {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 groups: null,
                 groupsStatus: null,
                 groupsError: null
@@ -166,7 +164,7 @@ function users(state = {}, action) {
     }
     case DELETEGROUP: {
         if (action.status === STATUS_DELETED) {
-            return assign({}, state, {
+            return Object.assign({}, state, {
                 groups: null,
                 groupsStatus: null,
                 groupsError: null

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -34,7 +34,6 @@ import {
 
 import { MAP_CONFIG_LOADED } from '../actions/config';
 import { DASHBOARD_LOADED, DASHBOARD_RESET } from '../actions/dashboard';
-import assign from 'object-assign';
 import set from 'lodash/fp/set';
 import { get, find, omit, mapValues, castArray, isEmpty } from 'lodash';
 import { arrayUpsert, compose, arrayDelete } from '../utils/ImmutableUtils';
@@ -142,7 +141,7 @@ function widgetsReducer(state = emptyState, action) {
         if (action.mode === "merge") {
             uValue = action.key === "maps"
                 ? oldWidget.maps.map(m => m.mapId === action.value?.mapId ? {...m, ...action?.value} : m)
-                : assign({}, oldWidget[action.key], action.value);
+                : Object.assign({}, oldWidget[action.key], action.value);
         }
         return arrayUpsert(`containers[${action.target}].widgets`,
             set(action.key, uValue, oldWidget), { id: action.id },

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -8,8 +8,6 @@
 
 import expect from 'expect';
 
-import assign from 'object-assign';
-
 import {
     isFeatureGridOpen,
     hasChangesSelector,
@@ -324,7 +322,7 @@ let initialState = {
 
 describe('Test featuregrid selectors', () => {
     afterEach(() => {
-        initialState = assign({}, initialState, {
+        initialState = Object.assign({}, initialState, {
             featuregrid: {
                 open: true,
                 saving: false,
@@ -463,7 +461,7 @@ describe('Test featuregrid selectors', () => {
 
     it('test hasSupportedGeometry', () => {
         expect(hasSupportedGeometry(initialState)).toBe(true);
-        let initialStateWithGmlGeometry = assign({}, initialState);
+        let initialStateWithGmlGeometry = Object.assign({}, initialState);
         initialStateWithGmlGeometry.query.featureTypes['editing:polygons.test'].original.featureTypes[0].properties[1].type = 'gml:Geometry';
         initialStateWithGmlGeometry.query.featureTypes['editing:polygons.test'].original.featureTypes[0].properties[1].localType = 'Geometry';
         expect(hasSupportedGeometry(initialStateWithGmlGeometry)).toBe(false);

--- a/web/client/selectors/print.js
+++ b/web/client/selectors/print.js
@@ -5,9 +5,8 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree.
 */
-import assign from "object-assign";
 
-export const printSpecificationSelector = (state) => state.print && state.print.spec && assign({}, state.print.spec, state.print.map || {});
+export const printSpecificationSelector = (state) => state.print && state.print.spec && Object.assign({}, state.print.spec, state.print.map || {});
 export const currentLayouts = (state) => state.print && state.print.capabilities &&
     state.print.capabilities.layouts.filter((layout) => layout.name.indexOf(state.print.spec.sheet) === 0) || [];
 export const twoPageEnabled = (state) => state.print && state.print.spec && state.print.spec.includeLegend;

--- a/web/client/selectors/rulesmanager.js
+++ b/web/client/selectors/rulesmanager.js
@@ -6,8 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-import assign from 'object-assign';
-
 import { uniq } from 'lodash';
 import { createSelector } from 'reselect';
 
@@ -18,21 +16,21 @@ export const rulesSelector = (state) => {
     const rules = state.rulesmanager.rules;
     return rules.map(rule => {
         const formattedRule = {};
-        assign(formattedRule, {'id': rule.id});
-        assign(formattedRule, {'priority': rule.priority});
-        assign(formattedRule, {'roleName': rule.roleName ? rule.roleName : '*'});
-        assign(formattedRule, {'roleAny': rule.roleAny ? rule.roleAny : '*'});
-        assign(formattedRule, {'userName': rule.userName ? rule.userName : '*'});
-        assign(formattedRule, {'userAny': rule.userAny ? rule.userAny : '*'});
-        assign(formattedRule, {'service': rule.service ? rule.service : '*'});
-        assign(formattedRule, {'serviceAny': rule.serviceAny ? rule.serviceAny : '*'});
-        assign(formattedRule, {'request': rule.request ? rule.request : '*'});
-        assign(formattedRule, {'requestAny': rule.requestAny ? rule.requestAny : '*'});
-        assign(formattedRule, {'workspace': rule.workspace ? rule.workspace : '*'});
-        assign(formattedRule, {'workspaceAny': rule.workspaceAny ? rule.workspaceAny : '*'});
-        assign(formattedRule, {'layer': rule.layer ? rule.layer : '*'});
-        assign(formattedRule, {'layerAny': rule.layerAny ? rule.layerAny : '*'});
-        assign(formattedRule, {'access': rule.access});
+        Object.assign(formattedRule, {'id': rule.id});
+        Object.assign(formattedRule, {'priority': rule.priority});
+        Object.assign(formattedRule, {'roleName': rule.roleName ? rule.roleName : '*'});
+        Object.assign(formattedRule, {'roleAny': rule.roleAny ? rule.roleAny : '*'});
+        Object.assign(formattedRule, {'userName': rule.userName ? rule.userName : '*'});
+        Object.assign(formattedRule, {'userAny': rule.userAny ? rule.userAny : '*'});
+        Object.assign(formattedRule, {'service': rule.service ? rule.service : '*'});
+        Object.assign(formattedRule, {'serviceAny': rule.serviceAny ? rule.serviceAny : '*'});
+        Object.assign(formattedRule, {'request': rule.request ? rule.request : '*'});
+        Object.assign(formattedRule, {'requestAny': rule.requestAny ? rule.requestAny : '*'});
+        Object.assign(formattedRule, {'workspace': rule.workspace ? rule.workspace : '*'});
+        Object.assign(formattedRule, {'workspaceAny': rule.workspaceAny ? rule.workspaceAny : '*'});
+        Object.assign(formattedRule, {'layer': rule.layer ? rule.layer : '*'});
+        Object.assign(formattedRule, {'layerAny': rule.layerAny ? rule.layerAny : '*'});
+        Object.assign(formattedRule, {'access': rule.access});
         return formattedRule;
     });
 };

--- a/web/client/selectors/security.js
+++ b/web/client/selectors/security.js
@@ -6,7 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-import assign from 'object-assign';
 
 import get from 'lodash/get';
 import castArray from "lodash/castArray";
@@ -18,15 +17,15 @@ export const rulesSelector = (state) => {
     const rules = state.security.rules;
     return rules.map(rule => {
         const formattedRule = {};
-        assign(formattedRule, {'id': rule.id});
-        assign(formattedRule, {'priority': rule.priority});
-        assign(formattedRule, {'roleName': rule.roleName ? rule.roleName : '*'});
-        assign(formattedRule, {'userName': rule.userName ? rule.userName : '*'});
-        assign(formattedRule, {'service': rule.service ? rule.service : '*'});
-        assign(formattedRule, {'request': rule.request ? rule.request : '*'});
-        assign(formattedRule, {'workspace': rule.workspace ? rule.workspace : '*'});
-        assign(formattedRule, {'layer': rule.layer ? rule.layer : '*'});
-        assign(formattedRule, {'access': rule.access});
+        Object.assign(formattedRule, {'id': rule.id});
+        Object.assign(formattedRule, {'priority': rule.priority});
+        Object.assign(formattedRule, {'roleName': rule.roleName ? rule.roleName : '*'});
+        Object.assign(formattedRule, {'userName': rule.userName ? rule.userName : '*'});
+        Object.assign(formattedRule, {'service': rule.service ? rule.service : '*'});
+        Object.assign(formattedRule, {'request': rule.request ? rule.request : '*'});
+        Object.assign(formattedRule, {'workspace': rule.workspace ? rule.workspace : '*'});
+        Object.assign(formattedRule, {'layer': rule.layer ? rule.layer : '*'});
+        Object.assign(formattedRule, {'access': rule.access});
         return formattedRule;
     });
 };

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -6,14 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import { head, isArray, get } from 'lodash';
 import CoordinatesUtils from './CoordinatesUtils';
 export const COG_LAYER_TYPE = 'cog';
 
 export const buildSRSMap = (srs) => {
     return srs.filter(s => CoordinatesUtils.isSRSAllowed(s)).reduce((previous, current) => {
-        return assign(previous, {[current]: true});
+        return Object.assign(previous, {[current]: true});
     }, {});
 };
 

--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import url from 'url';
 import axios from 'axios';
 import { castArray, isArray, isObject, endsWith, isNil, get, mergeWith } from 'lodash';
-import assign from 'object-assign';
 import { Promise } from 'es6-promise';
 import isMobile from 'ismobilejs';
 import {mergeConfigsPatch} from "@mapstore/patcher";
@@ -119,8 +118,8 @@ export const getParsedUrl = (urlToParse, options, params = []) => {
         let newPathname = null;
         if (endsWith(parsed.pathname, "wfs") || endsWith(parsed.pathname, "wms") || endsWith(parsed.pathname, "ows")) {
             newPathname = parsed.pathname.replace(/(wms|ows|wfs|wps)$/, "wps");
-            return url.format(assign({}, parsed, {search: null, pathname: newPathname }, {
-                query: assign({
+            return url.format(Object.assign({}, parsed, {search: null, pathname: newPathname }, {
+                query: Object.assign({
                     service: "WPS",
                     ...options
                 }, parsed.query)
@@ -160,7 +159,7 @@ export const getCenter = function(center, projection) {
     const point = isArray(center) ? {x: center[0], y: center[1]} : center;
     const crs = center.crs || projection || 'EPSG:4326';
     const transformed = crs !== 'EPSG:4326' ? Proj4js.transform(new Proj4js.Proj(crs), epsg4326, point) : point;
-    return assign({}, transformed, {crs: "EPSG:4326"});
+    return Object.assign({}, transformed, {crs: "EPSG:4326"});
 };
 
 export const setApiKeys = function(layer) {
@@ -278,7 +277,7 @@ export const copySourceOptions = function(layer, source) {
                 delete sourceParts.query[k];
             }
         }
-        layer.baseParams = assign({}, layer.baseParams, sourceParts.query);
+        layer.baseParams = Object.assign({}, layer.baseParams, sourceParts.query);
     }
     layer.url = normalizeSourceUrl(source.url);
 };

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -11,7 +11,6 @@ import geo from 'node-geo-distance';
 import Proj4js from 'proj4';
 const proj4 = Proj4js;
 import axios from '../libs/ajax';
-import assign from 'object-assign';
 
 import {
     isArray,
@@ -141,7 +140,7 @@ export const reproject = (point, source, dest, normalize = true) => {
     if (sourceProj && destProj) {
         let p = isArray(point) ? Proj4js.toPoint(point) : Proj4js.toPoint([point.x, point.y]);
 
-        const transformed = assign({}, source === dest ? numberize(p) : Proj4js.transform(sourceProj, destProj, numberize(p)), {srs: dest});
+        const transformed = Object.assign({}, source === dest ? numberize(p) : Proj4js.transform(sourceProj, destProj, numberize(p)), {srs: dest});
         if (normalize) {
             return normalizePoint(transformed);
         }
@@ -267,7 +266,7 @@ export const crsCodeTable = {
  * @memberof utils
  */
 export const setCrsLabels = (labels) => {
-    crsLabels = assign({}, crsLabels, labels);
+    crsLabels = Object.assign({}, crsLabels, labels);
 };
 export const getUnits = function(projection) {
     const proj = new Proj4js.Proj(projection);
@@ -484,13 +483,13 @@ export const getAvailableCRS = function() {
 };
 export const filterCRSList = (availableCRS, filterAllowedCRS, additionalCRS, projDefs ) => {
     let crs = Object.keys(availableCRS).reduce( (p, c) => {
-        return assign({}, filterAllowedCRS.indexOf(c) === -1 ? p : {...p, [c]: availableCRS[c]});
+        return Object.assign({}, filterAllowedCRS.indexOf(c) === -1 ? p : {...p, [c]: availableCRS[c]});
     }, {});
     const codeProjections = projDefs.map(p => p.code);
     let newAdditionalCRS = Object.keys(additionalCRS).reduce( (p, c) => {
-        return assign({}, codeProjections.indexOf(c) === -1 ? p : {...p, [c]: additionalCRS[c]});
+        return Object.assign({}, codeProjections.indexOf(c) === -1 ? p : {...p, [c]: additionalCRS[c]});
     }, {});
-    return assign({}, crs, newAdditionalCRS);
+    return Object.assign({}, crs, newAdditionalCRS);
 };
 export const calculateAzimuth = function(p1, p2, pj) {
     var p1proj = CoordinatesUtils.reproject(p1, pj, 'EPSG:4326');

--- a/web/client/utils/FileUtils.js
+++ b/web/client/utils/FileUtils.js
@@ -15,7 +15,6 @@ import tj from '@mapbox/togeojson';
 import JSZip from 'jszip';
 import { Promise } from 'es6-promise';
 const parser = new DOMParser();
-import assign from 'object-assign';
 import { hint as geojsonhint } from '@mapbox/geojsonhint/lib/object';
 import { toMapConfig } from './ogc/WMC';
 
@@ -60,11 +59,11 @@ export const shpToGeoJSON = function(zipBuffer) {
 };
 export const kmlToGeoJSON = function(xml) {
     const pureKml = cleanStyleFromKml(xml);
-    const geoJSON = [].concat(tj.kml(pureKml)).map(item => assign({}, item, {fileName: pureKml.getElementsByTagName('name')[0].innerHTML}));
+    const geoJSON = [].concat(tj.kml(pureKml)).map(item => Object.assign({}, item, {fileName: pureKml.getElementsByTagName('name')[0].innerHTML}));
     return geoJSON;
 };
 export const gpxToGeoJSON = function(xml, fileName) {
-    const geoJSON = [].concat(tj.gpx(xml)).map(item => assign({}, item, {
+    const geoJSON = [].concat(tj.gpx(xml)).map(item => Object.assign({}, item, {
         fileName: xml.getElementsByTagName('name')[0] && xml.getElementsByTagName('name')[0].innerHTML || fileName }));
     return geoJSON;
 };

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import toBbox from 'turf-bbox';
 import uuidv1 from 'uuid/v1';
 import isString from 'lodash/isString';
@@ -67,7 +66,7 @@ const reorderLayers = (groups, allLayers) => {
     return initialReorderLayers(groups, allLayers);
 };
 const createGroup = (groupId, groupTitle, groupName, layers, addLayers) => {
-    return assign({}, {
+    return Object.assign({}, {
         id: groupId,
         title: groupTitle ?? (groupName || "").replace(/\${dot}/g, "."),
         name: groupName,
@@ -79,7 +78,7 @@ const createGroup = (groupId, groupTitle, groupName, layers, addLayers) => {
 const getElevationDimension = (dimensions = []) => {
     return dimensions.reduce((previous, dim) => {
         return dim.name.toLowerCase() === 'elevation' || dim.name.toLowerCase() === 'depth' ?
-            assign({
+            Object.assign({
                 positive: dim.name.toLowerCase() === 'elevation'
             }, dim, {
                 name: dim.name.toLowerCase() === 'elevation' ? dim.name : 'DIM_' + dim.name
@@ -111,7 +110,7 @@ const isSupportedLayerFunc = (layer, maptype) => {
 
 
 const checkInvalidParam = (layer) => {
-    return layer && layer.invalid ? assign({}, layer, {invalid: false}) : layer;
+    return layer && layer.invalid ? Object.assign({}, layer, {invalid: false}) : layer;
 };
 
 export const getNode = (nodes, id) => {
@@ -366,13 +365,13 @@ export const extractDataFromSources = mapState => {
     if (!mapState || !mapState.layers || !isArray(mapState.layers)) {
         return null;
     }
-    const sources = mapState.mapInitialConfig && mapState.mapInitialConfig.sources && assign({}, mapState.mapInitialConfig.sources) || {};
+    const sources = mapState.mapInitialConfig && mapState.mapInitialConfig.sources && Object.assign({}, mapState.mapInitialConfig.sources) || {};
 
     return !isEmpty(sources) ? mapState.layers.map(l => {
 
         const tileMatrix = extractTileMatrixFromSources(sources, l);
 
-        return assign({}, l, tileMatrix);
+        return Object.assign({}, l, tileMatrix);
     }) : [...mapState.layers];
 };
 
@@ -469,7 +468,7 @@ export const normalizeMap = (rawMap = {}) =>
 export const belongsToGroup = (gid) => l => (l.group || DEFAULT_GROUP_ID) === gid || (l.group || "").indexOf(`${gid}.`) === 0;
 export const getLayersByGroup = (configLayers, configGroups) => {
     let i = 0;
-    let mapLayers = configLayers.map((layer) => assign({}, layer, {storeIndex: i++}));
+    let mapLayers = configLayers.map((layer) => Object.assign({}, layer, {storeIndex: i++}));
     let groupNames = mapLayers.reduce((groups, layer) => {
         return groups.indexOf(layer.group || DEFAULT_GROUP_ID) === -1 ? groups.concat([layer.group || DEFAULT_GROUP_ID]) : groups;
     }, []).filter((group) => group !== 'background').reverse();
@@ -507,7 +506,7 @@ export const getNotEmptyGroup = (group) => {
     const nodes = group.nodes.reduce((gNodes, node) => {
         return node.nodes ? gNodes.concat(LayersUtils.getNotEmptyGroup(node)) : gNodes.concat(node);
     }, []);
-    return nodes.length > 0 ? assign({}, group, {nodes: nodes}) : [];
+    return nodes.length > 0 ? Object.assign({}, group, {nodes: nodes}) : [];
 };
 export const reorderFunc = (groups, allLayers) => {
     return allLayers.filter((layer) => layer.group === 'background')
@@ -601,7 +600,7 @@ export const splitMapAndLayers = (mapState) => {
 
         let layers = extractDataFromSources(mapState);
 
-        return assign({}, mapState, {
+        return Object.assign({}, mapState, {
             layers: {
                 flat: LayersUtils.reorder(groups, layers),
                 groups: groups
@@ -655,7 +654,7 @@ export const geoJSONToLayer = (geoJSON, id) => {
     };
 };
 export const saveLayer = (layer) => {
-    return assign({
+    return Object.assign({
         id: layer.id,
         features: layer.features,
         format: layer.format,
@@ -797,7 +796,7 @@ export const getCapabilitiesUrl = (layer) => {
  */
 export const getSearchUrl = (l = {}) => l.search && l.search.url || l.url;
 export const invalidateUnsupportedLayer = (layer, maptype) => {
-    return isSupportedLayerFunc(layer, maptype) ? checkInvalidParam(layer) : assign({}, layer, {invalid: true});
+    return isSupportedLayerFunc(layer, maptype) ? checkInvalidParam(layer) : Object.assign({}, layer, {invalid: true});
 };
 /**
  * Establish if a layer is supported or not
@@ -947,7 +946,7 @@ It works for layers too
 **/
 export const deepRemove = (nodes, findValue) => {
     if (nodes && isArray(nodes) && nodes.length > 0) {
-        return nodes.filter((node) => (node.id && node.id !== findValue) || (isString(node) && node !== findValue )).map((node) => isObject(node) ? assign({}, node, node.nodes ? {
+        return nodes.filter((node) => (node.id && node.id !== findValue) || (isString(node) && node !== findValue )).map((node) => isObject(node) ? Object.assign({}, node, node.nodes ? {
             nodes: deepRemove(node.nodes, findValue)
         } : {}) : node);
     }
@@ -961,7 +960,7 @@ const updateGroupIds = (node, parentGroupId, newLayers) => {
             const newId = lastDot !== -1 ?
                 parentGroupId + node.id.slice(lastDot + (parentGroupId === '' ? 1 : 0)) :
                 parentGroupId + (parentGroupId === '' ? '' : '.') + node.id;
-            return assign({}, node, {id: newId, nodes: node.nodes.map(x => updateGroupIds(x, newId, newLayers))});
+            return Object.assign({}, node, {id: newId, nodes: node.nodes.map(x => updateGroupIds(x, newId, newLayers))});
         } else if (isString(node)) {
             // if it's just a string it means it is a layer id
             for (let layer of newLayers) {

--- a/web/client/utils/MapHistoryUtils.js
+++ b/web/client/utils/MapHistoryUtils.js
@@ -8,19 +8,17 @@
 import undoable, {ActionTypes} from 'redux-undo';
 import { isEqual } from 'lodash';
 
-import assign from 'object-assign';
-
 const mapConfigHistoryUtil = (reducer) => {
     return (state, action) => {
         let newState = reducer(state, action);
         let unredoState;
         // If undo modified the state we change mapStateSource
         if (action.type === ActionTypes.UNDO && state.past.length > 0) {
-            let mapC = assign({}, newState.present, {mapStateSource: "undoredo", style: state.present.style, resize: state.present.resize});
-            unredoState = assign({}, newState, {present: mapC});
+            let mapC = Object.assign({}, newState.present, {mapStateSource: "undoredo", style: state.present.style, resize: state.present.resize});
+            unredoState = Object.assign({}, newState, {present: mapC});
         } else if (action.type === ActionTypes.REDO && state.future.length > 0) {
-            let mapC = assign({}, newState.present, {mapStateSource: "undoredo", style: state.present.style, resize: state.present.resize});
-            unredoState = assign({}, newState, {present: mapC});
+            let mapC = Object.assign({}, newState.present, {mapStateSource: "undoredo", style: state.present.style, resize: state.present.resize});
+            unredoState = Object.assign({}, newState, {present: mapC});
         }
         return unredoState || {past: newState.past, present: newState.present, future: newState.future};
     };
@@ -29,7 +27,7 @@ const mapConfigHistoryUtil = (reducer) => {
 
 export const createHistory = (mapState) => {
     if (mapState && mapState.map && mapState.map.center) {
-        return assign({}, mapState, {
+        return Object.assign({}, mapState, {
             map: {
                 past: [],
                 present: mapState.map,

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -40,7 +40,6 @@ import {
     getTileMatrixSetLink,
     DEFAULT_GROUP_ID
 } from './LayersUtils';
-import assign from 'object-assign';
 
 export const DEFAULT_MAP_LAYOUT = {left: {sm: 300, md: 500, lg: 600}, right: {md: 548}, bottom: {sm: 30}};
 
@@ -583,7 +582,7 @@ export function saveMapConfiguration(currentMap, currentLayers, currentGroups, c
     return {
         version: 2,
         // layers are defined inside the map object
-        map: assign({}, map, {layers: formattedLayers, groups, backgrounds, text_search_config: textSearchConfig, bookmark_search_config: bookmarkSearchConfig},
+        map: Object.assign({}, map, {layers: formattedLayers, groups, backgrounds, text_search_config: textSearchConfig, bookmark_search_config: bookmarkSearchConfig},
             !isEmpty(sources) && {sources} || {}),
         ...additionalOptions
     };

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -7,7 +7,6 @@
  */
 
 import React from 'react';
-import assign from 'object-assign';
 import {endsWith, get, head, isArray, isFunction, isObject, isString, memoize, omit, size, maxBy } from 'lodash';
 import {connect as originalConnect} from 'react-redux';
 import url from 'url';
@@ -128,7 +127,7 @@ export const combineEpics = (plugins, epics = {}, epicWrapper) => {
  */
 export const filterState = memoize((state, monitor) => {
     return monitor.reduce((previous, current) => {
-        return assign(previous, {
+        return Object.assign(previous, {
             [current.name]: get(state, current.path)
         });
     }, {});
@@ -239,7 +238,7 @@ const includeLoaded = (name, loadedPlugins, plugin, stateSelector) => {
     if (loadedPlugins[name]) {
         const loaded = loadedPlugins[name];
         const impl = getPluginImplementation(loaded.component || loaded, stateSelector);
-        return assign(impl, plugin, {loadPlugin: undefined}, {...loaded.containers});
+        return Object.assign(impl, plugin, {loadPlugin: undefined}, {...loaded.containers});
     }
     return plugin;
 };
@@ -298,7 +297,7 @@ const parsePluginConfig = (state, requires, cfg) => {
     if (isObject(cfg)) {
         return Object.keys(cfg).reduce((previous, current) => {
             const value = cfg[current];
-            return assign(previous, {[current]: parsePluginConfig(state, requires, value)});
+            return Object.assign(previous, {[current]: parsePluginConfig(state, requires, value)});
         }, {});
     }
     return parseExpression(state, requires, cfg);
@@ -390,7 +389,7 @@ export const getPluginItems = (state, plugins = {}, pluginsConfig = {}, containe
 
 const pluginsMergeProps = (stateProps, dispatchProps, ownProps) => {
     const {pluginCfg, ...otherProps} = ownProps;
-    return assign({}, otherProps, stateProps, dispatchProps, pluginCfg || {});
+    return Object.assign({}, otherProps, stateProps, dispatchProps, pluginCfg || {});
 };
 
 /**
@@ -490,7 +489,7 @@ export const getPluginDescriptor = (state, plugins, pluginsConfig, pluginDef, lo
         id: id || name,
         name,
         impl: includeLoaded(name, loadedPlugins, getPluginImplementation(impl, stateSelector), stateSelector),
-        cfg: assign({}, impl.cfg || {}, isObject(pluginDef) ? parsePluginConfig(state, plugins.requires, pluginDef.cfg) : {}),
+        cfg: Object.assign({}, impl.cfg || {}, isObject(pluginDef) ? parsePluginConfig(state, plugins.requires, pluginDef.cfg) : {}),
         items: getPluginItems(state, plugins, pluginsConfig, name, id, isDefault, loadedPlugins)
     };
 };
@@ -592,13 +591,13 @@ export const createPlugin = (name, { component, options = {}, containers = {}, r
         loadPlugin: (resolve) => {
             loader().then(loadedImpl => {
                 const impl = loadedImpl.default || loadedImpl;
-                resolve(assign(impl, { isMapStorePlugin: true }));
+                resolve(Object.assign(impl, { isMapStorePlugin: true }));
             });
         },
         enabler
-    } : assign(component, { isMapStorePlugin: true });
+    } : Object.assign(component, { isMapStorePlugin: true });
     return {
-        [pluginName]: assign(pluginImpl, containers, options),
+        [pluginName]: Object.assign(pluginImpl, containers, options),
         reducers,
         epics
     };

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -28,7 +28,6 @@ import { getStore } from "./StateUtils";
 import { isLocalizedLayerStylesEnabledSelector, localizedLayerStylesEnvSelector } from '../selectors/localizedLayerStyles';
 import { currentLocaleLanguageSelector } from '../selectors/locale';
 import { printSpecificationSelector } from "../selectors/print";
-import assign from 'object-assign';
 import sortBy from "lodash/sortBy";
 import head from "lodash/head";
 import isNil from "lodash/isNil";
@@ -597,7 +596,7 @@ export const specCreators = {
             "styles": [
                 layer.style || ''
             ],
-            "customParams": addAuthenticationParameter(PrintUtils.normalizeUrl(layer.url), assign({
+            "customParams": addAuthenticationParameter(PrintUtils.normalizeUrl(layer.url), Object.assign({
                 "TRANSPARENT": true,
                 ...getPrintVendorParams(layer),
                 "EXCEPTIONS": "application/vnd.ogc.se_inimage",
@@ -821,7 +820,7 @@ export const specCreators = {
                 "format": layer.format || "image/png",
                 "type": "WMTS",
                 "layer": layer.name,
-                "customParams ": addAuthenticationParameter(layer.capabilitiesURL, assign({
+                "customParams ": addAuthenticationParameter(layer.capabilitiesURL, Object.assign({
                     "TRANSPARENT": true
                 })),
                 // rest parameter style is not included

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -9,7 +9,6 @@ import { keys } from 'lodash';
 
 import ConfigUtils from "./ConfigUtils";
 import URL from "url";
-import assign from "object-assign";
 import head from "lodash/head";
 import isNil from "lodash/isNil";
 import isArray from "lodash/isArray";
@@ -183,13 +182,13 @@ export function addAuthenticationParameter(url, parameters, securityToken) {
             return parameters;
         }
         const authParam = getAuthKeyParameter(url);
-        return assign(parameters || {}, {[authParam]: token});
+        return Object.assign(parameters || {}, {[authParam]: token});
     }
     case 'test': {
         const rule = getAuthenticationRule(url);
         const token = rule ? rule.token : "";
         const authParam = getAuthKeyParameter(url);
-        return assign(parameters || {}, { [authParam]: token });
+        return Object.assign(parameters || {}, { [authParam]: token });
     }
     default:
         // we cannot handle the required authentication method
@@ -221,8 +220,8 @@ export function addAuthenticationToSLD(layerParams, options) {
     if (layerParams.SLD) {
         const parsed = URL.parse(layerParams.SLD, true);
         const params = addAuthenticationParameter(layerParams.SLD, parsed.query, options.securityToken);
-        return assign({}, layerParams, {
-            SLD: URL.format(assign({}, parsed, {
+        return Object.assign({}, layerParams, {
+            SLD: URL.format(Object.assign({}, parsed, {
                 query: params,
                 search: undefined
             }))
@@ -241,7 +240,7 @@ export function getCredentials(id) {
 }
 export function setCredentials(id, credentials) {
     const securityStorage = JSON.parse(sessionStorage.getItem('credentialStorage') ?? "{}");
-    sessionStorage.setItem('credentialStorage', JSON.stringify(assign({}, securityStorage, {[id]: credentials})));
+    sessionStorage.setItem('credentialStorage', JSON.stringify(Object.assign({}, securityStorage, {[id]: credentials})));
 }
 /**
  * This utility class will get information about the current logged user directly from the store.

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -7,7 +7,6 @@
  */
 import expect from 'expect';
 import uuidv1 from 'uuid/v1';
-import assign from 'object-assign';
 import * as LayersUtils from '../LayersUtils';
 
 const { extractTileMatrixSetFromLayers, splitMapAndLayers, flattenGroups, getTitle} = LayersUtils;
@@ -996,7 +995,7 @@ describe('LayersUtils', () => {
             const maptype = "leaflet";
             const Layers = require('../' + maptype + '/Layers');
             Layers.registerType('wms', {});
-            const res = LayersUtils.isSupportedLayer(assign({}, wmsLayer, {invalid: true}), maptype);
+            const res = LayersUtils.isSupportedLayer(Object.assign({}, wmsLayer, {invalid: true}), maptype);
             expect(res).toBeFalsy();
         });
         it('type: mapquest  maptype: openlayers, with apikey supported', () => {
@@ -1017,7 +1016,7 @@ describe('LayersUtils', () => {
             const maptype = "openlayers";
             const Layers = require('../' + maptype + '/Layers');
             Layers.registerType('bing', {});
-            const res = LayersUtils.isSupportedLayer(assign({}, bingLayerWithApikey, {apiKey: "__API_KEY_MAPQUEST__"}), maptype);
+            const res = LayersUtils.isSupportedLayer(Object.assign({}, bingLayerWithApikey, {apiKey: "__API_KEY_MAPQUEST__"}), maptype);
             expect(res).toBeFalsy();
         });
         it('type: bing  maptype: openlayers, with apikey supported', () => {

--- a/web/client/utils/__tests__/PluginsUtils-test.js
+++ b/web/client/utils/__tests__/PluginsUtils-test.js
@@ -10,7 +10,6 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import expect from 'expect';
 import PluginsUtils from '../PluginsUtils';
-import assign from 'object-assign';
 
 import { testEpic } from '../../epics/__tests__/epicTestUtils';
 
@@ -36,7 +35,7 @@ describe('PluginsUtils', () => {
     });
 
     it('getPluginDescriptor', () => {
-        const P1 = assign( () => {}, {
+        const P1 = Object.assign( () => {}, {
             reducers: {
                 reducer1: () => {}
             }
@@ -44,7 +43,7 @@ describe('PluginsUtils', () => {
         const item = {
             test: "TEST"
         };
-        const P2 = assign( () => {}, {
+        const P2 = Object.assign( () => {}, {
             P1: item,
             reducers: {
                 reducer1: () => ({ A: "A"}),

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -9,7 +9,6 @@ import expect from "expect";
 
 import SecurityUtils from "../SecurityUtils";
 import ConfigUtils from "../ConfigUtils";
-import assign from "object-assign";
 import {setStore} from "../StateUtils";
 
 function setSecurityInfo(info) {
@@ -34,7 +33,7 @@ const securityInfoA = {
     user: userA
 };
 
-const userB = assign({}, userA, {
+const userB = Object.assign({}, userA, {
     name: "adminB",
     attribute: {
         name: "UUID",
@@ -47,7 +46,7 @@ const securityInfoB = {
     token: "263c6917-543f-43e3-8e1a-6a0d29952f72"
 };
 
-const userC = assign({}, userA, {
+const userC = Object.assign({}, userA, {
     name: "adminC",
     attribute: [{
         name: "UUID",

--- a/web/client/utils/featuregrid/EditorRegistry.jsx
+++ b/web/client/utils/featuregrid/EditorRegistry.jsx
@@ -7,8 +7,7 @@
 */
 
 const find = require('lodash/find');
-const assign = require('object-assign');
-let Editors = assign({}, require('../../components/data/featuregrid/editors/customEditors').default);
+let Editors = Object.assign({}, require('../../components/data/featuregrid/editors/customEditors').default);
 
 const isPresent = (editorName) => {
     return Object.keys(Editors).indexOf(editorName) !== -1;

--- a/web/client/utils/featuregrid/__tests__/EditorRegistry-test.js
+++ b/web/client/utils/featuregrid/__tests__/EditorRegistry-test.js
@@ -10,7 +10,6 @@ import React from 'react';
 import expect from 'expect';
 import DropDownEditor from '../../../components/data/featuregrid/editors/DropDownEditor';
 
-import assign from 'object-assign';
 import {
     register,
     clean,
@@ -75,7 +74,7 @@ describe('EditorRegistry tests ', () => {
     });
     it('register using custom editors', () => {
         const name = "custom_name_editor2";
-        const customEditors = assign({}, testEditors);
+        const customEditors = Object.assign({}, testEditors);
         delete customEditors.string;
         register({name, editors: customEditors});
         let Editors = get();
@@ -90,7 +89,7 @@ describe('EditorRegistry tests ', () => {
     });
     it('remove with name PRESENT in the list', () => {
         const name = "custom_name_editor2";
-        const customEditors = assign({}, testEditors);
+        const customEditors = Object.assign({}, testEditors);
         register({name, editors: customEditors});
 
         const result = remove(name);
@@ -98,21 +97,21 @@ describe('EditorRegistry tests ', () => {
     });
     it('getCustomEditor with positive match', () => {
         const name = "DropDownEditor";
-        const customEditors = assign({}, testEditors);
+        const customEditors = Object.assign({}, testEditors);
         register({name, editors: customEditors});
         const editor = getCustomEditor({attribute, url, typeName}, rules, {type: "string", props: {}});
         expect(editor).toExist();
     });
     it('getCustomEditor with positive match but not supported type, i.e. default editor', () => {
         const name = "DropDownEditor";
-        const customEditors = assign({}, testEditors);
+        const customEditors = Object.assign({}, testEditors);
         register({name, editors: customEditors});
         const editor = getCustomEditor({attribute, url, typeName}, rules, {type: "varchar", props: {}});
         expect(editor).toExist();
     });
     it('getCustomEditor with positive match but not supported type, return null', () => {
         const name = "DropDownEditor";
-        let customEditors = assign({}, testEditors);
+        let customEditors = Object.assign({}, testEditors);
         delete customEditors.defaultEditor;
         register({name, editors: customEditors});
         const editor = getCustomEditor({attribute, url, typeName}, rules, {type: "varchar", props: {}});
@@ -121,14 +120,14 @@ describe('EditorRegistry tests ', () => {
     it('getCustomEditor with negative match', () => {
         const attr = "STAsTE_NAME";
         const name = "DropDownEditor";
-        const customEditors = assign({}, testEditors);
+        const customEditors = Object.assign({}, testEditors);
         register({name, editors: customEditors});
         const editor = getCustomEditor({attribute: attr, url, typeName}, rules, {type: "string", props: {}});
         expect(editor).toBe(null);
     });
     it('getCustomEditor with no rules', () => {
         const name = "DropDownEditor";
-        const customEditors = assign({}, testEditors);
+        const customEditors = Object.assign({}, testEditors);
         register({name, editors: customEditors});
 
         const rulesempty = [{}];
@@ -138,7 +137,7 @@ describe('EditorRegistry tests ', () => {
 
     it('testing fetch of custom editors', () => {
         const name = "DropDownEditor";
-        const customEditors = assign({}, testEditors);
+        const customEditors = Object.assign({}, testEditors);
         register({name, editors: customEditors});
 
         const AutocompleteEditor = getCustomEditor({attribute, url, typeName}, rules, {type: "string", props: {autocompleteEnabled: true}});

--- a/web/client/utils/leaflet/Vector.js
+++ b/web/client/utils/leaflet/Vector.js
@@ -8,7 +8,6 @@
 
 const L = require('leaflet');
 const Icons = require('./Icons');
-const assign = require('object-assign');
 const {isMarkerStyle, isSymbolStyle} = require('../VectorStyleUtils');
 
 const getIcon = (style, geojson) => {
@@ -134,7 +133,7 @@ const VectorUtils = {
             return null;
         }
         let layer;
-        let style = props.style || assign({}, options.style && options.style[geometry.type] || options.style, {highlight: options.style && options.style.highlight});
+        let style = props.style || Object.assign({}, options.style && options.style[geometry.type] || options.style, {highlight: options.style && options.style.highlight});
 
         let latlng;
         let latlngs;
@@ -209,7 +208,7 @@ const VectorUtils = {
     updateHighlightStyle: (style) => {
         let {highlight} = style;
         if (highlight) {
-            return assign({}, style, {
+            return Object.assign({}, style, {
                 dashArray: highlight ? "10" : null
             });
         }

--- a/web/client/utils/leaflet/WMSUtils.js
+++ b/web/client/utils/leaflet/WMSUtils.js
@@ -7,7 +7,6 @@
  */
 
 import L from 'leaflet';
-import assign from 'object-assign';
 import { isNil } from 'lodash';
 import { creditsToAttribution, getWMSVendorParams } from '../LayersUtils';
 import { isVectorFormat } from '../VectorTileUtils';
@@ -118,7 +117,7 @@ export function getWMSURLs( urls ) {
 
 export const removeNulls = (obj = {}) => {
     return Object.keys(obj).reduce((previous, key) => {
-        return isNil(obj[key]) ? previous : assign(previous, {
+        return isNil(obj[key]) ? previous : Object.assign(previous, {
             [key]: obj[key]
         });
     }, {});

--- a/web/client/utils/mapinfo/wfs.js
+++ b/web/client/utils/mapinfo/wfs.js
@@ -16,7 +16,6 @@ import { describeFeatureType, getFeature } from '../../api/WFS';
 import { extractGeometryAttributeName } from '../WFSLayerUtils';
 
 import {addAuthenticationToSLD} from '../SecurityUtils';
-import assign from 'object-assign';
 
 // if the url uses following constant means the whole workflow is managed client side
 // and prevent request to a service
@@ -67,7 +66,7 @@ const buildRequest = (layer, { map = {}, point, currentLocale, params, maxItems 
             typeName: layer.name,
             srs: normalizeSRS(map.projection) || 'EPSG:4326',
             feature_count: maxItems,
-            ...assign({ params })
+            ...Object.assign({ params })
         }, layer),
         metadata: {
             title: isObject(layer.title) ? layer.title[currentLocale] || layer.title.default : layer.title,
@@ -133,7 +132,7 @@ export default {
                         }
 
                     },
-                    params: assign({}, layer.baseParams, layer.params, baseParams)
+                    params: Object.assign({}, layer.baseParams, layer.params, baseParams)
                 });
                 return getFeature(baseURL, layer.name, params);
             }));

--- a/web/client/utils/mapinfo/wms.js
+++ b/web/client/utils/mapinfo/wms.js
@@ -17,7 +17,6 @@ import axios from "../../libs/ajax";
 // import {parseString} from "xml2js";
 // import {stripPrefix} from "xml2js/lib/processors";
 import {addAuthenticationToSLD} from '../SecurityUtils';
-import assign from 'object-assign';
 import { interceptOGCError } from '../ObservableUtils';
 export default {
     /**
@@ -55,7 +54,7 @@ export default {
         const params = optionsToVendorParams({
             layerFilter: layer.layerFilter,
             filterObj: layer.filterObj,
-            params: assign({}, layer.baseParams, layer.params, defaultParams)
+            params: Object.assign({}, layer.baseParams, layer.params, defaultParams)
         });
         return {
             request: addAuthenticationToSLD({
@@ -79,7 +78,7 @@ export default {
                 info_format: infoFormat,
                 format: layer.format,
                 ENV,
-                ...assign({}, params)
+                ...Object.assign({}, params)
             }, layer),
             metadata: {
                 title: isObject(layer.title) ? layer.title[currentLocale] || layer.title.default : layer.title,

--- a/web/client/utils/mapinfo/wmts.js
+++ b/web/client/utils/mapinfo/wmts.js
@@ -24,7 +24,6 @@ import {optionsToVendorParams} from '../VendorParamsUtils';
 
 import {isObject, isNil, get} from 'lodash';
 
-import assign from 'object-assign';
 import Rx, {Observable} from "rxjs";
 import axios from "../../libs/ajax";
 import {parseString} from "xml2js";
@@ -86,7 +85,7 @@ export default {
         const params = optionsToVendorParams({
             layerFilter: layer.layerFilter,
             filterObj: layer.filterObj,
-            params: assign({}, layer.baseParams, layer.params, props.params)
+            params: Object.assign({}, layer.baseParams, layer.params, props.params)
         });
 
         return {
@@ -97,7 +96,7 @@ export default {
                 infoformat: props.format,
                 format: layer.format,
                 style: layer.style || '',
-                ...assign({}, params),
+                ...Object.assign({}, params),
                 tilecol: tileCol,
                 tilerow: tileRow,
                 tilematrix: currentTileMatrixId?.identifier,

--- a/web/client/utils/ogc/WPS/__tests__/autocomplete-test.js
+++ b/web/client/utils/ogc/WPS/__tests__/autocomplete-test.js
@@ -7,7 +7,6 @@
  */
 
 const expect = require('expect');
-const assign = require('object-assign');
 const {toOGCFilterParts} = require('../../../FilterUtils');
 const {getWpsPayload} = require('../autocomplete');
 
@@ -148,21 +147,21 @@ const getBodyPart3 = ({attribute, maxFeatures, startIndex}) => '             <og
 describe('Test WPS requests', () => {
 
     it('getWpsPayload with value', () => {
-        const options = assign({}, defaultOptions);
+        const options = Object.assign({}, defaultOptions);
         const requestBody = getWpsPayload(options);
         expect(requestBody).toExist();
         const expectedBody = getBodyPart1(options) + getBodyPart2(options) + getBodyPart3(options);
         expect(requestBody).toBe(expectedBody);
     });
     it('getWpsPayload with value null', () => {
-        const options = assign({}, defaultOptions, {value: null});
+        const options = Object.assign({}, defaultOptions, {value: null});
         const requestBody = getWpsPayload(options);
         expect(requestBody).toExist();
         const expectedBody = getBodyPart1(options) + getBodyPart3(options);
         expect(requestBody).toBe(expectedBody);
     });
     it('getWpsPayload with value undefined', () => {
-        const options = assign({}, defaultOptions, {value: undefined});
+        const options = Object.assign({}, defaultOptions, {value: undefined});
         const requestBody = getWpsPayload(options);
         expect(requestBody).toExist();
         const expectedBody = getBodyPart1(options) + getBodyPart3(options);
@@ -175,14 +174,14 @@ describe('Test WPS requests', () => {
         expect(requestBody).toBe(expectedBody);
     });
     it('getWpsPayload with layerFilter', () => {
-        const options = assign({}, defaultOptions, {layerFilter: sampleFilter});
+        const options = Object.assign({}, defaultOptions, {layerFilter: sampleFilter});
         const requestBody = getWpsPayload(options);
         expect(requestBody).toExist();
         const expectedBody = getBodyPart1(options) + getBodyPart2Both(options) + getBodyPart3(options);
         expect(requestBody).toBe(expectedBody);
     });
     it('getWpsPayload with layerFilter and value undefined', () => {
-        const options = assign({}, defaultOptions, {layerFilter: sampleFilter, value: undefined});
+        const options = Object.assign({}, defaultOptions, {layerFilter: sampleFilter, value: undefined});
         const requestBody = getWpsPayload(options);
         expect(requestBody).toExist();
         const expectedBody = getBodyPart1(options) + getBodyPart2WithLayerFilter(options) + getBodyPart3(options);

--- a/web/client/utils/openlayers/OlLocate.js
+++ b/web/client/utils/openlayers/OlLocate.js
@@ -8,7 +8,6 @@
  */
 
 import olPopUp from './OlPopUp';
-import assign from 'object-assign';
 import { getQueryParams } from '../URLUtils';
 
 import BaseObject from 'ol/Object';
@@ -60,7 +59,7 @@ class OlLocate extends BaseObject {
             }
         };
 
-        this.options = assign({}, defOptions, optOptions || {} );
+        this.options = Object.assign({}, defOptions, optOptions || {} );
         this.geolocate = new Geolocation({
             projection: this.map.getView().getProjection(),
             trackingOptions: this.options.locateOptions
@@ -290,7 +289,7 @@ class OlLocate extends BaseObject {
     };
 
     setStrings = function(newStrings) {
-        this.options.strings = assign({}, this.options.strings, newStrings);
+        this.options.strings = Object.assign({}, this.options.strings, newStrings);
     };
 
     setTrackingOptions = function(options) {

--- a/web/client/utils/openlayers/WMSUtils.js
+++ b/web/client/utils/openlayers/WMSUtils.js
@@ -5,7 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import assign from 'object-assign';
 import { get } from 'ol/proj';
 import TileGrid from 'ol/tilegrid/TileGrid';
 
@@ -64,7 +63,7 @@ export const toOLAttributions = credits => credits && creditsToAttribution(credi
 export function wmsToOpenlayersOptions(options) {
     const params = optionsToVendorParams(options);
     // NOTE: can we use opacity to manage visibility?
-    const result = assign({}, options.baseParams, {
+    const result = Object.assign({}, options.baseParams, {
         LAYERS: options.name,
         STYLES: options.style || "",
         FORMAT: options.format || 'image/png',
@@ -73,7 +72,7 @@ export function wmsToOpenlayersOptions(options) {
         CRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
         ...getWMSVendorParams(options),
         VERSION: options.version || "1.3.0"
-    }, assign(
+    }, Object.assign(
         {},
         (options._v_ ? {_v_: options._v_} : {}),
         (params || {}),


### PR DESCRIPTION
## Description
`Object.assign` is supported by all modern browsers and node.js 4+, which means we can remove the 3 polyfill packages from the project.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**

We are currently using 3 different npm packages to polyfill `Object.assign`.
See at more detailed description in this issue [#11036](https://github.com/geosolutions-it/MapStore2/issues/11036)

**What is the new behavior?**

Remove the following npm package and replace them with `Object.assign`
- object-assign
- es6-object-asssign
- babel-plugin-object-assign

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
