### PR TITLE
[Backport 2025.01.xx] Fix #11097 Confirmation modal should not appear if no changes are made (#11125)

### DIFF
--- a/web/client/plugins/ResourcesCatalog/actions/__tests__/resources-test.js
+++ b/web/client/plugins/ResourcesCatalog/actions/__tests__/resources-test.js
@@ -79,9 +79,10 @@ describe('resources actions', () => {
         });
     });
     it('updateSelectedResource', () => {
-        expect(updateSelectedResource({ name: 'Title' }, 'catalog')).toEqual({
+        expect(updateSelectedResource({ name: 'Title' }, false, 'catalog')).toEqual({
             type: UPDATE_SELECTED_RESOURCE,
             properties: { name: 'Title' },
+            initialize: false,
             id: 'catalog'
         });
     });

--- a/web/client/plugins/ResourcesCatalog/actions/resources.js
+++ b/web/client/plugins/ResourcesCatalog/actions/resources.js
@@ -65,10 +65,11 @@ export function setSelectedResource(selectedResource, id) {
     };
 }
 
-export function updateSelectedResource(properties, id) {
+export function updateSelectedResource(properties, initialize, id) {
     return {
         type: UPDATE_SELECTED_RESOURCE,
         properties,
+        initialize,
         id
     };
 }

--- a/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
@@ -94,8 +94,8 @@ function ResourceDetails({
         });
     }
 
-    function handleOnChange(options) {
-        onChange(options, resourcesGridId);
+    function handleOnChange(options, initialize) {
+        onChange(options, initialize, resourcesGridId);
     }
 
     // resource details component can be used with the resources grid (resourceType equal to undefined)

--- a/web/client/plugins/ResourcesCatalog/containers/ResourcePermissions.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourcePermissions.jsx
@@ -38,7 +38,7 @@ function ResourcePermissions({
                 .then((permissions) => isMounted(() => {
                     onChange({
                         permissions
-                    });
+                    }, true);
                 }))
                 .finally(() => isMounted(() => {
                     // include a delay to visualize the spinner

--- a/web/client/plugins/ResourcesCatalog/reducers/__tests__/resources-test.js
+++ b/web/client/plugins/ResourcesCatalog/reducers/__tests__/resources-test.js
@@ -56,6 +56,10 @@ describe('resources reducer', () => {
         expect(resources({ selectedResource: { id: 1, name: 'Resource' }, initialSelectedResource: { id: 1, name: 'Resource' } }, updateSelectedResource({ name: 'New Resource' })))
             .toEqual({ selectedResource: { id: 1, name: 'New Resource' }, initialSelectedResource: { id: 1, name: 'Resource' } });
     });
+    it('updateSelectedResource with initialize true', () => {
+        expect(resources({ selectedResource: { id: 1, name: 'Resource' }, initialSelectedResource: { id: 1, name: 'Resource' } }, updateSelectedResource({ name: 'New Resource' }, true)))
+            .toEqual({ selectedResource: { id: 1, name: 'New Resource' }, initialSelectedResource: { id: 1, name: 'New Resource' } });
+    });
     it('searchResources', () => {
         const newState = resources({}, searchResources({ params: { page: 2 }, clear: false, refresh: false }));
         const { id, ...search } = newState?.search;

--- a/web/client/plugins/ResourcesCatalog/reducers/resources.js
+++ b/web/client/plugins/ResourcesCatalog/reducers/resources.js
@@ -122,7 +122,12 @@ function resources(state = defaultState, action) {
             ...stateId,
             selectedResource: Object.keys(action.properties).reduce((selectedResource, path) => {
                 return set(path, action.properties[path], selectedResource);
-            }, stateId.selectedResource)
+            }, stateId.selectedResource),
+            ...(action.initialize && {
+                initialSelectedResource: Object.keys(action.properties).reduce((initialSelectedResource, path) => {
+                    return set(path, action.properties[path], initialSelectedResource);
+                }, stateId.initialSelectedResource)
+            })
         }));
     case RESET_SELECTED_RESOURCE:
         return setStateById(state, action, (stateId) => ({


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces a new argument to updateSelectedResource action to initialize specific property to prevent pending changes detection

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11097

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The loading of permissions does not trigger pending changes anymore

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
