### PR TITLE
Fix #11147 Ensure thumbnail is persisted in UI while editing

### DIFF
--- a/web/client/plugins/ResourcesCatalog/components/DetailsThumbnail.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/DetailsThumbnail.jsx
@@ -14,17 +14,20 @@ import tooltip from '../../../components/misc/enhancers/tooltip';
 import FlexBox from '../../../components/layout/FlexBox';
 import Text from '../../../components/layout/Text';
 import { THUMBNAIL_DATA_KEY } from '../../../utils/GeostoreUtils';
+
 const ButtonWithToolTip = tooltip(Button);
 
 function DetailsThumbnail({
     icon,
     editing,
-    thumbnail,
+    thumbnail: thumbnailProp,
     width,
     height,
     onChange,
     resource
 }) {
+
+    const thumbnail = resource?.attributes?.[THUMBNAIL_DATA_KEY] ?? thumbnailProp;
 
     const thumbnailRef = useRef(null);
     const handleUpload = () => {
@@ -50,7 +53,7 @@ function DetailsThumbnail({
                 ? <>
                     <Thumbnail
                         style={{ position: 'absolute', width: '100%', height: '100%' }}
-                        thumbnail={resource?.attributes?.[THUMBNAIL_DATA_KEY] ?? thumbnail}
+                        thumbnail={thumbnail}
                         onUpdate={(data) => {
                             onChange(data);
                         }}

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/DetailsThumbnail-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/DetailsThumbnail-test.jsx
@@ -12,6 +12,7 @@ import ReactDOM from 'react-dom';
 import expect from 'expect';
 import DetailsThumbnail from '../DetailsThumbnail';
 import { Simulate } from 'react-dom/test-utils';
+import { THUMBNAIL_DATA_KEY } from '../../../../utils/GeostoreUtils';
 
 describe('DetailsThumbnail component', () => {
     beforeEach((done) => {
@@ -80,5 +81,18 @@ describe('DetailsThumbnail component', () => {
         const buttons = detailsThumbnail.querySelectorAll('button');
         expect(buttons.length).toBe(2);
         Simulate.click(buttons[1]);
+    });
+    it('should render the thumbnail in editing if the attributes THUMBNAIL_DATA_KEY is available', () => {
+        ReactDOM.render(<DetailsThumbnail
+            thumbnail={undefined}
+            resource={{
+                attributes: {
+                    [THUMBNAIL_DATA_KEY]: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+                }
+            }}
+        />, document.getElementById('container'));
+        const detailsThumbnail = document.querySelector('.ms-details-thumbnail');
+        const img = detailsThumbnail.querySelector('img');
+        expect(img.getAttribute('src')).toBe('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR includes fixes for the issue reported in this comment https://github.com/geosolutions-it/MapStore2/pull/11149#issuecomment-2922452673.
The details thumbnail was updating the image only when the pencil icon was selected, with this fix the thumbnail will be always visually updated in both cases view and editing if pending changes are available.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11147

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The details thumbnail is updated if pending changes are available also in view mode

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
