### PR TITLE
Fix  #10966 adding securityPopup in other catalogs

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -208,6 +208,7 @@ export default class ContextCreator extends React.Component {
                 }
             },
             "TOCItemsSettings",
+            "SecurityPopup",
             "DrawerMenu",
             "OmniBar",
             "Search",

--- a/web/client/components/security/SecurityPopupDialog.jsx
+++ b/web/client/components/security/SecurityPopupDialog.jsx
@@ -9,6 +9,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {Glyphicon, InputGroup, ControlLabel, FormGroup, FormControl as FormControlRB} from 'react-bootstrap';
+import Portal from '../misc/Portal';
 
 import Modal from '../misc/Modal';
 import Message from '../I18N/Message';
@@ -77,88 +78,94 @@ function SecurityPopupDialog({
         return null;
     }
     return (
-        <Modal
-            show={show}
-            onHide={handleHide}
-            animation={false}
-        >
-            <FlexBox classNames={['_padding-lr-lg', '_padding-tb-md']} column gap="md">
-                <FlexBox centerChildrenVertically gap="sm">
-                    <Text fontSize="lg" strong component={FlexBox.Fill}>
-                        {titleId ? <Message msgId={titleId} msgParams={titleParams} /> : null}
-                    </Text>
-                    {showClose && onCancel &&
+        <Portal className="portal-security-popup-dialog">
+            <Modal
+                containerClassName="containerClassName"
+                backdropClassName="backdropClassName"
+                dialogClassName="dialogClassName"
+                className="security-popup-dialog"
+                show={show}
+                onHide={handleHide}
+                animation={false}
+            >
+                <FlexBox classNames={['_padding-lr-lg', '_padding-tb-md']} column gap="md">
+                    <FlexBox centerChildrenVertically gap="sm">
+                        <Text fontSize="lg" strong component={FlexBox.Fill}>
+                            {titleId ? <Message msgId={titleId} msgParams={titleParams} /> : null}
+                        </Text>
+                        {showClose && onCancel &&
                         <Button id="security-close-btn" square borderTransparent disabled={disabledClose} onClick={handleCancel}>
                             <Glyphicon glyph="1-close"/>
                         </Button>
-                    }
-                </FlexBox>
-                <FormGroup>
-                    <InputGroup>
-                        {service?.url}
-                    </InputGroup>
-                </FormGroup>
-                <FlexBox inline>
-                    <FormGroup style={{
-                        flex: 1,
-                        padding: "0px 5px 0px 0px"
-                    }}>
-                        <ControlLabel>
-                            <Message msgId="securityPopup.username" />
-                        </ControlLabel>
-                        <InputControl
-                            name={`username_${uuidv1()}`}
-                            value={creds.username}
-                            debounceTime={debounceTime}
-                            onChange={(username) => setCreds({...creds, username})}
-                            maxLength={maxLength}
-                        />
-                    </FormGroup>
-                    <FormGroup style={{
-                        flex: 1,
-                        padding: "0px 5px 0px 0px"
-                    }}>
-                        <ControlLabel>
-                            <Message msgId="securityPopup.pwd" />
-                        </ControlLabel>
-                        <InputGroup style={{width: "100%"}}>
-                            <InputControl
-                                name={`password_${uuidv1()}`}
-                                autoComplete="new-password"
-                                type={showPassword ? "text" : "password"}
-                                value={creds.password}
-                                debounceTime={debounceTime}
-                                onChange={(password) => setCreds({...creds, password })}
-                                maxLength={maxLength}
-                            />
-                            <InputGroup.Addon>
-                                <Button
-                                    id="security-show-hide"
-                                    tooltipId={showPassword ? "securityPopup.hide" : "securityPopup.show" }
-                                    onClick={() => {setShowPassword(!showPassword);}}>
-                                    <Glyphicon glyph={!showPassword ? "eye-open" : "eye-close"}/>
-                                </Button>
-                            </InputGroup.Addon>
+                        }
+                    </FlexBox>
+                    <FormGroup>
+                        <InputGroup>
+                            {service?.url}
                         </InputGroup>
                     </FormGroup>
-                    <FormGroup style={{alignContent: "flex-end"}}>
-                        <Button
-                            id="security-clear"
-                            onClick={handleClear} tooltipId="securityPopup.remove" >
-                            <Glyphicon glyph="trash"/>
+                    <FlexBox inline>
+                        <FormGroup style={{
+                            flex: 1,
+                            padding: "0px 5px 0px 0px"
+                        }}>
+                            <ControlLabel>
+                                <Message msgId="securityPopup.username" />
+                            </ControlLabel>
+                            <InputControl
+                                name={`username_${uuidv1()}`}
+                                value={creds.username}
+                                debounceTime={debounceTime}
+                                onChange={(username) => setCreds({...creds, username})}
+                                maxLength={maxLength}
+                            />
+                        </FormGroup>
+                        <FormGroup style={{
+                            flex: 1,
+                            padding: "0px 5px 0px 0px"
+                        }}>
+                            <ControlLabel>
+                                <Message msgId="securityPopup.pwd" />
+                            </ControlLabel>
+                            <InputGroup style={{width: "100%"}}>
+                                <InputControl
+                                    name={`password_${uuidv1()}`}
+                                    autoComplete="new-password"
+                                    type={showPassword ? "text" : "password"}
+                                    value={creds.password}
+                                    debounceTime={debounceTime}
+                                    onChange={(password) => setCreds({...creds, password })}
+                                    maxLength={maxLength}
+                                />
+                                <InputGroup.Addon>
+                                    <Button
+                                        id="security-show-hide"
+                                        tooltipId={showPassword ? "securityPopup.hide" : "securityPopup.show" }
+                                        onClick={() => {setShowPassword(!showPassword);}}>
+                                        <Glyphicon glyph={!showPassword ? "eye-open" : "eye-close"}/>
+                                    </Button>
+                                </InputGroup.Addon>
+                            </InputGroup>
+                        </FormGroup>
+                        <FormGroup style={{alignContent: "flex-end"}}>
+                            <Button
+                                id="security-clear"
+                                onClick={handleClear} tooltipId="securityPopup.remove" >
+                                <Glyphicon glyph="trash"/>
+                            </Button>
+                        </FormGroup>
+                    </FlexBox>
+                    <FlexBox centerChildrenVertically gap="sm">
+                        <FlexBox.Fill />
+                        <Button id="security-confirm"
+                            disabled={disabled || loading} variant={variant} onClick={handleConfirm}>
+                            <Message msgId={confirmId} />
+                            {loading ? <>{' '}<Spinner /></> : null}
                         </Button>
-                    </FormGroup>
+                    </FlexBox>
                 </FlexBox>
-                <FlexBox centerChildrenVertically gap="sm">
-                    <FlexBox.Fill />
-                    <Button id="security-confirm"
-                        disabled={disabled || loading} variant={variant} onClick={handleConfirm}>
-                        <Message msgId={confirmId} />
-                        {loading ? <>{' '}<Spinner /></> : null}
-                    </Button>
-                </FlexBox>
-            </FlexBox>
-        </Modal>
+            </Modal>
+        </Portal>
     );
 }
 

