### PR TITLE
Floating Dynamic Legend Plugin for ArcGIS & WMS layers

### DIFF
--- a/project/standard/templates/configs/pluginsConfig.json
+++ b/project/standard/templates/configs/pluginsConfig.json
@@ -140,6 +140,17 @@
       "autoEnableChildren": ["Permalink"]
     },
     {
+      "name": "DynamicLegend",
+      "glyph": "align-left",
+      "title": "plugins.DynamicLegend.title",
+      "description": "plugins.DynamicLegend.description",
+      "dependencies": [
+        "Toolbar",
+        "BurgerMenu",
+        "SidebarMenu"
+      ]
+    },
+    {
       "name": "Permalink",
       "glyph": "link",
       "title": "plugins.Permalink.title",

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -412,7 +412,7 @@
       { "name": "WidgetsTray" }
     ],
     "desktop": [
-      "Details",
+      "Details","DynamicLegend",
       {
         "name": "BrandNavbar",
         "cfg": {

--- a/web/client/configs/pluginsConfig.json
+++ b/web/client/configs/pluginsConfig.json
@@ -140,6 +140,17 @@
       "autoEnableChildren": ["Permalink"]
     },
     {
+      "name": "DynamicLegend",
+      "glyph": "align-left",
+      "title": "plugins.DynamicLegend.title",
+      "description": "plugins.DynamicLegend.description",
+      "dependencies": [
+        "Toolbar",
+        "BurgerMenu",
+        "SidebarMenu"
+      ]
+    },
+    {
       "name": "Permalink",
       "glyph": "link",
       "title": "plugins.Permalink.title",

--- a/web/client/configs/simple.json
+++ b/web/client/configs/simple.json
@@ -77,6 +77,9 @@
     ],
     "desktop": [
       {
+        "name": "DynamicLegend"
+      },
+      {
         "name": "Map",
         "cfg": {
           "toolsOptions": {

--- a/web/client/plugins/DynamicLegend.jsx
+++ b/web/client/plugins/DynamicLegend.jsx
@@ -1,0 +1,78 @@
+/* eslint-disable react/jsx-boolean-value */
+import React from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { get } from 'lodash';
+import { Glyphicon } from 'react-bootstrap';
+
+import { createPlugin } from '../utils/PluginsUtils';
+import { groupsSelector, layersSelector } from '../selectors/layers';
+import { keepLayer } from '../selectors/dynamiclegend';
+import { mapSelector } from '../selectors/map';
+import { updateNode } from '../actions/layers';
+import controls from '../reducers/controls';
+import { toggleControl } from '../actions/controls';
+import Message from '../components/I18N/Message';
+
+import DynamicLegend from './dynamicLegend/components/DynamicLegend';
+
+export default createPlugin('DynamicLegend', {
+    component: connect(
+        createSelector([
+            (state) => get(state, 'controls.dynamic-legend.enabled'),
+            groupsSelector,
+            layersSelector,
+            mapSelector
+        ], (isVisible, groups, layers, map) => ({
+            isVisible,
+            groups,
+            layers: layers.filter(keepLayer),
+            currentZoomLvl: map?.zoom,
+            mapBbox: map?.bbox
+        })),
+        {
+            onClose: toggleControl.bind(null, 'dynamic-legend', null),
+            onUpdateNode: updateNode
+        }
+    )(DynamicLegend),
+    options: {
+        disablePluginIf: "{state('router') && (state('router').endsWith('new') || state('router').includes('newgeostory') || state('router').endsWith('dashboard'))}"
+    },
+    reducers: { controls },
+    epics: {},
+    containers: {
+        BurgerMenu: {
+            name: 'dynamic-legend',
+            position: 1000,
+            priority: 2,
+            doNotHide: true,
+            text: <Message msgId="dynamiclegend.title" />,
+            tooltip: <Message msgId="dynamiclegend.tooltip" />,
+            icon: <Glyphicon glyph="align-left" />,
+            action: toggleControl.bind(null, 'dynamic-legend', null),
+            toggle: true
+        },
+        SidebarMenu: {
+            name: 'dynamic-legend',
+            position: 1000,
+            priority: 1,
+            doNotHide: true,
+            text: <Message msgId="dynamiclegend.title" />,
+            tooltip: <Message msgId="dynamiclegend.tooltip" />,
+            icon: <Glyphicon glyph="align-left" />,
+            action: toggleControl.bind(null, 'dynamic-legend', null),
+            toggle: true
+        },
+        Toolbar: {
+            name: 'dynamic-legend',
+            alwaysVisible: true,
+            position: 2,
+            priority: 0,
+            doNotHide: true,
+            tooltip: <Message msgId="dynamiclegend.title" />,
+            icon: <Glyphicon glyph="align-left" />,
+            action: toggleControl.bind(null, 'dynamic-legend', null),
+            toggle: true
+        }
+    }
+});

--- a/web/client/plugins/TOC/components/ArcGISLegend.jsx
+++ b/web/client/plugins/TOC/components/ArcGISLegend.jsx
@@ -36,7 +36,7 @@ function ArcGISLegend({
                 .then(({ data }) => {
                     const dynamicLegendIsEmpty = data.layers.every(layer => layer.legend.length === 0);
                     if ((node.dynamicLegendIsEmpty ?? null) !== dynamicLegendIsEmpty) {
-                        onUpdateNode(node.id, 'layers', { dynamicLegendIsEmpty });
+                        onUpdateNode({ dynamicLegendIsEmpty });
                     }
                     setLegendData(data);
                 })

--- a/web/client/plugins/TOC/components/ArcGISLegend.jsx
+++ b/web/client/plugins/TOC/components/ArcGISLegend.jsx
@@ -17,9 +17,11 @@ import { getLayerIds } from '../../../utils/ArcGISUtils';
 /**
  * ArcGISLegend renders legend from a MapServer or ImageServer service
  * @prop {object} node layer node options
+ * @prop {function} onUpdateNode return the changes of a specific node
  */
 function ArcGISLegend({
-    node = {}
+    node = {},
+    onUpdateNode = () => {}
 }) {
     const [legendData, setLegendData] = useState(null);
     const [error, setError] = useState(false);
@@ -31,7 +33,13 @@ function ArcGISLegend({
                     f: 'json'
                 }
             })
-                .then(({ data }) => setLegendData(data))
+                .then(({ data }) => {
+                    const dynamicLegendIsEmpty = data.layers.every(layer => layer.legend.length === 0);
+                    if ((node.dynamicLegendIsEmpty ?? null) !== dynamicLegendIsEmpty) {
+                        onUpdateNode(node.id, 'layers', { dynamicLegendIsEmpty });
+                    }
+                    setLegendData(data);
+                })
                 .catch(() => setError(true));
         }
     }, [legendUrl]);

--- a/web/client/plugins/TOC/components/DefaultLayer.jsx
+++ b/web/client/plugins/TOC/components/DefaultLayer.jsx
@@ -96,7 +96,7 @@ const NodeLegend = ({
                 <li>
                     {visible ? <ArcGISLegend
                         node={node}
-                        onChange={onChange}
+                        onUpdateNode={onChange}
                     /> : null}
                 </li>
             </>

--- a/web/client/plugins/TOC/components/DefaultLayer.jsx
+++ b/web/client/plugins/TOC/components/DefaultLayer.jsx
@@ -96,6 +96,7 @@ const NodeLegend = ({
                 <li>
                     {visible ? <ArcGISLegend
                         node={node}
+                        onChange={onChange}
                     /> : null}
                 </li>
             </>

--- a/web/client/plugins/TOC/components/Legend.jsx
+++ b/web/client/plugins/TOC/components/Legend.jsx
@@ -35,6 +35,7 @@ import { getWMSLegendConfig, LEGEND_FORMAT } from '../../../utils/LegendUtils';
  * @prop {string} language current language code
  * @prop {number} legendWidth width of the legend symbols
  * @prop {number} legendHeight height of the legend symbols
+ * @prop {function} onUpdateNode return the changes of a specific node
  */
 class Legend extends React.Component {
     static propTypes = {
@@ -49,7 +50,8 @@ class Legend extends React.Component {
         language: PropTypes.string,
         projection: PropTypes.string,
         mapSize: PropTypes.object,
-        bbox: PropTypes.object
+        bbox: PropTypes.object,
+        onUpdateNode: PropTypes.func
     };
 
     static defaultProps = {
@@ -57,7 +59,8 @@ class Legend extends React.Component {
         legendWidth: 12,
         legendOptions: "forceLabels:on",
         style: {maxWidth: "100%"},
-        scaleDependent: true
+        scaleDependent: true,
+        onUpdateNode: () => {}
     };
     state = {
         error: false
@@ -132,8 +135,12 @@ class Legend extends React.Component {
     validateImg = (img) => {
         // GeoServer response is a 1x2 px size when legend is not available.
         // In this case we need to show the "Legend Not available" message
-        if (img.height <= 1 && img.width <= 2) {
+        const imgError = img.height <= 1 && img.width <= 2;
+        if (imgError) {
             this.onImgError();
+        }
+        if ((this.props.layer.dynamicLegendIsEmpty ?? null) !== imgError) {
+            this.props.onUpdateNode(this.props.layer.id, 'layers', { dynamicLegendIsEmpty: imgError });
         }
     }
 }

--- a/web/client/plugins/TOC/components/Legend.jsx
+++ b/web/client/plugins/TOC/components/Legend.jsx
@@ -140,7 +140,7 @@ class Legend extends React.Component {
             this.onImgError();
         }
         if ((this.props.layer.dynamicLegendIsEmpty ?? null) !== imgError) {
-            this.props.onUpdateNode(this.props.layer.id, 'layers', { dynamicLegendIsEmpty: imgError });
+            this.props.onUpdateNode({ dynamicLegendIsEmpty: imgError });
         }
     }
 }

--- a/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
+++ b/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
@@ -108,7 +108,7 @@ class StyleBasedWMSJsonLegend extends React.Component {
         getJsonWMSLegend(jsonLegendUrl).then(data => {
             const dynamicLegendIsEmpty = data.length === 0 || data[0].rules.length === 0;
             if ((this.props.layer.dynamicLegendIsEmpty ?? null) !== dynamicLegendIsEmpty) {
-                this.props.onUpdateNode(this.props.layer.id, 'layers', { dynamicLegendIsEmpty });
+                this.props.onUpdateNode({ dynamicLegendIsEmpty });
             }
             this.setState({ jsonLegend: data[0], loading: false });
         }).catch(() => {

--- a/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
+++ b/web/client/plugins/TOC/components/StyleBasedWMSJsonLegend.jsx
@@ -46,7 +46,8 @@ class StyleBasedWMSJsonLegend extends React.Component {
         interactive: PropTypes.bool,        // the indicator flag that refers if this legend is interactive or not
         projection: PropTypes.string,
         mapSize: PropTypes.object,
-        mapBbox: PropTypes.object
+        mapBbox: PropTypes.object,
+        onUpdateNode: PropTypes.func
     };
 
     static defaultProps = {
@@ -56,7 +57,8 @@ class StyleBasedWMSJsonLegend extends React.Component {
         style: {maxWidth: "100%"},
         scaleDependent: true,
         onChange: () => {},
-        interactive: false
+        interactive: false,
+        onUpdateNode: () => {}
     };
     state = {
         error: false,
@@ -104,6 +106,10 @@ class StyleBasedWMSJsonLegend extends React.Component {
         }
         this.setState({ loading: true });
         getJsonWMSLegend(jsonLegendUrl).then(data => {
+            const dynamicLegendIsEmpty = data.length === 0 || data[0].rules.length === 0;
+            if ((this.props.layer.dynamicLegendIsEmpty ?? null) !== dynamicLegendIsEmpty) {
+                this.props.onUpdateNode(this.props.layer.id, 'layers', { dynamicLegendIsEmpty });
+            }
             this.setState({ jsonLegend: data[0], loading: false });
         }).catch(() => {
             this.setState({ error: true, loading: false });

--- a/web/client/plugins/TOC/components/TOC.jsx
+++ b/web/client/plugins/TOC/components/TOC.jsx
@@ -54,6 +54,7 @@ import {
  * @prop {object} config.groupOptions.tooltipOptions options for group title tooltip
  * @prop {object} config.layerOptions specific options for layer nodes
  * @prop {object} config.layerOptions.tooltipOptions options for layer title tooltip
+ * @prop {boolean} config.layerOptions.enableDynamicLegend make the legend dynamic
  * @prop {boolean} config.layerOptions.hideLegend hide the legend of the layer
  * @prop {object} config.layerOptions.legendOptions additional options for WMS legend
  * @prop {boolean} config.layerOptions.hideFilter hide the filter button in the layer nodes
@@ -137,6 +138,7 @@ export function ControlledTOC({
  * @prop {object} config.groupOptions.tooltipOptions options for group title tooltip
  * @prop {object} config.layerOptions specific options for layer nodes
  * @prop {object} config.layerOptions.tooltipOptions options for layer title tooltip
+ * @prop {boolean} config.layerOptions.enableDynamicLegend make the legend dynamic
  * @prop {boolean} config.layerOptions.hideLegend hide the legend of the layer
  * @prop {object} config.layerOptions.legendOptions additional options for WMS legend
  * @prop {boolean} config.layerOptions.hideFilter hide the filter button in the layer nodes

--- a/web/client/plugins/TOC/components/WMSLegend.jsx
+++ b/web/client/plugins/TOC/components/WMSLegend.jsx
@@ -68,7 +68,7 @@ class WMSLegend extends React.Component {
         this.setState({ containerWidth, ...this.state }); // eslint-disable-line -- TODO: need to be fixed
     }
     getLegendProps = () => {
-        return pick(this.props, ['currentZoomLvl', 'scales', 'scaleDependent', 'language', 'projection', 'mapSize', 'mapBbox']);
+        return pick(this.props, ['currentZoomLvl', 'scales', 'scaleDependent', 'language', 'projection', 'mapSize', 'mapBbox', 'enableDynamicLegend']);
     }
     render() {
         let node = this.props.node || {};
@@ -97,6 +97,7 @@ class WMSLegend extends React.Component {
                         }
                         legendOptions={this.props.WMSLegendOptions}
                         {...this.getLegendProps()}
+                        onUpdateNode={this.props.onChange}
                     />
                 </div>
             );

--- a/web/client/plugins/dynamicLegend/assets/dynamicLegend.css
+++ b/web/client/plugins/dynamicLegend/assets/dynamicLegend.css
@@ -1,0 +1,8 @@
+.ms-resizable-modal > .modal-content.legend-dialog {
+    top: 0vh;
+    right: -100vw;
+}
+
+.legend-content * .ms-node-title {
+    font-weight: bold !important
+}

--- a/web/client/plugins/dynamicLegend/components/DynamicLegend.jsx
+++ b/web/client/plugins/dynamicLegend/components/DynamicLegend.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { keepNode, isLayerVisible } from '../../../selectors/dynamiclegend';
+import { getResolutions } from '../../../utils/MapUtils';
+import Message from '../../../components/I18N/Message';
+import ResizableModal from '../../../components/misc/ResizableModal';
+import { ControlledTOC } from '../../TOC/components/TOC';
+import DefaultGroup from '../../TOC/components/DefaultGroup';
+import DefaultLayer from '../../TOC/components/DefaultLayer';
+
+import '../assets/dynamicLegend.css';
+
+function applyVersionParamToLegend(layer) {
+    // we need to pass a parameter that invalidate the cache for GetLegendGraphic
+    // all layer inside the dataset viewer apply a new _v_ param each time we switch page
+    return { ...layer, legendParams: { ...layer?.legendParams, _v_: layer?._v_ } };
+}
+
+function filterNode(node, currentResolution) {
+    const nodes = Array.isArray(node.nodes) ? node.nodes.filter(keepNode).map(applyVersionParamToLegend).map(n => filterNode(n, currentResolution)) : undefined;
+
+    return {
+        ...node,
+        isVisible: (node.visibility ?? true) && (nodes ? nodes.length > 0 && nodes.some(n => n.isVisible) : isLayerVisible(node, currentResolution)),
+        ...(nodes && { nodes })
+    };
+}
+
+export default ({
+    layers,
+    onUpdateNode,
+    currentZoomLvl,
+    onClose,
+    isVisible,
+    groups,
+    mapBbox
+}) => {
+    const layerDict = layers.reduce((acc, layer) => ({
+        ...acc,
+        ...{
+            [layer.id]: {
+                ...layer,
+                ...{enableDynamicLegend: true, enableInteractiveLegend: false}
+            }
+        }
+    }), {});
+    const getVisibilityStyle = nodeVisibility => ({
+        opacity: nodeVisibility ? 1 : 0,
+        height: nodeVisibility ? "auto" : "0"
+    });
+
+    const customGroupNodeComponent = props => (
+        <div style={getVisibilityStyle(props.node?.isVisible ?? true)}>
+            <DefaultGroup {...props} />
+        </div>
+    );
+    const customLayerNodeComponent = props => {
+        const layer = layerDict[props.node.id];
+        if (!layer) {
+            return null;
+        }
+
+        return (
+            <div style={getVisibilityStyle(props.node?.isVisible ?? true)}>
+                <DefaultLayer {...props} node={layer} />
+            </div>
+        );
+    };
+
+    return (
+        <ResizableModal
+            onClose = {onClose}
+            enableFooter={false}
+            title={<Message msgId="dynamiclegend.title" />}
+            dialogClassName=" legend-dialog"
+            show={isVisible}
+            draggable
+            style={{zIndex: 1993}}>
+            <ControlledTOC
+                tree={[filterNode(groups[0] ?? {}, getResolutions()[Math.round(currentZoomLvl)])]}
+                className="legend-content"
+                theme="legend"
+                onChange={onUpdateNode}
+                groupNodeComponent={customGroupNodeComponent}
+                layerNodeComponent={customLayerNodeComponent}
+                config={{
+                    sortable: false,
+                    showFullTitle: true,
+                    hideOpacitySlider: true,
+                    hideVisibilityButton: true,
+                    expanded: true,
+                    zoom: currentZoomLvl,
+                    layerOptions: {
+                        enableDynamicLegend: true,
+                        legendOptions: {
+                            legendWidth: 12,
+                            legendHeight: 12,
+                            mapBbox
+                        }
+                    }
+                }}
+            />
+        </ResizableModal>
+    );
+};

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -70,6 +70,7 @@ export const plugins = {
     DashboardImport: toModulePlugin('DashboardImport', () => import( /* webpackChunkName: 'plugins/dashboardImport' */'../plugins/DashboardImport')),
     DetailsPlugin: toModulePlugin('Details', () => import(/* webpackChunkName: 'plugins/details' */ '../plugins/Details')),
     DrawerMenuPlugin: toModulePlugin('DrawerMenu', () => import(/* webpackChunkName: 'plugins/drawerMenu' */ '../plugins/DrawerMenu')),
+    DynamicLegendPlugin: toModulePlugin('DynamicLegend', () => import(/* webpackChunkName: 'plugins/dynamiclegend' */ '../plugins/DynamicLegend')),
     ExpanderPlugin: toModulePlugin('Expander', () => import(/* webpackChunkName: 'plugins/expander' */ '../plugins/Expander')),
     FilterLayerPlugin: toModulePlugin('FilterLayer', () => import(/* webpackChunkName: 'plugins/filterLayer' */ '../plugins/FilterLayer')),
     FullScreenPlugin: toModulePlugin('FullScreen', () => import(/* webpackChunkName: 'plugins/fullScreen' */ '../plugins/FullScreen')),

--- a/web/client/selectors/dynamiclegend.js
+++ b/web/client/selectors/dynamiclegend.js
@@ -1,0 +1,12 @@
+const isLayer = node => node.nodeType === "layers";
+
+export const keepLayer = layer => (layer.group !== 'background' && ['wms', 'arcgis'].includes(layer.type));
+
+export const keepNode = node => !isLayer(node) || keepLayer(node);
+
+export const isLayerVisible = (node, currentResolution) => keepLayer(node)
+    && (!node.hasOwnProperty('dynamicLegendIsEmpty') || !node.dynamicLegendIsEmpty)
+    && (
+        (!node.minResolution || node.minResolution <= currentResolution) &&
+        (!node.maxResolution || node.maxResolution > currentResolution)
+    );

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1535,6 +1535,10 @@
         "height": "Höhe"
       }
     },
+    "dynamiclegend": {
+      "title": "Legende",
+      "tooltip": "Kartenlegende anzeigen"
+    },
     "permalink": {
       "title": "Permalink",
       "shareLinkTitle": "Permalink generiert",
@@ -3465,6 +3469,10 @@
       "Share": {
         "description": "Ermöglicht das Teilen der Karte auf verschiedene Arten (Link, QR-Code, Einbettung, soziale Netzwerke ...)",
         "title": "Freigabe-Werkzeug"
+      },
+      "DynamicLegend": {
+        "title": "Legende",
+        "description": "Kartenlegende anzeigen"
       },
       "Permalink": {
         "description": "Ermöglicht das Erstellen eines Permalinks der aktuell angezeigten Ressource",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1496,6 +1496,10 @@
         "height": "height"
       }
     },
+    "dynamiclegend": {
+      "title": "Legend",
+      "tooltip": "Display the map legend"
+    },
     "permalink": {
       "title": "Permalink",
       "shareLinkTitle": "Permalink generated",
@@ -3436,6 +3440,10 @@
       "Share": {
         "description": "Allows to share the map in various ways (link, QR-Code, embed, social networks...)",
         "title": "Share Tool"
+      },
+      "DynamicLegend": {
+        "title": "Legend",
+        "description": "Display the map legend"
       },
       "Permalink": {
         "description": "Allows to create a permalink of the current resource in view",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1496,6 +1496,10 @@
         "height": "altura"
       }
     },
+    "dynamiclegend": {
+      "title": "Leyenda",
+      "tooltip": "Mostrar la leyenda del mapa"
+    },
     "permalink": {
       "title": "Permalink",
       "shareLinkTitle": "Enlace permanente generado",
@@ -3426,6 +3430,10 @@
       "Share": {
         "description": "Permite compartir el mapa de varias maneras (enlace, código QR, incrustar, redes sociales ...)",
         "title": "Compartir herramienta"
+      },
+      "DynamicLegend": {
+        "title": "Leyenda",
+        "description": "Mostrar la leyenda del mapa"
       },
       "Permalink": {
         "description": "Permite crear un enlace permanente del recurso actual a la vista",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1497,6 +1497,10 @@
         "height": "la taille"
       }
     },
+    "dynamiclegend": {
+      "title": "Légende",
+      "tooltip": "Affiche la légende de la carte"
+    },
     "permalink": {
       "title": "Permalink",
       "shareLinkTitle": "Permalien généré",
@@ -3427,6 +3431,10 @@
       "Share": {
         "description": "Permet de partager la carte de diverses manières (lien, QR-Code, embarqué, réseaux sociaux ...)",
         "title": "Outil de partage"
+      },
+      "DynamicLegend": {
+        "title": "Légende",
+        "description": "Affiche la légende de la carte"
       },
       "Permalink": {
         "description": "Permet de créer un permalien de la ressource courante en vue",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1496,6 +1496,10 @@
         "height": "altezza"
       }
     },
+    "dynamiclegend": {
+      "title": "Legenda",
+      "tooltip": "Visualizza la legenda della mappa"
+    },
     "permalink": {
       "title": "Permalink",
       "shareLinkTitle": "Permalink generato",
@@ -3428,6 +3432,10 @@
       "Share": {
         "description": "Permette di condividere la mappa in diversi modi (link, QR-Code, embed, social network ...)",
         "title": "Strumento di condivisione"
+      },
+      "DynamicLegend": {
+        "title": "Legenda",
+        "description": "Visualizza la legenda della mappa"
       },
       "Permalink": {
         "description": "Permette di creare un permalink della risorsa attualmente in vista",


### PR DESCRIPTION
## Description
Displays the legend of the ArcGIS & WMS layers visible in the current extent of the map

![440788441-9596eab8-5042-48cb-8737-cb850a74ac27](https://github.com/user-attachments/assets/96ee848c-1726-4f6c-8aad-8621246880d5)


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
No floating legend
#<issue>

**What is the new behavior?**
Displays in a modal the legend of the ArcGIS & WMS layers visible in the current extent of the map and so automatically adapts its content on zoom in/out, pan or layers visibility toggle on/off
Displays the legends in the same hierarchy as the Layer List

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
