### PR TITLE
11071 improve interactions layerdownload plugin and comp DownloadDialog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,14 +309,13 @@
             </plugins>
         </pluginManagement>
 
-        <plugins>
+        <!-- <plugins>
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>9.0.9</version>
                 <configuration>
                     <skip>true</skip>
-                    <!-- <nvdApiKey>******-****-****-****-*********</nvdApiKey> -->
                 </configuration>
                 <executions>
                     <execution>
@@ -326,6 +325,6 @@
                     </execution>
                 </executions>
             </plugin>
-        </plugins>
+        </plugins> -->
     </build>
 </project>

--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -6,7 +6,7 @@
   * LICENSE file in the root directory of this source tree.
   */
 
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import { findIndex } from 'lodash';
 import assign from 'object-assign';
@@ -22,151 +22,243 @@ import DownloadOptions from './DownloadOptions';
 import Button from '../../misc/Button';
 import {getAttributesList} from "../../../utils/FeatureGridUtils";
 
-class DownloadDialog extends React.Component {
-    static propTypes = {
-        filterObj: PropTypes.object,
-        closeGlyph: PropTypes.string,
-        url: PropTypes.string,
-        wpsAvailable: PropTypes.bool,
-        service: PropTypes.string,
-        defaultSelectedService: PropTypes.string,
-        enabled: PropTypes.bool,
-        loading: PropTypes.bool,
-        checkingWPSAvailability: PropTypes.bool,
-        onClose: PropTypes.func,
-        onExport: PropTypes.func,
-        onCheckWPSAvailability: PropTypes.func,
-        setService: PropTypes.func,
-        onDownloadOptionChange: PropTypes.func,
-        onClearDownloadOptions: PropTypes.func,
-        onFormatOptionsFetch: PropTypes.func,
-        downloadOptions: PropTypes.object,
-        wfsFormats: PropTypes.array,
-        formats: PropTypes.array,
-        srsList: PropTypes.array,
-        defaultSrs: PropTypes.string,
-        layer: PropTypes.object,
-        formatsLoading: PropTypes.bool,
-        virtualScroll: PropTypes.bool,
-        customAttributeSettings: PropTypes.object,
-        attributes: PropTypes.array,
-        hideServiceSelector: PropTypes.bool
+import { parseString } from 'xml2js';
+import { stripPrefix } from 'xml2js/lib/processors';
+import { describeProcess } from '../../../observables/wps/describe';
+
+/**
+ * @prop {Array<{
+ *   name: string,               // MIME type of the format (e.g., 'application/json')
+ *   label: string,              // Human-readable label shown in the UI (e.g., 'GeoJSON')
+ *   type: 'vector' | 'raster',  // Type of data format, used to filter or group options
+ *   validServices: string[]     // List of services this format is valid for (e.g., ['wps', 'wfs'])
+ * }>} formats -
+ * List of available export formats. Each format defines the MIME type, display label,
+ * type of data (vector or raster), and the services (e.g., WPS, WFS) that support it.
+ * ABOUT MIME TYPES: 'application/wfs-collection-1.0' AND 'application/wfs-collection-1.1'
+
+    There is no direct 1:1 mapping, but if you want to export the same feature content using GML, the equivalent output formats would be:
+
+    JSON Format	GML Equivalent MIME Type	Notes
+    wfs-collection-1.0	text/xml; subtype=gml/2.1.2	Similar to WFS 1.0 with GML 2
+    wfs-collection-1.1	text/xml; subtype=gml/3.1.1	Similar to WFS 1.1 with GML 3.1
+
+    refer: https://docs.geoserver.org/main/en/user/services/wfs/outputformats.html
+ */
+const DownloadDialog = ({
+    filterObj,
+    closeGlyph,
+    wpsAvailable,
+    service,
+    defaultSelectedService, // per node
+    enabled,
+    loading,
+    checkingWPSAvailability,
+    onClose,
+    onExport,
+    onSetService,
+    onSetWPSAvailability,
+    onDownloadOptionChange,
+    onClearDownloadOptions,
+    onFormatOptionsFetch,
+    downloadOptions,
+    wfsFormats,
+    formats,
+    srsList,
+    defaultSrs,
+    mapLayer,
+    downloadLayer,
+    formatsLoading,
+    virtualScroll,
+    customAttributeSettings,
+    attributes,
+    hideServiceSelector
+}) => {
+
+    const selectedLayer = mapLayer || downloadLayer || {};
+
+    const [showLoader, setShowLoader] = useState(false);
+    // const [loadedLayer, setLoadedLayer] = useState(layer);
+
+    const checkWPSAvailability = (layerToCheck, selectedService) => {
+        setShowLoader(true);
+
+        describeProcess(layerToCheck.url, 'gs:DownloadEstimator,gs:Download')
+            .toPromise()
+            .then((response) => // xml to obj
+                new Promise((resolve, reject) => parseString(response.data, { tagNameProcessors: [stripPrefix] }, (err, res) => (err ? reject(err) : resolve(res))))
+            )
+            .then((xmlObj) => {
+                const ids = [
+                    xmlObj?.ProcessDescriptions?.ProcessDescription?.[0]?.Identifier?.[0],
+                    xmlObj?.ProcessDescriptions?.ProcessDescription?.[1]?.Identifier?.[0]
+                ];
+
+                const isWpsAvailable = findIndex(ids, x => x === 'gs:DownloadEstimator') > -1 && findIndex(ids, x => x === 'gs:Download') > -1;
+                const isWfsAvailable = layerToCheck.search?.url;
+                const shouldSelectWps = isWpsAvailable && (selectedService === 'wps' || !isWfsAvailable);
+
+                // eslint-disable-next-line no-console
+                // console.log('describeProcess', isWfsAvailable, isWpsAvailable, xmlObj);
+
+                onSetService(shouldSelectWps ? 'wps' : 'wfs');
+                onSetWPSAvailability(shouldSelectWps);
+            })
+            .catch(() => {
+                onSetService('wfs');
+                onSetWPSAvailability(false);
+            })
+            .finally(() => {
+                setShowLoader(false);
+            });
     };
 
-    static defaultProps = {
-        onExport: () => {},
-        onClose: () => {},
-        onCheckWPSAvailability: () => {},
-        setService: () => {},
-        onDownloadOptionChange: () => {},
-        onClearDownloadOptions: () => {},
-        onFormatOptionsFetch: () => {},
-        checkingWPSAvailability: false,
-        layer: {},
-        closeGlyph: "1-close",
-        wpsAvailable: false,
-        service: 'wfs',
-        defaultSelectedService: 'wps',
-        wfsFormats: [],
-        formats: [
-            {name: 'application/json', label: 'GeoJSON', type: 'vector', validServices: ['wps']},
-            {name: 'application/arcgrid', label: 'ArcGrid', type: 'raster', validServices: ['wps']},
-            {name: 'image/tiff', label: 'TIFF', type: 'raster', validServices: ['wps']},
-            {name: 'application/wfs-collection-1.0', label: 'wfs-collection-1.0', type: 'vector', validServices: ['wps']},
-            {name: 'application/wfs-collection-1.1', label: 'wfs-collection-1.1', type: 'vector', validServices: ['wps']},
-            {name: 'application/zip', label: 'Shapefile', type: 'vector', validServices: ['wps']},
-            {name: 'text/csv', label: 'CSV', type: 'vector', validServices: ['wps']}
-        ],
-        formatsLoading: false,
-        srsList: [
-            {name: "native", label: "Native"},
-            {name: "EPSG:4326", label: "WGS84"}
-        ],
-        virtualScroll: true,
-        downloadOptions: {},
-        hideServiceSelector: false
-    };
+    useEffect(() => {
+        if (enabled) {
+            onClearDownloadOptions();
 
-    componentDidUpdate(oldProps) {
-        if (this.props.enabled !== oldProps.enabled && this.props.enabled) {
-            this.props.onClearDownloadOptions();
-            if (this.props.layer.type === 'wms') {
-                this.props.onCheckWPSAvailability(
-                    this.props.url || this.props.layer.url,
-                    this.props.defaultSelectedService
-                );
+            if (selectedLayer.type === 'wms') {
+                // condition added only after this review:
+                // https://github.com/geosolutions-it/MapStore2/pull/6204/commits/7dfb575983cea4d5a3c36de5cdfb19a0141bd74d
+                //
+                checkWPSAvailability(selectedLayer, defaultSelectedService);
             }
         }
-    }
+    }, [enabled, selectedLayer, defaultSelectedService]); // equivalent componentDidUpdate
 
-    onClose = () => {
-        this.props.onClose();
+    const renderIcon = () => {
+        return loading ? <div style={{"float": "left"}}><Spinner spinnerName="circle" noFadeIn/></div> : <Glyphicon glyph="download" />;
     };
 
-    renderIcon = () => {
-        return this.props.loading ? <div style={{"float": "left"}}><Spinner spinnerName="circle" noFadeIn/></div> : <Glyphicon glyph="download" />;
+    const handleExport = () => {
+        const selectedSrs = downloadOptions && downloadOptions.selectedSrs || defaultSrs || (srsList[0] || {}).name;
+        const propertyName = getAttributesList(attributes, customAttributeSettings);
+        onExport(selectedLayer?.url, filterObj, assign({}, downloadOptions, {selectedSrs}, {propertyName}));
     };
 
-    render() {
-        const findValidFormats  = fmt => this.props.formats.filter(({validServices, type = 'vector'}) =>
-            (!validServices || findIndex(validServices, x => x === fmt) > -1) &&
-            (type === 'vector' && this.props.layer.search?.url || type === 'raster' && !this.props.layer.search?.url));
-        const validWFSFormats = findValidFormats('wfs');
-        const validWPSFormats = findValidFormats('wps');
-        const wfsFormats = validWFSFormats.length > 0 ?
-            validWFSFormats.filter(f => this.props.wfsFormats.find(wfsF => wfsF.name.toLowerCase() === f.name.toLowerCase())) :
-            this.props.wfsFormats;
-        const wfsAvailable = Boolean(this.props.layer.search?.url);
+    const findValidFormats  = fmt => formats.filter(({validServices, type = 'vector'}) =>
+        (!validServices || findIndex(validServices, x => x === fmt) > -1) &&
+            (type === 'vector' && selectedLayer?.search?.url || type === 'raster' && !selectedLayer?.search?.url));
+    const validWFSFormats = findValidFormats('wfs');
+    const validWPSFormats = findValidFormats('wps');
+    const wfsFormatsList = validWFSFormats.length > 0 ?
+        validWFSFormats.filter(f => wfsFormats.find(wfsF => wfsF.name.toLowerCase() === f.name.toLowerCase())) :
+        wfsFormats;
+    const wfsAvailable = Boolean(selectedLayer?.search?.url);
 
-        return this.props.enabled ? (<Portal><Dialog id="mapstore-export" draggable={false} modal>
+    const formatsAvailable = service === 'wfs' ? wfsFormatsList : validWPSFormats;
+
+    return enabled ? (<Portal>
+        <Dialog id="mapstore-export" draggable={false} modal>
             <span role="header">
                 <span className="modal-title  about-panel-title"><Message msgId="layerdownload.title" /></span>
-                <button onClick={this.onClose} className="settings-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>
+                <button onClick={onClose} className="settings-panel-close close">{closeGlyph ? <Glyphicon glyph={closeGlyph}/> : <span>×</span>}</button>
             </span>
             <div role="body">
-                {this.props.checkingWPSAvailability ?
+                {showLoader ?
                     <Loader size={100} style={{margin: '0 auto'}}/> :
-                    !this.props.wpsAvailable && !wfsAvailable ?
+                    !wpsAvailable && !wfsAvailable ?
+
                         <EmptyView title={<Message msgId="layerdownload.noSupportedServiceFound"/>}/> :
+
                         <DownloadOptions
-                            wpsAvailable={this.props.wpsAvailable}
+                            wpsAvailable={wpsAvailable}
                             wfsAvailable={wfsAvailable}
-                            service={this.props.service}
-                            downloadOptions={this.props.downloadOptions}
-                            setService={this.props.setService}
-                            onChange={this.props.onDownloadOptionChange}
-                            formatOptionsFetch={this.props.service === 'wfs' ? this.props.onFormatOptionsFetch : () => {}}
-                            formatsLoading={this.props.formatsLoading}
-                            formats={this.props.service === 'wfs' ? wfsFormats : validWPSFormats}
-                            srsList={this.props.srsList}
-                            defaultSrs={this.props.defaultSrs}
-                            wpsOptionsVisible={this.props.service === 'wps'}
-                            wpsAdvancedOptionsVisible={!this.props.layer.search?.url}
-                            downloadFilteredVisible={!!this.props.layer.search?.url}
-                            layer={this.props.layer}
-                            virtualScroll={this.props.virtualScroll}
-                            customAttributesSettings={this.props.customAttributeSettings}
-                            attributes={this.props.attributes}
-                            hideServiceSelector={this.props.hideServiceSelector}
+                            service={service}
+                            downloadOptions={downloadOptions}
+                            onSetService={onSetService}
+                            onChange={onDownloadOptionChange}
+                            formatOptionsFetch={service === 'wfs' ? onFormatOptionsFetch : () => {}}
+                            formatsLoading={formatsLoading}
+                            formats={formatsAvailable}
+                            srsList={srsList}
+                            defaultSrs={defaultSrs}
+                            wpsAdvancedOptionsVisible={!selectedLayer?.search?.url}
+                            downloadFilteredVisible={!!selectedLayer?.search?.url}
+                            layer={selectedLayer}
+                            virtualScroll={virtualScroll}
+                            customAttributesSettings={customAttributeSettings}
+                            attributes={attributes}
+                            hideServiceSelector={hideServiceSelector}
                         />}
             </div>
-            {!this.props.checkingWPSAvailability && <div role="footer">
+
+            {!checkingWPSAvailability && <div role="footer">
                 <Button
                     bsStyle="primary"
                     className="download-button"
-                    disabled={!this.props.downloadOptions.selectedFormat || this.props.loading}
-                    onClick={this.handleExport}>
-                    {this.renderIcon()} <Message msgId="layerdownload.export" />
+                    disabled={formatsLoading || formats.length === 0}
+                    onClick={handleExport}>
+                    {renderIcon()} <Message msgId="layerdownload.export" />
                 </Button>
             </div>}
-        </Dialog></Portal>) : null;
-    }
-    handleExport = () => {
-        const {url, filterObj, downloadOptions, defaultSrs, srsList, onExport, layer, attributes, customAttributeSettings} = this.props;
-        const selectedSrs = downloadOptions && downloadOptions.selectedSrs || defaultSrs || (srsList[0] || {}).name;
-        const propertyName = getAttributesList(attributes, customAttributeSettings);
-        onExport(url || layer.url, filterObj, assign({}, downloadOptions, {selectedSrs}, {propertyName}));
-    }
-}
+        </Dialog>
+    </Portal>) : null;
+};
+
+DownloadDialog.propTypes = {
+    attributes: PropTypes.array,
+    checkingWPSAvailability: PropTypes.bool,
+    closeGlyph: PropTypes.string,
+    customAttributeSettings: PropTypes.object,
+    defaultSelectedService: PropTypes.string,
+    defaultSrs: PropTypes.string,
+    downloadOptions: PropTypes.object,
+    enabled: PropTypes.bool,
+    filterObj: PropTypes.object,
+    formats: PropTypes.array,
+    formatsLoading: PropTypes.bool,
+    hideServiceSelector: PropTypes.bool,
+    mapLayer: PropTypes.object,
+    downloadLayer: PropTypes.object,
+    loading: PropTypes.bool,
+    onCheckWPSAvailability: PropTypes.func,
+    onClearDownloadOptions: PropTypes.func,
+    onClose: PropTypes.func,
+    onDownloadOptionChange: PropTypes.func,
+    onExport: PropTypes.func,
+    onFormatOptionsFetch: PropTypes.func,
+    onSetService: PropTypes.func,
+    onSetWPSAvailability: PropTypes.func,
+    service: PropTypes.string,
+    srsList: PropTypes.array,
+    virtualScroll: PropTypes.bool,
+    wfsFormats: PropTypes.array,
+    wpsAvailable: PropTypes.bool
+};
+
+DownloadDialog.defaultProps = {
+    onExport: () => {},
+    onClose: () => {},
+    onCheckWPSAvailability: () => {},
+    onSetService: () => {},
+    onSetWPSAvailability: () => {},
+    onDownloadOptionChange: () => {},
+    onClearDownloadOptions: () => {},
+    onFormatOptionsFetch: () => {},
+    checkingWPSAvailability: false,
+    closeGlyph: "1-close",
+    wpsAvailable: false,
+    service: 'wfs',
+    defaultSelectedService: 'wps',
+    wfsFormats: [],
+    formats: [
+        {name: 'image/tiff', label: 'TIFF', type: 'raster', validServices: ['wps']},
+        {name: 'application/arcgrid', label: 'ArcGrid', type: 'raster', validServices: ['wps']},
+        {name: 'application/json', label: 'GeoJSON', type: 'vector', validServices: ['wps']},
+        {name: 'application/zip', label: 'Shapefile', type: 'vector', validServices: ['wps']},
+        {name: 'text/csv', label: 'CSV', type: 'vector', validServices: ['wps']},
+        {name: 'application/wfs-collection-1.0', label: 'GML2', type: 'vector', validServices: ['wps']},
+        {name: 'application/wfs-collection-1.1', label: 'GML3', type: 'vector', validServices: ['wps']}
+    ],
+    formatsLoading: false,
+    srsList: [
+        {name: "native", label: "Native"},
+        {name: "EPSG:4326", label: "WGS84"}
+    ],
+    virtualScroll: true,
+    downloadOptions: {},
+    hideServiceSelector: false
+};
 
 export default DownloadDialog;

--- a/web/client/components/data/download/DownloadDialog.old.jsx
+++ b/web/client/components/data/download/DownloadDialog.old.jsx
@@ -1,0 +1,191 @@
+/**
+  * Copyright 2020, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { findIndex } from 'lodash';
+import assign from 'object-assign';
+import { Glyphicon } from 'react-bootstrap';
+import Spinner from 'react-spinkit';
+
+import Loader from '../../misc/Loader';
+import Dialog from '../../misc/Dialog';
+import Portal from '../../misc/Portal';
+import Message from '../../I18N/Message';
+import EmptyView from '../../misc/EmptyView';
+import DownloadOptions from './DownloadOptions';
+import Button from '../../misc/Button';
+import {getAttributesList} from "../../../utils/FeatureGridUtils";
+
+/**
+ * @prop {Array<{
+ *   name: string,               // MIME type of the format (e.g., 'application/json')
+ *   label: string,              // Human-readable label shown in the UI (e.g., 'GeoJSON')
+ *   type: 'vector' | 'raster',  // Type of data format, used to filter or group options
+ *   validServices: string[]     // List of services this format is valid for (e.g., ['wps', 'wfs'])
+ * }>} formats -
+ * List of available export formats. Each format defines the MIME type, display label,
+ * type of data (vector or raster), and the services (e.g., WPS, WFS) that support it.
+ * ABOUT MIME TYPES: 'application/wfs-collection-1.0' AND 'application/wfs-collection-1.1'
+
+    There is no direct 1:1 mapping, but if you want to export the same feature content using GML, the equivalent output formats would be:
+
+    JSON Format	GML Equivalent MIME Type	Notes
+    wfs-collection-1.0	text/xml; subtype=gml/2.1.2	Similar to WFS 1.0 with GML 2
+    wfs-collection-1.1	text/xml; subtype=gml/3.1.1	Similar to WFS 1.1 with GML 3.1
+
+    refer: https://docs.geoserver.org/main/en/user/services/wfs/outputformats.html
+ */
+class DownloadDialog extends React.Component {
+    static propTypes = {
+        filterObj: PropTypes.object,
+        closeGlyph: PropTypes.string,
+        url: PropTypes.string,
+        wpsAvailable: PropTypes.bool,
+        service: PropTypes.string,
+        defaultSelectedService: PropTypes.string,
+        enabled: PropTypes.bool,
+        loading: PropTypes.bool,
+        checkingWPSAvailability: PropTypes.bool,
+        onClose: PropTypes.func,
+        onExport: PropTypes.func,
+        onCheckWPSAvailability: PropTypes.func,
+        setService: PropTypes.func,
+        onDownloadOptionChange: PropTypes.func,
+        onClearDownloadOptions: PropTypes.func,
+        onFormatOptionsFetch: PropTypes.func,
+        downloadOptions: PropTypes.object,
+        wfsFormats: PropTypes.array,
+        formats: PropTypes.array,
+        srsList: PropTypes.array,
+        defaultSrs: PropTypes.string,
+        layer: PropTypes.object,
+        formatsLoading: PropTypes.bool,
+        virtualScroll: PropTypes.bool,
+        customAttributeSettings: PropTypes.object,
+        attributes: PropTypes.array,
+        hideServiceSelector: PropTypes.bool
+    };
+
+    static defaultProps = {
+        onExport: () => {},
+        onClose: () => {},
+        onCheckWPSAvailability: () => {},
+        setService: () => {},
+        onDownloadOptionChange: () => {},
+        onClearDownloadOptions: () => {},
+        onFormatOptionsFetch: () => {},
+        checkingWPSAvailability: false,
+        layer: {},
+        closeGlyph: "1-close",
+        wpsAvailable: false,
+        service: 'wfs',
+        defaultSelectedService: 'wps',
+        wfsFormats: [],
+        formats: [
+            {name: 'image/tiff', label: 'TIFF', type: 'raster', validServices: ['wps']},
+            {name: 'application/arcgrid', label: 'ArcGrid', type: 'raster', validServices: ['wps']},
+            {name: 'application/json', label: 'GeoJSON', type: 'vector', validServices: ['wps']},
+            {name: 'application/zip', label: 'Shapefile', type: 'vector', validServices: ['wps']},
+            {name: 'text/csv', label: 'CSV', type: 'vector', validServices: ['wps']},
+            {name: 'application/wfs-collection-1.0', label: 'GML2', type: 'vector', validServices: ['wps']},
+            {name: 'application/wfs-collection-1.1', label: 'GML3', type: 'vector', validServices: ['wps']}
+        ],
+        formatsLoading: false,
+        srsList: [
+            {name: "native", label: "Native"},
+            {name: "EPSG:4326", label: "WGS84"}
+        ],
+        virtualScroll: true,
+        downloadOptions: {},
+        hideServiceSelector: false
+    };
+
+    componentDidUpdate(oldProps) {
+        if (this.props.enabled !== oldProps.enabled && this.props.enabled) {
+            this.props.onClearDownloadOptions();
+            if (this.props.layer.type === 'wms') {
+                this.props.onCheckWPSAvailability(
+                    this.props.url || this.props.layer.url,
+                    this.props.defaultSelectedService
+                );
+            }
+        }
+    }
+
+    onClose = () => {
+        this.props.onClose();
+    };
+
+    renderIcon = () => {
+        return this.props.loading ? <div style={{"float": "left"}}><Spinner spinnerName="circle" noFadeIn/></div> : <Glyphicon glyph="download" />;
+    };
+
+    render() {
+        const findValidFormats  = fmt => this.props.formats.filter(({validServices, type = 'vector'}) =>
+            (!validServices || findIndex(validServices, x => x === fmt) > -1) &&
+            (type === 'vector' && this.props.layer.search?.url || type === 'raster' && !this.props.layer.search?.url));
+        const validWFSFormats = findValidFormats('wfs');
+        const validWPSFormats = findValidFormats('wps');
+        const wfsFormats = validWFSFormats.length > 0 ?
+            validWFSFormats.filter(f => this.props.wfsFormats.find(wfsF => wfsF.name.toLowerCase() === f.name.toLowerCase())) :
+            this.props.wfsFormats;
+        const wfsAvailable = Boolean(this.props.layer.search?.url);
+        const formats = this.props.service === 'wfs' ? wfsFormats : validWPSFormats;
+
+        return this.props.enabled ? (<Portal><Dialog id="mapstore-export" draggable={false} modal>
+            <span role="header">
+                <span className="modal-title  about-panel-title"><Message msgId="layerdownload.title" /></span>
+                <button onClick={this.onClose} className="settings-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>
+            </span>
+            <div role="body">
+                {this.props.checkingWPSAvailability ?
+                    <Loader size={100} style={{margin: '0 auto'}}/> :
+                    !this.props.wpsAvailable && !wfsAvailable ?
+                        <EmptyView title={<Message msgId="layerdownload.noSupportedServiceFound"/>}/> :
+                        <DownloadOptions
+                            wpsAvailable={this.props.wpsAvailable}
+                            wfsAvailable={wfsAvailable}
+                            service={this.props.service}
+                            downloadOptions={this.props.downloadOptions}
+                            setService={this.props.setService}
+                            onChange={this.props.onDownloadOptionChange}
+                            formatOptionsFetch={this.props.service === 'wfs' ? this.props.onFormatOptionsFetch : () => {}}
+                            formatsLoading={this.props.formatsLoading}
+                            formats={formats}
+                            srsList={this.props.srsList}
+                            defaultSrs={this.props.defaultSrs}
+                            wpsAdvancedOptionsVisible={!this.props.layer.search?.url}
+                            downloadFilteredVisible={!!this.props.layer.search?.url}
+                            layer={this.props.layer}
+                            virtualScroll={this.props.virtualScroll}
+                            customAttributesSettings={this.props.customAttributeSettings}
+                            attributes={this.props.attributes}
+                            hideServiceSelector={this.props.hideServiceSelector}
+                        />}
+            </div>
+            {!this.props.checkingWPSAvailability && <div role="footer">
+                <Button
+                    bsStyle="primary"
+                    className="download-button"
+                    disabled={this.props.loading || this.props.formats.length === 0}
+                    onClick={this.handleExport}>
+                    {this.renderIcon()} <Message msgId="layerdownload.export" />
+                </Button>
+            </div>}
+        </Dialog></Portal>) : null;
+    }
+    handleExport = () => {
+        const {url, filterObj, downloadOptions, defaultSrs, srsList, onExport, layer, attributes, customAttributeSettings} = this.props;
+        const selectedSrs = downloadOptions && downloadOptions.selectedSrs || defaultSrs || (srsList[0] || {}).name;
+        const propertyName = getAttributesList(attributes, customAttributeSettings);
+        onExport(url || layer.url, filterObj, assign({}, downloadOptions, {selectedSrs}, {propertyName}));
+    }
+}
+
+export default DownloadDialog;

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -10,7 +10,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
 import { Checkbox } from 'react-bootstrap';
-import { get, head } from 'lodash';
+import { get, head, isObject, isEmpty } from 'lodash';
+import InfoPopover from '../../widgets/widget/InfoPopover';
 
 import Message from '../../I18N/Message';
 import DownloadWPSOptions from './DownloadWPSOptions';
@@ -33,7 +34,7 @@ class DownloadOptions extends React.Component {
         formatOptionsFetch: PropTypes.func,
         formats: PropTypes.array,
         srsList: PropTypes.array,
-        setService: PropTypes.func,
+        onSetService: PropTypes.func,
         onChange: PropTypes.func,
         defaultSrs: PropTypes.string,
         wpsOptionsVisible: PropTypes.bool,
@@ -59,8 +60,8 @@ class DownloadOptions extends React.Component {
         downloadFilteredVisible: false,
         virtualScroll: true,
         services: [
-            { value: "wps", label: "WPS" },
-            { value: "wfs", label: "WFS" }
+            { value: "wps", label: <Message msgId="layerdownload.services.wps.title" /> },
+            { value: "wfs", label: <Message msgId="layerdownload.services.wfs.title" /> }
         ],
         hideServiceSelector: false
     };
@@ -69,52 +70,65 @@ class DownloadOptions extends React.Component {
         super(props);
     }
 
-    getSelectedFormat = () => {
-        return get(this.props, "downloadOptions.selectedFormat");
-    };
-    getSelectedSRS = () => {
-        return get(this.props, "downloadOptions.selectedSrs") || this.props.defaultSrs || get(head(this.props.srsList), "name");
+    componentDidMount = () => {
+        const format = get(this.props, "downloadOptions.selectedFormat") || head(this.props.formats);
+        const srs = get(this.props, "downloadOptions.selectedSrs") || get(this.props, "defaultSrs") || get(head(this.props.srsList), "name");
+        const filter = get(this.props, "layer.layerFilter");
+        const filtered = isObject(filter) && !isEmpty(filter);
+        this.props.onChange("selectedFormat", format);
+        this.props.onChange("selectedSrs", srs);
+        this.props.onChange("downloadFilteredDataSet", filtered);
     };
 
     render() {
+
+        const rasterOptionsVisibile = this.props.formats.some(item => item.type === 'raster');
+
         return (<form>
             {!this.props.hideServiceSelector && this.props.wpsAvailable && this.props.wfsAvailable &&
-                <>
-                    <label><Message msgId="layerdownload.service" /></label>
-                    <Select
-                        clearable={false}
-                        value={this.props.service}
-                        onChange={(sel) => this.props.setService(sel.value)}
-                        options={this.props.services} />
-                </>
+
+                <div className="mapstore-downloadoptions">
+                    <label>
+                        <Message msgId="layerdownload.downloadMode" />
+                    </label>
+                    <div className="mapstore-downloadoptions-row">
+                        <Select
+                            clearable={false}
+                            value={this.props.service}
+                            onChange={(sel) => this.props.onSetService(sel.value)}
+                            options={this.props.services} />
+                            &nbsp;<InfoPopover text={<Message msgId={`layerdownload.services.${this.props.service}.tooltip`} />} />
+                    </div>
+                </div>
             }
-            <label><Message msgId="layerdownload.format" /></label>
-            <Select
-                clearable={false}
-                isLoading={this.props.formatsLoading}
-                onOpen={() => this.props.formatOptionsFetch(this.props.layer)}
-                value={this.props.downloadOptions?.selectedFormat}
-                noResultsText={<Message msgId="layerdownload.format" />}
-                onChange={(sel) => this.props.onChange("selectedFormat", sel.value)}
-                options={this.props.formats.map(f => ({value: f.name, label: f.label || f.name}))} />
-            <label><Message msgId="layerdownload.srs" /></label>
-            <Select
-                clearable={false}
-                value={this.getSelectedSRS()}
-                onChange={(sel) => this.props.onChange("selectedSrs", sel.value)}
-                options={this.props.srsList.map(f => ({value: f.name, label: f.label || f.name}))} />
-            {this.props.wpsOptionsVisible &&
-                <DownloadWPSOptions
-                    cropDataSetVisible
-                    donwloadFilteredVisible={this.props.downloadFilteredVisible}
-                    advancedOptionsVisible={this.props.wpsAdvancedOptionsVisible}
-                    cropDataSetEnabled={this.props.downloadOptions.cropDataSet}
-                    downloadFilteredEnabled={this.props.downloadOptions.downloadFilteredDataSet}
-                    selectedCompression={this.props.downloadOptions.compression}
-                    quality={this.props.downloadOptions.quality}
-                    tileWidth={this.props.downloadOptions.tileWidth}
-                    tileHeight={this.props.downloadOptions.tileHeight}
-                    onChange={this.props.onChange}/>}
+
+            <div className="mapstore-downloadoptions">
+                <label><Message msgId="layerdownload.format" /></label>
+                <Select
+                    clearable={false}
+                    isLoading={this.props.formatsLoading}
+                    onOpen={() => this.props.formatOptionsFetch(this.props.layer)}
+                    value={this.props.downloadOptions?.selectedFormat}
+                    noResultsText={<Message msgId="layerdownload.format" />}
+                    onChange={(sel) => this.props.onChange("selectedFormat", sel.value)}
+                    options={this.props.formats.map(f => ({value: f.name, label: f.label || f.name}))} />
+            </div>
+
+            <DownloadWPSOptions
+                srsList={this.props.srsList}
+                selectedSrs={this.props.downloadOptions?.selectedSrs}
+                cropDataSetVisible
+                advancedOptionsVisible
+                wpsOptionsVisible={this.props.service === 'wps'}
+                rasterOptionsVisibile={rasterOptionsVisibile}
+                downloadFilteredVisible={this.props.downloadFilteredVisible}
+                downloadFilteredEnabled={this.props.downloadOptions.downloadFilteredDataSet}
+                cropDataSetEnabled={this.props.downloadOptions.cropDataSet}
+                selectedCompression={this.props.downloadOptions.compression}
+                quality={this.props.downloadOptions.quality}
+                tileWidth={this.props.downloadOptions.tileWidth}
+                tileHeight={this.props.downloadOptions.tileHeight}
+                onChange={this.props.onChange}/>
             {/* TODO for the future remove the virtualScroll prop since is no longer used*/}
             {this.props.virtualScroll ? null : <Checkbox checked={this.props.downloadOptions.singlePage} onChange={() => this.props.onChange("singlePage", !this.props.downloadOptions.singlePage ) }>
                 <Message msgId="layerdownload.downloadonlycurrentpage" />

--- a/web/client/components/data/download/DownloadWPSOptions.jsx
+++ b/web/client/components/data/download/DownloadWPSOptions.jsx
@@ -6,84 +6,143 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import { Button, Glyphicon, FormControl } from 'react-bootstrap';
 import Select from 'react-select';
-import { isString } from 'lodash';
+import { isString, head } from 'lodash';
 
 import SwitchButton from '../../misc/switch/SwitchButton';
 import Message from '../../I18N/Message';
 
 const DownloadWPSOptions = ({
+    advancedOptionsVisible = true,
     cropDataSetVisible = false,
     cropDataSetEnabled = false,
-    donwloadFilteredVisible = false,
+    wpsOptionsVisible = false,
+    downloadFilteredVisible = false,
     downloadFilteredEnabled = false,
-    advancedOptionsVisible = false,
-    compressionOptions = ['CCITT RLE', 'LZW', 'JPEG', 'ZLib', 'PackBits', 'Deflate'],
+    rasterOptionsVisibile = false,
+    compressionOptions = ['Deflate', 'JPEG', 'PackBits', 'LZW', 'CCITT RLE', 'ZLib'],
     selectedCompression,
     tileWidth,
     tileHeight,
     quality,
+    placeholders = {
+        /* select placeholder attribute not taking props */
+        tileWidth: '256',
+        tileHeight: '256',
+        quality: '0.75'
+    },
+    srsList,
+    selectedSrs,
     onChange = () => {}
 }) => {
-    const [advancedOptionsOpened, openAdvancedOptions] = React.useState(false);
+    const [advancedOptionsOpened, openAdvancedOptions] = useState(false);
+
+    useEffect(() => {
+        onChange('compression', selectedCompression || head(compressionOptions));
+    }, []);
 
     return (
         <>
-            {cropDataSetVisible && <div className="mapstore-downloadwpsoptions-menuitem">
-                <SwitchButton checked={cropDataSetEnabled} onClick={checked => onChange('cropDataSet', checked)}/>
-                <Message msgId="layerdownload.cropDataSet"/>
-            </div>}
-            {donwloadFilteredVisible && <div className="mapstore-downloadwpsoptions-menuitem">
-                <SwitchButton checked={downloadFilteredEnabled} onClick={checked => onChange('downloadFilteredDataSet', checked)}/>
-                <Message msgId="layerdownload.downloadFilteredDataSet"/>
-            </div>}
             {advancedOptionsVisible && <div className="mapstore-downloadwpsoptions-advanced-options">
                 <Button className="no-border" onClick={() => openAdvancedOptions(!advancedOptionsOpened)}>
                     <Glyphicon glyph={`chevron-${advancedOptionsOpened ? 'down' : 'right'}`}/>
+                    &nbsp;&nbsp;&nbsp;
+                    <Message msgId="layerdownload.advancedOptions"/>
                 </Button>
-                <Message msgId="layerdownload.advancedOptions"/>
             </div>}
-            {advancedOptionsOpened && advancedOptionsVisible && <div className="mapstore-downloadwpsoptions-advanced">
+            {advancedOptionsOpened && advancedOptionsVisible &&
+            <div className="mapstore-downloadwpsoptions-advanced">
+
+                {/* select SRS must be always visibile */}
                 <div className="mapstore-downloadwpsoptions-advanced-menuitem">
-                    <Message msgId="layerdownload.compression"/>
-                    <Select
-                        clearable
-                        value={selectedCompression}
-                        options={compressionOptions.map(opt => isString(opt) ? {value: opt, label: opt} : opt)}
-                        onChange={(e) => onChange('compression', e?.value)}/>
-                </div>
-                <div className="mapstore-downloadwpsoptions-advanced-menuitem">
-                    <Message msgId="layerdownload.quality"/>
                     <div className="mapstore-downloadwpsoptions-advanced-menuitem-control">
-                        <FormControl placeholder="0.75" type="number" min="0" max="1" value={quality || ''} onChange={e => onChange('quality', e.target.value)}/>
+                        <label><Message msgId="layerdownload.srs" /></label>
+                        <Select
+                            clearable={false}
+                            value={selectedSrs}
+                            onChange={(sel) => onChange("selectedSrs", sel.value)}
+                            options={srsList.map(f => ({value: f.name, label: f.label || f.name}))} />
                     </div>
                 </div>
-                <div className="mapstore-downloadwpsoptions-advanced-menuitem">
-                    <Message msgId="layerdownload.tileWidth"/>
-                    <div className="mapstore-downloadwpsoptions-advanced-menuitem-control">
-                        <FormControl
-                            placeholder="256"
-                            type="number"
-                            min="0"
-                            value={tileWidth || ''}
-                            onChange={e => onChange('tileWidth', e.target.value && e.target.value.length > 0 ? `${parseInt(e.target.value, 10)}` : '')}/>
-                        <span>px</span>
-                    </div>
-                </div>
-                <div className="mapstore-downloadwpsoptions-advanced-menuitem">
-                    <Message msgId="layerdownload.tileHeight"/>
-                    <div className="mapstore-downloadwpsoptions-advanced-menuitem-control">
-                        <FormControl
-                            placeholder="256"
-                            type="number"
-                            min="0"
-                            value={tileHeight || ''}
-                            onChange={e => onChange('tileHeight', e.target.value && e.target.value.length > 0 ? `${parseInt(e.target.value, 10)}` : '')}/>
-                        <span>px</span>
-                    </div>
-                </div>
+
+                {wpsOptionsVisible && <>
+
+                    {cropDataSetVisible && <>
+                        <div className="mapstore-downloadwpsoptions-advanced-menuitem">
+                            <div className="mapstore-downloadwpsoptions-advanced-menuitem-control">
+                                <SwitchButton checked={cropDataSetEnabled} onClick={checked => onChange('cropDataSet', checked)}/>
+                                <Message msgId="layerdownload.cropDataSet"/>
+                            </div>
+                        </div>
+                    </>
+                    }
+
+                    {downloadFilteredVisible && <>
+                        <div className="mapstore-downloadwpsoptions-advanced-menuitem">
+                            <div className="mapstore-downloadwpsoptions-advanced-menuitem-control">
+                                <SwitchButton checked={downloadFilteredEnabled} onClick={checked => onChange('downloadFilteredDataSet', checked)}/>
+                                <Message msgId="layerdownload.downloadFilteredDataSet"/>
+                            </div>
+                        </div>
+                    </>
+                    }
+
+                    {rasterOptionsVisibile && <>
+
+                        <div className="mapstore-downloadwpsoptions-advanced-menuitem">
+                            <Message msgId="layerdownload.compression"/>
+                            <div className="mapstore-downloadwpsoptions-advanced-menuitem-control">
+                                <Select
+                                    clearable={false}
+                                    value={selectedCompression}
+                                    options={compressionOptions.map(opt => isString(opt) ? {value: opt, label: opt} : opt)}
+                                    onChange={(e) => onChange('compression', e?.value)}/>
+                            </div>
+                        </div>
+                        <div className="mapstore-downloadwpsoptions-advanced-menuitem">
+                            <Message msgId="layerdownload.quality"/>
+                            <div className="mapstore-downloadwpsoptions-advanced-menuitem-control">
+                                <FormControl
+                                    placeholder={placeholders.quality}
+                                    type="number"
+                                    size="4"
+                                    min="0"
+                                    max="1"
+                                    step="0.1"
+                                    value={quality || ''}
+                                    onChange={e => onChange('quality', e.target.value)}/>
+                            </div>
+                        </div>
+                        <div className="mapstore-downloadwpsoptions-advanced-menuitem">
+                            <Message msgId="layerdownload.tileWidth"/>
+                            <div className="mapstore-downloadwpsoptions-advanced-menuitem-control">
+                                <FormControl
+                                    placeholder={placeholders.tileWidth}
+                                    type="number"
+                                    size="4"
+                                    min="0"
+                                    value={tileWidth || ''}
+                                    onChange={e => onChange('tileWidth', e.target.value && e.target.value.length > 0 ? `${parseInt(e.target.value, 10)}` : '')}/>
+                                <span>px</span>
+                            </div>
+                        </div>
+                        <div className="mapstore-downloadwpsoptions-advanced-menuitem">
+                            <Message msgId="layerdownload.tileHeight"/>
+                            <div className="mapstore-downloadwpsoptions-advanced-menuitem-control">
+                                <FormControl
+                                    placeholder={placeholders.tileHeight}
+                                    type="number"
+                                    size="4"
+                                    min="0"
+                                    value={tileHeight || ''}
+                                    onChange={e => onChange('tileHeight', e.target.value && e.target.value.length > 0 ? `${parseInt(e.target.value, 10)}` : '')}/>
+                                <span>px</span>
+                            </div>
+                        </div>
+                    </>}
+                </>}
             </div>}
         </>
     );

--- a/web/client/components/data/download/ExportDataResultsComponent.jsx
+++ b/web/client/components/data/download/ExportDataResultsComponent.jsx
@@ -20,7 +20,6 @@ import OverlayTrigger from '../../misc/OverlayTrigger';
 const ExportDataResultsComponent = ({
     active = false,
     showInfoBubble = false,
-    infoBubbleMessage = {},
     checkingExportDataEntries,
     results = [],
     currentLocale,
@@ -34,9 +33,11 @@ const ExportDataResultsComponent = ({
         }
     }, [active]);
 
+    const infoMsg = {msgId: 'layerdownload.exportResultsMessages.exportFailure', level: "success"};
+
     return (
         <>
-            {results.length > 0 ? <div id="mapstore-export-data-results-button-container">
+            {/* {results.length > 0*/ true ? <div id="mapstore-export-data-results-button-container"> */}
                 <OverlayTrigger placement="left" overlay={<Tooltip id="mapstore-export-data-results-tooltip"><Message msgId="exportDataResults.title"/></Tooltip>}>
                     <Button
                         bsStyle="primary"
@@ -45,10 +46,11 @@ const ExportDataResultsComponent = ({
                         <Glyphicon glyph="download"/>
                     </Button>
                 </OverlayTrigger>
+                {/* TODO refect replace with other Comp */}
                 <InfoBubble
                     show={showInfoBubble}
                     className="mapstore-export">
-                    <DefaultInfoBubbleInner {...infoBubbleMessage} />
+                    <DefaultInfoBubbleInner {...infoMsg} />
                 </InfoBubble>
             </div> : null}
             {/* Portal must be contained in a valid node tag not in <></> */}

--- a/web/client/components/data/download/__tests__/DownloadDialog.checkWPSAvailability-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadDialog.checkWPSAvailability-test.jsx
@@ -1,0 +1,111 @@
+
+// OLD Epic
+// export const checkWPSAvailabilityEpic = (action$, store) => action$
+//     .ofType(CHECK_WPS_AVAILABILITY)
+//     .switchMap(({url, selectedService}) => {
+//         return describeProcess(url, 'gs:DownloadEstimator,gs:Download')
+//             .switchMap(response => Rx.Observable.defer(() => new Promise((resolve, reject) => parseString(response.data, {tagNameProcessors: [stripPrefix]}, (err, res) => err ? reject(err) : resolve(res)))))
+//             .flatMap(xmlObj => {
+//                 const state = store.getState();
+//                 const layer = getSelectedLayer(state);
+//                 const ids = [
+//                     xmlObj?.ProcessDescriptions?.ProcessDescription?.[0]?.Identifier?.[0],
+//                     xmlObj?.ProcessDescriptions?.ProcessDescription?.[1]?.Identifier?.[0]
+//                 ];
+//                 const isWpsAvailable = findIndex(ids, x => x === 'gs:DownloadEstimator') > -1 && findIndex(ids, x => x === 'gs:Download') > -1;
+//                 const isWfsAvailable = layer.search?.url;
+//                 const shouldSelectWps = isWpsAvailable && (selectedService === 'wps' || !isWfsAvailable);
+//                 return Rx.Observable.of(
+//                     setService(shouldSelectWps ? 'wps' : 'wfs'),
+//                     setWPSAvailability(isWpsAvailable),
+//                     checkingWPSAvailability(false)
+//                 );
+//             })
+//             .catch(() => Rx.Observable.of(setService('wfs'), setWPSAvailability(false), checkingWPSAvailability(false)))
+//             .startWith(checkingWPSAvailability(true));
+//     });
+
+// moved here from epics/tests/layerdownload.js
+
+// it('check WPS availability', (done) => {
+//         const epicResult = actions => {
+//             expect(actions.length).toBe(4);
+//             expect(actions[0].type).toBe(CHECKING_WPS_AVAILABILITY);
+//             expect(actions[0].checking).toBe(true);
+//             expect(actions[3].type).toBe(CHECKING_WPS_AVAILABILITY);
+//             expect(actions[3].checking).toBe(false);
+
+//             actions.slice(1, actions.length - 1).map((action) => {
+//                 switch (action.type) {
+//                 case SET_SERVICE:
+//                     expect(action.service).toBe('wfs');
+//                     break;
+//                 case SET_WPS_AVAILABILITY:
+//                     expect(action.value).toBe(true);
+//                     break;
+//                 default:
+//                     break;
+//                 }
+//             });
+//             done();
+//         };
+
+//         mockAxios.onGet().reply(200, xmlData);
+//         const state = {
+//             controls: {
+//                 layerdownload: { enabled: false, downloadOptions: {}}
+//             },
+//             layers: {
+//                 flat: [
+//                     {
+//                         type: 'wfs',
+//                         visibility: true,
+//                         id: 'mapstore:states__7',
+//                         search: {
+//                             url: 'http://u.r.l'
+//                         }
+//                     }
+//                 ],
+//                 selected: [
+//                     'mapstore:states__7'
+//                 ]
+//             }
+//         };
+//         testEpic(checkWPSAvailabilityEpic, 4, checkWPSAvailability('http://check.wps.availability.url', 'wfs'), epicResult, state);
+//     });
+
+//     it('should select WPS service', (done) => {
+//         const epicResult = actions => {
+//             expect(actions.length).toBe(4);
+//             actions.map((action) => {
+//                 switch (action.type) {
+//                 case SET_SERVICE:
+//                     expect(action.service).toBe('wps');
+//                     break;
+//                 default:
+//                     break;
+//                 }
+//             });
+//             done();
+//         };
+
+//         mockAxios.onGet().reply(200, xmlData);
+//         const state = {
+//             controls: {
+//                 layerdownload: { enabled: false, downloadOptions: {}}
+//             },
+//             layers: {
+//                 flat: [
+//                     {
+//                         type: 'wms',
+//                         visibility: true,
+//                         id: 'mapstore:states__7'
+//                     }
+//                 ],
+//                 selected: [
+//                     'mapstore:states__7'
+//                 ]
+//             }
+//         };
+//         testEpic(checkWPSAvailabilityEpic, 4, checkWPSAvailability('http://check.wps.availability.url', 'wfs'), epicResult, state);
+//     });

--- a/web/client/components/data/download/__tests__/checkWPSAvailability-test.jsx
+++ b/web/client/components/data/download/__tests__/checkWPSAvailability-test.jsx
@@ -1,5 +1,7 @@
 
-// OLD Epic
+// TODO use ./data/download-estimation.xml.js
+
+// OLD Epic logic
 // export const checkWPSAvailabilityEpic = (action$, store) => action$
 //     .ofType(CHECK_WPS_AVAILABILITY)
 //     .switchMap(({url, selectedService}) => {
@@ -24,6 +26,9 @@
 //             .catch(() => Rx.Observable.of(setService('wfs'), setWPSAvailability(false), checkingWPSAvailability(false)))
 //             .startWith(checkingWPSAvailability(true));
 //     });
+
+
+// OLD UNIT TEST OF EPIC
 
 // moved here from epics/tests/layerdownload.js
 

--- a/web/client/components/data/download/__tests__/data/download-estimation.xml.js
+++ b/web/client/components/data/download/__tests__/data/download-estimation.xml.js
@@ -1,0 +1,362 @@
+export const xmlData = `<?xml version="1.0" encoding="UTF-8"?>
+<wps:ProcessDescriptions xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:lang="en" service="WPS" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd">
+  <ProcessDescription wps:processVersion="1.0.0" statusSupported="true" storeSupported="true">
+    <ows:Identifier>gs:DownloadEstimator</ows:Identifier>
+    <ows:Title>Estimator Process</ows:Title>
+    <ows:Abstract>Checks if the input file does not exceed the limits</ows:Abstract>
+    <DataInputs>
+      <Input maxOccurs="1" minOccurs="1">
+        <ows:Identifier>layerName</ows:Identifier>
+        <ows:Title>layerName</ows:Title>
+        <ows:Abstract>Original layer to download</ows:Abstract>
+        <LiteralData>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>filter</ows:Identifier>
+        <ows:Title>filter</ows:Title>
+        <ows:Abstract>Optional Vectorial Filter</ows:Abstract>
+        <ComplexData>
+          <Default>
+            <Format>
+              <MimeType>text/xml; subtype=filter/1.0</MimeType>
+            </Format>
+          </Default>
+          <Supported>
+            <Format>
+              <MimeType>text/xml; subtype=filter/1.0</MimeType>
+            </Format>
+            <Format>
+              <MimeType>text/xml; subtype=filter/1.1</MimeType>
+            </Format>
+            <Format>
+              <MimeType>text/plain; subtype=cql</MimeType>
+            </Format>
+          </Supported>
+        </ComplexData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>targetCRS</ows:Identifier>
+        <ows:Title>targetCRS</ows:Title>
+        <ows:Abstract>Target CRS</ows:Abstract>
+        <LiteralData>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>RoiCRS</ows:Identifier>
+        <ows:Title>RoiCRS</ows:Title>
+        <ows:Abstract>Region Of Interest CRS</ows:Abstract>
+        <LiteralData>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>ROI</ows:Identifier>
+        <ows:Title>ROI</ows:Title>
+        <ows:Abstract>Region Of Interest</ows:Abstract>
+        <ComplexData>
+          <Default>
+            <Format>
+              <MimeType>text/xml; subtype=gml/3.1.1</MimeType>
+            </Format>
+          </Default>
+          <Supported>
+            <Format>
+              <MimeType>text/xml; subtype=gml/3.1.1</MimeType>
+            </Format>
+            <Format>
+              <MimeType>text/xml; subtype=gml/2.1.2</MimeType>
+            </Format>
+            <Format>
+              <MimeType>application/wkt</MimeType>
+            </Format>
+            <Format>
+              <MimeType>application/gml-3.1.1</MimeType>
+            </Format>
+            <Format>
+              <MimeType>application/gml-2.1.2</MimeType>
+            </Format>
+            <Format>
+              <MimeType>application/json</MimeType>
+            </Format>
+          </Supported>
+        </ComplexData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>cropToROI</ows:Identifier>
+        <ows:Title>cropToROI</ows:Title>
+        <ows:Abstract>Crop to ROI</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:boolean</ows:DataType>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>targetSizeX</ows:Identifier>
+        <ows:Title>targetSizeX</ows:Title>
+        <ows:Abstract>X Size of the Target Image (applies to raster data only), or native resolution if missing</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:int</ows:DataType>
+          <ows:AllowedValues>
+            <ows:Range ows:rangeClosure="closed-open">
+              <ows:MinimumValue>1.0</ows:MinimumValue>
+            </ows:Range>
+          </ows:AllowedValues>
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>targetSizeY</ows:Identifier>
+        <ows:Title>targetSizeY</ows:Title>
+        <ows:Abstract>Y Size of the Target Image (applies to raster data only), or native resolution if missing</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:int</ows:DataType>
+          <ows:AllowedValues>
+            <ows:Range ows:rangeClosure="closed-open">
+              <ows:MinimumValue>1.0</ows:MinimumValue>
+            </ows:Range>
+          </ows:AllowedValues>
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="2147483647" minOccurs="0">
+        <ows:Identifier>selectedBands</ows:Identifier>
+        <ows:Title>selectedBands</ows:Title>
+        <ows:Abstract>Band Selection Indices</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:int</ows:DataType>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+    </DataInputs>
+    <ProcessOutputs>
+      <Output>
+        <ows:Identifier>result</ows:Identifier>
+        <ows:Title>result</ows:Title>
+        <LiteralOutput>
+          <ows:DataType>boolean</ows:DataType>
+        </LiteralOutput>
+      </Output>
+    </ProcessOutputs>
+  </ProcessDescription>
+  <ProcessDescription wps:processVersion="1.0.0" statusSupported="true" storeSupported="true">
+    <ows:Identifier>gs:Download</ows:Identifier>
+    <ows:Title>Enterprise Download Process</ows:Title>
+    <ows:Abstract>Downloads Layer Stream and provides a ZIP.</ows:Abstract>
+    <DataInputs>
+      <Input maxOccurs="1" minOccurs="1">
+        <ows:Identifier>layerName</ows:Identifier>
+        <ows:Title>layerName</ows:Title>
+        <ows:Abstract>Original layer to download</ows:Abstract>
+        <LiteralData>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>filter</ows:Identifier>
+        <ows:Title>filter</ows:Title>
+        <ows:Abstract>Optional Vector Filter</ows:Abstract>
+        <ComplexData>
+          <Default>
+            <Format>
+              <MimeType>text/xml; subtype=filter/1.0</MimeType>
+            </Format>
+          </Default>
+          <Supported>
+            <Format>
+              <MimeType>text/xml; subtype=filter/1.0</MimeType>
+            </Format>
+            <Format>
+              <MimeType>text/xml; subtype=filter/1.1</MimeType>
+            </Format>
+            <Format>
+              <MimeType>text/plain; subtype=cql</MimeType>
+            </Format>
+          </Supported>
+        </ComplexData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="1">
+        <ows:Identifier>outputFormat</ows:Identifier>
+        <ows:Title>outputFormat</ows:Title>
+        <ows:Abstract>format Mime-Type</ows:Abstract>
+        <LiteralData>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>targetCRS</ows:Identifier>
+        <ows:Title>targetCRS</ows:Title>
+        <ows:Abstract>Optional Target CRS</ows:Abstract>
+        <LiteralData>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>RoiCRS</ows:Identifier>
+        <ows:Title>RoiCRS</ows:Title>
+        <ows:Abstract>Optional Region Of Interest CRS</ows:Abstract>
+        <LiteralData>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>ROI</ows:Identifier>
+        <ows:Title>ROI</ows:Title>
+        <ows:Abstract>Optional Region Of Interest (Polygon)</ows:Abstract>
+        <ComplexData>
+          <Default>
+            <Format>
+              <MimeType>text/xml; subtype=gml/3.1.1</MimeType>
+            </Format>
+          </Default>
+          <Supported>
+            <Format>
+              <MimeType>text/xml; subtype=gml/3.1.1</MimeType>
+            </Format>
+            <Format>
+              <MimeType>text/xml; subtype=gml/2.1.2</MimeType>
+            </Format>
+            <Format>
+              <MimeType>application/wkt</MimeType>
+            </Format>
+            <Format>
+              <MimeType>application/gml-3.1.1</MimeType>
+            </Format>
+            <Format>
+              <MimeType>application/gml-2.1.2</MimeType>
+            </Format>
+            <Format>
+              <MimeType>application/json</MimeType>
+            </Format>
+          </Supported>
+        </ComplexData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>cropToROI</ows:Identifier>
+        <ows:Title>cropToROI</ows:Title>
+        <ows:Abstract>Crop to ROI</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:boolean</ows:DataType>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>interpolation</ows:Identifier>
+        <ows:Title>interpolation</ows:Title>
+        <ows:Abstract>Interpolation function to use when reprojecting / scaling raster data.  Values are NEAREST (default), BILINEAR, BICUBIC2, BICUBIC</ows:Abstract>
+        <LiteralData>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>targetSizeX</ows:Identifier>
+        <ows:Title>targetSizeX</ows:Title>
+        <ows:Abstract>X Size of the Target Image (applies to raster data only), or native resolution if missing</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:int</ows:DataType>
+          <ows:AllowedValues>
+            <ows:Range ows:rangeClosure="closed-open">
+              <ows:MinimumValue>1.0</ows:MinimumValue>
+            </ows:Range>
+          </ows:AllowedValues>
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>targetSizeY</ows:Identifier>
+        <ows:Title>targetSizeY</ows:Title>
+        <ows:Abstract>Y Size of the Target Image (applies to raster data only), or native resolution if missing</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:int</ows:DataType>
+          <ows:AllowedValues>
+            <ows:Range ows:rangeClosure="closed-open">
+              <ows:MinimumValue>1.0</ows:MinimumValue>
+            </ows:Range>
+          </ows:AllowedValues>
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="2147483647" minOccurs="0">
+        <ows:Identifier>selectedBands</ows:Identifier>
+        <ows:Title>selectedBands</ows:Title>
+        <ows:Abstract>Band Selection Indices</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:int</ows:DataType>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>writeParameters</ows:Identifier>
+        <ows:Title>writeParameters</ows:Title>
+        <ows:Abstract>Optional writing parameters</ows:Abstract>
+        <ComplexData>
+          <Default>
+            <Format>
+              <MimeType>text/xml</MimeType>
+            </Format>
+          </Default>
+          <Supported>
+            <Format>
+              <MimeType>text/xml</MimeType>
+            </Format>
+          </Supported>
+        </ComplexData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>minimizeReprojections</ows:Identifier>
+        <ows:Title>minimizeReprojections</ows:Title>
+        <ows:Abstract>When dealing with a Heterogeneous CRS mosaic, avoid reprojections of the granules within the ROI, having their nativeCRS equal to the targetCRS</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:boolean</ows:DataType>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>bestResolutionOnMatchingCRS</ows:Identifier>
+        <ows:Title>bestResolutionOnMatchingCRS</ows:Title>
+        <ows:Abstract>When dealing with a Heterogeneous CRS mosaic given a ROI and a TargetCRS, with no target size being specified, get the best  resolution of data having nativeCrs matching the TargetCRS</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:boolean</ows:DataType>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>resolutionsDifferenceTolerance</ows:Identifier>
+        <ows:Title>resolutionsDifferenceTolerance</ows:Title>
+        <ows:Abstract>the parameter allows to specify a tolerance value to control the use of native resolution of the data, when no target size has been specified and granules are reprojected. If  the percentage difference between original and reprojected coverages resolutions is below the specified tolerance value, native resolutions is the same for all the requested granules, the unit of measure is the same for native and target CRS, the reprojected coverage will be forced to use native resolutions</ows:Abstract>
+        <LiteralData>
+          <ows:DataType>xs:double</ows:DataType>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+      <Input maxOccurs="1" minOccurs="0">
+        <ows:Identifier>targetVerticalCRS</ows:Identifier>
+        <ows:Title>targetVerticalCRS</ows:Title>
+        <ows:Abstract>Optional Target VerticalCRS </ows:Abstract>
+        <LiteralData>
+          <ows:AnyValue />
+        </LiteralData>
+      </Input>
+    </DataInputs>
+    <ProcessOutputs>
+      <Output>
+        <ows:Identifier>result</ows:Identifier>
+        <ows:Title>result</ows:Title>
+        <ComplexOutput>
+          <Default>
+            <Format>
+              <MimeType>image/tiff</MimeType>
+            </Format>
+          </Default>
+          <Supported>
+            <Format>
+              <MimeType>image/tiff</MimeType>
+            </Format>
+            <Format>
+              <MimeType>application/zip</MimeType>
+            </Format>
+          </Supported>
+        </ComplexOutput>
+      </Output>
+    </ProcessOutputs>
+  </ProcessDescription>
+</wps:ProcessDescriptions>
+`;

--- a/web/client/components/misc/infobubble/InfoBubble.jsx
+++ b/web/client/components/misc/infobubble/InfoBubble.jsx
@@ -11,7 +11,7 @@ import classnames from 'classnames';
 
 const InfoBubble = ({
     show,
-    arrowDirection = 'bottom',
+    arrowDirection = 'top',
     className,
     containerClassName,
     children

--- a/web/client/components/widgets/enhancers/tools/withMenu.js
+++ b/web/client/components/widgets/enhancers/tools/withMenu.js
@@ -5,8 +5,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import  React from 'react';
-import  {
+import React from 'react';
+import {
     ButtonToolbar,
     DropdownButton,
     Glyphicon,
@@ -20,29 +20,41 @@ import  tooltip from '../../../misc/enhancers/tooltip';
 const isMenuItem = ({target, visible = true}) => visible && target === "menu";
 const hasMenuItems = (tt = []) => tt.filter(isMenuItem).length > 0;
 
-
 const MenuItem = tooltip(MenuItemBS);
 
 /**
  * transform `widgetTools` property items with `target` = `menu` into a DropDown button to put in `topRightItems` for WidgetContainer, as a menu
  */
 export default ({ className = "widget-menu", menuIcon = "option-vertical"} = {}) =>
-    withProps(({ widgetTools, topRightItems = []}) => ({
+    withProps(({ widgetTools, topRightItems = [], items = [], layer, id }) => ({
         topRightItems: hasMenuItems(widgetTools)
-            ? [...topRightItems, (<ButtonToolbar>
-                <DropdownButton pullRight bsStyle="default" className={className} title={<Glyphicon glyph={menuIcon} />} noCaret id="dropdown-no-caret">
-                    {widgetTools.filter(isMenuItem).map(({ onClick = () => { }, disabled = false, glyph, glyphClassName, text, textId, tooltipId, active}, i) =>
-                        <MenuItem
-                            active={active}
-                            tooltipId={tooltipId}
-                            onSelect={onClick}
-                            disabled={disabled}
-                            eventKey={i}>
-                            <Glyphicon className={glyphClassName} glyph={glyph} />
-                            {textId ? <Message msgId={textId} /> : text}
-                        </MenuItem>)
-                    }
-                </DropdownButton>
-            </ButtonToolbar>)]
+            ? [...topRightItems, (
+                <ButtonToolbar>
+                    <DropdownButton pullRight bsStyle="default" className={className} title={<Glyphicon glyph={menuIcon} />} noCaret id="dropdown-no-caret">
+                        {widgetTools.filter(isMenuItem)
+                            .map(({ onClick = () => { }, disabled = false, glyph, glyphClassName, text, textId, tooltipId, active}, i) =>
+                                <MenuItem
+                                    active={active}
+                                    tooltipId={tooltipId}
+                                    onSelect={onClick}
+                                    disabled={disabled}
+                                    eventKey={i}>
+                                    <Glyphicon className={glyphClassName} glyph={glyph} />
+                                    {textId ? <Message msgId={textId} /> : text}
+                                </MenuItem>)
+                        }
+                        {items.map((item) =>
+                            <item.Component
+                                key={item.name}
+                                layer={layer}
+                                widgetId={id}
+                                itemComponent={(props) => (
+                                    <MenuItem {...props}>
+                                        <Glyphicon glyph={props.glyph} />
+                                        <Message msgId={props.textId} />
+                                    </MenuItem>)
+                                } />)}
+                    </DropdownButton>
+                </ButtonToolbar>)]
             : topRightItems
     }));

--- a/web/client/components/widgets/widget/DefaultWidget.jsx
+++ b/web/client/components/widgets/widget/DefaultWidget.jsx
@@ -21,6 +21,7 @@ const getWidgetOpts = (w) => w?.widgetOpts?.[w.widgetType];
  * Renders proper widget by widgetType, binding props and methods
  */
 const DefaultWidget = ({
+    items,
     dependencies,
     toggleCollapse = () => {},
     exportCSV = () => {},
@@ -40,6 +41,7 @@ const DefaultWidget = ({
             dependencies={dependencies}
             onDelete={onDelete}
             onEdit={onEdit}
+            items={items}
         />
         : w.widgetType === "counter"
             ? <CounterWidget {...w}
@@ -54,7 +56,8 @@ const DefaultWidget = ({
                     toggleCollapse={toggleCollapse}
                     dependencies={dependencies}
                     onDelete={onDelete}
-                    onEdit={onEdit} />
+                    onEdit={onEdit}
+                    items={items} />
                 : w.widgetType === "legend"
                     ? <LegendWidget {...w}
                         {...getWidgetOpts(w)}

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -2,6 +2,7 @@
   "proxyUrl": {
     "url": "proxy/?url=",
     "useCORS": [
+      "http://localhost:7070/geoserver",
       "http://demo.geo-solutions.it/geoserver",
       "https://demo.geo-solutions.it:443/geoserver",
       "https://demo.geo-solutions.it/geoserver",
@@ -947,6 +948,7 @@
     ],
     "permalink": ["Permalink", "FeedbackMask"],
     "dashboard": [
+      { "name": "LayerDownload" },
       { "name": "ResourceDetails", "cfg": { "resourceType": "DASHBOARD" } },
       { "name": "Save", "cfg": { "resourceType": "DASHBOARD" } },
       { "name": "SaveAs", "cfg": { "resourceType": "DASHBOARD" } },

--- a/web/client/epics/__tests__/layerdownload-test.js
+++ b/web/client/epics/__tests__/layerdownload-test.js
@@ -14,7 +14,7 @@ import { toggleControl, TOGGLE_CONTROL } from '../../actions/controls';
 import { download } from '../../actions/layers';
 import { DOWNLOAD_OPTIONS_CHANGE, downloadFeatures, checkWPSAvailability, SET_SERVICE, SET_WPS_AVAILABILITY, CHECKING_WPS_AVAILABILITY } from '../../actions/layerdownload';
 import { QUERY_CREATE } from '../../actions/wfsquery';
-import { checkWPSAvailabilityEpic, closeExportDownload, openDownloadTool, startFeatureExportDownload } from '../layerdownload';
+import { closeExportDownload, openDownloadTool, startFeatureExportDownload } from '../layerdownload';
 import { testEpic } from './epicTestUtils';
 import { xmlData } from "./data/download-estimation.xml";
 describe('layerdownload Epics', () => {
@@ -38,87 +38,6 @@ describe('layerdownload Epics', () => {
 
         const state = {controls: { queryPanel: {enabled: false}, layerdownload: {enabled: true}}};
         testEpic(closeExportDownload, 1, toggleControl("queryPanel"), epicResult, state);
-    });
-    it('check WPS availability', (done) => {
-        const epicResult = actions => {
-            expect(actions.length).toBe(4);
-            expect(actions[0].type).toBe(CHECKING_WPS_AVAILABILITY);
-            expect(actions[0].checking).toBe(true);
-            expect(actions[3].type).toBe(CHECKING_WPS_AVAILABILITY);
-            expect(actions[3].checking).toBe(false);
-
-            actions.slice(1, actions.length - 1).map((action) => {
-                switch (action.type) {
-                case SET_SERVICE:
-                    expect(action.service).toBe('wfs');
-                    break;
-                case SET_WPS_AVAILABILITY:
-                    expect(action.value).toBe(true);
-                    break;
-                default:
-                    break;
-                }
-            });
-            done();
-        };
-
-        mockAxios.onGet().reply(200, xmlData);
-        const state = {
-            controls: {
-                layerdownload: { enabled: false, downloadOptions: {}}
-            },
-            layers: {
-                flat: [
-                    {
-                        type: 'wfs',
-                        visibility: true,
-                        id: 'mapstore:states__7',
-                        search: {
-                            url: 'http://u.r.l'
-                        }
-                    }
-                ],
-                selected: [
-                    'mapstore:states__7'
-                ]
-            }
-        };
-        testEpic(checkWPSAvailabilityEpic, 4, checkWPSAvailability('http://check.wps.availability.url', 'wfs'), epicResult, state);
-    });
-    it('should select WPS service', (done) => {
-        const epicResult = actions => {
-            expect(actions.length).toBe(4);
-            actions.map((action) => {
-                switch (action.type) {
-                case SET_SERVICE:
-                    expect(action.service).toBe('wps');
-                    break;
-                default:
-                    break;
-                }
-            });
-            done();
-        };
-
-        mockAxios.onGet().reply(200, xmlData);
-        const state = {
-            controls: {
-                layerdownload: { enabled: false, downloadOptions: {}}
-            },
-            layers: {
-                flat: [
-                    {
-                        type: 'wms',
-                        visibility: true,
-                        id: 'mapstore:states__7'
-                    }
-                ],
-                selected: [
-                    'mapstore:states__7'
-                ]
-            }
-        };
-        testEpic(checkWPSAvailabilityEpic, 4, checkWPSAvailability('http://check.wps.availability.url', 'wfs'), epicResult, state);
     });
     it('downloads a layer', (done) => {
         const epicResult = actions => {

--- a/web/client/epics/security.js
+++ b/web/client/epics/security.js
@@ -26,24 +26,24 @@ export const checkProtectedContentEpic = (action$) =>
         .switchMap((action) => {
             const config = action.config;
             const protectedLayers = config?.map?.layers.map(layer => {
-                return {protectedId: layer?.security?.sourceId, url: layer.url};
+                return { protectedId: layer?.security?.sourceId, url: layer.url };
             });
             const services = Object.keys(config?.catalogServices?.services)
                 .map(protectedService => {
                     const service = config?.catalogServices?.services?.[protectedService];
-                    return {protectedId: service?.protectedId, url: service?.url};
+                    return { protectedId: service?.protectedId, url: service?.url };
                 })
                 .concat(protectedLayers)
                 .filter(v => !!v.protectedId);
             const protectedServices = uniqBy(services, "protectedId")
-                .map(({protectedId, url}) => {
+                .map(({ protectedId, url }) => {
                     return {
                         protectedId,
                         url,
                         ...getCredentials(protectedId)
                     };
                 })
-                .filter(({username, password}) => !(username && password));
+                .filter(({ username, password }) => !(username && password));
 
             // group by similar url
             const uniqueServices = uniqBy(protectedServices, "url");
@@ -70,22 +70,22 @@ export const checkProtectedContentDashboardEpic = (action$) =>
                     return p.concat(w?.maps);
                 }, [])
                 .reduce((pre, c) => {
-                    return pre.concat(c.layers
+                    return pre.concat(c?.layers
                         ?.map(layer => {
-                            return {protectedId: layer?.security?.sourceId, url: layer.url};
+                            return { protectedId: layer?.security?.sourceId, url: layer.url };
                         })
                         .filter(v => !!v.protectedId));
                 }, []);
 
             const protectedServices = uniqBy(layers, "protectedId")
-                .map(({protectedId, url}) => {
+                .map(({ protectedId, url }) => {
                     return {
                         protectedId,
                         url,
                         ...getCredentials(protectedId)
                     };
                 })
-                .filter(({username, password}) => !(username && password));
+                .filter(({ username, password }) => !(username && password));
 
             // group by similar url
             const uniqueServices = uniqBy(protectedServices, "url");
@@ -109,20 +109,20 @@ export const checkProtectedContentDashboardMapEpic = (action$) =>
                 .reduce((pre, c) => {
                     return pre.concat(c.layers
                         ?.map(layer => {
-                            return {protectedId: layer?.security?.sourceId, url: layer.url};
+                            return { protectedId: layer?.security?.sourceId, url: layer.url };
                         })
                         .filter(v => !!v.protectedId));
                 }, []);
 
             const protectedServices = uniqBy(layers, "protectedId")
-                .map(({protectedId, url}) => {
+                .map(({ protectedId, url }) => {
                     return {
                         protectedId,
                         url,
                         ...getCredentials(protectedId)
                     };
                 })
-                .filter(({username, password}) => !(username && password));
+                .filter(({ username, password }) => !(username && password));
 
             // group by similar url
             const uniqueServices = uniqBy(protectedServices, "url");
@@ -144,19 +144,19 @@ export const checkProtectedContentGeostoryMapSelectionEpic = (action$, store) =>
             const map = selectedItemSelector(store.getState());
             const layers = map?.data?.layers
                 ?.map(layer => {
-                    return {protectedId: layer?.security?.sourceId, url: layer.url};
+                    return { protectedId: layer?.security?.sourceId, url: layer.url };
                 })
                 .filter(v => !!v.protectedId);
 
             const protectedServices = uniqBy(layers, "protectedId")
-                .map(({protectedId, url}) => {
+                .map(({ protectedId, url }) => {
                     return {
                         protectedId,
                         url,
                         ...getCredentials(protectedId)
                     };
                 })
-                .filter(({username, password}) => !(username && password));
+                .filter(({ username, password }) => !(username && password));
 
             // group by similar url
             const uniqueServices = uniqBy(protectedServices, "url");
@@ -176,20 +176,20 @@ export const checkProtectedContentGeostoryEpic = (action$) =>
             const layers = resources?.reduce((p, c) => {
                 return p.concat(c?.data?.layers
                     ?.map(layer => {
-                        return {protectedId: layer?.security?.sourceId, url: layer.url};
+                        return { protectedId: layer?.security?.sourceId, url: layer.url };
                     })
                     .filter(v => !!v.protectedId)
                 );
             }, []);
             const protectedServices = uniqBy(layers, "protectedId")
-                .map(({protectedId, url}) => {
+                .map(({ protectedId, url }) => {
                     return {
                         protectedId,
                         url,
                         ...getCredentials(protectedId)
                     };
                 })
-                .filter(({username, password}) => !(username && password));
+                .filter(({ username, password }) => !(username && password));
 
             // group by similar url
             const uniqueServices = uniqBy(protectedServices, "url");

--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -50,6 +50,7 @@ import widgetsEpics from '../epics/widgets';
 import GlobalSpinner from '../components/misc/spinners/GlobalSpinner/GlobalSpinner';
 import { createPlugin } from '../utils/PluginsUtils';
 import { canTableWidgetBeDependency } from '../utils/WidgetsUtils';
+import usePluginItems from '../hooks/usePluginItems';
 
 const WidgetsView = compose(
     connect(
@@ -152,6 +153,8 @@ const WidgetsView = compose(
  */
 class DashboardPlugin extends React.Component {
     static propTypes = {
+        items: PropTypes.array,
+        addonsItems: PropTypes.array,
         enabled: PropTypes.bool,
         rowHeight: PropTypes.number,
         cols: PropTypes.object,
@@ -186,6 +189,7 @@ class DashboardPlugin extends React.Component {
     render() {
         return this.props.enabled
             ? <WidgetsView
+                items={this.props.items}
                 width={this.props.width}
                 height={this.props.height}
                 rowHeight={this.props.rowHeight}
@@ -199,13 +203,29 @@ class DashboardPlugin extends React.Component {
     }
 }
 
+const DashboardComponentWrapper = (props, context) => {
+    const { loadedPlugins } = context;
+    const addonsItems = usePluginItems({ items: props.items, loadedPlugins })
+        .filter(({ target }) => target === 'table-menu-download');
+
+    return <DashboardPlugin {...props} addonsItems={addonsItems} items={addonsItems}/>;
+};
+
+DashboardComponentWrapper.contextTypes = {
+    loadedPlugins: PropTypes.object
+};
+
 export default createPlugin("Dashboard", {
-    component: connect((state) => ({dashboardTitle: dashboardTitleSelector(state)}))(withResizeDetector(DashboardPlugin)),
+    component: connect((state) => ({dashboardTitle: dashboardTitleSelector(state)}))(withResizeDetector(DashboardComponentWrapper)),
     reducers: {
         dashboard: dashboardReducers,
         widgets: widgetsReducers
     },
     containers: {
+        BrandNavbar: {
+            name: "Dashboard-brandnavbar",
+            alwaysVisible: true
+        },
         SidebarMenu: {
             name: "Dashboard-spinner",
             alwaysVisible: true,

--- a/web/client/plugins/widgetbuilder/enhancers/layerSelector.js
+++ b/web/client/plugins/widgetbuilder/enhancers/layerSelector.js
@@ -13,10 +13,19 @@ import { addSearch } from '../../../observables/wms';
 import API from '../../../api/catalog';
 
 // layers like tms or wmts don't need the recordToLayer conversion
-export const toLayer = (r, service) => ["tms", "wfs"].includes(service?.type) // for tms and wfs the layer is ready
-    ? r
-    // the type wms is default (for csw and wms), wmts have to be passed. // TODO: improve and centralize more
-    : API[service?.type || 'wms'].getLayerFromRecord(r, { service });
+export const toLayer = (r, service) => {
+
+    return ["tms", "wfs"].includes(service?.type) // for tms and wfs the layer is ready
+        ? {
+            ...r,
+            search: r.type === 'wfs' ? {
+                url: r.url,
+                type: "wfs"
+            } : undefined
+        }
+        // the type wms is default (for csw and wms), wmts have to be passed. // TODO: improve and centralize more
+        : API[service?.type || 'wms'].getLayerFromRecord(r, { service });
+};
 
 // checks for tms, wmts & wfs, in order to skip addSearch
 export const addSearchObservable = (selected, service) => ["tms", "wmts", "wfs"].includes(service?.type) ? Rx.Observable.of(toLayer(selected, service)) : addSearch(toLayer(selected, service));

--- a/web/client/reducers/layerdownload.js
+++ b/web/client/reducers/layerdownload.js
@@ -26,6 +26,7 @@ import {
     CHECKING_EXPORT_DATA_ENTRIES,
     SET_WPS_AVAILABILITY
 } from '../actions/layerdownload';
+import { DOWNLOAD } from '../actions/layers';
 
 /**
  * reducer for layerdownload
@@ -40,6 +41,11 @@ import {
  */
 function layerdownload( state = {downloadOptions: {singlePage: true}}, action) {
     switch (action.type) {
+    case DOWNLOAD:
+        return {
+            ...state,
+            downloadLayer: action.layer
+        };
     case DOWNLOAD_FEATURES:
         return {
             ...state,

--- a/web/client/selectors/layerdownload.js
+++ b/web/client/selectors/layerdownload.js
@@ -12,6 +12,8 @@ import { isFeatureGridOpen } from './featuregrid';
 import { getSelectedLayer } from './layers';
 import { wfsFilter } from './query';
 
+import { getTableWidgets } from './widgets';
+
 export const layerDonwloadControlEnabledSelector = state => state?.controls?.layerdownload?.enabled;
 export const downloadOptionsSelector = state => state?.layerdownload?.downloadOptions;
 export const loadingSelector = state => state?.layerdownload?.loading;
@@ -20,13 +22,30 @@ export const wfsFormatsSelector = state => state?.layerdownload?.wfsFormats;
 export const formatsLoadingSelector = state => state?.layerdownload?.formatsLoading;
 export const wpsAvailableSelector = state => state?.layerdownload?.wpsAvailable;
 export const serviceSelector = state => state?.layerdownload?.service;
+
+export const downloadLayerSelector = state => state?.layerdownload?.downloadLayer;
+
 export const wfsFilterSelector = createSelector(
-    isFeatureGridOpen, wfsFilter, getSelectedLayer,
-    (featureGridOpen, wfsFilterObj, layer) => featureGridOpen ? wfsFilterObj : layer?.name ? {
-        featureTypeName: layer.name,
-        filterType: 'OGC',
-        ogcVersion: '1.1.0'
-    } : null
+    isFeatureGridOpen,
+    wfsFilter,
+    getSelectedLayer,
+    downloadLayerSelector,
+    getTableWidgets,
+    (
+        featureGridOpen,
+        wfsFilterObj,
+        mapLayer,
+        downloadLayer,
+        tableWidgets
+    ) => {
+        const selectedLayer = mapLayer || downloadLayer;
+        const widget = tableWidgets.filter(w => w.id === downloadLayer?.widgetId)[0];
+        return featureGridOpen ? wfsFilterObj || widget?.filter : selectedLayer?.name ? widget?.filter || {
+            featureTypeName: selectedLayer.name,
+            filterType: 'OGC',
+            ogcVersion: '1.1.0'
+        } : null;
+    }
 );
 export const exportDataResultsControlEnabledSelector = state => state?.controls?.exportDataResults?.enabled;
 export const exportDataResultsSelector = state => state?.layerdownload?.results;

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -97,6 +97,10 @@
             }
         }
     }
+
+    .popover {
+        z-index: 10000; /* patch to show it above open modals */
+    }
 }
 
 // **************

--- a/web/client/themes/default/less/layerdownload.less
+++ b/web/client/themes/default/less/layerdownload.less
@@ -111,7 +111,8 @@
     }
 }
 
-.mapstore-downloadwpsoptions-menuitem, .mapstore-downloadwpsoptions-advanced-options {
+.mapstore-downloadwpsoptions-menuitem,
+.mapstore-downloadwpsoptions-advanced-options {
     display: flex;
     margin: 10px 0 10px 0;
 
@@ -119,12 +120,13 @@
         display: inline-flex;
         align-items: center;
     };
-    
+
     & > .btn, .mapstore-switch-btn {
         margin: 0 1em 0 0;
     }
 }
 
+.mapstore-downloadoptions,
 .mapstore-downloadwpsoptions-advanced-options {
     margin: 20px 0 10px 0;
 }
@@ -135,6 +137,7 @@
 
     .mapstore-downloadwpsoptions-advanced-menuitem {
         display: table-row;
+        padding-top: 10px;
 
         & > span {
             display: table-cell;
@@ -147,13 +150,40 @@
 
         .mapstore-downloadwpsoptions-advanced-menuitem-control {
             display: table-cell;
-            padding-top: 10px;
+            padding-top: 15px;
 
             & > input {
                 display: inline-block;
                 max-width: 5em;
                 margin-right: 0.5em;
             }
+
+
+            & > span {
+                display: inline-flex;
+                align-items: center;
+                vertical-align: super
+            };
+
+            & > .btn, .mapstore-switch-btn {
+                margin: 0 1em 0 0;
+            }
         }
+    }
+}
+
+.mapstore-downloadoptions-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+
+    .Select {
+        width: 16em;
+        flex-shrink: 1;
+        max-width: 100%;
+    }
+
+    .mapstore-info-popover {
+        flex-shrink: 0;
     }
 }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2025,6 +2025,7 @@
     "layerdownload": {
       "title": "Daten exportieren",
       "service": "Service",
+      "downloadMode": "Export modus",
       "format": "Dateiformat",
       "srs": "Räumliches Bezugssystem",
       "export": "Export",
@@ -2054,6 +2055,16 @@
         "executeProcessXhrFailed": "ExecuteProcess-Anforderung fehlgeschlagen! Der Server ist möglicherweise falsch konfiguriert oder nicht mehr erreichbar",
         "getExecutionStatusXhrFailed": "GetExecutionStatus-Anforderung fehlgeschlagen! Der Server ist möglicherweise falsch konfiguriert oder nicht mehr erreichbar",
         "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten"
+      },
+      "services": {
+        "wps": {
+          "title": "Asynchron (WPS)",
+          "tooltip": "Der asynchrone Modus mit WPS (Web Processing Service) funktioniert durch Ausführen eines entfernten Prozesses; sobald die Verarbeitung abgeschlossen ist, erhältst du eine Benachrichtigung mit einem Link zum Herunterladen der Daten."
+        },
+        "wfs": {
+          "title": "Synchron (WFS)",
+          "tooltip": "Der synchrone Download mit WFS (Web Feature Service), geeignet für kleine Datensätze, funktioniert durch das Senden einer Anfrage, die sofort eine Vektordatei zurückgibt."
+        }
       },
       "noSupportedServiceFound": "Der Server unterstützt keinen WFS- oder WPS-Download für diese Ebene!"
     },

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1986,6 +1986,7 @@
     "layerdownload": {
       "title": "Export Data",
       "service": "Service",
+      "downloadMode": "Download Mode",
       "format": "File Format",
       "srs": "Spatial Reference System",
       "export": "Export",
@@ -2015,6 +2016,16 @@
         "executeProcessXhrFailed": "ExecuteProcess request failed! The server might be misconfigured or it has become unreachable",
         "getExecutionStatusXhrFailed": "GetExecutionStatus request failed! The server might be misconfigured or it has become unreachable",
         "unexpectedError": "Unexpected error occurred"
+      },
+      "services": {
+        "wps": {
+          "title": "Asynchronous (WPS)",
+          "tooltip": "Asynchronous mode with WPS (Web Processing Service) works by executing a remote process; once the processing is complete, you will receive a notification with a link to download the data."
+        },
+        "wfs": {
+          "title": "Synchronous (WFS)",
+          "tooltip": "Synchronous download with WFS (Web Feature Service), suitable for small datasets, works by sending a request that immediately returns a vector file."
+        }
       },
       "noSupportedServiceFound": "The server doesn't support WFS or WPS download for this layer!"
     },

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1986,6 +1986,7 @@
     "layerdownload": {
       "title": "Exportar los datos",
       "service": "Servicio",
+      "downloadMode": "Modo de exportación",
       "format": "Formato de fichero",
       "srs": "Sistema de referencia espacial",
       "export": "Exportar",
@@ -2015,6 +2016,16 @@
         "executeProcessXhrFailed": "¡La solicitud ExecuteProcess falló! El servidor puede estar mal configurado o no se puede acceder",
         "getExecutionStatusXhrFailed": "¡La solicitud GetExecutionStatus falló! El servidor puede estar mal configurado o no se puede acceder",
         "unexpectedError": "Ocurrió un error inesperado"
+      },
+      "services": {
+        "wps": {
+          "title": "Asíncrono",
+          "tooltip": "El modo asíncrono con WPS (Web Processing Service) se lleva a cabo ejecutando un proceso remoto; una vez completado el procesamiento, se te mostrará una notificación para descargar los datos."
+        },
+        "wfs": {
+          "title": "Síncrono",
+          "tooltip": "La descarga síncrona con WFS (Web Feature Service), adecuada para datos de pequeño tamaño, se realiza enviando una solicitud que devuelve inmediatamente un archivo vectorial."
+        }
       },
       "noSupportedServiceFound": "¡El servidor no admite la descarga de WFS o WPS para esta capa!"
     },

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1987,6 +1987,7 @@
     "layerdownload": {
       "title": "Exporter des données",
       "service": "Service",
+      "downloadMode": "Mode d’exportation",
       "format": "Format de fichier",
       "srs": "Système de référence spatiale",
       "export": "Exporter",
@@ -2016,6 +2017,16 @@
         "executeProcessXhrFailed": "La requête ExecuteProcess a échoué! Le serveur est peut-être mal configuré ou il est devenu inaccessible",
         "getExecutionStatusXhrFailed": "La demande GetExecutionStatus a échoué! Le serveur est peut-être mal configuré ou il est devenu inaccessible",
         "unexpectedError": "Une erreur inattendue s'est produite"
+      },
+      "services": {
+        "wps": {
+          "title": "Asynchrone (WPS)",
+          "tooltip": "Le mode asynchrone avec WPS (Web Processing Service) fonctionne en exécutant un processus à distance ; une fois le traitement terminé, vous recevrez une notification avec un lien pour télécharger les données."
+        },
+        "wfs": {
+          "title": "Synchrone (WFS)",
+          "tooltip": "Le téléchargement synchrone avec WFS (Web Feature Service), adapté aux petits jeux de données, fonctionne en envoyant une requête qui renvoie immédiatement un fichier vectoriel."
+        }
       },
       "noSupportedServiceFound": "Le serveur ne prend pas en charge le téléchargement WFS ou WPS pour cette couche!"
     },

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1987,6 +1987,7 @@
     "layerdownload": {
       "title": "Esporta dati",
       "service": "Servizio",
+      "downloadMode": "Modalità di esportazione",
       "format": "Formato file",
       "srs": "Sistema di riferimento",
       "export": "Esporta",
@@ -2016,6 +2017,16 @@
         "executeProcessXhrFailed": "Richiesta ExecuteProcess non riuscita! Il server potrebbe essere configurato in modo errato o è diventato irraggiungibile",
         "getExecutionStatusXhrFailed": "Richiesta GetExecutionStatus non riuscita! Il server potrebbe essere configurato in modo errato o è diventato irraggiungibile",
         "unexpectedError": "Si è verificato un errore imprevisto"
+      },
+      "services": {
+        "wps": {
+          "title": "Asincrono (WPS)",
+          "tooltip": "Modo asincrono con WPS (Web Processing Service) avviene eseguendo un processo remoto, una volta completato l’elaborazione ti verra mostrata una notifica per il download dei dati."
+        },
+        "wfs": {
+          "title": "Sincrono (WFS)",
+          "tooltip": "Il download sincrono con WFS (Web Feature Service) adatto per dati di piccole dimensioni avviene inviando una richiesta che restituisce immediatamente un file vettoriale."
+        }
       },
       "noSupportedServiceFound": "Il server non supporta il download WFS o WPS per questo livello!"
     },


### PR DESCRIPTION
## Description
Refactor and fixes for layer download functionality

- Moved `layerDownload` to advanced section selectors  
- Refactored `DownloadDialog` to functional component  
- Moved `checkWPSAvailabilityEpic` into `DownloadDialog`  
- Fixed visibility of advanced section in synchronous mode  
- Fixed style alignment and helper positioning for selects  
- Fixed defaults format labels  

#General
- Fixed tooltip rendering inside modal  
- change position of ExportData results button moved to BrandNavbar for Map and Dashboards

## Dashboard

- Added `layerDownload` menu to `TableWidget`  
- Fixed layer download in dashboard, including widget filtering  
- Moved `ExportDownload` button to `BrandNavbar` (map and dashboard)  

## Internationalization

- Added i18n for services and various labels  for layerDownload all langs

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [] Bugfix
 - [x] Feature
 - [x] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Dashboard Table Layer download

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11071 

**What is the new behavior?**
Show a menu "Download Data" in table also in Dashboard

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
