### PR TITLE
Remove unused dependency util

### DIFF
--- a/package.json
+++ b/package.json
@@ -283,7 +283,6 @@
     "turf-point-on-surface": "3.0.10",
     "turf-union": "3.0.10",
     "url": "0.11.0",
-    "util": "0.12.3",
     "uuid": "3.0.1",
     "vis": "4.21.0",
     "web-ifc": "0.0.50",


### PR DESCRIPTION
## Description
This pull request removes util from package.json
The npm package is not being used anywhere and can safely be removed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
https://github.com/geosolutions-it/MapStore2/issues/11047

**What is the current behavior?**
We are currently downloading the npm package util but it is not being used anywhere

**What is the new behavior?**
Remove util from package.json

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
