### PR TITLE
Remove unused devDependency react-motion

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "process": "0.11.10",
     "progress-bar-webpack-plugin": "1.12.1",
     "raw-loader": "0.5.1",
-    "react-motion": "0.5.0",
     "react-transition-group": "1.1.3",
     "readline-promise": "1.0.4",
     "redux-devtools": "3.4.0",


### PR DESCRIPTION
## Description
This pull request removes react-motion from package.json
The npm package is not being used anywhere and can safely be removed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
https://github.com/geosolutions-it/MapStore2/issues/11044

**What is the current behavior?**
We are currently downloading the npm package react-motion but it is not being used anywhere

**What is the new behavior?**
Remove react-motion from package.json

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
