### PR TITLE
#10836: Allow printing by freely setting the scale factor

### DIFF
--- a/web/client/actions/__tests__/print-test.js
+++ b/web/client/actions/__tests__/print-test.js
@@ -103,6 +103,22 @@ describe('Test correctness of the print actions', () => {
         expect(retVal.currentLocale).toBe('en-US');
         expect(retVal.useFixedScales).toBe(true);
     });
+    it('configurePrintMap with disableScaleLocking', () => {
+        const retVal = configurePrintMap({x: 1, y: 1}, 5, 6, 2.0, [], 'EPSG:4326', 'en-US', true, true);
+        expect(retVal).toExist();
+        expect(retVal.type).toBe(CONFIGURE_PRINT_MAP);
+        expect(retVal.center).toExist();
+        expect(retVal.center.x).toBe(1);
+        expect(retVal.zoom).toBe(5);
+        expect(retVal.scaleZoom).toBe(6);
+        expect(retVal.scale).toBe(2.0);
+        expect(retVal.layers).toExist();
+        expect(retVal.layers.length).toBe(0);
+        expect(retVal.projection).toBe('EPSG:4326');
+        expect(retVal.currentLocale).toBe('en-US');
+        expect(retVal.useFixedScales).toBe(true);
+        expect(retVal.disableScaleLocking).toBe(true);
+    });
 
     it('changePrintZoomLevel', () => {
         const retVal = changePrintZoomLevel(5, 10000);

--- a/web/client/actions/print.js
+++ b/web/client/actions/print.js
@@ -132,7 +132,7 @@ export function printTransformerAdded(name) {
     };
 }
 
-export function configurePrintMap(center, zoom, scaleZoom, scale, layers, projection, currentLocale, useFixedScales) {
+export function configurePrintMap(center, zoom, scaleZoom, scale, layers, projection, currentLocale, useFixedScales = false, disableScaleLockingParams = {}) {
     return {
         type: CONFIGURE_PRINT_MAP,
         center,
@@ -142,19 +142,22 @@ export function configurePrintMap(center, zoom, scaleZoom, scale, layers, projec
         layers,
         projection,
         currentLocale,
-        useFixedScales
+        useFixedScales,
+        disableScaleLocking: disableScaleLockingParams?.disableScaleLocking || false,
+        mapResolution: disableScaleLockingParams?.mapResolution
     };
 }
 
-export function changePrintZoomLevel(zoom, scale) {
+export function changePrintZoomLevel(zoom, scale, resolution) {
     return {
         type: CHANGE_PRINT_ZOOM_LEVEL,
         zoom,
-        scale
+        scale,
+        resolution
     };
 }
 
-export function changeMapPrintPreview(center, zoom, bbox, size, mapStateSource, projection) {
+export function changeMapPrintPreview(center, zoom, bbox, size, mapStateSource, projection, _, resolution) {
     return {
         type: CHANGE_MAP_PRINT_PREVIEW,
         center,
@@ -162,6 +165,7 @@ export function changeMapPrintPreview(center, zoom, bbox, size, mapStateSource, 
         bbox,
         size,
         mapStateSource,
-        projection
+        projection,
+        resolution
     };
 }

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -68,7 +68,8 @@ class OpenlayersMap extends React.Component {
         onWarning: PropTypes.func,
         maxExtent: PropTypes.array,
         limits: PropTypes.object,
-        onMouseOut: PropTypes.func
+        onMouseOut: PropTypes.func,
+        disableScaleLocking: PropTypes.bool
     };
 
     static defaultProps = {
@@ -90,7 +91,8 @@ class OpenlayersMap extends React.Component {
         interactive: true,
         onMouseOut: () => {},
         center: { x: 13, y: 45, crs: 'EPSG:4326' },
-        zoom: 5
+        zoom: 5,
+        disableScaleLocking: false
     };
 
     componentDidMount() {
@@ -558,7 +560,12 @@ class OpenlayersMap extends React.Component {
             let center = reproject({ x: newProps.center.x, y: newProps.center.y }, 'EPSG:4326', newProps.projection, true);
             view.setCenter([center.x, center.y]);
         }
-        if (Math.round(newProps.zoom) !== this.props.zoom) {
+        if (this.props.disableScaleLocking) {
+            // this is for map print only
+            if (newProps.mapResolution !== this.props.mapResolution) {
+                view.setResolution(newProps.mapResolution);
+            }
+        } else if (Math.round(newProps.zoom) !== this.props.zoom) {
             view.setZoom(Math.round(newProps.zoom));
         }
         if (newProps.bbox && newProps.bbox.rotation !== undefined || this.bbox && this.bbox.rotation !== undefined && newProps.bbox.rotation !== this.props.bbox.rotation) {

--- a/web/client/components/map/openlayers/ZoomSlider.jsx
+++ b/web/client/components/map/openlayers/ZoomSlider.jsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect } from 'react';
+import ZoomSlider from 'ol/control/ZoomSlider';
+
+export default function ZoomSliderComp({
+    className = 'ol-zoomslider',
+    duration = 200,
+    map
+}) {
+    useEffect(() => {
+        let zoomSlider = new ZoomSlider({
+            className, duration
+        });
+        if (map) {
+            map.addControl(zoomSlider);
+        }
+        return () => {
+            if (document.querySelector(className)) {
+                try {
+                    map.getViewport().removeChild(document.querySelector(className));
+                } catch (e) {
+                    // do nothing...
+                }
+
+            }
+        };
+    }, []);
+    return null;
+}

--- a/web/client/components/map/openlayers/__tests__/ZoomSlider-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/ZoomSlider-test.jsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+import ZoomSlider from '../ZoomSlider';
+
+import { Map, View } from 'ol';
+import { act } from 'react-dom/test-utils';
+
+describe('Openlayers ZoomSlider component', () => {
+    let map;
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="map"></div><div id="container"></div>';
+        map = new Map({
+            layers: [
+            ],
+            target: 'map',
+            view: new View({
+                center: [0, 0],
+                zoom: 5
+            })
+        });
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        map.setTarget(null);
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('create ZoomSlider with defaults', () => {
+        act(() => {ReactDOM.render(<ZoomSlider map={map}/>, document.getElementById("container"));});
+        const domMap = map.getViewport();
+        const zoomSliders = domMap.getElementsByClassName('ol-zoomslider');
+        expect(zoomSliders.length).toBe(1);
+    });
+});

--- a/web/client/components/map/openlayers/index.js
+++ b/web/client/components/map/openlayers/index.js
@@ -4,6 +4,7 @@ import LMapComp from './Map.jsx';
 import MeasurementSupportComp from './MeasurementSupport';
 import OverviewComp from './Overview';
 import ScaleBarComp from './ScaleBar';
+import ZoomSliderComp from './ZoomSlider';
 
 export const Feature = FeatureComp;
 export const LLayer = LLayerComp;
@@ -11,6 +12,7 @@ export const LMap = LMapComp;
 export const MeasurementSupport = MeasurementSupportComp;
 export const Overview = OverviewComp;
 export const ScaleBar = ScaleBarComp;
+export const ZoomSlider = ZoomSliderComp;
 
 export default {
     LLayer,
@@ -18,5 +20,6 @@ export default {
     MeasurementSupport,
     Overview,
     ScaleBar,
-    Feature
+    Feature,
+    ZoomSlider
 };

--- a/web/client/components/map/plugins/openlayers.js
+++ b/web/client/components/map/plugins/openlayers.js
@@ -17,7 +17,8 @@ export default () => {
         ScaleBar: require('../openlayers/ScaleBar').default,
         DrawSupport: require('../openlayers/DrawSupport').default,
         PopupSupport: require('../openlayers/PopupSupport').default,
-        BoxSelectionSupport: require('../openlayers/BoxSelectionSupport').default
+        BoxSelectionSupport: require('../openlayers/BoxSelectionSupport').default,
+        ZoomSlider: require('../openlayers/ZoomSlider').default
     };
 };
 

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -227,6 +227,7 @@ class MapPlugin extends React.Component {
         toolsOptions: {
             measurement: {},
             locate: {},
+            zoomSlider: {},
             scalebar: {
                 [MapLibraries.LEAFLET]: {
                     position: "bottomright"

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -39,6 +39,7 @@ import { MapLibraries } from '../utils/MapTypeUtils';
 import FlexBox from '../components/layout/FlexBox';
 import Text from '../components/layout/Text';
 import Button from '../components/layout/Button';
+import { getResolutionMultiplier } from '../utils/PrintUtils';
 
 /**
  * Print plugin. This plugin allows to print current map view. **note**: this plugin requires the  **printing module** to work.
@@ -92,6 +93,9 @@ import Button from '../components/layout/Button';
  *
  * @prop {boolean} cfg.useFixedScales if true the printing scale is constrained to the nearest scale of the ones configured
  * in the config.yml file, if false the current scale is used
+ * @prop {boolean} cfg.disableScaleLocking if true the print service can take scale value rather than of the capabilities scales in case it is configured in the config.yml file,
+ * if false the default behavior of taking a scale within the capabilities scales
+ * if useFixedScales = true and disableScaleLocking = true --> the disableScaleLocking setting will override the fixed scales
  * @prop {object} cfg.overrideOptions overrides print options, this will override options created from current state of map
  * @prop {boolean} cfg.overrideOptions.geodetic prints in geodetic mode: in geodetic mode scale calculation is more precise on
  * printed maps, but the preview is not accurate
@@ -350,7 +354,8 @@ export default {
                         overrideOptions: {},
                         items: [],
                         printingService: getDefaultPrintingService(),
-                        printMap: {}
+                        printMap: {},
+                        disableScaleLocking: false
                     };
                     constructor(props) {
                         super(props);
@@ -397,7 +402,7 @@ export default {
                         const map = this.props.printingService.getMapConfiguration();
                         return {
                             ...map,
-                            layers: this.filterLayers(map.layers, this.props.useFixedScales ? map.scaleZoom : map.zoom, map.projection)
+                            layers: this.filterLayers(map.layers, this.props.useFixedScales && !this.props.disableScaleLocking ? map.scaleZoom : map.zoom, map.projection)
                         };
                     };
                     getMapSize = (layout) => {
@@ -410,7 +415,7 @@ export default {
                     getPreviewResolution = (zoom, projection) => {
                         const dpu = dpi2dpu(DEFAULT_SCREEN_DPI, projection);
                         const roundZoom = Math.round(zoom);
-                        const scale = this.props.useFixedScales
+                        const scale = this.props.useFixedScales && !this.props.disableScaleLocking
                             ? getPrintScales(this.props.capabilities)[roundZoom]
                             : this.props.scales[roundZoom];
                         return scale / dpu;
@@ -582,7 +587,13 @@ export default {
                         }
                         return filtered;
                     };
-
+                    getRatio = () => {
+                        let mapPrintLayout = this.getLayout();
+                        if (this.props?.mapWidth && mapPrintLayout) {
+                            return getResolutionMultiplier(mapPrintLayout?.map?.width || 0, this?.props?.mapWidth || 0, this.props.printRatio);
+                        }
+                        return 1;
+                    };
                     configurePrintMap = (props) => {
                         const {
                             map: newMap,
@@ -592,7 +603,8 @@ export default {
                             currentLocale,
                             layers,
                             printMap,
-                            printSpec
+                            printSpec,
+                            disableScaleLocking
                         } = props || this.props;
                         if (newMap && newMap.bbox && capabilities) {
                             const selectedPrintProjection = (printSpec && printSpec?.params?.projection) || (printSpec && printSpec?.projection) || (printMap && printMap.projection) || 'EPSG:3857';
@@ -603,14 +615,19 @@ export default {
                             const scales = getPrintScales(capabilities);
                             const printMapScales = getScales(printSrs);
                             const scaleZoom = getNearestZoom(zoom, scales, printMapScales);
-                            if (useFixedScales) {
+                            if (useFixedScales && !disableScaleLocking) {
                                 const scale = scales[scaleZoom];
                                 configurePrintMapProp(newMap.center, zoom, scaleZoom, scale,
                                     layers, newMap.projection, currentLocale, useFixedScales);
                             } else {
                                 const scale = printMapScales[zoom];
-                                configurePrintMapProp(newMap.center, zoom, scaleZoom, scale,
-                                    layers, newMap.projection, currentLocale, useFixedScales);
+                                let resolutions = getResolutions(printSrs).map((resolution) => resolution * this.getRatio());
+                                const reqScaleZoom = disableScaleLocking ? zoom : scaleZoom;
+                                configurePrintMapProp(newMap.center, zoom, reqScaleZoom, scale,
+                                    layers, newMap.projection, currentLocale, useFixedScales, {
+                                        disableScaleLocking,
+                                        mapResolution: resolutions[zoom]
+                                    });
                             }
                         }
                     };
@@ -622,7 +639,7 @@ export default {
                             excludeLayersFromLegend: this.props.excludeLayersFromLegend,
                             mergeableParams: this.props.mergeableParams,
                             layers: this.getMapConfiguration()?.layers,
-                            scales: this.props.useFixedScales ? getPrintScales(this.props.capabilities) : undefined,
+                            scales: this.props.useFixedScales && !this.props.disableScaleLocking ? getPrintScales(this.props.capabilities) : undefined,
                             bbox: this.props.map?.bbox
                         })
                             .then((spec) =>

--- a/web/client/plugins/__tests__/Print-test.jsx
+++ b/web/client/plugins/__tests__/Print-test.jsx
@@ -286,6 +286,50 @@ describe('Print Plugin', () => {
             }
         });
     });
+    it('test configuration with disableScaleLocking = true', (done) => {
+        const printingService = {
+            getMapConfiguration() {
+                return {
+                    layers: [],
+                    center: {
+                        x: 0,
+                        y: 0,
+                        crs: "EPSG:4326"
+                    }
+                };
+            },
+            validate() { return {};}
+        };
+        getPrintPlugin({
+            state: {...initialState,
+                print: {...initialState.print,
+                    capabilities: {...initialState.print.capabilities,
+                        scales: [1000000, 500000, 100000].map(value => ({name: value, value}))}
+                }}
+        }).then(({ Plugin }) => {
+            try {
+                ReactDOM.render(<Plugin
+                    projectionOptions={{
+                        "projections": [{"name": "UTM32N", "value": "EPSG:23032"}, {"name": "EPSG:3857", "value": "EPSG:3857"}, {"name": "EPSG:4326", "value": "EPSG:4326"}]
+                    }}
+                    printingService={printingService}
+                    disableScaleLocking mapPreviewOptions={{
+                        enableScalebox: false
+                    }}/>, document.getElementById("container"));
+                const comp = document.getElementById("container");
+                ReactTestUtils.act(() => new Promise((resolve) => resolve(comp))).then(()=>{
+                    expect(comp).toExist();
+                    const scaleBoxComp = document.querySelector("#mappreview-scalebox select");
+                    expect(scaleBoxComp).toNotExist();
+                    const zoomSlider = document.querySelector('.ol-zoomslider');
+                    expect(zoomSlider).toExist();
+                    done();
+                });
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
     it('default configuration with not allowed layers', (done) => {
         getPrintPlugin({
             layers: [{visibility: true, type: "bing"}]

--- a/web/client/plugins/map/index.js
+++ b/web/client/plugins/map/index.js
@@ -117,6 +117,7 @@ const pluginsCreator = (mapType, actions) => {
             tools: {
                 overview: components.Overview || Empty,
                 scalebar: components.ScaleBar || Empty,
+                zoomSlider: components.ZoomSlider || Empty,
                 draw: DrawSupport,
                 highlight: HighlightSupport,
                 selection: SelectionSupport,

--- a/web/client/plugins/print/MapPreview.jsx
+++ b/web/client/plugins/print/MapPreview.jsx
@@ -3,11 +3,20 @@ import PropTypes from "prop-types";
 
 import MapPreviewComp from "../../components/print/MapPreview";
 import Message from "../../components/I18N/Message";
+import { getScales } from "../../utils/MapUtils";
+import { assign } from "lodash";
 
 export const MapPreview = ({mapSize, layout, layoutName, resolutions, useFixedScales,
     localizedLayerStylesEnv, mapPreviewOptions, mapType,
-    map, capabilities, onRefresh, validation = {valid: true}, ...rest}) => {
-    const scales = capabilities.scales.slice(0).reverse().map((scale) => parseFloat(scale.value)) || [];
+    map, capabilities, onRefresh, validation = {valid: true}, disableScaleLocking, printMap, printSpec, ...rest}) => {
+    // scales need to be reviewed
+    let printSpecState = printSpec && assign({}, printSpec, printMap || {});
+    const selectedPrintProjection = (printSpecState && printSpecState?.params?.projection) || (printSpecState && printSpecState?.projection) || (printMap && printMap.projection) || 'EPSG:3857';
+    // need to be reviewed
+    const scales = disableScaleLocking ? getScales(
+        selectedPrintProjection,
+        map && map.mapOptions && map.mapOptions.view && map.mapOptions.view.DPI || null
+    ) : capabilities.scales.slice(0).reverse().map((scale) => parseFloat(scale.value)) || [];
     return validation.valid ? (
         <MapPreviewComp
             {...rest}
@@ -21,6 +30,7 @@ export const MapPreview = ({mapSize, layout, layoutName, resolutions, useFixedSc
             resolutions={resolutions}
             useFixedScales={useFixedScales}
             env={localizedLayerStylesEnv}
+            disableScaleLocking={disableScaleLocking}
             {...mapPreviewOptions}
         />
     ) : <div id="map-preview-disabled-message"><Message msgId="print.disabledpreview"/></div>;

--- a/web/client/reducers/__tests__/print-test.js
+++ b/web/client/reducers/__tests__/print-test.js
@@ -129,7 +129,28 @@ describe('Test the print reducer', () => {
         expect(state.map.projection).toBe('EPSG:4326');
         expect(state.map.useFixedScales).toBe(true);
     });
-
+    it('configure print map with disableScaleLocking = true', () => {
+        const state = print({capabilities: {}, spec: {}}, {
+            type: CONFIGURE_PRINT_MAP,
+            center: {x: 1, y: 1},
+            zoom: 5,
+            scaleZoom: 6,
+            scale: 10000,
+            layers: [],
+            projection: 'EPSG:4326',
+            useFixedScales: true,
+            disableScaleLocking: true
+        });
+        expect(state.map).toExist();
+        expect(state.map.center).toExist();
+        expect(state.map.center.x).toBe(1);
+        expect(state.map.zoom).toBe(5);
+        expect(state.map.scale).toBe(10000);
+        expect(state.map.layers.length).toBe(0);
+        expect(state.map.projection).toBe('EPSG:4326');
+        expect(state.map.useFixedScales).toBe(true);
+        expect(state.map.disableScaleLocking).toBe(true);
+    });
     it('configure print map title', () => {
         const state = print({capabilities: {}, spec: {}}, {
             type: CONFIGURE_PRINT_MAP,
@@ -168,7 +189,21 @@ describe('Test the print reducer', () => {
         expect(state.map.zoom).toBe(7);
         expect(state.map.scaleZoom).toBe(8);
     });
-
+    it('change print zoom level with resolution', () => {
+        const state = print({capabilities: {}, spec: {}, map: {
+            zoom: 5,
+            scaleZoom: 6
+        }}, {
+            type: CHANGE_PRINT_ZOOM_LEVEL,
+            zoom: 8,
+            scale: 10000,
+            resolution: 123456
+        });
+        expect(state.map).toExist();
+        expect(state.map.zoom).toBe(7);
+        expect(state.map.scaleZoom).toBe(8);
+        expect(state.map.mapResolution).toBe(123456);
+    });
     it('change map print preview', () => {
         const state = print({capabilities: {}, spec: {}}, {
             type: CHANGE_MAP_PRINT_PREVIEW,
@@ -190,7 +225,29 @@ describe('Test the print reducer', () => {
             "crs": "EPSG:4326"
         });
     });
-
+    it('change map print preview with resolution value', () => {
+        const state = print({capabilities: {}, spec: {}}, {
+            type: CHANGE_MAP_PRINT_PREVIEW,
+            size: 1000,
+            center: {
+                "x": 15.935325658757531,
+                "y": 42.729598714490606,
+                "crs": "EPSG:4326"
+            },
+            zoom: 6,
+            resolution: 123456
+        });
+        expect(state.map).toExist();
+        expect(state.map.size).toEqual(1000);
+        expect(state.map.zoom).toEqual(6);
+        expect(state.map.scaleZoom).toEqual(6);
+        expect(state.map.center).toEqual({
+            "x": 15.935325658757531,
+            "y": 42.729598714490606,
+            "crs": "EPSG:4326"
+        });
+        expect(state.map.mapResolution).toEqual(123456);
+    });
     it('print submitting', () => {
         const state = print({capabilities: {}, spec: {}}, {
             type: PRINT_SUBMITTING
@@ -295,6 +352,31 @@ describe('Test the print reducer', () => {
         expect(state.map.layers.length).toBe(1);
         expect(state.map.layers[0].title).toBe('Layer001');
         expect(state.map.projection).toBe('EPSG:4326');
+    });
+    it('configure print map with disableScaleLocking and mapResolution', () => {
+        const state = print({capabilities: {}, spec: {}}, {
+            type: CONFIGURE_PRINT_MAP,
+            center: {x: 1, y: 1},
+            zoom: 5,
+            scaleZoom: 6,
+            scale: 10000,
+            layers: [{
+                title: 'Layer001'
+            }],
+            projection: 'EPSG:4326',
+            disableScaleLocking: true,
+            mapResolution: 123456
+        });
+        expect(state.map).toExist();
+        expect(state.map.center).toExist();
+        expect(state.map.center.x).toBe(1);
+        expect(state.map.zoom).toBe(5);
+        expect(state.map.scale).toBe(10000);
+        expect(state.map.layers.length).toBe(1);
+        expect(state.map.layers[0].title).toBe('Layer001');
+        expect(state.map.projection).toBe('EPSG:4326');
+        expect(state.map.disableScaleLocking).toEqual(true);
+        expect(state.map.mapResolution).toEqual(123456);
     });
     it('default legend options', () => {
         const state = print(undefined, {});

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -98,7 +98,9 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
                 layers,
                 size: action.size ?? state.map?.size,
                 projection: action.projection,
-                useFixedScales: action.useFixedScales
+                useFixedScales: action.useFixedScales,
+                disableScaleLocking: action.disableScaleLocking,
+                mapResolution: action?.mapResolution
             },
             error: null
         }
@@ -110,7 +112,8 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
             map: assign({}, state.map, {
                 scaleZoom: action.zoom,
                 zoom: state.map.zoom + diff >= 0 ? state.map.zoom + diff : 0,
-                scale: action.scale
+                scale: action.scale,
+                mapResolution: action.resolution
             })
         }
         );
@@ -122,7 +125,8 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
                 zoom: action.zoom,
                 scaleZoom: action.zoom,
                 bbox: action.bbox,
-                center: action.center
+                center: action.center,
+                mapResolution: action.resolution
             })
         }
         );

--- a/web/client/themes/default/less/select.less
+++ b/web/client/themes/default/less/select.less
@@ -99,6 +99,11 @@
             .background-color-var(@theme-vars[main-bg]);
         }
     }
+    #mappreview-scalebox{
+        .scale-box-create-select{
+            min-width: 160px;
+        }
+    }
 }
 
 // **************

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -838,7 +838,8 @@
       "projection": "Koordinatensystem",
       "projectionmismatch": "Nichtübereinstimmung des Koordinatensystems zwischen gedruckter und Bildschirmkarte",
       "graticule": "Raster mit Etiketten hinzufügen",
-      "additionalLayers": "Überlagerungen einschließen"
+      "additionalLayers": "Überlagerungen einschließen",
+      "createScaleOption": "Gewünschten Skalenwert hinzufügen"
     },
     "backgroundSwitcher": {
       "tooltip": "Wähle Hintergrund"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -799,7 +799,8 @@
       "projection": "Coordinates System",
       "projectionmismatch": "Coordinate system mismatch among printed and screen map",
       "graticule": "add grid with labels",
-      "additionalLayers": "Include overlays"
+      "additionalLayers": "Include overlays",
+      "createScaleOption": "Add desired scale value"
     },
     "backgroundSwitcher": {
       "tooltip": "Select Background"

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -799,7 +799,8 @@
       "projection": "Sistema de coordenadas",
       "projectionmismatch": "Falta de coincidencia del sistema de coordenadas entre el mapa impreso y en pantalla",
       "graticule": "agregar cuadrícula con etiquetas",
-      "additionalLayers": "Incluir superposiciones"
+      "additionalLayers": "Incluir superposiciones",
+      "createScaleOption": "Agregar el valor de escala deseado"
     },
     "backgroundSwitcher": {
       "tooltip": "Selección del fondo"

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -799,7 +799,8 @@
       "projection": "Système de coordonnées",
       "projectionmismatch": "Non-concordance du système de coordonnées entre la carte imprimée et la carte à l'écran",
       "graticule": "ajouter une grille avec des étiquettes",
-      "additionalLayers": "Inclure les superpositions"
+      "additionalLayers": "Inclure les superpositions",
+      "createScaleOption": "Ajouter la valeur d'échelle souhaitée"
     },
     "backgroundSwitcher": {
       "tooltip": "Sélection du fond de plan"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -799,7 +799,8 @@
       "projection": "Sistema di coordinate",
       "projectionmismatch": "Sistema di coordinate di stampa diverso da quello a schermo",
       "graticule": "aggiungi griglia con label",
-      "additionalLayers": "Includi sovrapposizioni"
+      "additionalLayers": "Includi sovrapposizioni",
+      "createScaleOption": "Aggiungi il valore di scala desiderato"
     },
     "backgroundSwitcher": {
       "tooltip": "Scegli lo sfondo"

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -410,6 +410,24 @@ export function getZoomFromResolution(targetResolution, resolutions = getResolut
     return zoom;
 }
 
+/**
+ * Calculate the exact zoom level corresponding to a given resolution
+ *
+ * @param {number} targetResolution resolution to be converted in zoom
+ * @param {number[]} resolutions list of all available resolutions
+ * @returns {number} - A floating-point number representing the exact zoom level that corresponds
+ *                   to the provided resolution.
+ *
+ * @example
+ * const resolutions = [2048, 1024, 512, 256];
+ * const zoom = getExactZoom(600, resolutions);
+ * console.log(zoom); // e.g., ~1.77
+ */
+export function getExactZoomFromResolution(targetResolution, resolutions = getResolutions()) {
+    const maxResolution = resolutions[0]; // zoom level 0
+    return Math.log2(maxResolution / targetResolution);
+}
+
 export function defaultGetZoomForExtent(extent, mapSize, minZoom, maxZoom, dpi, mapResolutions) {
     const wExtent = extent[2] - extent[0];
     const hExtent = extent[3] - extent[1];
@@ -944,6 +962,7 @@ export const getResolutionObject = (value, type, {projection, resolutions} = {})
         zoom: getZoomFromResolution(value, resolutions)
     };
 };
+window.__ = getResolutionObject;
 
 export function calculateExtent(center = {x: 0, y: 0, crs: "EPSG:3857"}, resolution, size = {width: 100, height: 100}, projection = "EPSG:3857") {
     const {x, y} = reproject(center, center.crs ?? projection, projection);

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -281,10 +281,10 @@ export const getMapfishPrintSpecification = (rawSpec, state) => {
     const spec = {...baseSpec, ...params};
     const printMap = state?.print?.map;
     const projectedCenter = reproject(spec.center, 'EPSG:4326', spec.projection);
-    // * use [spec.zoom] the actual zoom in case useFixedScale = false else use [spec.scaleZoom] the fixed zoom scale not actual
-    const projectedZoom = Math.round(printMap?.useFixedScales ? spec.scaleZoom : spec.zoom);
+    // * use [spec.zoom] the actual zoom in case useFixedScales = false else use [spec.scaleZoom] the fixed zoom scale not actual
+    const projectedZoom = Math.round(printMap?.useFixedScales && !printMap?.disableScaleLocking ? spec.scaleZoom : spec.zoom);
     const scales = spec.scales || getScales(spec.projection);
-    const reprojectedScale = scales[projectedZoom] || defaultScales[projectedZoom];
+    const reprojectedScale = printMap?.disableScaleLocking ? scales[projectedZoom] : scales[projectedZoom] || defaultScales[projectedZoom];
 
     const projectedSpec = {
         ...spec,

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -42,7 +42,8 @@ import {
     getResolutionObject,
     reprojectZoom,
     getRandomPointInCRS,
-    convertResolution
+    convertResolution,
+    getExactZoomFromResolution
 } from '../MapUtils';
 import { VisualizationModes } from '../MapTypeUtils';
 
@@ -2430,5 +2431,11 @@ describe('Test the MapUtils', () => {
     });
     it('convertResolution', () => {
         expect(convertResolution('EPSG:3857', 'EPSG:4326', 2000).transformedResolution).toBe(0.017986440587896155);
+    });
+    it('test get exact zoom level from resolution using getExactZoomFromResolution', () => {
+        const resolutions =  [156543, 78271, 39135, 19567, 9783, 4891, 2445, 1222];
+        expect(getExactZoomFromResolution(100000, resolutions)).toEqual(0.6465589981535295);
+        expect(getExactZoomFromResolution(50000, resolutions)).toEqual(1.6465589981535294);
+        expect(getExactZoomFromResolution(10000, resolutions)).toEqual(3.9684870930408915);
     });
 });

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -670,6 +670,39 @@ describe('PrintUtils', () => {
         expect(printSpec).toExist();
         expect(printSpec.pages[0].scale).toBe(getScales(projection)[3]);
     });
+    it('getMapfishPrintSpecification with disableScaleLocking', () => {
+        const printSpec = getMapfishPrintSpecification({
+            ...testSpec,
+            scaleZoom: 3,
+            scales: [2030400, 1020020, 504060, 104020, 50406],
+            zoom: 3
+        }, {
+            print: {
+                map: {
+                    disableScaleLocking: true
+                }
+            }
+        });
+        expect(printSpec).toExist();
+        expect(printSpec.pages[0].scale).toBe(104020);
+    });
+    it('getMapfishPrintSpecification with disableScaleLocking = true and useFixedScales = true', () => {
+        const printSpec = getMapfishPrintSpecification({
+            ...testSpec,
+            scaleZoom: 3,
+            scales: [2030400, 1020020, 504060, 104020, 50406],
+            zoom: 3
+        }, {
+            print: {
+                map: {
+                    disableScaleLocking: true,
+                    useFixedScales: true
+                }
+            }
+        });
+        expect(printSpec).toExist();
+        expect(printSpec.pages[0].scale).toBe(104020);
+    });
     it('from rgba to rgb', () => {
         const rgb = rgbaTorgb("rgba(255, 255, 255, 0.1)");
         expect(rgb).toExist();


### PR DESCRIPTION
This PR handles allowing printing by freely setting using zoom slider or entering a value in DD of scales if a cfg '**disableScaleLocking**' for Print plugin equals true and compatable with print service in config.yml file.
This PR includes: 
- creating ZoomSliderComp
- allow to configure **disableScaleLocking** for print plugin to enable disable scales lock in print to be compatable with print service
- handle editable DD for scales by adding new scale values to list
- handle sending the actual scale of map in case **disableScaleLocking = true**
- if **useFixedScales** and **disableScaleLocking** are configured to Print plugin the priority will be for **disableScaleLocking** 
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10839 

**What is the new behavior?**
User can print with be set freely using zoom slider or entering a value in DD of scales

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
