### PR TITLE
#11162: Improve MS actions to automatically zoom to filtered features

### DIFF
--- a/web/client/actions/__tests__/mapInfo-test.js
+++ b/web/client/actions/__tests__/mapInfo-test.js
@@ -126,6 +126,25 @@ describe('Test correctness of the map actions', () => {
         expect(action.itemId).toBe(itemId);
         expect(action.ignoreVisibilityLimits).toBe(ignoreVisibilityLimits);
     });
+    it('test featureInfoClick with filterNameList, overrideParams,  ignoreVisibilityLimits flag [search service case] and bbox of feature', () => {
+        const point = {latlng: {lat: 1, lng: 3}};
+        const layer = {id: "layer.1"};
+        const filterNameList = [];
+        const itemId = "itemId";
+        const overrideParams = {cql_filter: "ID_ORIG=1234"};
+        const ignoreVisibilityLimits = true;
+
+        const action = featureInfoClick(point, layer, filterNameList, overrideParams, itemId, ignoreVisibilityLimits, [1, 2, 3, 4]);
+        expect(action).toExist();
+        expect(action.type).toBe(FEATURE_INFO_CLICK);
+        expect(action.point).toBe(point);
+        expect(action.layer).toBe(layer);
+        expect(action.filterNameList).toBe(filterNameList);
+        expect(action.overrideParams).toBe(overrideParams);
+        expect(action.itemId).toBe(itemId);
+        expect(action.ignoreVisibilityLimits).toBe(ignoreVisibilityLimits);
+        expect(action.bbox).toEqual([1, 2, 3, 4]);
+    });
     it('reset reverse geocode data', () => {
         const e = hideMapinfoRevGeocode();
         expect(e).toExist();

--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -196,7 +196,7 @@ export function updateCenterToMarker(status) {
  * @param {string} [itemId=null] id of the item needed for filtering results
  * @param {string} [ignoreVisibilityLimits=false] a boolean flag for ignoring layer visibility limits restrictions to apply GFI
  */
-export function featureInfoClick(point, layer, filterNameList = [], overrideParams = {}, itemId = null, ignoreVisibilityLimits = false) {
+export function featureInfoClick(point, layer, filterNameList = [], overrideParams = {}, itemId = null, ignoreVisibilityLimits = false, bbox = null) {
     return {
         type: FEATURE_INFO_CLICK,
         point,
@@ -204,7 +204,8 @@ export function featureInfoClick(point, layer, filterNameList = [], overridePara
         filterNameList,
         overrideParams,
         itemId,
-        ignoreVisibilityLimits
+        ignoreVisibilityLimits,
+        bbox
     };
 }
 

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -655,6 +655,7 @@ describe('search Epics', () => {
             expect(actions).toExist();
             expect(actions.length).toBe(NUM_ACTIONS);
             expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
+            expect(actions[0].bbox).toEqual([8.69736995, 44.46808721, 8.7002344, 44.4699759]);
             expect(actions[1].type).toBe(SHOW_MAPINFO_MARKER);
             done();
         }, testStore);
@@ -687,6 +688,7 @@ describe('search Epics', () => {
                 expect(actions).toExist();
                 expect(actions.length).toBe(NUM_ACTIONS);
                 expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
+                expect(actions[0].bbox).toEqual([8.69736995, 44.46808721, 8.7002344, 44.4699759]);
                 const popupAction = actions[1];
                 expect(popupAction.type).toBe(ADD_MAP_POPUP);
                 expect(popupAction.popup?.position?.coordinates?.[0]).toBe(

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -27,7 +27,7 @@ import { SET_CONTROL_PROPERTIES, SET_CONTROL_PROPERTY, TOGGLE_CONTROL } from '..
 import { closeFeatureGrid, updateFilter, toggleEditMode, CLOSE_FEATURE_GRID } from '../actions/featuregrid';
 import { QUERY_CREATE } from '../actions/wfsquery';
 import { CHANGE_MOUSE_POINTER, CLICK_ON_MAP, UNREGISTER_EVENT_LISTENER, CHANGE_MAP_VIEW, MOUSE_MOVE, zoomToPoint, changeMapView,
-    registerEventListener, unRegisterEventListener } from '../actions/map';
+    registerEventListener, unRegisterEventListener, zoomToExtent} from '../actions/map';
 import { browseData } from '../actions/layers';
 import { closeAnnotations } from '../plugins/Annotations/actions/annotations';
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -77,7 +77,7 @@ import { getDerivedLayersVisibility } from '../utils/LayersUtils';
  */
 export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { } }) =>
     action$.ofType(FEATURE_INFO_CLICK)
-        .switchMap(({ point, filterNameList = [], overrideParams = {}, ignoreVisibilityLimits }) => {
+        .switchMap(({ point, filterNameList = [], overrideParams = {}, ignoreVisibilityLimits, bbox }) => {
             const groups = rawGroupsSelector(getState());
 
             // ignoreVisibilityLimits is for ignore limits of layers visibility
@@ -108,7 +108,8 @@ export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { }
             ];
 
             let firstResponseReturned = false;
-
+            // 'isQueryJustOneLayer' if just one layer to query
+            const isQueryJustOneLayer = queryableLayers.filter(l => filterNameList.length ? (filterNameList.filter(name => name.indexOf(l.name) !== -1).length > 0) : true)?.length === 1;
             const out$ = Rx.Observable.from((queryableLayers.filter(l => {
             // filtering a subset of layers
                 return filterNameList.length ? (filterNameList.filter(name => name.indexOf(l.name) !== -1).length > 0) : true;
@@ -138,7 +139,7 @@ export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { }
                             // this delay allows the panel to open and show the spinner for the first one
                             // this delay mitigates the freezing of the app when there are a great amount of queried layers at the same time
                             .delay(0)
-                            .map((response) =>loadFeatureInfo(reqId, response.data, requestParams, { ...lMetaData, features: response.features, featuresCrs: response.featuresCrs }, layer))
+                            .map((response) =>loadFeatureInfo(reqId, response.data, requestParams, { ...lMetaData, features: response.features, featuresCrs: response.featuresCrs, isQueryJustOneLayer, featureBbox: bbox }, layer))
                             .catch((e) => Rx.Observable.of(errorFeatureInfo(reqId, e, requestParams, lMetaData)))
                             .concat(Rx.Observable.defer(() => {
                                 // update the layout only after the initial response
@@ -282,14 +283,22 @@ export const zoomToVisibleAreaEpic = (action$, store) =>
                         right: parseLayoutValue(boundingMapRect.right, map.size.width),
                         top: parseLayoutValue(boundingMapRect.top, map.size.height)
                     };
+                    // 'isQueryJustOneLayer' is a flag if true --> don't disable update center to marker to center the map to identify marker
+                    // it is helpful for (query-param for one layer || identify feature within one layer) within the visible area on map
+                    const isQueryJustOneLayer = loadFeatInfoAction?.layerMetadata?.isQueryJustOneLayer;
+                    const featureBbox = loadFeatInfoAction?.layerMetadata?.featureBbox;
+                    const isFeatInsideVisibleArea = isQueryJustOneLayer ? false : isInsideVisibleArea(coords, map, layoutBounds, resolution);
                     // exclude cesium with cartographic options
-                    if (!map || !layoutBounds || !coords || action.point.cartographic || isInsideVisibleArea(coords, map, layoutBounds, resolution) || isMouseMoveIdentifyActiveSelector(state)) {
+                    if (!map || !layoutBounds || !coords || action.point.cartographic || isFeatInsideVisibleArea || isMouseMoveIdentifyActiveSelector(state)) {
                         return Rx.Observable.of(updateCenterToMarker('disabled'));
                     }
                     if (reprojectExtent && !isPointInsideExtent(coords, reprojectExtent)) {
                         return Rx.Observable.empty();
                     }
                     const center = centerToVisibleArea(coords, map, layoutBounds, resolution);
+                    if (featureBbox && isQueryJustOneLayer) {       // only with query-param action
+                        return Rx.Observable.of(updateCenterToMarker('enabled'), zoomToExtent(featureBbox, center.crs));
+                    }
                     return Rx.Observable.of(updateCenterToMarker('enabled'), zoomToPoint(center.pos, center.zoom, center.crs))
                         // restore initial position
                         .concat(

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -12,6 +12,7 @@ import pointOnSurface from '@turf/point-on-surface';
 import assign from 'object-assign';
 import {isNil, sortBy} from 'lodash';
 import uuid from 'uuid';
+import bboxTurf from '@turf/bbox';
 
 import {centerToMarkerSelector, getLayerFromName, layersSelector} from '../selectors/layers';
 
@@ -338,7 +339,7 @@ export const searchOnStartEpic = (action$, store) =>
                     })
                         .then( (response = {}) => response.features && response.features.length && {...response.features[0], typeName: name})
                 )
-                    .switchMap(({ type, geometry, typeName }) => {
+                    .switchMap(({ type, geometry, typeName, bbox }) => {
                         const coord = pointOnSurface({ type, geometry }).geometry.coordinates;
 
                         if (coord) {
@@ -370,7 +371,7 @@ export const searchOnStartEpic = (action$, store) =>
                                     { latlng },
                                     typeName,
                                     [typeName],
-                                    { [typeName]: { cql_filter: cqlFilter } }, null, ignoreVisibilityLimits
+                                    { [typeName]: { cql_filter: cqlFilter } }, null, ignoreVisibilityLimits, (bbox ? bbox : bboxTurf(geometry))
                                 )
                             )
                                 .merge(mapActionObservable);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR enhances the zoom process to the filter features using query params action. It includes:
- enhance zooming functionality if the queried layers is just one by auto zooming
- automate that zoom process without the need to include any coordinates in query param action url


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#11162

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11162 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now if user open map viewer with query param with mapinfo, mapinfofilter without providing any coordinates like:
http://localhost:8081/#/viewer/55570?mapinfo=unesco:Unesco_point&mapInfoFilter=componente='Centro%20storico%20di%20Roma'
This will zoom to the bbox of the filtered feature.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
