### PR TITLE
Remove unused devDependency parallelshell

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "mini-css-extract-plugin": "1.3.9",
     "mkdirp": "0.5.1",
     "ncp": "2.0.0",
-    "parallelshell": "1.2.0",
     "postcss": "8.3.5",
     "postcss-loader": "6.1.0",
     "postcss-prefix-selector": "1.10.0",


### PR DESCRIPTION
## Description
This pull request removes the parallelshell npm package from devdependencies in package.json
The npm package is not being used anywhere.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
https://github.com/geosolutions-it/MapStore2/issues/11038

**What is the current behavior?**
We are currently downloading the npm package parallelshell which is not being used anywhere.

#<issue>

**What is the new behavior?**
The npm package parallelshell should be removed from package.json

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
