### PR TITLE
Remove unused dependency b64-to-blob

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "@znemz/cesium-navigation": "4.0.0",
     "assert": "2.0.0",
     "axios": "0.28.1",
-    "b64-to-blob": "1.2.19",
     "babel-polyfill": "6.8.0",
     "babel-standalone": "6.7.7",
     "bootstrap": "3.4.1",

--- a/web/client/components/import/dragZone/enhancers/__tests__/testData.js
+++ b/web/client/components/import/dragZone/enhancers/__tests__/testData.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-// const b64toBlob = require('b64-to-blob');
 import * as Rx from 'rxjs';
 
 const SHP_FILE_URL = 'base/web/client/test-resources/caput-mundi/caput-mundi.zip';


### PR DESCRIPTION
## Description
This pull request removes b64-to-blob from package.json
The npm package is not being used anywhere and can safely be removed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
https://github.com/geosolutions-it/MapStore2/issues/11043

**What is the current behavior?**
We are currently downloading the npm package b64-to-blob but it is not being used anywhere

**What is the new behavior?**
Remove b64-to-blob from package.json

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
