### PR TITLE
#11164: make bar chart legend clickable by items

### DIFF
--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -570,7 +570,13 @@ export const toPlotly = (_props) => {
             autosize: false,
             height,
             width,
-            ...(types.includes('pie') && isModeBarVisible && { legend: {x: 1.05, y: 0.5} }), // Position legend to right and centered vertically
+            // for pie: Position legend to right and centered vertically
+            // for bar: use groupclick to be for item toggle by overriding the default 'togglegroup' with 'toggleitem'
+            // ** see: https://plotly.com/javascript/reference/layout/#layout-legend-groupclick
+            ...((types.includes('pie') && isModeBarVisible) ? { legend: {x: 1.05, y: 0.5} } : types.includes('bar') ? {legend: {
+                "tracegroupgap": 10,
+                "groupclick": "toggleitem"
+            }} : {}),
             hovermode: 'x unified',
             uirevision: true,
             ...gridProperty


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR handles toggle legend items for bar charts by adding property 'groupclick' by 'toggleitem' to enable toggle items in legend for bar charts in Plotly.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11164 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

https://github.com/user-attachments/assets/a014fcf6-15e9-4165-9c25-ed3de4c40085



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
https://plotly.com/javascript/reference/layout/#layout-legend-groupclick