### PR TITLE
Add features count on dynamic & interactive legend for WMS layers

### DIFF
--- a/web/client/utils/LegendUtils.js
+++ b/web/client/utils/LegendUtils.js
@@ -58,11 +58,12 @@ export const getWMSLegendConfig = ({
     };
     if (layer.serverType !== ServerTypes.NO_VENDOR) {
         const addContentDependantParams = layer.enableDynamicLegend || layer.enableInteractiveLegend;
+        const layerisNotBackground = layer.group !== "background";
         return {
             ...baseParams,
             ...(addContentDependantParams && {
-                // hideEmptyRules and countMatched is applied for all layers except background layers
-                LEGEND_OPTIONS: `hideEmptyRules:${layer.group !== "background"};countMatched:${layer.group !== "background"};${legendOptions}`,
+                // hideEmptyRules, countMatched and fontAntiAliasing are applied for all layers except background layers
+                LEGEND_OPTIONS: `hideEmptyRules:${layerisNotBackground};countMatched:${layerisNotBackground};fontAntiAliasing:${layerisNotBackground};${legendOptions}`,
                 SRCWIDTH: mapSize?.width ?? 512,
                 SRCHEIGHT: mapSize?.height ?? 512,
                 SRS: projection,

--- a/web/client/utils/LegendUtils.js
+++ b/web/client/utils/LegendUtils.js
@@ -61,8 +61,8 @@ export const getWMSLegendConfig = ({
         return {
             ...baseParams,
             ...(addContentDependantParams && {
-                // hideEmptyRules is applied for all layers except background layers
-                LEGEND_OPTIONS: `hideEmptyRules:${layer.group !== "background"};${legendOptions}`,
+                // hideEmptyRules and countMatched is applied for all layers except background layers
+                LEGEND_OPTIONS: `hideEmptyRules:${layer.group !== "background"};countMatched:${layer.group !== "background"};${legendOptions}`,
                 SRCWIDTH: mapSize?.width ?? 512,
                 SRCHEIGHT: mapSize?.height ?? 512,
                 SRS: projection,
@@ -121,4 +121,3 @@ export default {
     getWMSLegendConfig,
     updateLayerWithLegendFilters
 };
-


### PR DESCRIPTION
## Description
Add features count on dynamic & interactive legend for WMS layers

![image](https://github.com/user-attachments/assets/7d2cba6d-d7e4-4d35-8e72-f04b68e0f3c3)


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
No features count on dynamic & interactive legend for WMS layers
#<issue>

**What is the new behavior?**
Effect visible in the TOC
Effect visible in the Display tab option

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
