### PR TITLE
Fix #10966 basic auth for services

### DIFF
--- a/build/docma-config.json
+++ b/build/docma-config.json
@@ -310,6 +310,7 @@
                 "web/client/plugins/SearchByBookmark.jsx",
                 "web/client/plugins/SearchServicesConfig.jsx",
                 "web/client/plugins/Settings.jsx",
+                "web/client/plugins/SecurityPopup.jsx",
                 "web/client/plugins/Share.jsx",
                 "web/client/plugins/SidebarMenu.jsx",
                 "web/client/plugins/Snapshot.jsx",

--- a/package.json
+++ b/package.json
@@ -294,8 +294,8 @@
   "scripts": {
     "start": "npm run app:start",
     "app:start": "concurrently -n frontend,backend -c green,blue \"npm:fe:start\" \"npm:be:start\"",
-    "fe:start": "webpack serve --progress --color --port 8082 --hot --inline --config build/webpack.config.js --content-base web/client",
-    "fe:start-prod": "webpack serve --progress --color --port 8082 --hot --inline --config build/prod-webpack.config.js --content-base web/client",
+    "fe:start": "webpack serve --progress --color --port 8081 --hot --inline --config build/webpack.config.js --content-base web/client",
+    "fe:start-prod": "webpack serve --progress --color --port 8081 --hot --inline --config build/prod-webpack.config.js --content-base web/client",
     "fe:build": "npm run clean && mkdirp ./web/client/dist && webpack build --progress --color --config build/prod-webpack.config.js",
     "compile": "npm run fe:build",
     "be:build": "mvn clean install -Pprinting",

--- a/package.json
+++ b/package.json
@@ -294,8 +294,8 @@
   "scripts": {
     "start": "npm run app:start",
     "app:start": "concurrently -n frontend,backend -c green,blue \"npm:fe:start\" \"npm:be:start\"",
-    "fe:start": "webpack serve --progress --color --port 8081 --hot --inline --config build/webpack.config.js --content-base web/client",
-    "fe:start-prod": "webpack serve --progress --color --port 8081 --hot --inline --config build/prod-webpack.config.js --content-base web/client",
+    "fe:start": "webpack serve --progress --color --port 8082 --hot --inline --config build/webpack.config.js --content-base web/client",
+    "fe:start-prod": "webpack serve --progress --color --port 8082 --hot --inline --config build/prod-webpack.config.js --content-base web/client",
     "fe:build": "npm run clean && mkdirp ./web/client/dist && webpack build --progress --color --config build/prod-webpack.config.js",
     "compile": "npm run fe:build",
     "be:build": "mvn clean install -Pprinting",

--- a/web/client/actions/__tests__/layers-test.js
+++ b/web/client/actions/__tests__/layers-test.js
@@ -60,9 +60,7 @@ import {
     showLayerMetadata,
     hideLayerMetadata,
     updateSettingsParams,
-    addGroup,
-    refreshSecurityLayers,
-    REFRESH_SECURITY_LAYERS
+    addGroup
 } from '../layers';
 
 import { getLayerCapabilities } from '../layerCapabilities';
@@ -346,10 +344,6 @@ describe('Test correctness of the layers actions', () => {
         expect(action.parent).toBe('group1.group2');
     });
 
-    it('refreshSecurityLayers', () => {
-        const action = refreshSecurityLayers();
-        expect(action.type).toBe(REFRESH_SECURITY_LAYERS);
-    });
 
     it('add group with options', () => {
         const options = {

--- a/web/client/actions/__tests__/layers-test.js
+++ b/web/client/actions/__tests__/layers-test.js
@@ -60,7 +60,9 @@ import {
     showLayerMetadata,
     hideLayerMetadata,
     updateSettingsParams,
-    addGroup
+    addGroup,
+    refreshSecurityLayers,
+    REFRESH_SECURITY_LAYERS
 } from '../layers';
 
 import { getLayerCapabilities } from '../layerCapabilities';
@@ -342,6 +344,11 @@ describe('Test correctness of the layers actions', () => {
         expect(action.type).toBe(ADD_GROUP);
         expect(action.group).toBe('newgroup');
         expect(action.parent).toBe('group1.group2');
+    });
+
+    it('refreshSecurityLayers', () => {
+        const action = refreshSecurityLayers();
+        expect(action.type).toBe(REFRESH_SECURITY_LAYERS);
     });
 
     it('add group with options', () => {

--- a/web/client/actions/__tests__/security-test.js
+++ b/web/client/actions/__tests__/security-test.js
@@ -81,7 +81,7 @@ describe('Test correctness of the close actions', () => {
     });
     it('setShowModalStatus', () => {
         expect(security.setShowModalStatus(true)).toEqual({
-            type: security.CHECK_LOGGED_USER,
+            type: security.SET_SHOW_MODAL_STATUS,
             status: true
         });
     });

--- a/web/client/actions/__tests__/security-test.js
+++ b/web/client/actions/__tests__/security-test.js
@@ -10,6 +10,7 @@ import expect from 'expect';
 
 import * as security from '../security';
 import { base64ToUtf8 } from '../../utils/EncodeUtils';
+import { getCredentials } from '../../utils/SecurityUtils';
 
 
 describe('Test correctness of the close actions', () => {
@@ -77,6 +78,33 @@ describe('Test correctness of the close actions', () => {
     it('loginRequired, loginPromptClosed', () => {
         expect(security.loginRequired().type).toBe(security.LOGIN_REQUIRED);
         expect(security.loginPromptClosed().type).toBe(security.LOGIN_PROMPT_CLOSED);
+    });
+    it('setShowModalStatus', () => {
+        expect(security.setShowModalStatus(true)).toEqual({
+            type: security.CHECK_LOGGED_USER,
+            status: true
+        });
+    });
+    it('setProtectedServices ', () => {
+        expect(security.setProtectedServices({})).toEqual({
+            type: security.SET_PROTECTED_SERVICES,
+            protectedServices: {}
+        });
+    });
+    it('clearSecurity ', () => {
+        expect(security.clearSecurity("id")).toEqual({
+            type: security.CLEAR_SECURITY,
+            protectedId: "id"
+        });
+    });
+    it('setCredentialsAction ', () => {
+        expect(security.setCredentialsAction({
+            protectedId: "123"
+        }, {name: "creds"})).toEqual({
+            type: security.SET_CREDENTIALS,
+            protectedService: {protectedId: "123"}
+        });
+        expect(getCredentials("123")).toEqual({name: "creds"});
     });
     it('checkLoggedUser', () => {
         expect(security.checkLoggedUser().type).toBe(security.CHECK_LOGGED_USER);

--- a/web/client/actions/__tests__/security-test.js
+++ b/web/client/actions/__tests__/security-test.js
@@ -109,6 +109,8 @@ describe('Test correctness of the close actions', () => {
     it('checkLoggedUser', () => {
         expect(security.checkLoggedUser().type).toBe(security.CHECK_LOGGED_USER);
     });
-
-
+    it('refreshSecurityLayers', () => {
+        const action = security.refreshSecurityLayers();
+        expect(action.type).toBe(security.REFRESH_SECURITY_LAYERS);
+    });
 });

--- a/web/client/actions/layers.js
+++ b/web/client/actions/layers.js
@@ -25,7 +25,6 @@ export const SHOW_SETTINGS = 'SHOW_SETTINGS';
 export const HIDE_SETTINGS = 'HIDE_SETTINGS';
 export const UPDATE_SETTINGS = 'UPDATE_SETTINGS';
 export const REFRESH_LAYERS = 'REFRESH_LAYERS';
-export const REFRESH_SECURITY_LAYERS = 'LAYERS:REFRESH_SECURITY_LAYERS';
 export const UPDATE_LAYERS_DIMENSION = 'LAYERS:UPDATE_LAYERS_DIMENSION';
 export const LAYERS_REFRESHED = 'LAYERS_REFRESHED';
 export const LAYERS_REFRESH_ERROR = 'LAYERS_REFRESH_ERROR';
@@ -234,11 +233,6 @@ export function refreshLayers(layers, options) {
         type: REFRESH_LAYERS,
         layers,
         options
-    };
-}
-export function refreshSecurityLayers() {
-    return {
-        type: REFRESH_SECURITY_LAYERS
     };
 }
 

--- a/web/client/actions/layers.js
+++ b/web/client/actions/layers.js
@@ -25,6 +25,7 @@ export const SHOW_SETTINGS = 'SHOW_SETTINGS';
 export const HIDE_SETTINGS = 'HIDE_SETTINGS';
 export const UPDATE_SETTINGS = 'UPDATE_SETTINGS';
 export const REFRESH_LAYERS = 'REFRESH_LAYERS';
+export const REFRESH_SECURITY_LAYERS = 'LAYERS:REFRESH_SECURITY_LAYERS';
 export const UPDATE_LAYERS_DIMENSION = 'LAYERS:UPDATE_LAYERS_DIMENSION';
 export const LAYERS_REFRESHED = 'LAYERS_REFRESHED';
 export const LAYERS_REFRESH_ERROR = 'LAYERS_REFRESH_ERROR';
@@ -233,6 +234,11 @@ export function refreshLayers(layers, options) {
         type: REFRESH_LAYERS,
         layers,
         options
+    };
+}
+export function refreshSecurityLayers() {
+    return {
+        type: REFRESH_SECURITY_LAYERS
     };
 }
 

--- a/web/client/actions/security.js
+++ b/web/client/actions/security.js
@@ -29,6 +29,9 @@ export const LOGOUT = 'LOGOUT';
 export const REFRESH_SUCCESS = 'REFRESH_SUCCESS';
 export const SESSION_VALID = 'SESSION_VALID';
 
+export const SET_SHOW_MODAL_STATUS = 'SECURITY:SET_SHOW_MODAL_STATUS';
+export const SET_CREDENTIALS = 'SECURITY:SET_CREDENTIALS';
+
 export function loginSuccess(userDetails, username, password, authProvider) {
     return {
         type: LOGIN_SUCCESS,
@@ -168,3 +171,24 @@ export function verifySession() {
 }
 
 export const checkLoggedUser = () => ({type: CHECK_LOGGED_USER});
+
+/**
+ * set status to show modal for inserting credentials
+ * @param {boolean} status
+ */
+export const setShowModalStatus = (status) => {
+    return {
+        status,
+        type: SET_SHOW_MODAL_STATUS
+    };
+};
+/**
+ * set credentials for a service ogc
+ * @param {object} protectedService
+ */
+export const setCredentials = (protectedService) => {
+    return {
+        protectedService,
+        type: SET_CREDENTIALS
+    };
+};

--- a/web/client/actions/security.js
+++ b/web/client/actions/security.js
@@ -33,7 +33,7 @@ export const SET_SHOW_MODAL_STATUS = 'SECURITY:SET_SHOW_MODAL_STATUS';
 export const SET_CREDENTIALS = 'SECURITY:SET_CREDENTIALS';
 export const CLEAR_SECURITY = 'SECURITY:CLEAR_SECURITY';
 export const SET_PROTECTED_SERVICES = 'SECURITY:SET_PROTECTED_SERVICES';
-
+export const REFRESH_SECURITY_LAYERS = 'SECURITY:REFRESH_SECURITY_LAYERS';
 export function loginSuccess(userDetails, username, password, authProvider) {
     return {
         type: LOGIN_SUCCESS,
@@ -220,3 +220,12 @@ export const setCredentialsAction = (protectedService, creds) => {
         type: SET_CREDENTIALS
     };
 };
+
+/**
+ * action to use to rerender layers in map when security changed
+ */
+export function refreshSecurityLayers() {
+    return {
+        type: REFRESH_SECURITY_LAYERS
+    };
+}

--- a/web/client/actions/security.js
+++ b/web/client/actions/security.js
@@ -11,7 +11,7 @@
  */
 import AuthenticationAPI from '../api/GeoStoreDAO';
 
-import {getToken, getRefreshToken} from '../utils/SecurityUtils';
+import {setCredentials, getToken, getRefreshToken} from '../utils/SecurityUtils';
 import {encodeUTF8} from '../utils/EncodeUtils';
 
 
@@ -31,6 +31,8 @@ export const SESSION_VALID = 'SESSION_VALID';
 
 export const SET_SHOW_MODAL_STATUS = 'SECURITY:SET_SHOW_MODAL_STATUS';
 export const SET_CREDENTIALS = 'SECURITY:SET_CREDENTIALS';
+export const CLEAR_SECURITY = 'SECURITY:CLEAR_SECURITY';
+export const SET_PROTECTED_SERVICES = 'SECURITY:SET_PROTECTED_SERVICES';
 
 export function loginSuccess(userDetails, username, password, authProvider) {
     return {
@@ -183,10 +185,36 @@ export const setShowModalStatus = (status) => {
     };
 };
 /**
+ * set protected services to request to provide username and password
+ * @param {object[]} protectedServices
+ */
+export const setProtectedServices = (protectedServices) => {
+    return {
+        protectedServices,
+        type: SET_PROTECTED_SERVICES
+    };
+};
+/**
+ * clear security of layers
+ * @param {string} id
+ */
+export const clearSecurity = (protectedId) => {
+    return {
+        protectedId,
+        type: CLEAR_SECURITY
+    };
+};
+/**
  * set credentials for a service ogc
  * @param {object} protectedService
  */
-export const setCredentials = (protectedService) => {
+export const setCredentialsAction = (protectedService, creds) => {
+    if (creds && protectedService.protectedId) {
+        setCredentials(protectedService.protectedId, {
+            ...creds,
+            url: protectedService.url
+        });
+    }
     return {
         protectedService,
         type: SET_CREDENTIALS

--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -259,6 +259,7 @@ class Catalog extends React.Component {
                 authkeyParamNames={this.props.authkeyParamNames}
                 catalogURL={this.isValidServiceSelected() && this.props.services[this.props.selectedService].url || ""}
                 service={this.props.services[this.props.selectedService]}
+                selectedService={this.props.selectedService}
                 catalogType={this.props.services[this.props.selectedService] && this.props.services[this.props.selectedService].type}
                 showTemplate={this.props.services[this.props.selectedService].showTemplate}
                 onLayerAdd={this.props.onLayerAdd}

--- a/web/client/components/catalog/CatalogServiceEditor.jsx
+++ b/web/client/components/catalog/CatalogServiceEditor.jsx
@@ -40,6 +40,7 @@ const CatalogServiceEditor = ({
     serviceTypes = [{ name: "csw", label: "CSW" }],
     onChangeTitle = () => {},
     onChangeUrl = () => {},
+    addonsItems,
     onChangeType = () => {},
     id,
     urlTooltip,
@@ -77,6 +78,7 @@ const CatalogServiceEditor = ({
                 serviceTypes={serviceTypes}
                 onChangeTitle={onChangeTitle}
                 onChangeUrl={onChangeUrl}
+                addonsItems={addonsItems}
                 onChangeType={onChangeType}
                 onChangeServiceProperty={onChangeServiceProperty}
                 urlTooltip={urlTooltip}

--- a/web/client/components/catalog/RecordGrid.jsx
+++ b/web/client/components/catalog/RecordGrid.jsx
@@ -77,6 +77,7 @@ class RecordGrid extends React.Component {
                     catalogURL={this.props.catalogURL}
                     catalogType={this.props.catalogType}
                     service={this.props.service}
+                    selectedService={this.props.selectedService}
                     showTemplate={this.props.showTemplate}
                     record={record}
                     authkeyParamNames={this.props.authkeyParamNames}

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -164,13 +164,12 @@ class RecordItem extends React.Component {
             .then((layer) => {
                 if (layer) {
                     let layerOpts = layer;
-                    if (this.props.service?.isProtected && this.props.selectedService) {
+                    if (this.props.service?.protectedId && this.props.selectedService) {
                         layerOpts = {
                             ...layerOpts,
-                            serviceId: this.props.selectedService,
                             security: {
-                                username: this.props.service?.username,
-                                password: this.props.service?.password
+                                type: "basic",
+                                sourceId: this.props.service.protectedId
                             }
                         };
                     }

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -58,7 +58,8 @@ class RecordItem extends React.Component {
         onAddBackgroundProperties: PropTypes.func,
         deletedId: PropTypes.string,
         clearModal: PropTypes.func,
-        service: PropTypes.service,
+        service: PropTypes.object,
+        selectedService: PropTypes.string,
         showTemplate: PropTypes.bool,
         defaultFormat: PropTypes.string
     };
@@ -162,7 +163,18 @@ class RecordItem extends React.Component {
         }, true)
             .then((layer) => {
                 if (layer) {
-                    this.addLayer(layer, record);
+                    let layerOpts = layer;
+                    if (this.props.service?.isProtected && this.props.selectedService) {
+                        layerOpts = {
+                            ...layerOpts,
+                            serviceId: this.props.selectedService,
+                            security: {
+                                username: this.props.service?.username,
+                                password: this.props.service?.password
+                            }
+                        };
+                    }
+                    this.addLayer(layerOpts, record);
                 }
             }).finally(()=> {
                 this.setState({ loading: false });

--- a/web/client/components/catalog/editor/MainForm.jsx
+++ b/web/client/components/catalog/editor/MainForm.jsx
@@ -7,44 +7,70 @@
  */
 import React, { useState } from 'react';
 import {get, find} from 'lodash';
+import { Button, InputGroup, FormControl as FC, Form, Col, FormGroup, ControlLabel, Alert } from "react-bootstrap";
+
 import Message from '../../I18N/Message';
 import HTML from '../../I18N/HTML';
-
 import {getConfigProp} from '../../../utils/ConfigUtils';
-
 import InfoPopover from '../../widgets/widget/InfoPopover';
-import { FormControl as FC, Form, Col, FormGroup, ControlLabel, Alert } from "react-bootstrap";
-
 import localizedProps from '../../misc/enhancers/localizedProps';
 import {checkUrl} from "./MainFormUtils";
-
-const FormControl = localizedProps('placeholder')(FC);
-
-const CUSTOM = "custom";
-const TMS = "tms";
-
-const DefaultURLEditor = ({ service = {}, onChangeUrl = () => { } }) => {
-
-    return (
-
-        <FormGroup controlId="URL">
-            <Col xs={12}>
-                <ControlLabel><Message msgId="catalog.url"/></ControlLabel>
-                <FormControl
-                    type="text"
-                    style={{
-                        textOverflow: "ellipsis"
-                    }}
-                    placeholder={'catalog.urlPlaceHolders.' + service.type}
-                    value={service && service.url}
-                    onChange={(e) => onChangeUrl(e.target.value)}/>
-            </Col>
-        </FormGroup>
-    );
-};
-
+import IconRB from '../../../plugins/ResourcesCatalog/components/Icon';
 // selector for tile provider
 import CONFIG_PROVIDER from '../../../utils/ConfigProvider';
+import tooltip from '../../misc/enhancers/tooltip';
+
+const FormControl = localizedProps('placeholder')(FC);
+const CUSTOM = "custom";
+const TMS = "tms";
+const Icon = tooltip(IconRB);
+
+const UrlAddon = ({
+    onClick,
+    glyph,
+    service,
+    tooltipId,
+    btnClassName
+}) => <InputGroup.Addon
+    onClick={() => {
+        onClick(service);
+    }}
+>
+    <Button className={btnClassName || ""}>
+        <Icon
+            glyph={glyph}
+            type="glyphicon"
+            tooltipId={tooltipId}
+        />
+    </Button>
+</InputGroup.Addon>;
+
+const DefaultURLEditor = ({
+    service = {},
+    addonsItems = [],
+    onChangeUrl = () => { }
+} ) => {
+
+    const UrlForm = (<FormControl
+        type="text"
+        style={{
+            textOverflow: "ellipsis"
+        }}
+        placeholder={'catalog.urlPlaceHolders.' + service.type}
+        value={service && service.url}
+        onChange={(e) => onChangeUrl(e.target.value)}/>);
+
+    return (<FormGroup controlId="URL" bsSize="medium">
+        <Col xs={12}>
+            <ControlLabel><Message msgId="catalog.url"/></ControlLabel>
+            <InputGroup style={{width: "100%"}}>
+                {UrlForm}
+                {addonsItems.map((item) => <item.Component key={item.name} itemComponent={(props) => <UrlAddon {...props} service={service}/> } service={service} />)}
+            </InputGroup>
+        </Col>
+    </FormGroup>
+    );
+};
 
 const getProviderLabel = k=> k === TMS ? "TMS 1.0.0" : k;
 const TmsURLEditor = ({ serviceTypes = [], onChangeServiceProperty, service = {}, onChangeUrl = () => { }, onChangeTitle = () => { } }) => {
@@ -150,6 +176,7 @@ export default ({
     onChangeTitle,
     onChangeUrl,
     onChangeServiceProperty,
+    addonsItems,
     onChangeType,
     setValid = () => {}
 }) => {
@@ -194,7 +221,9 @@ export default ({
                         onChange={(e) => onChangeTitle(e.target.value)} />
                 </Col>
             </FormGroup>
-            <URLEditor key="url-row" serviceTypes={serviceTypes} service={service} onChangeUrl={handleProtocolValidity} onChangeTitle={onChangeTitle} onChangeServiceProperty={onChangeServiceProperty} />
+            <URLEditor
+                addonsItems={addonsItems}
+                key="url-row" serviceTypes={serviceTypes} service={service} onChangeUrl={handleProtocolValidity} onChangeTitle={onChangeTitle} onChangeServiceProperty={onChangeServiceProperty} />
 
             {error ? <Alert bsStyle="danger">
                 <Message msgId={error} />

--- a/web/client/components/map/cesium/plugins/TileProviderLayer.js
+++ b/web/client/components/map/cesium/plugins/TileProviderLayer.js
@@ -12,6 +12,7 @@ import TileProvider from '../../../../utils/TileConfigProvider';
 import ConfigUtils from '../../../../utils/ConfigUtils';
 import {creditsToAttribution} from '../../../../utils/LayersUtils';
 import {getProxyUrl} from '../../../../utils/ProxyUtils';
+import isEqual from 'lodash/isEqual';
 
 function splitUrl(originalUrl) {
     let url = originalUrl;
@@ -92,7 +93,10 @@ const create = (options) => {
 };
 
 const update = (layer, newOptions, oldOptions) => {
-    if (newOptions.forceProxy !== oldOptions.forceProxy) {
+    if (
+        newOptions.forceProxy !== oldOptions.forceProxy ||
+        !isEqual(oldOptions.security, newOptions.security)
+    ) {
         return create(newOptions);
     }
     return null;

--- a/web/client/components/map/cesium/plugins/WFSLayer.js
+++ b/web/client/components/map/cesium/plugins/WFSLayer.js
@@ -147,7 +147,11 @@ const createLayer = (options, map) => {
 Layers.registerType('wfs', {
     create: createLayer,
     update: (layer, newOptions, oldOptions, map) => {
-        if (needsReload(oldOptions, newOptions) || oldOptions.forceProxy !== newOptions.forceProxy) {
+        if (
+            needsReload(oldOptions, newOptions) ||
+            oldOptions.forceProxy !== newOptions.forceProxy ||
+            !isEqual(oldOptions.security, newOptions.security)
+        ) {
             return createLayer(newOptions, map);
         }
         if (layer?.styledFeatures && !isEqual(newOptions.style, oldOptions.style)) {

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -49,6 +49,7 @@ const updateLayer = (layer, newOptions, oldOptions) => {
         });
     if (newParameters.length > 0 ||
         newOptions.securityToken !== oldOptions.securityToken ||
+        !isEqual(oldOptions.security, newOptions.security) ||
         !isEqual(newOptions.layerFilter, oldOptions.layerFilter) ||
         newOptions.tileSize !== oldOptions.tileSize || newOptions.forceProxy !== oldOptions.forceProxy) {
         return createLayer(newOptions);

--- a/web/client/components/map/cesium/plugins/WMTSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMTSLayer.js
@@ -15,9 +15,10 @@ import {
 import * as WMTSUtils from '../../../../utils/WMTSUtils';
 import { creditsToAttribution, getAuthenticationParam, getURLs } from '../../../../utils/LayersUtils';
 import assign from 'object-assign';
-import { isObject, isArray, slice, get, head} from 'lodash';
+import { isEqual, isObject, isArray, slice, get, head} from 'lodash';
 import urlParser from 'url';
 import { isVectorFormat } from '../../../../utils/VectorTileUtils';
+import { getCredentials } from '../../../../utils/SecurityUtils';
 
 function splitUrl(originalUrl) {
     let url = originalUrl;
@@ -115,11 +116,19 @@ function wmtsToCesiumOptions(_options) {
     const queryParametersString = urlParser.format({ query: {...getAuthenticationParam(options)}});
     const cr = options.credits;
     const credit = cr ? new Cesium.Credit(creditsToAttribution(cr)) : '';
+    let headers;
+    if (options.security) {
+        const storedProtectedService = getCredentials(options.security?.sourceId) || {};
+        headers = {
+            "Authorization": `Basic ${btoa(storedProtectedService.username + ":" + storedProtectedService.password)}`
+        };
+    }
     return assign({
         // TODO: multi-domain support, if use {s} switches to RESTFul mode
         url: new Cesium.Resource({
             url: head(getURLs(isArray(options.url) ? options.url : [options.url], queryParametersString)),
-            proxy: proxy && new WMTSProxy(proxy) || new NoProxy()
+            proxy: proxy && new WMTSProxy(proxy) || new NoProxy(),
+            ...(headers)
         }),
         // set image format to png if vector to avoid errors while switching between map type
         format: isVectorFormat(options.format) && 'image/png' || options.format || 'image/png',
@@ -160,6 +169,7 @@ const createLayer = options => {
 const updateLayer = (layer, newOptions, oldOptions) => {
     if (newOptions.securityToken !== oldOptions.securityToken
     || oldOptions.format !== newOptions.format
+    || !isEqual(oldOptions.security, newOptions.security)
     || oldOptions.credits !== newOptions.credits || newOptions.forceProxy !== oldOptions.forceProxy) {
         return createLayer(newOptions);
     }

--- a/web/client/components/map/cesium/plugins/WMTSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMTSLayer.js
@@ -116,11 +116,13 @@ function wmtsToCesiumOptions(_options) {
     const queryParametersString = urlParser.format({ query: {...getAuthenticationParam(options)}});
     const cr = options.credits;
     const credit = cr ? new Cesium.Credit(creditsToAttribution(cr)) : '';
-    let headers;
+    let headersOpts;
     if (options.security) {
         const storedProtectedService = getCredentials(options.security?.sourceId) || {};
-        headers = {
-            "Authorization": `Basic ${btoa(storedProtectedService.username + ":" + storedProtectedService.password)}`
+        headersOpts = {
+            headers: {
+                "Authorization": `Basic ${btoa(storedProtectedService.username + ":" + storedProtectedService.password)}`
+            }
         };
     }
     return assign({
@@ -128,7 +130,7 @@ function wmtsToCesiumOptions(_options) {
         url: new Cesium.Resource({
             url: head(getURLs(isArray(options.url) ? options.url : [options.url], queryParametersString)),
             proxy: proxy && new WMTSProxy(proxy) || new NoProxy(),
-            ...(headers)
+            ...(headersOpts)
         }),
         // set image format to png if vector to avoid errors while switching between map type
         format: isVectorFormat(options.format) && 'image/png' || options.format || 'image/png',

--- a/web/client/components/map/openlayers/plugins/TMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/TMSLayer.js
@@ -5,13 +5,29 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { get } from 'lodash';
-
-import Layers from '../../../../utils/openlayers/Layers';
+import { get, isEqual } from 'lodash';
+import axios from 'axios';
 import XYZ from 'ol/source/XYZ';
 import TileGrid from 'ol/tilegrid/TileGrid';
-
 import TileLayer from 'ol/layer/Tile';
+
+import Layers from '../../../../utils/openlayers/Layers';
+import { getCredentials } from '../../../../utils/SecurityUtils';
+
+const tileLoadFunction = options => (image, src) => {
+    const storedProtectedService = getCredentials(options.security?.sourceId) || {};
+    axios.get(src, {
+        headers: {
+            "Authorization": `Basic ${btoa(storedProtectedService.username + ":" + storedProtectedService.password)}`
+        },
+        responseType: 'blob'
+    }).then(response => {
+        image.getImage().src = URL.createObjectURL(response.data);
+    }).catch(e => {
+        image.getImage().src = null;
+        console.error(e);
+    });
+};
 
 function tileXYZToOpenlayersOptions(options = {}) {
     const { minx, miny, maxx, maxy } = get(options, "bbox.bounds", {});
@@ -20,6 +36,10 @@ function tileXYZToOpenlayersOptions(options = {}) {
         url: `${options.tileMapUrl}/{z}/{x}/{-y}.${options.extension}`, // TODO use resolutions
         attributions: options.attribution ? [options.attribution] : []
     };
+    if (options.security) {
+        sourceOpt.tileLoadFunction = tileLoadFunction(options);
+    }
+
     let source = new XYZ(sourceOpt);
     const defaultTileGrid = source.getTileGrid();
 
@@ -68,6 +88,9 @@ Layers.registerType('tms', {
         }
         if (oldOptions.maxResolution !== newOptions.maxResolution) {
             layer.setMaxResolution(newOptions.maxResolution === undefined ? Infinity : newOptions.maxResolution);
+        }
+        if (!isEqual(oldOptions.security, newOptions.security)) {
+            layer.getSource().setTileLoadFunction(tileLoadFunction(newOptions));
         }
     }
 });

--- a/web/client/components/map/openlayers/plugins/TileProviderLayer.js
+++ b/web/client/components/map/openlayers/plugins/TileProviderLayer.js
@@ -12,11 +12,28 @@ import CoordinatesUtils from '../../../../utils/CoordinatesUtils';
 import { getUrls, template } from '../../../../utils/TileProviderUtils';
 import XYZ from 'ol/source/XYZ';
 import TileLayer from 'ol/layer/Tile';
-
+import axios from 'axios';
+import { getCredentials } from '../../../../utils/SecurityUtils';
+import { isEqual } from 'lodash';
 function lBoundsToOlExtent(bounds, destPrj) {
     var [ [ miny, minx], [ maxy, maxx ] ] = bounds;
     return CoordinatesUtils.reprojectBbox([minx, miny, maxx, maxy], 'EPSG:4326', CoordinatesUtils.normalizeSRS(destPrj));
 }
+
+const tileLoadFunction = options => (image, src) => {
+    const storedProtectedService = getCredentials(options.security?.sourceId) || {};
+    axios.get(src, {
+        headers: {
+            "Authorization": `Basic ${btoa(storedProtectedService.username + ":" + storedProtectedService.password)}`
+        },
+        responseType: 'blob'
+    }).then(response => {
+        image.getImage().src = URL.createObjectURL(response.data);
+    }).catch(e => {
+        image.getImage().src = null;
+        console.error(e);
+    });
+};
 function tileXYZToOpenlayersOptions(options) {
     let urls = options.url.match(/(\{s\})/) ? getUrls(options) : [template(options.url, options)];
     let sourceOpt = assign({}, {
@@ -25,6 +42,9 @@ function tileXYZToOpenlayersOptions(options) {
         maxZoom: options.maxZoom ? options.maxZoom : 18,
         minZoom: options.minZoom ? options.minZoom : 0 // dosen't affect ol layer rendering UNSUPPORTED
     });
+    if (options.security) {
+        sourceOpt.tileLoadFunction = tileLoadFunction(options);
+    }
     let source = new XYZ(sourceOpt);
     let olOpt = assign({}, {
         msId: options.id,
@@ -50,6 +70,9 @@ Layers.registerType('tileprovider', {
         }
         if (oldOptions.maxResolution !== newOptions.maxResolution) {
             layer.setMaxResolution(newOptions.maxResolution === undefined ? Infinity : newOptions.maxResolution);
+        }
+        if (!isEqual(oldOptions.security, newOptions.security)) {
+            layer.getSource().setTileLoadFunction(tileLoadFunction(newOptions));
         }
     }
 });

--- a/web/client/components/map/openlayers/plugins/WFSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WFSLayer.js
@@ -8,7 +8,7 @@
 
 import Layers from '../../../../utils/openlayers/Layers';
 import { ServerTypes } from '../../../../utils/LayersUtils';
-
+import isEqual from 'lodash/isEqual';
 
 import {getStyle} from '../VectorStyle';
 import VectorSource from 'ol/source/Vector';
@@ -167,7 +167,7 @@ Layers.registerType('wfs', {
                 f.getGeometry().transform(oldCrs, newCrs);
             });
         }
-        if (needsReload(oldOptions, options)) {
+        if (needsReload(oldOptions, options) || !isEqual(oldOptions.security, options.security)) {
             source.setLoader(createLoader(source, options));
             source.clear();
             source.refresh();

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -18,7 +18,7 @@ import { getProjection } from '../../../../utils/ProjectionUtils';
 import { getConfigProp } from '../../../../utils/ConfigUtils';
 
 import {optionsToVendorParams} from '../../../../utils/VendorParamsUtils';
-import {addAuthenticationToSLD, addAuthenticationParameter, getAuthenticationHeaders} from '../../../../utils/SecurityUtils';
+import {/* getCredentials, */addAuthenticationToSLD, addAuthenticationParameter, getAuthenticationHeaders} from '../../../../utils/SecurityUtils';
 
 import ImageLayer from 'ol/layer/Image';
 import ImageWMS from 'ol/source/ImageWMS';
@@ -85,6 +85,7 @@ const loadFunction = (options, headers) => function(image, src) {
                     console.error("error: " + response.data);
                 }
             }).catch(e => {
+                image.getImage().src = null;
                 console.error(e);
             });
         } else {
@@ -106,7 +107,7 @@ const createLayer = (options, map, mapId) => {
     const urls = getWMSURLs(isArray(options.url) ? options.url : [options.url]);
     const queryParameters = wmsToOpenlayersOptions(options) || {};
     urls.forEach(url => addAuthenticationParameter(url, queryParameters, options.securityToken));
-    const headers = getAuthenticationHeaders(urls[0], options.securityToken);
+    const headers = getAuthenticationHeaders(urls[0], options.securityToken, options.security);
     const vectorFormat = isVectorFormat(options.format);
 
     if (options.singleTile && !vectorFormat) {
@@ -135,6 +136,7 @@ const createLayer = (options, map, mapId) => {
         tileGrid: generateTileGrid(options, map),
         tileLoadFunction: loadFunction(options, headers)
     };
+
     const wmsSource = new TileWMS({ ...sourceOptions });
     const layerConfig = {
         msId: options.id,
@@ -261,6 +263,12 @@ Layers.registerType('wms', {
         }
         if (oldOptions.maxResolution !== newOptions.maxResolution) {
             layer.setMaxResolution(newOptions.maxResolution === undefined ? Infinity : newOptions.maxResolution);
+        }
+        if (!isEqual(oldOptions.security, newOptions.security)) {
+            const urls = getWMSURLs(isArray(newOptions.url) ? newOptions.url : [newOptions.url]);
+            const headers = getAuthenticationHeaders(urls[0], newOptions.securityToken, newOptions.security);
+            wmsSource.setTileLoadFunction(loadFunction(newOptions, headers));
+            wmsSource.refresh();
         }
         if (needsRefresh) {
             // forces tile cache drop

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -18,7 +18,7 @@ import { getProjection } from '../../../../utils/ProjectionUtils';
 import { getConfigProp } from '../../../../utils/ConfigUtils';
 
 import {optionsToVendorParams} from '../../../../utils/VendorParamsUtils';
-import {/* getCredentials, */addAuthenticationToSLD, addAuthenticationParameter, getAuthenticationHeaders} from '../../../../utils/SecurityUtils';
+import {addAuthenticationToSLD, addAuthenticationParameter, getAuthenticationHeaders} from '../../../../utils/SecurityUtils';
 
 import ImageLayer from 'ol/layer/Image';
 import ImageWMS from 'ol/source/ImageWMS';

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -419,6 +419,9 @@
         }
       },
       {
+        "name": "SecurityPopup"
+      },
+      {
         "name": "Map",
         "cfg": {
           "mapOptions": {

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -279,6 +279,7 @@
   },
   "plugins": {
     "mobile": [
+      { "name": "SecurityPopup" },
       {
         "name": "Map",
         "cfg": {
@@ -418,9 +419,7 @@
           "containerPosition": "header"
         }
       },
-      {
-        "name": "SecurityPopup"
-      },
+      { "name": "SecurityPopup" },
       {
         "name": "Map",
         "cfg": {
@@ -952,9 +951,7 @@
       { "name": "Save", "cfg": { "resourceType": "DASHBOARD" } },
       { "name": "SaveAs", "cfg": { "resourceType": "DASHBOARD" } },
       "Details",
-      {
-        "name": "SecurityPopup"
-      },
+      { "name": "SecurityPopup" },
       "AddWidgetDashboard",
       "MapConnectionDashboard",
       {
@@ -1098,6 +1095,7 @@
     ],
     "geostory-embedded": [
       "GeoStory",
+      { "name": "SecurityPopup" },
       {
         "name": "GeoStoryNavigation",
         "cfg": {
@@ -1118,12 +1116,11 @@
           "minLayoutWidth": 768
         }
       },
+      { "name": "SecurityPopup" },
       { "name": "FeedbackMask" }
     ],
     "geostory": [
-      {
-        "name": "SecurityPopup"
-      },
+      { "name": "SecurityPopup" },
       {
         "name": "ResourceDetails",
         "cfg": { "containerPosition": "columns", "resourceType": "GEOSTORY" }

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -952,6 +952,9 @@
       { "name": "Save", "cfg": { "resourceType": "DASHBOARD" } },
       { "name": "SaveAs", "cfg": { "resourceType": "DASHBOARD" } },
       "Details",
+      {
+        "name": "SecurityPopup"
+      },
       "AddWidgetDashboard",
       "MapConnectionDashboard",
       {
@@ -1118,6 +1121,9 @@
       { "name": "FeedbackMask" }
     ],
     "geostory": [
+      {
+        "name": "SecurityPopup"
+      },
       {
         "name": "ResourceDetails",
         "cfg": { "containerPosition": "columns", "resourceType": "GEOSTORY" }

--- a/web/client/epics/security.js
+++ b/web/client/epics/security.js
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import Rx from 'rxjs';
+import uniqBy from 'lodash/uniqBy';
+import isArray from 'lodash/isArray';
+import { DASHBOARD_LOADED } from '../actions/dashboard';
+import { SET_CURRENT_STORY } from '../actions/geostory';
+import { EDITOR_CHANGE } from '../actions/widgets';
+import { UPDATE_ITEM } from '../actions/mediaEditor';
+import { currentMediaTypeSelector, selectedItemSelector } from '../selectors/mediaEditor';
+import { MAP_CONFIG_LOADED } from '../actions/config';
+import { setShowModalStatus, setProtectedServices } from '../actions/security';
+import { getCredentials } from '../utils/SecurityUtils';
+
+/**
+ * checks if a content is protected in a map
+ *
+ */
+export const checkProtectedContentEpic = (action$) =>
+    action$.ofType(MAP_CONFIG_LOADED)
+        .switchMap((action) => {
+            const config = action.config;
+            const protectedLayers = config?.map?.layers.map(layer => {
+                return {protectedId: layer?.security?.sourceId, url: layer.url};
+            });
+            const services = Object.keys(config?.catalogServices?.services)
+                .map(protectedService => {
+                    const service = config?.catalogServices?.services?.[protectedService];
+                    return {protectedId: service?.protectedId, url: service?.url};
+                })
+                .concat(protectedLayers)
+                .filter(v => !!v.protectedId);
+            const protectedServices = uniqBy(services, "protectedId")
+                .map(({protectedId, url}) => {
+                    return {
+                        protectedId,
+                        url,
+                        ...getCredentials(protectedId)
+                    };
+                })
+                .filter(({username, password}) => !(username && password));
+
+            // group by similar url
+            const uniqueServices = uniqBy(protectedServices, "url");
+
+            if (uniqueServices.length) {
+                return Rx.Observable.of(
+                    setProtectedServices(uniqueServices),
+                    setShowModalStatus(true)
+                );
+            }
+            return Rx.Observable.empty();
+        });
+
+/**
+ * checks if a content is protected in a map
+ *
+ */
+export const checkProtectedContentDashboardEpic = (action$) =>
+    action$.ofType(DASHBOARD_LOADED)
+        .switchMap((action) => {
+            const widgets = action.data?.widgets || [];
+            const layers = widgets
+                .reduce((p, w) => {
+                    return p.concat(w?.maps);
+                }, [])
+                .reduce((pre, c) => {
+                    return pre.concat(c.layers
+                        ?.map(layer => {
+                            return {protectedId: layer?.security?.sourceId, url: layer.url};
+                        })
+                        .filter(v => !!v.protectedId));
+                }, []);
+
+            const protectedServices = uniqBy(layers, "protectedId")
+                .map(({protectedId, url}) => {
+                    return {
+                        protectedId,
+                        url,
+                        ...getCredentials(protectedId)
+                    };
+                })
+                .filter(({username, password}) => !(username && password));
+
+            // group by similar url
+            const uniqueServices = uniqBy(protectedServices, "url");
+
+            if (uniqueServices.length) {
+                return Rx.Observable.of(
+                    setProtectedServices(uniqueServices),
+                    setShowModalStatus(true)
+                );
+            }
+            return Rx.Observable.empty();
+        });
+
+
+export const checkProtectedContentDashboardMapEpic = (action$) =>
+    action$.ofType(EDITOR_CHANGE)
+        .filter(action => action.key === "maps" && isArray(action.value))
+        .switchMap((action) => {
+            const maps = action.value || [];
+            const layers = maps
+                .reduce((pre, c) => {
+                    return pre.concat(c.layers
+                        ?.map(layer => {
+                            return {protectedId: layer?.security?.sourceId, url: layer.url};
+                        })
+                        .filter(v => !!v.protectedId));
+                }, []);
+
+            const protectedServices = uniqBy(layers, "protectedId")
+                .map(({protectedId, url}) => {
+                    return {
+                        protectedId,
+                        url,
+                        ...getCredentials(protectedId)
+                    };
+                })
+                .filter(({username, password}) => !(username && password));
+
+            // group by similar url
+            const uniqueServices = uniqBy(protectedServices, "url");
+
+            if (uniqueServices.length) {
+                return Rx.Observable.of(
+                    setProtectedServices(uniqueServices),
+                    setShowModalStatus(true)
+                );
+            }
+            return Rx.Observable.empty();
+        });
+export const checkProtectedContentGeostoryMapSelectionEpic = (action$, store) =>
+    action$.ofType(UPDATE_ITEM)
+        .filter((action) => {
+            return currentMediaTypeSelector(store.getState()) === "map" && action.item.type === "map";
+        })
+        .switchMap(() => {
+            const map = selectedItemSelector(store.getState());
+            const layers = map?.data?.layers
+                ?.map(layer => {
+                    return {protectedId: layer?.security?.sourceId, url: layer.url};
+                })
+                .filter(v => !!v.protectedId);
+
+            const protectedServices = uniqBy(layers, "protectedId")
+                .map(({protectedId, url}) => {
+                    return {
+                        protectedId,
+                        url,
+                        ...getCredentials(protectedId)
+                    };
+                })
+                .filter(({username, password}) => !(username && password));
+
+            // group by similar url
+            const uniqueServices = uniqBy(protectedServices, "url");
+
+            if (uniqueServices.length) {
+                return Rx.Observable.of(
+                    setProtectedServices(uniqueServices),
+                    setShowModalStatus(true)
+                );
+            }
+            return Rx.Observable.empty();
+        });
+export const checkProtectedContentGeostoryEpic = (action$) =>
+    action$.ofType(SET_CURRENT_STORY)
+        .switchMap((action) => {
+            const resources = action.story?.resources || [];
+            const layers = resources?.reduce((p, c) => {
+                return p.concat(c?.data?.layers
+                    ?.map(layer => {
+                        return {protectedId: layer?.security?.sourceId, url: layer.url};
+                    })
+                    .filter(v => !!v.protectedId)
+                );
+            }, []);
+            const protectedServices = uniqBy(layers, "protectedId")
+                .map(({protectedId, url}) => {
+                    return {
+                        protectedId,
+                        url,
+                        ...getCredentials(protectedId)
+                    };
+                })
+                .filter(({username, password}) => !(username && password));
+
+            // group by similar url
+            const uniqueServices = uniqBy(protectedServices, "url");
+
+            if (uniqueServices.length) {
+                return Rx.Observable.of(
+                    setProtectedServices(uniqueServices),
+                    setShowModalStatus(true)
+                );
+            }
+            return Rx.Observable.empty();
+        });

--- a/web/client/hooks/usePluginItems.js
+++ b/web/client/hooks/usePluginItems.js
@@ -12,9 +12,9 @@ import { getConfiguredPlugin } from '../utils/PluginsUtils';
 
 /**
  * hook to load and configure items in plugins container.
- * It normalizes, orders and adds configuration coming from localConfig.json to each items entries recieved by a plugin based on the container system.
+ * It normalizes, orders and adds configuration coming from localConfig.json to each items entries received by a plugin based on the container system.
  * Each of the returned configured item will be an object with at minimum the following properties:
- * - `name` neme of the injected plugin component that could be used as react key
+ * - `name` name of the injected plugin component that could be used as react key
  * - `Component` the configured react component that can be rendered inside the container
  * @param {array} items list of items received by a plugin as prop
  * @param {object} loadedPlugins context loaded plugins

--- a/web/client/hooks/usePluginItems.js
+++ b/web/client/hooks/usePluginItems.js
@@ -29,7 +29,7 @@ import { getConfiguredPlugin } from '../utils/PluginsUtils';
  * }
  */
 const usePluginItems = ({
-    items,
+    items = [],
     loadedPlugins,
     loaderComponent
 }, dependencies = []) => {

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -385,9 +385,7 @@ const AddLayerButton = connect(() => ({}), {
  *          MetadataExplorer: {
  *              name: "TOOLNAME", // a name for the current tool.
  *              target: "url-addon", // the target where to insert the component
- *              Component: MyAddonComponent,
- *              // selector is `optional` and it will receive same prop as the Component eg.:
- *              // selector: ({ status, statusTypes }) => status === statusTypes.DESELECT,
+ *              Component: MyAddonComponent
  *          },
  * // ...
  * ```

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -85,6 +85,7 @@ import { isLocalizedLayerStylesEnabledSelector } from '../selectors/localizedLay
 import { projectionSelector } from '../selectors/map';
 import { mapLayoutValuesSelector } from '../selectors/maplayout';
 import ResponsivePanel from "../components/misc/panels/ResponsivePanel";
+import usePluginItems from '../hooks/usePluginItems';
 
 export const DEFAULT_ALLOWED_PROVIDERS = ["OpenStreetMap", "OpenSeaMap", "Stamen"];
 
@@ -167,6 +168,7 @@ class MetadataExplorerComponent extends React.Component {
         closeGlyph: PropTypes.string,
         buttonStyle: PropTypes.object,
         services: PropTypes.object,
+        addonsItems: PropTypes.array,
         servicesWithBackgrounds: PropTypes.object,
         selectedService: PropTypes.string,
         style: PropTypes.object,
@@ -259,6 +261,20 @@ class MetadataExplorerComponent extends React.Component {
     }
 }
 
+const MetadataExplorerComponentWrapper = (props, context) => {
+
+    const { loadedPlugins } = context;
+    const addonsItems = usePluginItems({ items: props.items, loadedPlugins }).filter(({ target }) => target === 'url-addon');
+    // filtrare
+
+    return <MetadataExplorerComponent {...props} addonsItems={addonsItems}/>;
+};
+
+
+MetadataExplorerComponentWrapper.contextTypes = {
+    loadedPlugins: PropTypes.object
+};
+
 const MetadataExplorerPlugin = connect(metadataExplorerSelector, {
     clearModal: clearModalParameters,
     onSearch: textSearch,
@@ -291,7 +307,7 @@ const MetadataExplorerPlugin = connect(metadataExplorerSelector, {
     onStartChange: setControlProperty.bind(null, 'backgroundSelector', 'start'),
     setNewServiceStatus,
     onInitPlugin: initPlugin
-})(MetadataExplorerComponent);
+})(MetadataExplorerComponentWrapper);
 
 const AddLayerButton = connect(() => ({}), {
     onClick: setControlProperties.bind(null, 'metadataexplorer', 'enabled', true, 'group')

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -262,11 +262,8 @@ class MetadataExplorerComponent extends React.Component {
 }
 
 const MetadataExplorerComponentWrapper = (props, context) => {
-
     const { loadedPlugins } = context;
     const addonsItems = usePluginItems({ items: props.items, loadedPlugins }).filter(({ target }) => target === 'url-addon');
-    // filtrare
-
     return <MetadataExplorerComponent {...props} addonsItems={addonsItems}/>;
 };
 

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -354,6 +354,43 @@ const AddLayerButton = connect(() => ({}), {
  * @prop {number} cfg.zoomToLayer enable/disable zoom to layer when added
  * @prop {number} cfg.autoSetVisibilityLimits if true, allows fetching and setting visibility limits of the layer from capabilities on layer add (Note: The default configuration value is applied only on new catalog service (WMS/CSW))
  * @prop {number} [delayAutoSearch] time in ms passed after a search is triggered by filter changes, default 1000
+ * @prop {object[]} addonsItems this property contains the items injected from the other plugins,
+ * using the `url-addon` option in the plugin that want to inject the components.
+ * You can select the position where to insert the components adding the `target` property.
+ * The allowed targets are:
+ * - `url-addon` target add an addon button in the url field of catalog form (in main viewer) in edit mode
+ * ```javascript
+ * const MyAddonComponent = connect(null,
+ * {
+ *     onSetShowModal: setShowModalStatus,
+ *    }
+ * )(({
+ *    onSetShowModal, // opens a modal to enter credentials
+ *    itemComponent // default component that provides a consistent UI (see UrlAddon in MainForm.jsx)
+ *    }) => {
+ *    const Component = itemComponent;
+ *    return (<Component
+ *        onClick={(value) => {
+ *            onSetShowModal(true);
+ *        }}
+ *        btnClassName={condition ? "btn-success" : ""}
+ *        glyph="glyph"
+ *        tooltipId="path"
+ *    />  );
+ * });
+ * createPlugin(
+ *  'MyPlugin',
+ *  {
+ *      containers: {
+ *          MetadataExplorer: {
+ *              name: "TOOLNAME", // a name for the current tool.
+ *              target: "url-addon", // the target where to insert the component
+ *              Component: MyAddonComponent,
+ *              // selector is `optional` and it will receive same prop as the Component eg.:
+ *              // selector: ({ status, statusTypes }) => status === statusTypes.DESELECT,
+ *          },
+ * // ...
+ * ```
  */
 export default {
     MetadataExplorerPlugin: assign(MetadataExplorerPlugin, {

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -354,7 +354,7 @@ const AddLayerButton = connect(() => ({}), {
  * @prop {number} cfg.zoomToLayer enable/disable zoom to layer when added
  * @prop {number} cfg.autoSetVisibilityLimits if true, allows fetching and setting visibility limits of the layer from capabilities on layer add (Note: The default configuration value is applied only on new catalog service (WMS/CSW))
  * @prop {number} [delayAutoSearch] time in ms passed after a search is triggered by filter changes, default 1000
- * @prop {object[]} addonsItems this property contains the items injected from the other plugins,
+ * @prop {object[]} items this property contains the items injected from the other plugins,
  * using the `url-addon` option in the plugin that want to inject the components.
  * You can select the position where to insert the components adding the `target` property.
  * The allowed targets are:

--- a/web/client/plugins/SecurityPopup.jsx
+++ b/web/client/plugins/SecurityPopup.jsx
@@ -5,25 +5,36 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useState } from 'react';
-import { InputGroup, ControlLabel, FormGroup } from 'react-bootstrap';
+import React, {useState} from 'react';
+import { Button as ButtonRB, InputGroup, ControlLabel, FormGroup } from 'react-bootstrap';
 import {connect} from 'react-redux';
 import {createStructuredSelector} from 'reselect';
+import omit from 'lodash/omit';
+import uuidv1 from 'uuid/v1';
 
 import ConfirmDialog from '../components/layout/ConfirmDialog';
 import InputControl from './ResourcesCatalog/components/InputControl';
 import security from '../reducers/security';
 import {
     showModalSelector,
-    protectedServiceSelector
+    protectedServicesSelector
 } from '../selectors/security';
-import {
-    setCredentials,
-    setShowModalStatus
-} from '../actions/security';
-import Message from '../components/I18N/Message';
 
+import {
+    setCredentialsAction,
+    setShowModalStatus,
+    setProtectedServices,
+    clearSecurity
+} from '../actions/security';
+import {
+    refreshSecurityLayers
+} from '../actions/layers';
+import * as securityPopups from '../epics/security';
+import Message from '../components/I18N/Message';
+import tooltip from '../components/misc/enhancers/tooltip';
 import {createPlugin} from '../utils/PluginsUtils';
+
+const Button = tooltip(ButtonRB);
 
 /**
  *
@@ -32,30 +43,63 @@ import {createPlugin} from '../utils/PluginsUtils';
  * @name SecurityPopup
  * @prop {function} onSetCredentials used to update credentials for a catalog service
  * @prop {function} onSetShowModal used to update flag to show or not the modal
+ * @prop {function} onSetProtectedServices used to update protected services
+ * @prop {function} onRefreshLayers used to trigger state update of layers that have been provided credentials
+ * @prop {function} onClear used to clean up protection to layers
  * @prop {boolean} showModal flag to show or not the modal
- * @prop {object} service data related to a service
+ * @prop {object[]} services data related to services
  */
 function SecurityPopup({
     showModal,
-    service = {},
+    services = [],
+    onClear = () => {},
+    onRefreshLayers = () => {},
     onSetCredentials = () => {},
+    onSetProtectedServices = () => {},
     onSetShowModal = () => {}
 }) {
-    const [newService, setNewService] = useState(() => service || {});
+    const [currentFormIndex, setCurrentFormIndex] = useState(0);
+    const [creds, setCreds] = useState({});
+    const DEBOUNCE_TIME = 300;
+    const MAX_LENGTH = 255;
     function handleCancel() {
-        onSetShowModal(false);
-        onSetCredentials({
-            ...newService,
-            isProtected: false
-        });
+        const show = currentFormIndex < services.length - 1;
+        const nextIndex = show ? currentFormIndex + 1 : 0;
+        onSetShowModal(show);
+        setCurrentFormIndex(nextIndex);
+    }
+    function handleClear() {
+        const id = services[currentFormIndex]?.protectedId;
+        const show = currentFormIndex < services.length - 1;
+        const nextIndex = show ? currentFormIndex + 1 : 0;
+        const newService = omit(services[currentFormIndex], ["protectedId" ]);
+        sessionStorage.removeItem(id);
+        setCreds({});
+        onSetCredentials(newService, {});
+        onSetProtectedServices(services.map((service, index) => {
+            return index === currentFormIndex ? newService : service;
+        }));
+        onSetShowModal(show);
+        onClear(id);
+        setCurrentFormIndex(nextIndex);
     }
 
     function handleConfirm() {
-        onSetCredentials({
-            ...newService,
-            isProtected: true
-        });
-        onSetShowModal(false);
+        onSetCredentials(
+            {
+                ...services[currentFormIndex],
+                protectedId: services[currentFormIndex]?.protectedId || uuidv1() || null
+            },
+            creds
+        );
+        setCreds({});
+        if (services.length - 1 === currentFormIndex ) {
+            onRefreshLayers();
+            setCurrentFormIndex(0);
+        } else {
+            setCurrentFormIndex(currentFormIndex + 1);
+        }
+        onSetShowModal(services.length - 1 !== currentFormIndex );
     }
 
     return (
@@ -63,20 +107,15 @@ function SecurityPopup({
             <ConfirmDialog
                 show={showModal}
                 preventHide
+                disabled={!(creds.username && creds.password)}
                 onCancel={handleCancel}
                 onConfirm={handleConfirm}
-                // descriptionId={"securityPopup.descriptionId"}
                 titleId={`securityPopup.title`}
-                // cancelId={`resourcesCatalog.${messagePrefix}Cancel`}
-                // confirmId={`resourcesCatalog.${messagePrefix}Confirm`}
                 variant="success"
             >
                 <FormGroup>
                     <InputGroup>
-                        {service.title}
-                    </InputGroup>
-                    <InputGroup>
-                        {service.url}
+                        {services[currentFormIndex]?.url}
                     </InputGroup>
                 </FormGroup>
                 <FormGroup>
@@ -84,21 +123,32 @@ function SecurityPopup({
                         <Message msgId="securityPopup.username" />
                     </ControlLabel>
                     <InputControl
-                        value={newService.username}
-                        debounceTime={300}
-                        onChange={(username) => setNewService({...newService, username })}
-                        maxLength={255}
+                        autoComplete="new-username"
+                        name="serviceUsername"
+                        value={creds.username}
+                        debounceTime={DEBOUNCE_TIME}
+                        onChange={(username) => setCreds({...creds, username})}
+                        maxLength={MAX_LENGTH}
                     />
                     <ControlLabel>
                         <Message msgId="securityPopup.pwd" />
                     </ControlLabel>
                     <InputControl
-                        value={newService.password}
-                        debounceTime={300}
-                        onChange={(password) => setNewService({...newService, password })}
-                        maxLength={255}
+                        autoComplete="new-password"
+                        name="servicePassword"
+                        type="password"
+                        value={creds.password}
+                        debounceTime={DEBOUNCE_TIME}
+                        onChange={(password) => setCreds({...creds, password })}
+                        maxLength={MAX_LENGTH}
                     />
                 </FormGroup>
+                <FormGroup>
+                    <Button onClick={handleClear} tooltipId="securityPopup.remove" >
+                        <Message msgId="securityPopup.removeClear" />
+                    </Button>
+                </FormGroup>
+
             </ConfirmDialog>
         </>
     );
@@ -107,10 +157,13 @@ function SecurityPopup({
 const ConnectedPlugin = connect(
     createStructuredSelector({
         showModal: showModalSelector,
-        service: protectedServiceSelector
+        services: protectedServicesSelector
     }),
     {
-        onSetCredentials: setCredentials,
+        onClear: clearSecurity,
+        onSetCredentials: setCredentialsAction,
+        onRefreshLayers: refreshSecurityLayers,
+        onSetProtectedServices: setProtectedServices,
         onSetShowModal: setShowModalStatus
     }
 )(SecurityPopup);
@@ -123,25 +176,29 @@ const SecurityPopupPlugin = createPlugin('SecurityPopup', {
             Component: connect(null,
                 {
                     onSetShowModal: setShowModalStatus,
-                    onSetCredentials: setCredentials
+                    onSetCredentials: setCredentialsAction,
+                    onSetProtectedServices: setProtectedServices
                 }
-            )(({onSetCredentials, onSetShowModal, service, itemComponent}) => {
-                const Component = itemComponent; // itemComponent is the default component defined in MainForm.jsx
+            )(({onSetCredentials, onSetProtectedServices, onSetShowModal, service, itemComponent}) => {
+                // itemComponent is the default component defined in MainForm.jsx
+                const Component = itemComponent;
                 return (<Component
                     onClick={(value) => {
                         onSetShowModal(true);
                         onSetCredentials(value);
+                        onSetProtectedServices([value]);
                     }}
-                    btnClassName={service.isProtected ? "btn-success" : ""}
+                    btnClassName={service.protectedId ? "btn-success" : ""}
                     glyph="1-user-mod"
                     tooltipId="securityPopup.insertCredentials"
-                />);
+                />  );
             })
         }
     },
     reducers: {
         security
-    }
+    },
+    epics: securityPopups
 });
 
 export default SecurityPopupPlugin;

--- a/web/client/plugins/SecurityPopup.jsx
+++ b/web/client/plugins/SecurityPopup.jsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, { useState } from 'react';
+import { InputGroup, ControlLabel, FormGroup } from 'react-bootstrap';
+import {connect} from 'react-redux';
+import {createStructuredSelector} from 'reselect';
+
+import ConfirmDialog from '../components/layout/ConfirmDialog';
+import InputControl from './ResourcesCatalog/components/InputControl';
+import security from '../reducers/security';
+import {
+    showModalSelector,
+    protectedServiceSelector
+} from '../selectors/security';
+import {
+    setCredentials,
+    setShowModalStatus
+} from '../actions/security';
+import Message from '../components/I18N/Message';
+
+import {createPlugin} from '../utils/PluginsUtils';
+
+/**
+ *
+ * @memberof plugins
+ * @class
+ * @name SecurityPopup
+ * @prop {function} onSetCredentials used to update credentials for a catalog service
+ * @prop {function} onSetShowModal used to update flag to show or not the modal
+ * @prop {boolean} showModal flag to show or not the modal
+ * @prop {object} service data related to a service
+ */
+function SecurityPopup({
+    showModal,
+    service = {},
+    onSetCredentials = () => {},
+    onSetShowModal = () => {}
+}) {
+    const [newService, setNewService] = useState(() => service || {});
+    function handleCancel() {
+        onSetShowModal(false);
+        onSetCredentials({
+            ...newService,
+            isProtected: false
+        });
+    }
+
+    function handleConfirm() {
+        onSetCredentials({
+            ...newService,
+            isProtected: true
+        });
+        onSetShowModal(false);
+    }
+
+    return (
+        <>
+            <ConfirmDialog
+                show={showModal}
+                preventHide
+                onCancel={handleCancel}
+                onConfirm={handleConfirm}
+                // descriptionId={"securityPopup.descriptionId"}
+                titleId={`securityPopup.title`}
+                // cancelId={`resourcesCatalog.${messagePrefix}Cancel`}
+                // confirmId={`resourcesCatalog.${messagePrefix}Confirm`}
+                variant="success"
+            >
+                <FormGroup>
+                    <InputGroup>
+                        {service.title}
+                    </InputGroup>
+                    <InputGroup>
+                        {service.url}
+                    </InputGroup>
+                </FormGroup>
+                <FormGroup>
+                    <ControlLabel>
+                        <Message msgId="securityPopup.username" />
+                    </ControlLabel>
+                    <InputControl
+                        value={newService.username}
+                        debounceTime={300}
+                        onChange={(username) => setNewService({...newService, username })}
+                        maxLength={255}
+                    />
+                    <ControlLabel>
+                        <Message msgId="securityPopup.pwd" />
+                    </ControlLabel>
+                    <InputControl
+                        value={newService.password}
+                        debounceTime={300}
+                        onChange={(password) => setNewService({...newService, password })}
+                        maxLength={255}
+                    />
+                </FormGroup>
+            </ConfirmDialog>
+        </>
+    );
+}
+
+const ConnectedPlugin = connect(
+    createStructuredSelector({
+        showModal: showModalSelector,
+        service: protectedServiceSelector
+    }),
+    {
+        onSetCredentials: setCredentials,
+        onSetShowModal: setShowModalStatus
+    }
+)(SecurityPopup);
+
+const SecurityPopupPlugin = createPlugin('SecurityPopup', {
+    component: ConnectedPlugin,
+    containers: {
+        MetadataExplorer: {
+            target: 'url-addon',
+            Component: connect(null,
+                {
+                    onSetShowModal: setShowModalStatus,
+                    onSetCredentials: setCredentials
+                }
+            )(({onSetCredentials, onSetShowModal, service, itemComponent}) => {
+                const Component = itemComponent; // itemComponent is the default component defined in MainForm.jsx
+                return (<Component
+                    onClick={(value) => {
+                        onSetShowModal(true);
+                        onSetCredentials(value);
+                    }}
+                    btnClassName={service.isProtected ? "btn-success" : ""}
+                    glyph="1-user-mod"
+                    tooltipId="securityPopup.insertCredentials"
+                />);
+            })
+        }
+    },
+    reducers: {
+        security
+    }
+});
+
+export default SecurityPopupPlugin;

--- a/web/client/plugins/SecurityPopup.jsx
+++ b/web/client/plugins/SecurityPopup.jsx
@@ -24,11 +24,9 @@ import {
     setCredentialsAction,
     setShowModalStatus,
     setProtectedServices,
-    clearSecurity
-} from '../actions/security';
-import {
+    clearSecurity,
     refreshSecurityLayers
-} from '../actions/layers';
+} from '../actions/security';
 import * as securityPopups from '../epics/security';
 import Message from '../components/I18N/Message';
 import tooltip from '../components/misc/enhancers/tooltip';

--- a/web/client/plugins/SecurityPopup.jsx
+++ b/web/client/plugins/SecurityPopup.jsx
@@ -39,7 +39,6 @@ const Button = tooltip(ButtonRB);
 /**
  *
  * @memberof plugins
- * @class
  * @name SecurityPopup
  * @prop {function} onSetCredentials used to update credentials for a catalog service
  * @prop {function} onSetShowModal used to update flag to show or not the modal

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -115,6 +115,7 @@ export const plugins = {
     SettingsPlugin: toModulePlugin('Settings', () => import(/* webpackChunkName: 'plugins/settings' */ '../plugins/Settings')),
     SidebarMenuPlugin: toModulePlugin('SidebarMenu', () => import(/* webpackChunkName: 'plugins/sidebarMenu' */ '../plugins/SidebarMenu')),
     SharePlugin: toModulePlugin('Share', () => import(/* webpackChunkName: 'plugins/share' */ '../plugins/Share')),
+    SecurityPopup: toModulePlugin('SecurityPopup', () => import(/* webpackChunkName: 'plugins/securityPopup' */ '../plugins/SecurityPopup')),
     PermalinkPlugin: toModulePlugin('Permalink', () => import(/* webpackChunkName: 'plugins/permalink' */ '../plugins/Permalink')),
     SnapshotPlugin: toModulePlugin('Snapshot', () => import(/* webpackChunkName: 'plugins/snapshot' */ '../plugins/Snapshot')),
     StreetView: toModulePlugin('StreetView', () => import(/* webpackChunkName: 'plugins/streetView' */ '../plugins/StreetView')),

--- a/web/client/reducers/__tests__/catalog-test.js
+++ b/web/client/reducers/__tests__/catalog-test.js
@@ -30,7 +30,9 @@ const serviceNew = {
     isNew: true
 };
 import catalog from '../catalog';
-
+import {
+    setCredentialsAction
+} from '../../actions/security';
 import {
     RECORD_LIST_LOADED,
     ADD_LAYER_ERROR,
@@ -363,5 +365,16 @@ describe('Test the catalog reducer', () => {
         }, initPlugin());
         expect(state.editingAllowedRoles).toEqual(option.editingAllowedRoles);
         expect(state.editingAllowedGroups).toEqual(option.editingAllowedGroups);
+    });
+    it('SET_CREDENTIALS ', () => {
+        let state = catalog({
+            newService: {
+                oldService: 'wms basic',
+                protectedId: '7298d7f0-2448-11f0-ba06-932081a38bd8'
+            }
+        }, setCredentialsAction({
+            oldService: 'wms basic54d803ef-f86c-402f-9f76-68873aa5c64f'
+        }));
+        expect(state.newService.protectedId).toEqual(undefined);
     });
 });

--- a/web/client/reducers/__tests__/geostory-test.js
+++ b/web/client/reducers/__tests__/geostory-test.js
@@ -35,7 +35,7 @@ import {
     enableDraw,
     resetGeostory
 } from '../../actions/geostory';
-import { refreshSecurityLayers } from '../../actions/layers';
+import { refreshSecurityLayers } from '../../actions/security';
 
 import geostory from '../../reducers/geostory';
 import {

--- a/web/client/reducers/__tests__/geostory-test.js
+++ b/web/client/reducers/__tests__/geostory-test.js
@@ -35,6 +35,8 @@ import {
     enableDraw,
     resetGeostory
 } from '../../actions/geostory';
+import { refreshSecurityLayers } from '../../actions/layers';
+
 import geostory from '../../reducers/geostory';
 import {
     controlSelectorCreator,
@@ -60,6 +62,8 @@ import {
 import TEST_STORY from "../../test-resources/geostory/sampleStory_1.json";
 import TEST_STORY_1 from "../../test-resources/geostory/story_state.json";
 import { Controls, Modes, getDefaultSectionTemplate, lists } from '../../utils/GeoStoryUtils';
+import { clearSecurity } from './../../actions/security';
+
 
 describe('geostory reducer', () => {
     it('setEditing sets mode', () => {
@@ -487,5 +491,31 @@ describe('geostory reducer', () => {
     it('RESET_GEOSTORY', () => {
         const state = geostory({ resource: { id: 10 }}, resetGeostory());
         expect(state.resource).toBe(undefined);
+    });
+    it('REFRESH_SECURITY_LAYERS', () => {
+        const state = geostory({
+            currentStory: {
+                resources: [{
+                    data: {
+                        layers: [{
+                            security: {}
+                        }]
+                    }
+                }]
+            }}, refreshSecurityLayers());
+        expect(state.currentStory.resources[0].data.layers[0].security.rand).toBeTruthy();
+    });
+    it('CLEAR_SECURITY', () => {
+        const state = geostory({
+            currentStory: {
+                resources: [{
+                    data: {
+                        layers: [{
+                            security: {}
+                        }]
+                    }
+                }]
+            }}, clearSecurity());
+        expect(state.currentStory.resources[0].data.layers[0].security).toEqual(undefined);
     });
 });

--- a/web/client/reducers/__tests__/layers-test.js
+++ b/web/client/reducers/__tests__/layers-test.js
@@ -8,9 +8,9 @@
 import expect from 'expect';
 
 import layers from '../layers';
-import { changeLayerParams, addLayer, addGroup, moveNode, ADD_GROUP, refreshSecurityLayers } from '../../actions/layers';
+import { changeLayerParams, addLayer, addGroup, moveNode, ADD_GROUP } from '../../actions/layers';
 import { DEFAULT_GROUP_ID } from '../../utils/LayersUtils';
-import { clearSecurity } from './../../actions/security';
+import { refreshSecurityLayers, clearSecurity } from './../../actions/security';
 
 
 describe('Test the layers reducer', () => {

--- a/web/client/reducers/__tests__/layers-test.js
+++ b/web/client/reducers/__tests__/layers-test.js
@@ -8,8 +8,9 @@
 import expect from 'expect';
 
 import layers from '../layers';
-import { changeLayerParams, addLayer, addGroup, moveNode, ADD_GROUP } from '../../actions/layers';
+import { changeLayerParams, addLayer, addGroup, moveNode, ADD_GROUP, refreshSecurityLayers } from '../../actions/layers';
 import { DEFAULT_GROUP_ID } from '../../utils/LayersUtils';
+import { clearSecurity } from './../../actions/security';
 
 
 describe('Test the layers reducer', () => {
@@ -974,5 +975,21 @@ describe('Test the layers reducer', () => {
                 nodes: []
             }
         ]);
+    });
+    it('REFRESH_SECURITY_LAYERS', () => {
+        const state = layers({
+            flat: [{
+                security: {}
+            }]
+        }, refreshSecurityLayers());
+        expect(state.flat[0].security.rand).toBeTruthy();
+    });
+    it('CLEAR_SECURITY', () => {
+        const state = layers({
+            flat: [{
+                security: {}
+            }]
+        }, clearSecurity());
+        expect(state.flat[0].security).toEqual(undefined);
     });
 });

--- a/web/client/reducers/__tests__/mediaEditor-test.js
+++ b/web/client/reducers/__tests__/mediaEditor-test.js
@@ -24,6 +24,8 @@ import {
     loadingSelectedMedia,
     loadingMediaList, disableMediaType
 } from '../../actions/mediaEditor';
+import { refreshSecurityLayers } from '../../actions/layers';
+import { clearSecurity } from '../../actions/security';
 
 describe('Test the mediaEditor reducer', () => {
 
@@ -229,5 +231,57 @@ describe('Test the mediaEditor reducer', () => {
         expect(state).toEqual({
             disabledMediaType: ['image']
         });
+    });
+    it('REFRESH_SECURITY_LAYERS', () => {
+        const state = mediaEditor({
+            settings: {
+                mediaType: "map",
+                sourceId: "geostoreMap"
+            },
+            selected: "selected",
+            data: {
+                map: {
+                    geostoreMap: {
+                        resultData: {
+                            resources: [{
+                                id: "selected",
+                                data: {
+                                    layers: [{
+                                        security: {}
+                                    }]
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        }, refreshSecurityLayers());
+        expect(state.data.map.geostoreMap.resultData.resources[0].data.layers[0].security.rand).toBeTruthy();
+    });
+    it('CLEAR_SECURITY', () => {
+        const state = mediaEditor({
+            settings: {
+                mediaType: "map",
+                sourceId: "geostoreMap"
+            },
+            selected: "selected",
+            data: {
+                map: {
+                    geostoreMap: {
+                        resultData: {
+                            resources: [{
+                                id: "selected",
+                                data: {
+                                    layers: [{
+                                        security: {}
+                                    }]
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        }, clearSecurity());
+        expect(state.data.map.geostoreMap.resultData.resources[0].data.layers[0].security).toEqual(undefined);
     });
 });

--- a/web/client/reducers/__tests__/mediaEditor-test.js
+++ b/web/client/reducers/__tests__/mediaEditor-test.js
@@ -24,8 +24,7 @@ import {
     loadingSelectedMedia,
     loadingMediaList, disableMediaType
 } from '../../actions/mediaEditor';
-import { refreshSecurityLayers } from '../../actions/layers';
-import { clearSecurity } from '../../actions/security';
+import { refreshSecurityLayers, clearSecurity } from '../../actions/security';
 
 describe('Test the mediaEditor reducer', () => {
 

--- a/web/client/reducers/__tests__/security-test.js
+++ b/web/client/reducers/__tests__/security-test.js
@@ -18,10 +18,12 @@ import {
     CHANGE_PASSWORD_FAIL,
     REFRESH_SUCCESS,
     SESSION_VALID,
-    CHANGE_PASSWORD
+    CHANGE_PASSWORD,
+    SET_SHOW_MODAL_STATUS,
+    SET_PROTECTED_SERVICES
 } from '../../actions/security';
 
-import { SET_CONTROL_PROPERTY } from '../../actions/controls';
+import { SET_CONTROL_PROPERTY, RESET_CONTROLS } from '../../actions/controls';
 import { USERMANAGER_UPDATE_USER } from '../../actions/users';
 
 describe('Test the security reducer', () => {
@@ -240,5 +242,28 @@ describe('Test the security reducer', () => {
         expect(state.token).toBe("aaa");
         expect(state.refresh_token).toBe("bbb");
         expect(state.user.name).toBe("sec2");
+    });
+    it('show modal status', () => {
+        let state = security(
+            {},
+            {type: SET_SHOW_MODAL_STATUS, status: true}
+        );
+        expect(state.showModalSecurityPopup).toBeTruthy();
+    });
+
+    it('SET_PROTECTED_SERVICES', () => {
+        let state = security(
+            {},
+            {type: SET_PROTECTED_SERVICES, protectedServices: [{}]}
+        );
+        expect(state.protectedServices).toEqual([{}]);
+    });
+    it('RESET_CONTROLS', () => {
+        let state = security(
+            {},
+            {type: RESET_CONTROLS}
+        );
+        expect(state.showModalSecurityPopup).toBeFalsy();
+        expect(state.protectedServices).toEqual([]);
     });
 });

--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -35,7 +35,7 @@ import widgets from '../widgets';
 import { getFloatingWidgets, getVisibleFloatingWidgets, getCollapsedIds } from '../../selectors/widgets';
 import expect from 'expect';
 import { find, get } from 'lodash';
-import { refreshSecurityLayers } from '../../actions/layers';
+import { refreshSecurityLayers } from '../../actions/security';
 
 describe('Test the widgets reducer', () => {
     it('initial state', () => {

--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -35,6 +35,7 @@ import widgets from '../widgets';
 import { getFloatingWidgets, getVisibleFloatingWidgets, getCollapsedIds } from '../../selectors/widgets';
 import expect from 'expect';
 import { find, get } from 'lodash';
+import { refreshSecurityLayers } from '../../actions/layers';
 
 describe('Test the widgets reducer', () => {
     it('initial state', () => {
@@ -497,5 +498,33 @@ describe('Test the widgets reducer', () => {
         }, toggleMaximize(widgetToMaximize));
 
         expect(resultState).toEqual(initialState);
+    });
+    it('widgets refreshSecurityLayers', () => {
+
+        const resultState = widgets({
+            containers: {
+                floating: {
+                    widgets: [{
+                        id: 'a7122cc0-f7a9-11e8-8602-03b7e0c9537b',
+                        maps: [{
+                            layers: [{
+                                security: {}
+                            }]
+                        }]
+                    }]
+                }
+            },
+            builder: {
+                editor: {
+                    maps: [{
+                        layers: [{
+                            security: {}
+                        }]
+                    }]
+                }
+            }
+        }, refreshSecurityLayers());
+        expect(resultState.containers.floating.widgets[0].maps[0].layers[0].security.rand).toBeTruthy();
+        expect(resultState.builder.editor.maps[0].layers[0].security.rand).toBeTruthy();
     });
 });

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -37,6 +37,7 @@ import {
     INIT_PLUGIN
 } from '../actions/catalog';
 import {
+    CLEAR_SECURITY,
     SET_CREDENTIALS
 } from '../actions/security';
 
@@ -240,7 +241,23 @@ function catalog(state = {
         return set("isNewServiceAdded", action.status, state);
     }
     case SET_CREDENTIALS: {
-        const newState = set("newService", action.protectedService, state);
+        const newService = action.protectedService;
+        const newState = set("newService", newService, state);
+        return newState;
+    }
+    case CLEAR_SECURITY: {
+        const id = action.protectedId;
+        const services = Object.keys(state.services).reduce((p, service) => {
+            const item = state.services[service];
+            const newItem = item?.protectedId === id ? {
+                ...item,
+                protectedId: undefined
+            } : item;
+            return {
+                ...p,
+                [service]: newItem};
+        }, {});
+        const newState = set("services", services, state);
         return newState;
     }
     default:

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -36,6 +36,9 @@ import {
     NEW_SERVICE_STATUS,
     INIT_PLUGIN
 } from '../actions/catalog';
+import {
+    SET_CREDENTIALS
+} from '../actions/security';
 
 import { MAP_CONFIG_LOADED } from '../actions/config';
 import { set } from '../utils/ImmutableUtils';
@@ -235,6 +238,10 @@ function catalog(state = {
     }
     case NEW_SERVICE_STATUS: {
         return set("isNewServiceAdded", action.status, state);
+    }
+    case SET_CREDENTIALS: {
+        const newState = set("newService", action.protectedService, state);
+        return newState;
     }
     default:
         return state;

--- a/web/client/reducers/geostory.js
+++ b/web/client/reducers/geostory.js
@@ -15,7 +15,6 @@ import {
     updateGeoCarouselSections
 } from '../utils/GeoStoryUtils';
 import uuidv1 from 'uuid/v1';
-import { REFRESH_SECURITY_LAYERS } from '../actions/layers';
 import {
     ADD,
     ADD_RESOURCE,
@@ -45,7 +44,7 @@ import {
     ENABLE_DRAW,
     RESET_GEOSTORY
 } from '../actions/geostory';
-import { CLEAR_SECURITY } from "../actions/security";
+import { REFRESH_SECURITY_LAYERS, CLEAR_SECURITY } from "../actions/security";
 
 
 /**

--- a/web/client/reducers/geostory.js
+++ b/web/client/reducers/geostory.js
@@ -14,7 +14,8 @@ import {
     SectionTypes,
     updateGeoCarouselSections
 } from '../utils/GeoStoryUtils';
-
+import uuidv1 from 'uuid/v1';
+import { REFRESH_SECURITY_LAYERS } from '../actions/layers';
 import {
     ADD,
     ADD_RESOURCE,
@@ -44,6 +45,7 @@ import {
     ENABLE_DRAW,
     RESET_GEOSTORY
 } from '../actions/geostory';
+import { CLEAR_SECURITY } from "../actions/security";
 
 
 /**
@@ -378,6 +380,53 @@ export default (state = INITIAL_STATE, action) => {
     }
     case RESET_GEOSTORY: {
         return INITIAL_STATE;
+    }
+    case REFRESH_SECURITY_LAYERS: {
+        return {
+            ...state,
+            currentStory: {
+                ...state.currentStory,
+                resources: state.currentStory?.resources?.map(res => {
+                    return {
+                        ...res,
+                        data: {
+                            ...res.data,
+                            layers: res.data.layers.map(l => {
+                                return l.security ? {
+                                    ...l,
+                                    security: {
+                                        ...l.security,
+                                        rand: uuidv1()
+                                    }
+                                } : l;
+                            })
+                        }
+                    };
+                }
+                )}
+        };
+    }
+    case CLEAR_SECURITY: {
+        return {
+            ...state,
+            currentStory: {
+                ...state.currentStory,
+                resources: state.currentStory?.resources?.map(res => {
+                    return {
+                        ...res,
+                        data: {
+                            ...res.data,
+                            layers: res.data.layers.map(l => {
+                                return l?.security?.sourceId === action.protectedId ? {
+                                    ...l,
+                                    security: undefined
+                                } : l;
+                            })
+                        }
+                    };
+                }
+                )}
+        };
     }
     default:
         return state;

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -25,7 +25,6 @@ import {
     HIDE_SETTINGS,
     UPDATE_SETTINGS,
     REFRESH_LAYERS,
-    REFRESH_SECURITY_LAYERS,
     LAYERS_REFRESH_ERROR,
     LAYERS_REFRESHED,
     CLEAR_LAYERS,
@@ -37,7 +36,7 @@ import {
 } from '../actions/layers';
 
 import { TOGGLE_CONTROL } from '../actions/controls';
-import { CLEAR_SECURITY } from '../actions/security';
+import { REFRESH_SECURITY_LAYERS, CLEAR_SECURITY } from '../actions/security';
 import assign from 'object-assign';
 import uuidv1 from 'uuid/v1';
 import { isString, includes, castArray } from 'lodash';

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -25,6 +25,7 @@ import {
     HIDE_SETTINGS,
     UPDATE_SETTINGS,
     REFRESH_LAYERS,
+    REFRESH_SECURITY_LAYERS,
     LAYERS_REFRESH_ERROR,
     LAYERS_REFRESHED,
     CLEAR_LAYERS,
@@ -36,6 +37,7 @@ import {
 } from '../actions/layers';
 
 import { TOGGLE_CONTROL } from '../actions/controls';
+import { CLEAR_SECURITY } from '../actions/security';
 import assign from 'object-assign';
 import uuidv1 from 'uuid/v1';
 import { isString, includes, castArray } from 'lodash';
@@ -117,6 +119,33 @@ function layers(state = { flat: [] }, action) {
             return action.layers.filter((l) => l.layer === layer.id).length === 0;
         });
         return assign({}, state, {refreshing: newLayers});
+    }
+    case REFRESH_SECURITY_LAYERS: {
+        const newLayers = state?.flat?.map(l => {
+            return l.security ? {
+                ...l,
+                security: {
+                    ...l.security,
+                    rand: uuidv1()
+                }
+            } : l;
+        });
+        return {
+            ...state,
+            flat: newLayers
+        };
+    }
+    case CLEAR_SECURITY: {
+        const newLayers = state?.flat?.map(l => {
+            return l?.security?.sourceId === action.protectedId ? {
+                ...l,
+                security: undefined
+            } : l;
+        });
+        return {
+            ...state,
+            flat: newLayers
+        };
     }
     case CHANGE_LAYER_PARAMS:
     case CHANGE_LAYER_PROPERTIES: {

--- a/web/client/reducers/mediaEditor.js
+++ b/web/client/reducers/mediaEditor.js
@@ -23,9 +23,6 @@ import {
     LOADING_MEDIA_LIST,
     MEDIA_TYPE_DISABLE
 } from '../actions/mediaEditor';
-import {
-    REFRESH_SECURITY_LAYERS
-} from '../actions/layers';
 import {LOCATION_CHANGE} from 'connected-react-router';
 import { compose, set, unset} from '../utils/ImmutableUtils';
 import {
@@ -33,7 +30,7 @@ import {
     currentMediaTypeSelector,
     resultDataSelector
 } from './../selectors/mediaEditor';
-import { CLEAR_SECURITY } from '../actions/security';
+import { REFRESH_SECURITY_LAYERS, CLEAR_SECURITY } from '../actions/security';
 
 const GEOSTORY_SOURCE_ID = "geostory";
 export const DEFAULT_STATE = {

--- a/web/client/reducers/security.js
+++ b/web/client/reducers/security.js
@@ -17,7 +17,7 @@ import {
     SESSION_VALID,
     CHANGE_PASSWORD,
     SET_SHOW_MODAL_STATUS,
-    SET_CREDENTIALS
+    SET_PROTECTED_SERVICES
 } from '../actions/security';
 
 import { RESET_CONTROLS, SET_CONTROL_PROPERTY } from '../actions/controls';
@@ -119,19 +119,20 @@ function security(state = initialState, action) {
             showModalSecurityPopup: action.status
         };
     }
-    case SET_CREDENTIALS:
+    case SET_PROTECTED_SERVICES:
     {
         return {
             ...state,
-            protectedService: action.protectedService
+            protectedServices: action.protectedServices
+
         };
     }
     case RESET_CONTROLS:
     {
         return {
             ...state,
-            protectedService: {},
-            showModalSecurityPopup: false
+            showModalSecurityPopup: false,
+            protectedServices: []
 
         };
     }

--- a/web/client/reducers/security.js
+++ b/web/client/reducers/security.js
@@ -15,16 +15,18 @@ import {
     RESET_ERROR,
     REFRESH_SUCCESS,
     SESSION_VALID,
-    CHANGE_PASSWORD
+    CHANGE_PASSWORD,
+    SET_SHOW_MODAL_STATUS,
+    SET_CREDENTIALS
 } from '../actions/security';
 
-import { SET_CONTROL_PROPERTY } from '../actions/controls';
+import { RESET_CONTROLS, SET_CONTROL_PROPERTY } from '../actions/controls';
 import { USERMANAGER_UPDATE_USER } from '../actions/users';
 import {getUserAttributes} from '../utils/SecurityUtils';
 import assign from 'object-assign';
 import { cloneDeep, head } from 'lodash';
-
-function security(state = {user: null, errorCause: null}, action) {
+const initialState = {user: null, errorCause: null};
+function security(state = initialState, action) {
     switch (action.type) {
     case USERMANAGER_UPDATE_USER:
         if (state.user && action.user && state.user.id === action.user.id) {
@@ -109,6 +111,29 @@ function security(state = {user: null, errorCause: null}, action) {
             user: action.userDetails.User,
             loginError: null
         });
+    }
+    case SET_SHOW_MODAL_STATUS:
+    {
+        return {
+            ...state,
+            showModalSecurityPopup: action.status
+        };
+    }
+    case SET_CREDENTIALS:
+    {
+        return {
+            ...state,
+            protectedService: action.protectedService
+        };
+    }
+    case RESET_CONTROLS:
+    {
+        return {
+            ...state,
+            protectedService: {},
+            showModalSecurityPopup: false
+
+        };
     }
     default:
         return state;

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import uuidv1 from 'uuid/v1';
 import {
     EDIT_NEW,
     INSERT,
@@ -31,7 +32,8 @@ import {
     REPLACE,
     WIDGETS_REGEX
 } from '../actions/widgets';
-
+import { REFRESH_SECURITY_LAYERS } from '../actions/layers';
+import { CLEAR_SECURITY } from '../actions/security';
 import { MAP_CONFIG_LOADED } from '../actions/config';
 import { DASHBOARD_LOADED, DASHBOARD_RESET } from '../actions/dashboard';
 import assign from 'object-assign';
@@ -196,6 +198,69 @@ function widgetsReducer(state = emptyState, action) {
         return set(`containers[${DEFAULT_TARGET}]`, {
             ...data
         }, state);
+    case REFRESH_SECURITY_LAYERS: {
+        let newWidgets = state?.containers?.[DEFAULT_TARGET].widgets;
+        newWidgets = newWidgets.map(w => {
+            const newMaps = w.maps.map(map => {
+                return {
+                    ...map,
+                    layers: map.layers.map(l => {
+                        return l.security ? {
+                            ...l,
+                            security: {
+                                ...l.security,
+                                rand: uuidv1()
+                            }
+                        } : l;
+                    })
+                };
+            });
+            return {...w, maps: newMaps};
+        });
+        const newMaps = state.builder?.editor?.maps?.map(map => {
+            return {
+                ...map,
+                layers: map.layers.map(l => {
+                    return l.security ? {
+                        ...l,
+                        security: {
+                            ...l.security,
+                            rand: uuidv1()
+                        }
+                    } : l;
+                })
+            };
+        });
+        return set(`containers[${DEFAULT_TARGET}].widgets`, newWidgets, set(`builder.editor.maps`, newMaps, state));}
+    case CLEAR_SECURITY: {
+        let newWidgets = state?.containers?.[DEFAULT_TARGET].widgets;
+        newWidgets = newWidgets.map(w => {
+            const maps = w.maps.map(map => {
+                return {
+                    ...map,
+                    layers: map.layers.map(l => {
+                        return l?.security?.sourceId === action.protectedId ? {
+                            ...l,
+                            security: undefined
+                        } : l;
+                    })
+                };
+            });
+            return {...w, maps};
+        });
+        const maps = state.builder?.editor?.maps?.map(map => {
+            return {
+                ...map,
+                layers: map.layers.map(l => {
+                    return l?.security?.sourceId === action.protectedId ? {
+                        ...l,
+                        security: undefined
+                    } : l;
+                })
+            };
+        });
+        return set(`containers[${DEFAULT_TARGET}].widgets`, newWidgets, set(`builder.editor.maps`, maps, state));
+    }
     case MAP_CONFIG_LOADED:
         let { widgetsConfig } = (action.config || {});
         if (!isEmpty(widgetsConfig)) {

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -32,8 +32,7 @@ import {
     REPLACE,
     WIDGETS_REGEX
 } from '../actions/widgets';
-import { REFRESH_SECURITY_LAYERS } from '../actions/layers';
-import { CLEAR_SECURITY } from '../actions/security';
+import { REFRESH_SECURITY_LAYERS, CLEAR_SECURITY } from '../actions/security';
 import { MAP_CONFIG_LOADED } from '../actions/config';
 import { DASHBOARD_LOADED, DASHBOARD_RESET } from '../actions/dashboard';
 import assign from 'object-assign';

--- a/web/client/selectors/__tests__/security-test.js
+++ b/web/client/selectors/__tests__/security-test.js
@@ -17,7 +17,9 @@ import {
     userGroupSecuritySelector,
     userParamsSelector,
     userGroupsEnabledSelector,
-    isUserAllowedSelectorCreator
+    isUserAllowedSelectorCreator,
+    showModalSelector,
+    protectedServicesSelector
 } from '../security';
 
 const id = 1833;
@@ -177,5 +179,19 @@ describe('Test security selectors', () => {
                 allowedGroups: ['some']
             })(state)).toBeFalsy();
         });
+    });
+    it('test showModalSelector ', () => {
+        expect(showModalSelector({
+            security: {
+                showModalSecurityPopup: true
+            }
+        })).toBeTruthy();
+    });
+    it('test protectedServicesSelector  ', () => {
+        expect(protectedServicesSelector({
+            security: {
+                protectedServices: [{id: "1"}]
+            }
+        })).toEqual([{id: "1"}]);
     });
 });

--- a/web/client/selectors/security.js
+++ b/web/client/selectors/security.js
@@ -79,6 +79,6 @@ export const isUserAllowedSelectorCreator = ({
 export const showModalSelector = state => {
     return state?.security?.showModalSecurityPopup;
 };
-export const protectedServiceSelector = state => {
-    return state?.security?.protectedService;
+export const protectedServicesSelector = state => {
+    return state?.security?.protectedServices || [];
 };

--- a/web/client/selectors/security.js
+++ b/web/client/selectors/security.js
@@ -5,11 +5,9 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree.
 */
-
-import assign from 'object-assign';
-
-import get from 'lodash/get';
 import castArray from "lodash/castArray";
+import get from 'lodash/get';
+import assign from 'object-assign';
 
 export const rulesSelector = (state) => {
     if (!state.security || !state.security.rules) {
@@ -76,4 +74,11 @@ export const isUserAllowedSelectorCreator = ({
         || castArray(allowedGroups)
             .some((group) => groups.includes(group))
     );
+};
+
+export const showModalSelector = state => {
+    return state?.security?.showModalSecurityPopup;
+};
+export const protectedServiceSelector = state => {
+    return state?.security?.protectedService;
 };

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -68,6 +68,10 @@
         .background-color-var(@theme-vars[success]);
         .color-var(@theme-vars[primary-contrast]);
     }
+    .input-group-addon:has(button) {
+        border: 0px;
+        padding: 0px;
+    }
     .DraftEditor-editorContainer,
     .template-html-renderer,
     .ms-template-viewer
@@ -253,7 +257,6 @@ textarea {
                 border-color: transparent;
                 background-color: transparent;
             }
-
             .close-filter {
                 cursor: pointer;
             }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -63,6 +63,15 @@
     "showEmptyMessageGFI": "Nachricht mit leeren Ergebnissen anzeigen",
     "remove": "Löschen",
     "removeThumbnail": "Miniaturbild entfernen",
+    "securityPopup": {
+      "insertCredentials": "Klicken Sie hier, um Anmeldeinformationen hinzuzufügen und diesen Dienst zu schützen",
+      "username": "Benutzername",
+      "pwd": "Passwort",
+      "serviceUrl": "Dienst-URL",
+      "title": "Geschützter Dienst",
+      "remove": "Schutz für diesen Dienst entfernen und das Modalfenster schließen",
+      "removeClear": "Löschen"
+    },
     "layerProperties": {
       "windowTitle": "Ebenen Eigenschaften",
       "title": "Titel",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -65,12 +65,12 @@
     "removeThumbnail": "Remove thumbnail",
     "securityPopup": {
       "insertCredentials": "click to add credentials to make this a protected service",
-      "descriptionId": "add service credentials",
       "username": "username",
       "pwd": "password",
       "serviceUrl": "service url",
-      "serviceName": "service name",
-      "title": "Protected service"
+      "title": "Protected service",
+      "remove": "Remove protection from this service and close the modal",
+      "removeClear": "Clear"
     },
     "layerProperties": {
       "windowTitle": "Layer Properties",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -63,6 +63,15 @@
     "showEmptyMessageGFI": "Show empty results message in GetFeatureInfo panel",
     "remove": "Delete",
     "removeThumbnail": "Remove thumbnail",
+    "securityPopup": {
+      "insertCredentials": "click to add credentials to make this a protected service",
+      "descriptionId": "add service credentials",
+      "username": "username",
+      "pwd": "password",
+      "serviceUrl": "service url",
+      "serviceName": "service name",
+      "title": "Protected service"
+    },
     "layerProperties": {
       "windowTitle": "Layer Properties",
       "title": "Title",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -63,6 +63,15 @@
     "showEmptyMessageGFI": "Mostrar mensaje de resultados vacío en el panel de GFI",
     "remove": "Borrar",
     "removeThumbnail": "Eliminar miniatura",
+    "securityPopup": {
+      "insertCredentials": "Haga clic para agregar credenciales y convertir este servicio en un servicio protegido",
+      "username": "Nombre de usuario",
+      "pwd": "Contraseña",
+      "serviceUrl": "URL del servicio",
+      "title": "Servicio protegido",
+      "remove": "Eliminar la protección de este servicio y cerrar la ventana modal",
+      "removeClear": "Borrar"
+    },
     "layerProperties": {
       "windowTitle": "Propiedades de la capa",
       "title": "Título",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -63,6 +63,15 @@
     "showEmptyMessageGFI": "Afficher un message de résultat vide dans le panneau GetFeatureInfo",
     "remove": "Supprimer",
     "removeThumbnail": "Supprimer la miniature",
+    "securityPopup": {
+      "insertCredentials": "Cliquez pour ajouter des identifiants afin de protéger ce service",
+      "username": "Nom d'utilisateur",
+      "pwd": "Mot de passe",
+      "serviceUrl": "URL du service",
+      "title": "Service protégé",
+      "remove": "Supprimer la protection de ce service et fermer la fenêtre modale",
+      "removeClear": "Effacer"
+    },
     "layerProperties": {
       "windowTitle": "Propriétés de la couche",
       "title": "Titre",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -63,6 +63,15 @@
     "showEmptyMessageGFI": "Mostra il messaggio: Nessuna feature per gli altri layer",
     "remove": "Rimuovi",
     "removeThumbnail": "Rimuovi anteprima",
+    "securityPopup": {
+      "insertCredentials": "Clicca per aggiungere le credenziali per rendere questo servizio protetto",
+      "username": "Nome utente",
+      "pwd": "Password",
+      "serviceUrl": "URL del servizio",
+      "title": "Servizio protetto",
+      "remove": "Rimuovi la protezione da questo servizio e chiudi la finestra modale",
+      "removeClear": "Rimuovi"
+    },
     "layerProperties": {
       "windowTitle": "Proprietà del livello",
       "title": "Titolo",

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -717,6 +717,7 @@ export const saveLayer = (layer) => {
     layer.localizedLayerStyles ? { localizedLayerStyles: layer.localizedLayerStyles } : {},
     layer.options ? { options: layer.options } : {},
     layer.credits ? { credits: layer.credits } : {},
+    layer.security ? { security: layer.security } : {},
     layer.tileGrids ? { tileGrids: layer.tileGrids } : {},
     layer.tileGridStrategy ? { tileGridStrategy: layer.tileGridStrategy } : {},
     layer.tileGridCacheSupport ? { tileGridCacheSupport: layer.tileGridCacheSupport } : {},

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -18,6 +18,14 @@ import {setStore as stateSetStore, getState} from "./StateUtils";
 
 export const USER_GROUP_ALL = 'everyone';
 
+export function getCredentials(id) {
+    const securityStorage = JSON.parse(sessionStorage.getItem('credentialStorage') ?? "{}");
+    return securityStorage[id] || {};
+}
+export function setCredentials(id, credentials) {
+    const securityStorage = JSON.parse(sessionStorage.getItem('credentialStorage') ?? "{}");
+    sessionStorage.setItem('credentialStorage', JSON.stringify(assign({}, securityStorage, {[id]: credentials})));
+}
 /**
  * Stores the logged user security information.
  */
@@ -144,9 +152,15 @@ export function getAuthKeyParameter(url) {
     return foundRule?.authkeyParamName ?? 'authkey';
 }
 
-export function getAuthenticationHeaders(url, securityToken) {
+export function getAuthenticationHeaders(url, securityToken, security) {
     if (!url || !isAuthenticationActivated()) {
         return null;
+    }
+    const storedProtectedService = getCredentials(security?.sourceId);
+    if (security && storedProtectedService) {
+        return {
+            "Authorization": `Basic ${btoa(storedProtectedService.username + ":" + storedProtectedService.password)}`
+        };
     }
     switch (getAuthenticationMethod(url)) {
     case 'bearer': {
@@ -235,18 +249,13 @@ export function cleanAuthParamsFromURL(url) {
     return ConfigUtils.filterUrlParams(url, [getAuthKeyParameter(url)].filter(p => p));
 }
 
-export function getCredentials(id) {
-    const securityStorage = JSON.parse(sessionStorage.getItem('credentialStorage') ?? "{}");
-    return securityStorage[id] || {};
-}
-export function setCredentials(id, credentials) {
-    const securityStorage = JSON.parse(sessionStorage.getItem('credentialStorage') ?? "{}");
-    sessionStorage.setItem('credentialStorage', JSON.stringify(assign({}, securityStorage, {[id]: credentials})));
-}
+
 /**
  * This utility class will get information about the current logged user directly from the store.
  */
 const SecurityUtils = {
+    getCredentials,
+    setCredentials,
     setStore,
     getSecurityInfo,
     getUser,

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1319,6 +1319,15 @@ describe('LayersUtils', () => {
                     expect(l.forceProxy).toBeTruthy();
                 }
             ],
+            // save forceProxy if present
+            [
+                {
+                    security: {}
+                },
+                l => {
+                    expect(l.security).toEqual({});
+                }
+            ],
             // save fields
             [
                 {

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -240,6 +240,12 @@ describe('Test security utils methods', () => {
         ConfigUtils.setConfigProp('authenticationRules', headerAuthenticationRules);
         expect(SecurityUtils.getAuthenticationHeaders("http://header-site.com/something", null)).toEqual({'X-Auth-Token': 'goodtoken'});
     });
+    it('test getAuthenticationHeaders using basic auth', () => {
+        setSecurityInfo(securityInfoToken);
+        ConfigUtils.setConfigProp("useAuthenticationRules", true);
+        ConfigUtils.setConfigProp('authenticationRules', headerAuthenticationRules);
+        expect(SecurityUtils.getAuthenticationHeaders("http://header-site.com/something", null, {sourceId: "id"})).toEqual({Authorization: "Basic dW5kZWZpbmVkOnVuZGVmaW5lZA=="});
+    });
     it('cleanAuthParamsFromURL', () => {
         // mocking the authentication rules
         expect(SecurityUtils.cleanAuthParamsFromURL('http://www.some-site.com/geoserver?parameter1=value1&parameter2=value2&authkey=SOME_AUTH_KEY').indexOf('authkey')).toBe(-1);
@@ -262,5 +268,10 @@ describe('Test security utils methods', () => {
 
         cleanParams = SecurityUtils.clearNilValuesForParams(validAndInvalidParams);
         expect(cleanParams).toEqual({"param1": "some val"});
+    });
+    it('setCredentials & getCredentials ', () => {
+        const creds = {data: "value"};
+        SecurityUtils.setCredentials("id", creds);
+        expect(SecurityUtils.getCredentials("id")).toEqual(creds);
     });
 });

--- a/web/client/utils/cesium/WMSUtils.js
+++ b/web/client/utils/cesium/WMSUtils.js
@@ -69,7 +69,7 @@ export const getProxy = (options) => {
  */
 export const wmsToCesiumOptionsBIL = (options) => {
     let url = options.url;
-    const headers = getAuthenticationHeaders(url, options.securityToken);
+    const headers = getAuthenticationHeaders(url, options.securityToken, options.security);
     const params = getAuthenticationParam(options);
     // MapStore only supports "image/bil" format for WMS provider
     return {
@@ -98,7 +98,7 @@ export function wmsToCesiumOptions(options) {
     const credit = cr ? new Cesium.Credit(creditsToAttribution(cr)) : options.attribution;
     // NOTE: can we use opacity to manage visibility?
     const urls = getURLs(isArray(options.url) ? options.url : [options.url]);
-    const headers = getAuthenticationHeaders(urls[0], options.securityToken);
+    const headers = getAuthenticationHeaders(urls[0], options.securityToken, options.security);
 
     return {
         url: new Cesium.Resource({
@@ -153,7 +153,7 @@ export function wmsToCesiumOptionsSingleTile(options) {
 
     const url = (isArray(options.url) ? options.url[Math.round(randomInt(options.url.length - 1))] : options.url) + '?service=WMS&version=1.1.0&request=GetMap&'
         + getQueryString(addAuthenticationToSLD(parameters, options));
-    const headers = getAuthenticationHeaders(url, options.securityToken);
+    const headers = getAuthenticationHeaders(url, options.securityToken, options.security);
     return {
         url: new Cesium.Resource({
             url,

--- a/web/client/utils/cesium/__tests__/WMSUtils-test.js
+++ b/web/client/utils/cesium/__tests__/WMSUtils-test.js
@@ -11,7 +11,8 @@ import {
     wmsToCesiumOptions,
     wmsToCesiumOptionsSingleTile
 } from '../WMSUtils';
-
+import { setCredentials } from './../../SecurityUtils';
+import ConfigUtils from './../../ConfigUtils';
 const testLayerConfig = {
     "type": "terrain",
     "provider": "wms",
@@ -44,6 +45,21 @@ describe('Test the WMSUtil for Cesium', () => {
         expect(config.layerName).toBe(testConfig.name);
         expect(config.crs).toBe(testConfig.crs);
     });
+    it('wmsToCesiumOptionsBIL with no proxy using creds', () => {
+        ConfigUtils.setConfigProp('useAuthenticationRules', true);
+        const testConfig = {
+            ...testLayerConfig,
+            url: [location.href],
+            noCors: false,
+            security: {
+                sourceId: "id"
+            }
+        };
+        setCredentials("id", {username: "u", password: "p"});
+        let config = wmsToCesiumOptionsBIL(testConfig);
+        sessionStorage.removeItem("id");
+        expect(config.headers).toEqual({Authorization: "Basic dTpw"});
+    });
     it('wmsToCesiumOptions', () => {
         const options = {
             type: 'wms',
@@ -65,6 +81,22 @@ describe('Test the WMSUtil for Cesium', () => {
             height: 256
         });
     });
+    it('wmsToCesiumOptions using creds', () => {
+        ConfigUtils.setConfigProp('useAuthenticationRules', true);
+        const testConfig = {
+            ...testLayerConfig,
+            url: [location.href],
+            noCors: false,
+            security: {
+                sourceId: "id"
+            }
+        };
+        setCredentials("id", {username: "u", password: "p"});
+        let config = wmsToCesiumOptions(testConfig);
+        sessionStorage.removeItem("id");
+        ConfigUtils.setConfigProp('useAuthenticationRules', false);
+        expect(config.url.headers).toEqual({Authorization: "Basic dTpw"});
+    });
     it('wmsToCesiumOptions with version', () => {
         const options = {
             type: 'wms',
@@ -84,5 +116,23 @@ describe('Test the WMSUtil for Cesium', () => {
         };
         const cesiumOptions = wmsToCesiumOptionsSingleTile(options);
         expect(cesiumOptions.url.url).toBe('/geoserver/wms?service=WMS&version=1.1.0&request=GetMap&styles=&format=image%2Fpng&transparent=true&opacity=1&TILED=true&layers=workspace%3Alayer&width=2000&height=2000&bbox=-180.0%2C-90%2C180.0%2C90&srs=EPSG%3A4326&_v_=0123456789');
+    });
+    it('wmsToCesiumOptionsSingleTile with creds', () => {
+        ConfigUtils.setConfigProp('useAuthenticationRules', true);
+        const options = {
+            type: 'wms',
+            url: '/geoserver/wms',
+            name: 'workspace:layer',
+            _v_: '0123456789',
+            security: {
+                sourceId: "id"
+            }
+        };
+        setCredentials("id", {username: "u", password: "p"});
+        const cesiumOptions = wmsToCesiumOptionsSingleTile(options);
+        sessionStorage.removeItem("id");
+        ConfigUtils.setConfigProp('useAuthenticationRules', false);
+
+        expect(cesiumOptions.url.headers).toEqual({Authorization: "Basic dTpw"});
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

A new SecurityPopup plugin has been added to handle secured services using basic auth.

main features
- you can defined protected services in the catalog service editor of main viewer through a new button 
- this button is injected from SecurityPlugin to enhance Catalog one
![image](https://github.com/user-attachments/assets/4d6d1935-e15f-4856-b624-a076466dee54)
- when defined a new username and password for a particular service and you save the service all layers added now will be "secured"
![image](https://github.com/user-attachments/assets/c58c028a-4542-4031-941f-539c84819d9e)
- credentials are stored in session storage
- security object of layers are stored, but it only stores the sourceId to be able to fetch from session storage an the type of method  ("basic")
- also services has a protectedId property that detemines if a service requires basic auth
- this is applied to maps, dashboards and geostories
- when resource page is loaded a check is done and if we find one or more services/layers protected we ask for introducing credentials if  they are not present is session storage otherwise
- all layers update functions have been considering a security change (rand property is used to trigger the refresh and therefore render the layer)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10966 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

This is how a secured service look like 
![image](https://github.com/user-attachments/assets/8a1586bc-86d4-47bd-8fdf-9e49f82015b8)


### For tester
We created a set of rules using GeoFence in gs-stable for testing. i have created a layer "linea costa basic" that has access using some credentials, can can ask in pvt. so you can try using it
![image](https://github.com/user-attachments/assets/1c527f93-ea24-42a9-9f5e-12d517bb3946)

the idea is that this will only work if a protected service is configured, and failing if not. This will be valid for many layer types in ol and cesium
