### PR TITLE
Fix #10966 updated logic and make security popup static

### DIFF
--- a/web/client/plugins/SecurityPopup.jsx
+++ b/web/client/plugins/SecurityPopup.jsx
@@ -9,7 +9,9 @@ import React, {useState} from 'react';
 import {connect} from 'react-redux';
 import {createStructuredSelector} from 'reselect';
 import omit from 'lodash/omit';
+import isEmpty from 'lodash/isEmpty';
 import uuidv1 from 'uuid/v1';
+import { getCredentials } from '../utils/SecurityUtils';
 
 import security from '../reducers/security';
 import {
@@ -144,15 +146,16 @@ const SecurityPopupPlugin = createPlugin('SecurityPopup', {
             )(({onSetCredentials, onSetProtectedServices, onSetShowModal, service, itemComponent}) => {
                 // itemComponent is the default component defined in MainForm.jsx
                 const Component = itemComponent;
+                const isProtectedAndStorageIsPresent = !isEmpty(getCredentials(service?.protectedId));
                 return (<Component
                     onClick={(value) => {
                         onSetShowModal(true);
                         onSetCredentials(value);
                         onSetProtectedServices([value]);
                     }}
-                    btnClassName={service.protectedId ? "btn-success" : ""}
+                    btnClassName={isProtectedAndStorageIsPresent ? "btn-success" : ""}
                     glyph="1-user-mod"
-                    tooltipId="securityPopup.insertCredentials"
+                    tooltipId={isProtectedAndStorageIsPresent ? "securityPopup.updateCredentials" : "securityPopup.insertCredentials"}
                 />  );
             })
         },
@@ -167,15 +170,16 @@ const SecurityPopupPlugin = createPlugin('SecurityPopup', {
             )(({onSetCredentials, onSetProtectedServices, onSetShowModal, service, itemComponent}) => {
                 // itemComponent is the default component defined in MainForm.jsx
                 const Component = itemComponent;
+                const isProtectedAndStorageIsPresent = !isEmpty(getCredentials(service?.protectedId));
                 return (<Component
                     onClick={(value) => {
                         onSetShowModal(true);
                         onSetCredentials(value);
                         onSetProtectedServices([value]);
                     }}
-                    btnClassName={service.protectedId ? "btn-success" : ""}
+                    btnClassName={isProtectedAndStorageIsPresent ? "btn-success" : ""}
                     glyph="1-user-mod"
-                    tooltipId="securityPopup.insertCredentials"
+                    tooltipId={ isProtectedAndStorageIsPresent ? "securityPopup.updateCredentials" : "securityPopup.insertCredentials" }
                 />  );
             })
         }

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -22,6 +22,7 @@ import MetadataInfo from '../plugins/MetadataInfo';
 import TOC from '../plugins/TOC';
 import * as resourcesCatalogPlugins from '../plugins/ResourcesCatalog';
 import SearchServicesConfig from "../plugins/SearchServicesConfig";
+import SecurityPopup from "../plugins/SecurityPopup";
 
 import {toModulePlugin} from "../utils/ModulePluginsUtils";
 
@@ -47,6 +48,7 @@ export const plugins = {
     FeatureEditorPlugin: FeatureEditor,
     MetadataInfoPlugin: MetadataInfo,
     SearchServicesConfigPlugin: SearchServicesConfig,
+    SecurityPopupPlugin: SecurityPopup,
     TOCPlugin: TOC,
 
     // ### DYNAMIC PLUGINS ### //
@@ -115,7 +117,6 @@ export const plugins = {
     SettingsPlugin: toModulePlugin('Settings', () => import(/* webpackChunkName: 'plugins/settings' */ '../plugins/Settings')),
     SidebarMenuPlugin: toModulePlugin('SidebarMenu', () => import(/* webpackChunkName: 'plugins/sidebarMenu' */ '../plugins/SidebarMenu')),
     SharePlugin: toModulePlugin('Share', () => import(/* webpackChunkName: 'plugins/share' */ '../plugins/Share')),
-    SecurityPopup: toModulePlugin('SecurityPopup', () => import(/* webpackChunkName: 'plugins/securityPopup' */ '../plugins/SecurityPopup')),
     PermalinkPlugin: toModulePlugin('Permalink', () => import(/* webpackChunkName: 'plugins/permalink' */ '../plugins/Permalink')),
     SnapshotPlugin: toModulePlugin('Snapshot', () => import(/* webpackChunkName: 'plugins/snapshot' */ '../plugins/Snapshot')),
     StreetView: toModulePlugin('StreetView', () => import(/* webpackChunkName: 'plugins/streetView' */ '../plugins/StreetView')),

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -65,6 +65,7 @@
     "removeThumbnail": "Miniaturbild entfernen",
     "securityPopup": {
       "insertCredentials": "Klicken Sie hier, um Anmeldeinformationen hinzuzufügen und diesen Dienst zu schützen",
+      "updateCredentials": "Klicken Sie hier, um die Anmeldeinformationen für diesen geschützten Dienst zu aktualisieren",
       "username": "Benutzername",
       "pwd": "Passwort",
       "show": "Anzeigen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -64,7 +64,8 @@
     "remove": "Delete",
     "removeThumbnail": "Remove thumbnail",
     "securityPopup": {
-      "insertCredentials": "click to add credentials to make this a protected service",
+      "insertCredentials": "Click to add credentials to make this a protected service",
+      "updateCredentials": "Click to update credentials for this protected service",
       "username": "Username",
       "pwd": "Password",
       "show": "Show",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -64,7 +64,7 @@
     "remove": "Borrar",
     "removeThumbnail": "Eliminar miniatura",
     "securityPopup": {
-      "insertCredentials": "Haga clic para agregar credenciales y convertir este servicio en un servicio protegido",
+      "insertCredentials": "Haga clic para agregar credenciales y convertir este servicio en un servicio protegido","updateCredentials": "Haga clic para actualizar las credenciales de este servicio protegido",
       "username": "Nombre de usuario",
       "pwd": "Contraseña",
       "show": "Mostrar",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -64,7 +64,8 @@
     "remove": "Borrar",
     "removeThumbnail": "Eliminar miniatura",
     "securityPopup": {
-      "insertCredentials": "Haga clic para agregar credenciales y convertir este servicio en un servicio protegido","updateCredentials": "Haga clic para actualizar las credenciales de este servicio protegido",
+      "insertCredentials": "Haga clic para agregar credenciales y convertir este servicio en un servicio protegido",
+      "updateCredentials": "Haga clic para actualizar las credenciales de este servicio protegido",
       "username": "Nombre de usuario",
       "pwd": "Contraseña",
       "show": "Mostrar",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -65,6 +65,7 @@
     "removeThumbnail": "Supprimer la miniature",
     "securityPopup": {
       "insertCredentials": "Cliquez pour ajouter des identifiants afin de protéger ce service",
+      "updateCredentials": "Cliquez pour mettre à jour les informations d'identification pour ce service protégé",
       "username": "Nom d'utilisateur",
       "pwd": "Mot de passe",
       "show": "Afficher",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -64,7 +64,7 @@
     "remove": "Rimuovi",
     "removeThumbnail": "Rimuovi anteprima",
     "securityPopup": {
-      "insertCredentials": "Clicca per aggiungere le credenziali per rendere questo servizio protetto",
+      "insertCredentials": "Clicca per aggiungere le credenziali per rendere questo servizio protetto","updateCredentials": "Clicca per aggiornare le credenziali di questo servizio protetto",
       "username": "Nome utente",
       "pwd": "Password",
       "show": "Mostra",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -64,7 +64,8 @@
     "remove": "Rimuovi",
     "removeThumbnail": "Rimuovi anteprima",
     "securityPopup": {
-      "insertCredentials": "Clicca per aggiungere le credenziali per rendere questo servizio protetto","updateCredentials": "Clicca per aggiornare le credenziali di questo servizio protetto",
+      "insertCredentials": "Clicca per aggiungere le credenziali per rendere questo servizio protetto",
+      "updateCredentials": "Clicca per aggiornare le credenziali di questo servizio protetto",
       "username": "Nome utente",
       "pwd": "Password",
       "show": "Mostra",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
see here https://github.com/geosolutions-it/MapStore2/pull/11083#issuecomment-2866782134

Also made the button green only when credentials are also present in session storage

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #10966 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
