### PR TITLE
Remove unused dependency react-input-autosize

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,7 +240,6 @@
     "react-error-boundary": "1.2.5",
     "react-grid-layout": "1.2.0",
     "react-image-lightbox": "4.2.2",
-    "react-input-autosize": "1.1.4",
     "react-intersection-observer": "8.24.1",
     "react-intl": "2.3.0",
     "react-notification-system": "0.2.14",


### PR DESCRIPTION
## Description
This pull request removes react-input-autosize from package.json
The npm package is not being used anywhere and can safely be removed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
https://github.com/geosolutions-it/MapStore2/issues/11045

**What is the current behavior?**
We are currently downloading the npm package react-input-autosize but it is not being used anywhere

**What is the new behavior?**
Remove react-input-autosize from package.json

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
