### PR TITLE
#11143: Use another layer as input for attribute table dropdown

### DIFF
--- a/web/client/components/data/featuregrid/editors/CustomAutocompleteEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/CustomAutocompleteEditor.jsx
@@ -86,7 +86,14 @@ class CustomAutocompleteEditor extends AttributeEditor {
         };
     }
     render() {
-        return <AutocompleteCombobox {...this.props} url={ConfigUtils.getParsedUrl(this.props.url, {"outputFormat": "json"})} filter="contains" autocompleteStreamFactory={createCustomPagedUniqueAutompleteStream}/>;
+        return (
+            <AutocompleteCombobox
+                {...this.props}
+                url={ConfigUtils.getParsedUrl(this.props.url, {"outputFormat": "json"})}
+                filter="contains"
+                autocompleteStreamFactory={createCustomPagedUniqueAutompleteStream}
+            />
+        );
     }
 }
 

--- a/web/client/components/data/featuregrid/editors/CustomAutocompleteEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/CustomAutocompleteEditor.jsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { createCustomPagedUniqueAutompleteStream } from '../../../../observables/autocomplete';
+import ConfigUtils from '../../../../utils/ConfigUtils';
+import { AutocompleteCombobox } from '../../../misc/AutocompleteCombobox';
+import AttributeEditor from './AttributeEditor';
+
+/**
+ * Editor for FeatureGrid, used for strings with auto-complete
+ *
+ * @name CustomAutocompleteEditor
+ * @memberof components.data.featuregrid.editors
+ * @prop {object} column - The column object representing the attribute being edited.
+ * @prop {string} dataType - The data type of the attribute.
+ * @prop {object} inputProps - Additional input properties passed to AutocompleteCombobox.
+ * @prop {function} isValid - A function to validate the input value.
+ * @prop {function} onBlur - Callback triggered when the input loses focus.
+ * @prop {string} url - The base URL for the WPS service.
+ * @prop {string} typeName - The typename of the layer currently being edited.
+ * @prop {string} value - The current value of the attribute being edited.
+ * @prop {string} isValidRegex - An optional regex string for validation.
+ * @prop {object} filterProps - Configuration for filtering and fetching unique values.
+ * @prop {string[]} filterProps.blacklist - An array of values to exclude from the fetched results.
+ * @prop {number} filterProps.maxFeatures - The maximum number of unique features to fetch per page.
+ * @prop {string[]} filterProps.queriableAttributes - An array of attribute names from the `typeName` layer.
+ * @prop {string} filterProps.predicate - The comparison operator for filtering (e.g., "ILIKE", "EQUAL_TO").
+ * @prop {string} filterProps.srsName - The SRS name to use in WFS queries.
+ * @prop {string} filterProps.typeName - The typename of the **source layer** from which to fetch unique values.
+ * @prop {boolean} filterProps.performFetch - If `false`, fetching will be disabled.
+ * @type {Object}
+ */
+class CustomAutocompleteEditor extends AttributeEditor {
+    static propTypes = {
+        column: PropTypes.object,
+        dataType: PropTypes.string,
+        inputProps: PropTypes.object,
+        isValid: PropTypes.func,
+        onBlur: PropTypes.func,
+        url: PropTypes.string,
+        typeName: PropTypes.string,
+        value: PropTypes.string,
+        isValidRegex: PropTypes.string,
+        filterProps: PropTypes.shape({
+            blacklist: PropTypes.arrayOf(PropTypes.string),
+            maxFeatures: PropTypes.number,
+            queriableAttributes: PropTypes.arrayOf(PropTypes.string),
+            predicate: PropTypes.string,
+            srsName: PropTypes.string,
+            typeName: PropTypes.string,
+            performFetch: PropTypes.bool
+        })
+    };
+    static defaultProps = {
+        isValid: () => true,
+        dataType: "string",
+        filter: "contains",
+        filterProps: {
+            maxFeatures: 5,
+            predicate: "ILIKE",
+            srsName: "EPSG:4326",
+            queriableAttributes: [],
+            performFetch: true
+        }
+    };
+    constructor(props) {
+        super(props);
+        this.validate = (value) => {
+            try {
+                return this.props.isValid(value[this.props.column && this.props.column.key]);
+            } catch (e) {
+                return false;
+            }
+        };
+        this.getValue = () => {
+            const updated = super.getValue();
+            return updated;
+        };
+    }
+    render() {
+        return <AutocompleteCombobox {...this.props} url={ConfigUtils.getParsedUrl(this.props.url, {"outputFormat": "json"})} filter="contains" autocompleteStreamFactory={createCustomPagedUniqueAutompleteStream}/>;
+    }
+}
+
+export default CustomAutocompleteEditor;

