### PR TITLE
Remove unused devDependency redux-immutable-state-invariant

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "redux-devtools": "3.4.0",
     "redux-devtools-dock-monitor": "1.1.2",
     "redux-devtools-log-monitor": "1.3.0",
-    "redux-immutable-state-invariant": "2.1.0",
     "redux-mock-store": "1.2.2",
     "rimraf": "2.5.2",
     "simple-git": "2.20.1",


### PR DESCRIPTION
## Description
The npm package redux-immutable-state-invariant is not used anywhere and can be removed from package.json

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
https://github.com/geosolutions-it/MapStore2/issues/11046

**What is the current behavior?**
We are currently downloading the npm package package redux-immutable-state-invariant but its not being used anywhere.

**What is the new behavior?**
Remove package redux-immutable-state-invariant from package.json

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