--- a/web/client/components/widgets/builder/wizard/MapWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/MapWizard.jsx
@@ -25,6 +25,7 @@ export default ({
     selectedNodes = [],
     onNodeSelect = () => {},
     editorData = {},
+    addonsItems = [],
     editNode,
     setEditNode = () => {},
     closeNodeEditor = () => {},
@@ -51,6 +52,7 @@ export default ({
                     onChange={onChange}
                     value={editorData.selectedMapId}
                     setSelectedMap={setSelectedMap}
+                    addonsItems={addonsItems}
                     selectedMap={selectedMap}
                     setEmptyMap={setEmptyMap}
                     emptyMap={emptyMap}
@@ -59,6 +61,7 @@ export default ({
                 {!emptyMap && <MapOptions
                     editNode={editNode}
                     setEditNode={setEditNode}
+                    addonsItems={addonsItems}
                     closeNodeEditor={closeNodeEditor}
                     onNodeSelect={onNodeSelect}
                     selectedNodes={selectedNodes}

--- a/web/client/epics/security.js
+++ b/web/client/epics/security.js
@@ -47,7 +47,7 @@ export const checkProtectedContentEpic = (action$) =>
                     setShowModalStatus(true)
                 );
             }
-            return Rx.Observable.empty();
+            return Rx.Observable.of(setShowModalStatus(false));
         });
 
 /**
@@ -89,7 +89,7 @@ export const checkProtectedContentDashboardEpic = (action$) =>
                     setShowModalStatus(true)
                 );
             }
-            return Rx.Observable.empty();
+            return Rx.Observable.of(setShowModalStatus(false));
         });
 
 
@@ -126,7 +126,7 @@ export const checkProtectedContentDashboardMapEpic = (action$) =>
                     setShowModalStatus(true)
                 );
             }
-            return Rx.Observable.empty();
+            return Rx.Observable.of(setShowModalStatus(false));
         });
 export const checkProtectedContentGeostoryMapSelectionEpic = (action$, store) =>
     action$.ofType(UPDATE_ITEM)
@@ -160,7 +160,7 @@ export const checkProtectedContentGeostoryMapSelectionEpic = (action$, store) =>
                     setShowModalStatus(true)
                 );
             }
-            return Rx.Observable.empty();
+            return Rx.Observable.of(setShowModalStatus(false));
         });
 export const checkProtectedContentGeostoryEpic = (action$) =>
     action$.ofType(SET_CURRENT_STORY)
@@ -193,5 +193,6 @@ export const checkProtectedContentGeostoryEpic = (action$) =>
                     setShowModalStatus(true)
                 );
             }
-            return Rx.Observable.empty();
+            return Rx.Observable.of(setShowModalStatus(false));
         });
+

--- a/web/client/epics/security.js
+++ b/web/client/epics/security.js
@@ -27,15 +27,8 @@ export const checkProtectedContentEpic = (action$) =>
             const config = action.config;
             const protectedLayers = config?.map?.layers.map(layer => {
                 return {protectedId: layer?.security?.sourceId, url: layer.url};
-            });
-            const services = Object.keys(config?.catalogServices?.services || {})
-                ?.map(protectedService => {
-                    const service = config?.catalogServices?.services?.[protectedService];
-                    return {protectedId: service?.protectedId, url: service?.url};
-                })
-                .concat(protectedLayers)
-                .filter(v => !!v.protectedId);
-            const protectedServices = uniqBy(services, "protectedId")
+            }).filter(v => !!v.protectedId);
+            const protectedServices = uniqBy(protectedLayers, "protectedId")
                 .map(({protectedId, url}) => {
                     return {
                         protectedId,

--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -23,6 +23,7 @@ import withDashboardExitButton from './widgetbuilder/enhancers/withDashboardExit
 import WidgetTypeBuilder from './widgetbuilder/WidgetTypeBuilder';
 import epics from '../epics/dashboard';
 import dashboard from '../reducers/dashboard';
+import usePluginItems from '../hooks/usePluginItems';
 
 const Builder =
     compose(
@@ -61,6 +62,7 @@ class DashboardEditorComponent extends React.Component {
         src: PropTypes.string,
         style: PropTypes.object,
         pluginCfg: PropTypes.object,
+        addonsItems: PropTypes.array,
         catalog: PropTypes.object,
         disableEmptyMap: PropTypes.bool,
         servicesPermission: PropTypes.object
@@ -98,6 +100,7 @@ class DashboardEditorComponent extends React.Component {
                 className="dashboard-editor de-builder">
                 <Builder
                     disableEmptyMap={this.props.disableEmptyMap}
+                    addonsItems={this.props.addonsItems}
                     defaultSelectedService={defaultSelectedService}
                     defaultServices={defaultServices}
                     canEditService={this.props.canEditService}
@@ -109,6 +112,13 @@ class DashboardEditorComponent extends React.Component {
             : false;
     }
 }
+
+const DashboardEditorComponentWrapper = (props, context) => {
+    const { loadedPlugins } = context;
+    const addonsItems = usePluginItems({ items: props.items, loadedPlugins }).filter(({ target }) => target === 'url-addon');
+    return <DashboardEditorComponent {...props} addonsItems={addonsItems}/>;
+};
+
 
 const Plugin = connect(
     createSelector(
@@ -122,7 +132,7 @@ const Plugin = connect(
         onMount: () => setEditorAvailable(true),
         onUnmount: () => setEditorAvailable(false)
     }
-)(DashboardEditorComponent);
+)(DashboardEditorComponentWrapper);
 export default createPlugin('DashboardEditor', {
     component: Plugin,
     reducers: {

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -86,6 +86,7 @@ import { projectionSelector } from '../selectors/map';
 import { mapLayoutValuesSelector } from '../selectors/maplayout';
 import ResponsivePanel from "../components/misc/panels/ResponsivePanel";
 import usePluginItems from '../hooks/usePluginItems';
+import { setProtectedServices, setShowModalStatus } from '../actions/security';
 
 export const DEFAULT_ALLOWED_PROVIDERS = ["OpenStreetMap", "OpenSeaMap", "Stamen"];
 
@@ -303,6 +304,8 @@ const MetadataExplorerPlugin = connect(metadataExplorerSelector, {
     onLayerChange: setControlProperty.bind(null, 'backgroundSelector'),
     onStartChange: setControlProperty.bind(null, 'backgroundSelector', 'start'),
     setNewServiceStatus,
+    onShowSecurityModal: setShowModalStatus,
+    onSetProtectedServices: setProtectedServices,
     onInitPlugin: initPlugin
 })(MetadataExplorerComponentWrapper);
 

--- a/web/client/plugins/SecurityPopup.jsx
+++ b/web/client/plugins/SecurityPopup.jsx
@@ -155,6 +155,29 @@ const SecurityPopupPlugin = createPlugin('SecurityPopup', {
                     tooltipId="securityPopup.insertCredentials"
                 />  );
             })
+        },
+        DashboardEditor: {
+            target: 'url-addon',
+            Component: connect(null,
+                {
+                    onSetShowModal: setShowModalStatus,
+                    onSetCredentials: setCredentialsAction,
+                    onSetProtectedServices: setProtectedServices
+                }
+            )(({onSetCredentials, onSetProtectedServices, onSetShowModal, service, itemComponent}) => {
+                // itemComponent is the default component defined in MainForm.jsx
+                const Component = itemComponent;
+                return (<Component
+                    onClick={(value) => {
+                        onSetShowModal(true);
+                        onSetCredentials(value);
+                        onSetProtectedServices([value]);
+                    }}
+                    btnClassName={service.protectedId ? "btn-success" : ""}
+                    glyph="1-user-mod"
+                    tooltipId="securityPopup.insertCredentials"
+                />  );
+            })
         }
     },
     reducers: {

--- a/web/client/plugins/mapEditor/DefaultConfiguration.js
+++ b/web/client/plugins/mapEditor/DefaultConfiguration.js
@@ -49,7 +49,13 @@ export default {
             }
         },
         {
-            "name": "SecurityPopup"
+            "name": "SecurityPopup",
+            "override": {
+                "MetadataExplorer": {
+                    // this priority is used to ensure that the main component is not included
+                    "priority": 1
+                }
+            }
         },
         {
             "name": "TOC",

--- a/web/client/plugins/mapEditor/DefaultConfiguration.js
+++ b/web/client/plugins/mapEditor/DefaultConfiguration.js
@@ -49,6 +49,9 @@ export default {
             }
         },
         {
+            "name": "SecurityPopup"
+        },
+        {
             "name": "TOC",
             "cfg": {
                 "activateQueryTool": false,

--- a/web/client/plugins/widgetbuilder/MapBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/MapBuilder.jsx
@@ -113,6 +113,7 @@ export default mapBuilder(({
     enabled, onClose = () => {},
     toggleLayerSelector = () => {},
     editorData = {},
+    addonsItems = [],
     editNode, setEditNode, closeNodeEditor, isLocalizedLayerStylesEnabled, env, selectedGroups = [], exitButton, selectedLayers = [], selectedNodes, onNodeSelect = () => {},
     availableDependencies = [], toggleConnection = () => {}, ...props
 } = {}) =>
@@ -132,6 +133,7 @@ export default mapBuilder(({
     >
         {enabled ? <Builder
             setEditNode={setEditNode}
+            addonsItems={addonsItems}
             editNode={editNode}
             closeNodeEditor={closeNodeEditor}
             onNodeSelect={onNodeSelect}

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -451,3 +451,11 @@ div#sync-popover.popover {
     }
     margin-bottom: 8px;
 }
+
+
+div:has(.security-popup-dialog) .modal-backdrop.in {
+    z-index: 3050;
+}
+.security-popup-dialog {
+    z-index: 3150;
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

- avoiding to show modal if no protected layers are present
- adding security popup in 
  - dashboard editor
  - context editor
  - map editor in geostory
- if no credentials are present in the sessionStorage if you click the search button it will open the security modal popup

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
fix #10966

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