--- a/web/client/components/data/featuregrid/editors/__tests__/CustomAutocompleteEditor-test.jsx
+++ b/web/client/components/data/featuregrid/editors/__tests__/CustomAutocompleteEditor-test.jsx
@@ -1,0 +1,39 @@
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import {createCustomPagedUniqueAutompleteStream} from '../../../../../observables/autocomplete';
+import CustomAutocompleteEditor from '../CustomAutocompleteEditor';
+
+let testColumn = {
+    key: 'columnKey'
+};
+const value = "1.1";
+describe('FeatureGrid CustomAutocompleteEditor component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('CustomAutocompleteEditor Editor no stream provided', () => {
+        const cmp = ReactDOM.render(<CustomAutocompleteEditor
+            value={value}
+            rowIdx={1}
+            column={testColumn}/>, document.getElementById("container"));
+        expect(cmp.getValue().columnKey).toBe(value);
+        expect(cmp.validate(value)).toBe(true);
+    });
+    it('CustomAutocompleteEditor Editor no stream provided', () => {
+        const cmp = ReactDOM.render(<CustomAutocompleteEditor
+            value={value}
+            rowIdx={1}
+            autocompleteStreamFactory={createCustomPagedUniqueAutompleteStream}
+            column={testColumn}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+});

--- a/web/client/components/data/featuregrid/editors/customEditors.jsx
+++ b/web/client/components/data/featuregrid/editors/customEditors.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import DropDownEditor from './DropDownEditor';
 import NumberEditor from './NumberEditor';
 import FormatEditor from './FormatEditor';
+import CustomAutocompleteEditor from './CustomAutocompleteEditor';
 
 /**
  * MapStore allows for adding custom editors to Attribute Table.
@@ -43,6 +44,9 @@ const Editors = {
     },
     "FormatEditor": {
         "string": (props) => <FormatEditor dataType="string" {...props}/>
+    },
+    "CustomAutocompleteEditor": {
+        "string": (props) => <CustomAutocompleteEditor dataType="string" {...props}/>
     }
 };
 

--- a/web/client/components/data/featuregrid/editors/customEditors.jsx
+++ b/web/client/components/data/featuregrid/editors/customEditors.jsx
@@ -27,6 +27,7 @@ import CustomAutocompleteEditor from './CustomAutocompleteEditor';
  * * {@link #components.data.featuregrid.editors.DropDownEditor | DropDownEditor} - editor that allows to choose a value from a pre-configured values list
  * * {@link #components.data.featuregrid.editors.NumberEditor | NumberEditor} - editor that supports numeric data, setting min/max bounds on a value
  * * {@link #components.data.featuregrid.editors.FormatEditor | FormatEditor} - editor that checks if data matches a particular regular expression
+ * * {@link #components.data.featuregrid.editors.CustomAutocompleteEditor | CustomAutocompleteEditor} - editor that enables dynamic fetching of unique attribute values from a source layer to target layer's attribute.
  *
  * Each editor has a specific section in framework documentation with available properties.
  *

--- a/web/client/observables/__tests__/autocomplete-test.js
+++ b/web/client/observables/__tests__/autocomplete-test.js
@@ -16,7 +16,8 @@ import assign from 'object-assign';
 import {
     createPagedUniqueAutompleteStream,
     singleAttributeFilter,
-    createWFSFetchStream
+    createWFSFetchStream,
+    createCustomPagedUniqueAutompleteStream
 } from '../autocomplete';
 
 import AutocompleteEditor from '../../components/data/featuregrid/editors/AutocompleteEditor';
@@ -159,5 +160,62 @@ describe('\nAutocomplete Observables', () => {
     it("test singleAttributeFilter empty queriable attributes, returns empty string", () => {
         const filter = singleAttributeFilter({});
         expect(filter).toBe("");
+    });
+    it('test createCustomPagedUniqueAutompleteStream with fake stream, filterProps not a prop', (done) => {
+        const ReactItem = mapPropsStream(props$ =>
+            createCustomPagedUniqueAutompleteStream(props$).map(p => {
+                if (!isEmpty(p) && p.fetchedData !== undefined) {
+                    expect(p.fetchedData.values.length).toBe(0);
+                    expect(p.fetchedData.size).toBe(0);
+                    expect(p.busy).toBe(false);
+                    done();
+                }
+            })
+        )(AutocompleteEditor);
+        const item = ReactDOM.render(<ReactItem {...assign({}, props)}/>, document.getElementById("container"));
+        expect(item).toExist();
+    });
+
+    it('test createCustomPagedUniqueAutompleteStream with fake stream, filterProps is a prop', (done) => {
+        const ReactItem = mapPropsStream(props$ =>
+            createCustomPagedUniqueAutompleteStream(props$).map(p => {
+                if (!isEmpty(p) && p.fetchedData !== undefined ) {
+                    expect(p.fetchedData.values.length).toBe(2);
+                    expect(p.fetchedData.values[0]).toBe("value1");
+                    expect(p.fetchedData.size).toBe(2);
+                    expect(p.busy).toBe(false);
+                    done();
+                }
+            })
+        )(AutocompleteEditor);
+        const item = ReactDOM.render(<ReactItem {...assign({}, props, {filterProps: {
+            "blacklist": [],
+            "maxFeatures": 3,
+            "queriableAttributes": ["COMUNE"],
+            "predicate": "ILIKE",
+            "typeName": "test:Linea_costa"
+        }})}/>, document.getElementById("container"));
+        expect(item).toExist();
+    });
+
+    it('test a failure case intercepted into catch statement with createCustomPagedUniqueAutompleteStream', (done) => {
+        const ReactItem = mapPropsStream(props$ =>
+            createCustomPagedUniqueAutompleteStream(props$).map(p => {
+                if (!isEmpty(p) && p.fetchedData !== undefined ) {
+                    expect(p.fetchedData.values.length).toBe(0);
+                    expect(p.fetchedData.size).toBe(0);
+                    expect(p.busy).toBe(false);
+                    done();
+                }
+            })
+        )(AutocompleteEditor);
+        const item = ReactDOM.render(<ReactItem {...assign({}, props, {url: "wrong"}, {filterProps: {
+            "blacklist": [],
+            "maxFeatures": 3,
+            "queriableAttributes": ["COMUNE"],
+            "predicate": "ILIKE",
+            "typeName": "test:Linea_costa"
+        }})}/>, document.getElementById("container"));
+        expect(item).toExist();
     });
 });

--- a/web/client/observables/autocomplete.js
+++ b/web/client/observables/autocomplete.js
@@ -63,7 +63,75 @@ export const createPagedUniqueAutompleteStream = (props$) => props$
         }
         return Rx.Observable.of({fetchedData: {values: [], size: 0}, busy: false});
     }).startWith({});
+/**
+ * creates a stream for fetching data via WPS based on the provided `filterProps`
+ * configuration to retrieve unique attribute values from a specified source layer
+ * @param  {external:Observable} props
+ * @memberof observables.autocomplete
+ * @return {external:Observable} the stream used for fetching data for the autocomplete editor
+*/
+export const createCustomPagedUniqueAutompleteStream = (props$) => props$
+    .distinctUntilChanged( ({value, currentPage, filterProps = {}}, newProps = {}) =>{
+    // Extract filterProps safely
+        const newFilterProps = newProps.filterProps || {};
+        // Compare relevant properties to avoid unnecessary fetches
+        return !(
+            newProps.value !== value ||
+                newProps.currentPage !== currentPage ||
+                newFilterProps.typeName !== filterProps.typeName ||
+                // Deep compare queriableAttributes array using JSON.stringify for simplicity
+                JSON.stringify(newFilterProps.queriableAttributes) !== JSON.stringify(filterProps.queriableAttributes) ||
+                newFilterProps.maxFeatures !== filterProps.maxFeatures ||
+                newFilterProps.predicate !== filterProps.predicate
+        );
+    })
+    .throttle(props => Rx.Observable.timer(props.delayDebounce || 0))
+    .merge(props$.debounce(props => Rx.Observable.timer(props.delayDebounce || 0))).distinctUntilChanged()
+    .switchMap((p) => {
+        const { filterProps = {}, value, currentPage } = p;
+        const {
+            typeName: sourceTypeName,
+            queriableAttributes,
+            maxFeatures: configuredMaxFeatures,
+            blacklist,
+            performFetch = true,
+            predicate
+        } = filterProps;
+        if (performFetch && p.url && sourceTypeName && queriableAttributes && queriableAttributes.length > 0) {
+            const startIndex = (currentPage - 1) * configuredMaxFeatures;
+            const targetAttribute = queriableAttributes[0]; // ** Note: Currently, only the 'first' attribute in this array (`queriableAttributes[0]`) is used
 
+            const data = getWpsPayload({
+                attribute: targetAttribute,
+                layerName: sourceTypeName,
+                maxFeatures: configuredMaxFeatures,
+                startIndex: startIndex,
+                value: value,
+                predicate
+            });
+            if (!data) {
+                return Rx.Observable.of({ fetchedData: { values: [], size: 0 }, busy: false });
+            }
+            return Rx.Observable.fromPromise(
+                axios.post(p.url, data, {
+                    timeout: 60000,
+                    headers: {'Accept': 'application/json', 'Content-Type': 'application/xml'}
+                }).then(response => {
+                    let fetchedValues = response.data?.values || [];
+                    const totalSize = response.data?.size || 0;
+                    // filter blacklist
+                    if (blacklist && Array.isArray(blacklist) && blacklist.length > 0) {
+                        fetchedValues = fetchedValues.filter(val => !blacklist.includes(val));
+                    }
+
+                    return { fetchedData: { values: fetchedValues, size: totalSize }, busy: false };
+                }))
+                .catch(() => {
+                    return Rx.Observable.of({fetchedData: {values: [], size: 0}, busy: false});
+                }).startWith({busy: true});
+        }
+        return Rx.Observable.of({fetchedData: {values: [], size: 0}, busy: false});
+    }).startWith({});
 export const createWFSFetchStream = (props$) =>
     Rx.Observable.merge(
         props$.distinctUntilChanged(({value} = {}, {value: nextValue} = {}) => value === nextValue ).debounce(props => Rx.Observable.timer(props.delayDebounce || 0)),
@@ -111,5 +179,6 @@ export const createWFSFetchStream = (props$) =>
 export default {
     createPagedUniqueAutompleteStream,
     createWFSFetchStream,
-    singleAttributeFilter
+    singleAttributeFilter,
+    createCustomPagedUniqueAutompleteStream
 };

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -47,10 +47,41 @@ import {isViewportFilterActive} from "../selectors/featuregrid";
   *        "editorProps": {
   *            "values": ["Option1", "Option2", "Option3", "Option4"]
   *        }
-  *    }
+  *    }, {
+  *        "regex": {
+  *            "attribute": "SUB_REGION",
+  *            "typeName": "gs:us_states"
+  *        },
+  *        "editor": "CustomAutocompleteEditor",
+  *        "editorProps": {
+  *            "filterProps": {
+  *                "blacklist": [],
+  *                "maxFeatures": 3,
+  *                "queriableAttributes": ["FIELD01"],
+  *                "predicate": "ILIKE",
+  *                "typeName": "test:layer01",
+  *                "srsName": "EPSG:4326",
+  *                "performFetch": true
+  *            }
+  *        }
   *    }]
   *}
   * ```
+  *
+  * ### For editor `CustomAutocompleteEditor` in cfg.rules
+  * The `CustomAutocompleteEditor` enables dynamic fetching of unique attribute values from a source layer to provide
+  * autocomplete functionality when editing attributes in a target layer. This is particularly useful for maintaining
+  * data consistency and providing users with valid options based on existing data from related layers.
+  *
+  * **Editor Properties (`editorProps.filterProps`) for `CustomAutocompleteEditor`:**
+  * - `filterProps.blacklist` (string[]): Array of values to exclude from the fetched results
+  * - `filterProps.maxFeatures` (number): Maximum number of unique features to fetch per page
+  * - `filterProps.queriableAttributes` (string[]): Array of attribute names from the source layer to query
+  * - `filterProps.predicate` (string): Comparison operator for filtering (e.g., "ILIKE", "EQUAL_TO")
+  * - `filterProps.typeName` (string): The typename of the **source layer** from which to fetch unique values.
+  * - `filterProps.srsName` (string, optional): The SRS name to use in WFS queries
+  * - `filterProps.performFetch` (boolean, optional): If false, fetching will be disabled. Default is true
+  *
   * @prop {string[]} cfg.editingAllowedRoles array of user roles allowed to enter in edit mode.
   * Support predefined ('ADMIN', 'USER', 'ALL') and custom roles. Default value is ['ADMIN'].
   * Configuring with ["ALL"] allows all users to have access regardless of user's permission.

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -29,6 +29,13 @@ import {isViewportFilterActive} from "../selectors/featuregrid";
   * - `editor`: the string name of the editor. For more information about custom editors and their specific props (`editorProps`), see {@link api/framework#components.data.featuregrid.editors.customEditors}
   * - `regex`: An object with 2 regular expression, `attribute` and `typeName` that have to match with the specific attribute name and feature type name.
   * - `editorProps`: the properties to pass to the specific editor.
+  * - `filterProps.blacklist` (string[]): Array of values to exclude from the fetched results
+  * - `filterProps.maxFeatures` (number): Maximum number of unique features to fetch per page
+  * - `filterProps.queriableAttributes` (string[]): Array of attribute names from the source layer to query
+  * - `filterProps.predicate` (string): Comparison operator for filtering (e.g., "ILIKE", "EQUAL_TO")
+  * - `filterProps.typeName` (string): The typename of the **source layer** from which to fetch unique values.
+  * - `filterProps.srsName` (string, optional): The SRS name to use in WFS queries
+  * - `filterProps.performFetch` (boolean, optional): If false, fetching will be disabled. Default is true
   * Example:
   * ```json
   * "customEditorsOptions": {
@@ -67,15 +74,6 @@ import {isViewportFilterActive} from "../selectors/featuregrid";
   *    }]
   *}
   * ```
-  *
-  * **Editor Properties (`editorProps.filterProps`) for `CustomAutocompleteEditor`:**
-  * - `filterProps.blacklist` (string[]): Array of values to exclude from the fetched results
-  * - `filterProps.maxFeatures` (number): Maximum number of unique features to fetch per page
-  * - `filterProps.queriableAttributes` (string[]): Array of attribute names from the source layer to query
-  * - `filterProps.predicate` (string): Comparison operator for filtering (e.g., "ILIKE", "EQUAL_TO")
-  * - `filterProps.typeName` (string): The typename of the **source layer** from which to fetch unique values.
-  * - `filterProps.srsName` (string, optional): The SRS name to use in WFS queries
-  * - `filterProps.performFetch` (boolean, optional): If false, fetching will be disabled. Default is true
   *
   * @prop {string[]} cfg.editingAllowedRoles array of user roles allowed to enter in edit mode.
   * Support predefined ('ADMIN', 'USER', 'ALL') and custom roles. Default value is ['ADMIN'].

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -68,11 +68,6 @@ import {isViewportFilterActive} from "../selectors/featuregrid";
   *}
   * ```
   *
