### PR TITLE
#11085 - Fix: Context maps are no longer opened at the right path

### DIFF
--- a/web/client/api/__tests__/ResourcesCatalog-test.js
+++ b/web/client/api/__tests__/ResourcesCatalog-test.js
@@ -264,7 +264,7 @@ describe('ResourceCatalog api', () => {
                                 "name": "contextName",
                                 "attributes": {}
                             },
-                            "info": { "title": "Map", "icon": { "glyph": "1-map", "type": "glyphicon" }, "thumbnailUrl": undefined, "viewerPath": "/viewer/1", "viewerUrl": "#/viewer/1" },
+                            "info": { "title": "Map", "icon": { "glyph": "1-map", "type": "glyphicon" }, "thumbnailUrl": undefined, "viewerPath": "/context/contextName/1", "viewerUrl": "#/context/contextName/1" },
                             "status": { "items": [{
                                 "type": 'icon',
                                 "glyph": 'cogs',

--- a/web/client/plugins/ResourcesCatalog/components/ResourceCard.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/ResourceCard.jsx
@@ -21,8 +21,7 @@ import FlexBox from '../../../components/layout/FlexBox';
 import Text from '../../../components/layout/Text';
 import tooltip from '../../../components/misc/enhancers/tooltip';
 import { getTagColorVariables } from '../../../utils/ResourcesFiltersUtils';
-import { replaceResourcePaths } from '../../../utils/GeostoreUtils';
-import { getResourceInfo } from '../../../utils/ResourcesUtils';
+import { replaceResourcePaths, getResourceInfo } from '../../../utils/ResourcesUtils';
 const ButtonWithTooltip = tooltip(Button);
 
 const ResourceCardButton = ({

--- a/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
@@ -12,7 +12,7 @@ import useRequestResource from '../hooks/useRequestResource';
 import DetailsInfo from '../components/DetailsInfo';
 import ButtonMS from '../../../components/layout/Button';
 import Icon from '../components/Icon';
-import { replaceResourcePaths } from '../../../utils/GeostoreUtils';
+import { replaceResourcePaths } from '../../../utils/ResourcesUtils';
 import DetailsHeader from '../components/DetailsHeader';
 import { isEmpty } from 'lodash';
 import useParsePluginConfigExpressions from '../hooks/useParsePluginConfigExpressions';

--- a/web/client/utils/ResourcesUtils.js
+++ b/web/client/utils/ResourcesUtils.js
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 import get from 'lodash/get';
+import isArray from 'lodash/isArray';
+import isObject from 'lodash/isObject';
 
 /**
  * return the resource info
@@ -23,4 +25,26 @@ export const getResourceInfo = (resource) => {
  */
 export const getResourceStatus = (resource = {}) => {
     return get(resource, '@extras.status', {});
+};
+
+/**
+ * replaces paths in a resource object with corresponding values.
+ * @param {array|object} value value to be transformed
+ * @param {object} resource - The resource object used to resolve values via paths.
+ * @param {object} [facets=[]] - Optional array of facet objects
+ * @returns {array|object} The transformed value with resolved resource paths and facet data (if any)
+ */
+export const replaceResourcePaths = (value, resource, facets = []) => {
+    if (isArray(value)) {
+        return value.map(val => replaceResourcePaths(val, resource, facets));
+    }
+    if (isObject(value)) {
+        const facet = facets.find(fc => fc.id === value.facet);
+        const valuePath = value.path && { value: get(resource, value.path) };
+        return Object.keys(value).reduce((acc, key) => ({
+            ...acc,
+            [key]: replaceResourcePaths(value[key], resource, facets)
+        }), { ...facet, ...valuePath });
+    }
+    return value;
 };

--- a/web/client/utils/__tests__/GeostoreUtils-test.js
+++ b/web/client/utils/__tests__/GeostoreUtils-test.js
@@ -51,11 +51,9 @@ describe('GeostoreUtils', () => {
                 attributes: {
                     thumbnail: '/thumb/2'
                 },
-                '@extras': {
-                    context: {
-                        name: 'context'
-                    }
-                }
+                '@extras': {}
+            }, {
+                name: 'context'
             })).toEqual({ title: 'Map', icon: { glyph: '1-map', type: 'glyphicon' }, thumbnailUrl: '/thumb/2', viewerPath: '/context/context/1', viewerUrl: '#/context/context/1' });
 
             expect(getGeostoreResourceTypesInfo({
@@ -190,6 +188,16 @@ describe('GeostoreUtils', () => {
             expect(resource?.attributes?.detailsSettings).toEqual({ showAsModal: false, showAtStartup: false });
             resource = parseResourceProperties(resource);
             expect(resource?.attributes?.detailsSettings).toEqual({ showAsModal: false, showAtStartup: false });
+        });
+        it('should parse the extras of resource', () => {
+            let resource = parseResourceProperties({ id: "1", "@extras": {name: "test"}, category: { name: "MAP" } });
+            expect(resource?.["@extras"]).toBeTruthy();
+            expect(resource?.["@extras"].name).toEqual("test");
+            expect(resource?.["@extras"].info.icon.glyph).toEqual("1-map");
+            expect(resource?.["@extras"].info.icon.glyph).toEqual("1-map");
+            expect(resource?.["@extras"].info.viewerUrl).toEqual("#/viewer/1");
+            resource = parseResourceProperties({ id: "1", "@extras": {name: "test"}, category: { name: "MAP" } }, {name: "context-name"});
+            expect(resource?.["@extras"].info.viewerUrl).toEqual("#/context/context-name/1");
         });
     });
 });

--- a/web/client/utils/__tests__/ResourcesUtils-test.js
+++ b/web/client/utils/__tests__/ResourcesUtils-test.js
@@ -8,7 +8,8 @@
 
 import {
     getResourceInfo,
-    getResourceStatus
+    getResourceStatus,
+    replaceResourcePaths
 } from '../ResourcesUtils';
 import expect from 'expect';
 
@@ -81,6 +82,49 @@ describe('ResourcesUtils', () => {
         it('should return an empty object when resource is undefined', () => {
             const result = getResourceStatus();
             expect(result).toEqual({});
+        });
+    });
+
+    describe('replaceResourcePaths', () => {
+        it('should return the same value if it is neither an array nor an object', () => {
+            const result = replaceResourcePaths('test', {}, []);
+            expect(result).toEqual('test');
+        });
+
+        it('should recursively replace paths in an array', () => {
+            const resource = { key1: 'value1', key2: 'value2' };
+            const value = [{ path: 'key1' }, { path: 'key2' }];
+            const result = replaceResourcePaths(value, resource, []);
+            expect(result).toEqual([ { value: 'value1', path: 'key1' }, { value: 'value2', path: 'key2' } ]);
+        });
+
+        it('should replace paths in an object and merge facet data', () => {
+            const resource = { key1: 'value1' };
+            const facets = [{ id: 'facet1', name: 'Facet Name' }];
+            const value = { facet: 'facet1', path: 'key1', other: 'data' };
+            const result = replaceResourcePaths(value, resource, facets);
+            expect(result).toEqual({ id: 'facet1', name: 'Facet Name', value: 'value1', facet: 'facet1', path: 'key1', other: 'data' });
+        });
+
+        it('should handle nested objects and arrays', () => {
+            const resource = { key1: 'value1', key2: 'value2' };
+            const facets = [{ id: 'facet1', name: 'Facet Name' }];
+            const value = {
+                facet: 'facet1',
+                path: 'key1',
+                nested: [{ path: 'key2' }, 'staticValue']
+            };
+            const result = replaceResourcePaths(value, resource, facets);
+            expect(result).toEqual({ id: 'facet1', name: 'Facet Name', value: 'value1',
+                facet: 'facet1', path: 'key1', nested: [ { value: 'value2', path: 'key2' }, 'staticValue' ] } );
+        });
+
+        it('should return an empty object if no matching facet is found', () => {
+            const resource = { key1: 'value1' };
+            const facets = [{ id: 'facet2', name: 'Facet Name' }];
+            const value = { facet: 'facet1', path: 'key1' };
+            const result = replaceResourcePaths(value, resource, facets);
+            expect(result).toEqual({ value: 'value1', facet: 'facet1', path: 'key1' });
         });
     });
 });


### PR DESCRIPTION
## Description
This PR fixes the incorrect path generation when map is a context map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #11085 

**What is the new behavior?**
The context map paths are generated correctly

<img width="600" alt="image" src="https://github.com/user-attachments/assets/314a5ba8-d3c3-493b-9270-3a7b176276d7" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
