### PR TITLE
Fix #11064. Restored arguments for login event

### DIFF
--- a/web/client/actions/login.js
+++ b/web/client/actions/login.js
@@ -70,7 +70,7 @@ export function onShowLogin(providers = [{type: "basic", provider: "geostore"}])
     const provider = providers?.[0];
     switch (provider?.type) {
     case "openID":
-        return openIDLogin(provider);
+        return openIDLogin(provider, provider?.goToPage); // goToPage is normally empty, but can be used to mock the redirect in tests
     case "basic":
         return showLoginWindow();
     default:

--- a/web/client/plugins/__tests__/Login-test.js
+++ b/web/client/plugins/__tests__/Login-test.js
@@ -181,6 +181,22 @@ describe('Login Plugin', () => {
             const entries = document.querySelectorAll("#mapstore-navbar-container ul li[role=\"presentation\"]");
             expect(entries.length).toEqual(1); // only user.logout
         });
+        it('openID automatic login is mapped when 1 provider only is present', () => {
+            const spyOn = {
+                goToPage: () => {}
+            };
+            expect.spyOn(spyOn, 'goToPage');
+            ConfigUtils.setConfigProp("authenticationProviders", [{type: "openID", provider: "oidc", goToPage: spyOn.goToPage}]); // goToPage is normally empty, but can be used to mock the redirect in tests
+
+            const { Plugin } = getPluginForTest(Login, {});
+            const { Plugin: OmniBarPlugin } = getPluginForTest(OmniBar, {}, { LoginPlugin: Login });
+            TestUtils.act(() => {
+                ReactDOM.render(<OmniBarPlugin items={[{ ...Login.LoginPlugin.OmniBar, plugin: Plugin.LoginPlugin}]} />, document.getElementById("container"));
+            });
+            document.querySelector("#mapstore-navbar-container > div > ul > li > a").click();
+            expect(spyOn.goToPage).toHaveBeenCalled();
+            expect(spyOn.goToPage.calls[0].arguments[0]).toEqual(`/rest/geostore/openid/oidc/login`);
+        });
         it('openID with userInfo configured', () => {
             ConfigUtils.setConfigProp("authenticationProviders", [{type: "openID", provider: "google", showAccountInfo: true}]);
             const storeState = stateMocker(toggleControl('LoginForm', 'enabled'), loginSuccess({  User: { name: "Test", access_token: "some-token" }, authProvider: "google"}) );

--- a/web/client/plugins/login/index.js
+++ b/web/client/plugins/login/index.js
@@ -114,10 +114,10 @@ export const Login = connect((state) => ({
     onError: loginFail
 })(LoginModalComp);
 
-export const LoginMenuItem = userMenuConnect(({itemComponent, showLogin = true, onShowLoggedin}) => {
+export const LoginMenuItem = userMenuConnect(({itemComponent, showLogin = true, onShowLoggedin, providers}) => {
     const Menuitem = itemComponent;
     if (Menuitem && showLogin) {
-        return (<Menuitem glyph="log-in" msgId= "user.login" onClick={onShowLoggedin}/>);
+        return (<Menuitem glyph="log-in" msgId= "user.login" onClick={() => onShowLoggedin(providers)}/>);
     }
     return null;
 });


### PR DESCRIPTION
## Description

The main problem was that with the new implementation the arguments to pass to the login was not passed anymore, so the `onShowLogin` argument (`providers`) was always the default (`(providers = [{type: "basic", provider: "geostore"}]) `). 
With this changes, we pass the providers to the  request in any case, so the event is intercepted.
I also added some minimal wiring to allow unit testsing (and intercept the event of redirect without effectively redirecting). 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #11064.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Fix #11064.
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

This can be tested only with a local custom configruation. On dev we can test it with normal menu entries.

