### PR TITLE
[Backport 2025.01.xx] Fix #11099 Align the behavior of contexts management on the front end to the backend model (#11108)

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -669,8 +669,7 @@ Finally replace the content of the `common` and `maps` (homepage) sections with 
                                 {
                                     "labelId": "resourcesCatalog.createContext",
                                     "type": "link",
-                                    "href": "#/context-creator/new",
-                                    "disableIf": "{state('userrole') !== 'ADMIN'}"
+                                    "href": "#/context-creator/new"
                                 }
                             ]
                         }

--- a/web/client/components/contextcreator/__tests__/ConfigurePluginsStep-test.jsx
+++ b/web/client/components/contextcreator/__tests__/ConfigurePluginsStep-test.jsx
@@ -239,4 +239,29 @@ describe('ConfigurePluginsStep component', () => {
         expect(docLink.length).toBe(1);
         expect(docLink[0].href).toBe(docUrl);
     });
+    it('should render upload and remove button when hideUploadExtension is false', () => {
+        const plugins = [{
+            title: "Extension",
+            isExtension: true,
+            enabled: false,
+            name: "Plugin_1",
+            description: "Test plugin"
+        }];
+        ReactDOM.render(<ConfigurePluginsStep allPlugins={plugins} hideUploadExtension={false}/>, document.getElementById("container"));
+        const buttonsGlyphicon = [...document.querySelectorAll('button .glyphicon')];
+        expect(buttonsGlyphicon.length).toBe(2);
+        expect(buttonsGlyphicon.map(glyph => glyph.getAttribute('class'))).toEqual(['glyphicon glyphicon-upload', 'glyphicon glyphicon-trash']);
+    });
+    it('should not render upload and remove button when hideUploadExtension is true', () => {
+        const plugins = [{
+            title: "Extension",
+            isExtension: true,
+            enabled: false,
+            name: "Plugin_1",
+            description: "Test plugin"
+        }];
+        ReactDOM.render(<ConfigurePluginsStep allPlugins={plugins} hideUploadExtension/>, document.getElementById("container"));
+        const buttonsGlyphicon = [...document.querySelectorAll('button .glyphicon')];
+        expect(buttonsGlyphicon.length).toBe(0);
+    });
 });

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -868,8 +868,7 @@
                 {
                   "labelId": "resourcesCatalog.createContext",
                   "type": "link",
-                  "href": "#/context-creator/new",
-                  "disableIf": "{state('userrole') !== 'ADMIN'}"
+                  "href": "#/context-creator/new"
                 }
               ]
             }

--- a/web/client/plugins/ContextCreator.jsx
+++ b/web/client/plugins/ContextCreator.jsx
@@ -39,7 +39,8 @@ import {
     selectedThemeSelector,
     customVariablesEnabledSelector,
     isNewContext,
-    tutorialsSelector
+    tutorialsSelector,
+    hideUploadExtensionSelector
 } from '../selectors/contextcreator';
 import {mapTypeSelector} from '../selectors/maptype';
 import {tutorialSelector} from '../selectors/tutorial';
@@ -89,7 +90,8 @@ export const contextCreatorSelector = createStructuredSelector({
     showBackToPageConfirmation: showBackToPageConfirmationSelector,
     selectedTheme: selectedThemeSelector,
     customVariablesEnabled: customVariablesEnabledSelector,
-    enableClickOnStep: state => !isNewContext(state)
+    enableClickOnStep: state => !isNewContext(state),
+    hideUploadExtension: hideUploadExtensionSelector
 });
 
 /**

--- a/web/client/selectors/__tests__/contextcreator-test.js
+++ b/web/client/selectors/__tests__/contextcreator-test.js
@@ -16,7 +16,8 @@ import {
     prefetchedDataSelector,
     disableImportSelector,
     generateContextResource,
-    isNewPluginsUploaded
+    isNewPluginsUploaded,
+    hideUploadExtensionSelector
 } from '../contextcreator';
 
 const testState = {
@@ -204,5 +205,10 @@ describe('contextcreator selectors', () => {
                 uploadedPlugins: []
             }
         })).toBeFalsy();
+    });
+    it('hideUploadExtensionSelector', () => {
+        expect(hideUploadExtensionSelector()).toBe(true);
+        expect(hideUploadExtensionSelector({ security: { user: { role: 'ADMIN' } } })).toBe(false);
+        expect(hideUploadExtensionSelector({ security: { user: { role: 'ADMIN' } } }, { hideUploadExtension: true })).toBe(true);
     });
 });

--- a/web/client/selectors/contextcreator.js
+++ b/web/client/selectors/contextcreator.js
@@ -11,6 +11,7 @@ import { get, omit, pick } from 'lodash';
 import { mapSelector } from './map';
 import { mapSaveSelector } from './mapsave';
 import { flattenPluginTree, makePlugins } from '../utils/ContextCreatorUtils';
+import { isAdminUserSelector } from './security';
 
 export const newContextSelector = state => state.contextcreator && state.contextcreator.newContext;
 export const mapConfigSelector = createSelector(newContextSelector, context => context && context.mapConfig);
@@ -105,4 +106,12 @@ export const generateContextResource = (state) => {
 export const isNewPluginsUploaded = (state) => {
     const uploadedPlugins = state.contextcreator?.uploadedPlugins || [];
     return uploadedPlugins.length > 0;
+};
+
+export const hideUploadExtensionSelector = (state, props) => {
+    // prioritize cfg configuration over state selector
+    if (props?.hideUploadExtension !== undefined) {
+        return props.hideUploadExtension;
+    }
+    return !isAdminUserSelector(state);
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR remove restriction on creating Context resources by allowing all user roles.
The upload and remove buttons of extensions management are visible only to admin users

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11099

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

All users can create and edit contexts

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] Yes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