-  * ### For editor `CustomAutocompleteEditor` in cfg.rules
-  * The `CustomAutocompleteEditor` enables dynamic fetching of unique attribute values from a source layer to provide
-  * autocomplete functionality when editing attributes in a target layer. This is particularly useful for maintaining
-  * data consistency and providing users with valid options based on existing data from related layers.
-  *
   * **Editor Properties (`editorProps.filterProps`) for `CustomAutocompleteEditor`:**
   * - `filterProps.blacklist` (string[]): Array of values to exclude from the fetched results
   * - `filterProps.maxFeatures` (number): Maximum number of unique features to fetch per page


### PR DESCRIPTION



## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR introduces a new capability within the **FeatureEditor** plugin to handle fetching/paginated and displaying unique attribute values from a specified source layer for use in editing attributes of another (target) layer. This is achieved by introducing a new rule with the editor key CustomAutocompleteEditor within cfg.customEditorsOptions.rules.

**Configuration Example:**
```
{
            "name": "FeatureEditor",
            "cfg": {
                "customEditorsOptions": {
                    "rules": [{
                        "regex": {
                            "attribute": "SUB_REGION",
                            "typeName": "gs:us_states"
                        },
                        "editor": "CustomAutocompleteEditor",
                        "editorProps": {
                            "filterProps": {
                            "blacklist": [],
                            "maxFeatures": 3,
                            "queriableAttributes": ["COMUNE"],
                            "predicate": "ILIKE",
                            "typeName": "test:Linea_costa"
                            }
                        }
                    }]
                }
            }
          },
```
The PR includes:
- create CustomAutocompleteEditor component to be used for the new requirements [fetching/displaying atrribute values from layer to be used in another layer]. A new editor designed to leverage a configurable stream for fetching autocomplete suggestions for feature attribute fields.
- create custom stream 'createCustomPagedUniqueAutompleteStream' to fetch values
- add unit tests


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#11143 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11143 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
 User can now define rules into **FeatureEditor** plugin in localConfig.json to specify an external source layer and attribute from which autocomplete suggestions are fetched to be used in add new feature or edit an existing feature.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
