### PR TITLE
[Backport 2025.01.xx] Fix #11147 Problems with save resource workflow

### DIFF
--- a/web/client/api/ResourcesCatalog.js
+++ b/web/client/api/ResourcesCatalog.js
@@ -208,15 +208,11 @@ export const requestResources = ({
         });
 };
 
-export const requestResource = ({ resource, user }) => {
-    return getResource(resource.id, { includeAttributes: true, withData: false, withPermissions: !!user })
+export const requestResource = ({ resource }) => {
+    return getResource(resource.id, { includeAttributes: true, withData: false })
         .toPromise()
-        .then(({ permissions, attributes, data, ...res }) => {
-            return parseResourceProperties({
-                ...resource,
-                ...res,
-                permissions: permissions || []
-            });
+        .then(({ data, ...newResource }) => {
+            return parseResourceProperties({ ...newResource, category: resource?.category });
         });
 };
 

--- a/web/client/plugins/ResourcesCatalog/ResourceDetails.jsx
+++ b/web/client/plugins/ResourcesCatalog/ResourceDetails.jsx
@@ -347,7 +347,7 @@ function BrandNavbarDetailsButton({
             name: resourceType
         }
     });
-    const { title } = getResourceInfo(resource);
+    const { title } = getResourceInfo(resource || selectedResource);
     return (
         <FlexBox component="li" centerChildrenVertically gap="xs">
             <ButtonWithTooltip

--- a/web/client/plugins/ResourcesCatalog/components/DetailsThumbnail.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/DetailsThumbnail.jsx
@@ -14,17 +14,20 @@ import tooltip from '../../../components/misc/enhancers/tooltip';
 import FlexBox from '../../../components/layout/FlexBox';
 import Text from '../../../components/layout/Text';
 import { THUMBNAIL_DATA_KEY } from '../../../utils/GeostoreUtils';
+
 const ButtonWithToolTip = tooltip(Button);
 
 function DetailsThumbnail({
     icon,
     editing,
-    thumbnail,
+    thumbnail: thumbnailProp,
     width,
     height,
     onChange,
     resource
 }) {
+
+    const thumbnail = resource?.attributes?.[THUMBNAIL_DATA_KEY] ?? thumbnailProp;
 
     const thumbnailRef = useRef(null);
     const handleUpload = () => {
@@ -50,7 +53,7 @@ function DetailsThumbnail({
                 ? <>
                     <Thumbnail
                         style={{ position: 'absolute', width: '100%', height: '100%' }}
-                        thumbnail={resource?.attributes?.[THUMBNAIL_DATA_KEY] ?? thumbnail}
+                        thumbnail={thumbnail}
                         onUpdate={(data) => {
                             onChange(data);
                         }}

--- a/web/client/plugins/ResourcesCatalog/components/DetailsThumbnail.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/DetailsThumbnail.jsx
@@ -13,6 +13,7 @@ import Button from '../../../components/layout/Button';
 import tooltip from '../../../components/misc/enhancers/tooltip';
 import FlexBox from '../../../components/layout/FlexBox';
 import Text from '../../../components/layout/Text';
+import { THUMBNAIL_DATA_KEY } from '../../../utils/GeostoreUtils';
 const ButtonWithToolTip = tooltip(Button);
 
 function DetailsThumbnail({
@@ -21,8 +22,10 @@ function DetailsThumbnail({
     thumbnail,
     width,
     height,
-    onChange
+    onChange,
+    resource
 }) {
+
     const thumbnailRef = useRef(null);
     const handleUpload = () => {
         const input = thumbnailRef?.current?.querySelector('input');
@@ -47,7 +50,7 @@ function DetailsThumbnail({
                 ? <>
                     <Thumbnail
                         style={{ position: 'absolute', width: '100%', height: '100%' }}
-                        thumbnail={thumbnail}
+                        thumbnail={resource?.attributes?.[THUMBNAIL_DATA_KEY] ?? thumbnail}
                         onUpdate={(data) => {
                             onChange(data);
                         }}

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/DetailsThumbnail-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/DetailsThumbnail-test.jsx
@@ -12,6 +12,7 @@ import ReactDOM from 'react-dom';
 import expect from 'expect';
 import DetailsThumbnail from '../DetailsThumbnail';
 import { Simulate } from 'react-dom/test-utils';
+import { THUMBNAIL_DATA_KEY } from '../../../../utils/GeostoreUtils';
 
 describe('DetailsThumbnail component', () => {
     beforeEach((done) => {
@@ -80,5 +81,18 @@ describe('DetailsThumbnail component', () => {
         const buttons = detailsThumbnail.querySelectorAll('button');
         expect(buttons.length).toBe(2);
         Simulate.click(buttons[1]);
+    });
+    it('should render the thumbnail in editing if the attributes THUMBNAIL_DATA_KEY is available', () => {
+        ReactDOM.render(<DetailsThumbnail
+            thumbnail={undefined}
+            resource={{
+                attributes: {
+                    [THUMBNAIL_DATA_KEY]: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+                }
+            }}
+        />, document.getElementById('container'));
+        const detailsThumbnail = document.querySelector('.ms-details-thumbnail');
+        const img = detailsThumbnail.querySelector('img');
+        expect(img.getAttribute('src')).toBe('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
     });
 });

--- a/web/client/plugins/ResourcesCatalog/containers/ResourceAbout.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceAbout.jsx
@@ -12,7 +12,7 @@ import Message from '../../../components/I18N/Message';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { getInitialSelectedResource } from '../selectors/resources';
-import { parseNODATA } from '../../../utils/GeostoreUtils';
+import { parseNODATA, DETAILS_DATA_KEY } from '../../../utils/GeostoreUtils';
 import FlexBox from '../../../components/layout/FlexBox';
 import Icon from '../components/Icon';
 import Text from '../../../components/layout/Text';
@@ -41,18 +41,15 @@ function ResourceAbout({
     resource,
     onChange = () => {}
 }) {
-    const details = parseNODATA(resource?.attributes?.details || '');
-    // workaround: after save events, `detailsUrl` contains temporary the about content
-    // for this reason, `isValidResourceURL` is used to determine the status
-    // if the resource have to be loaded or not.
-    const [about, setAbout] = useState(isValidResourceURL(detailsUrl) ? '' : details);
+    const detailsData = resource?.attributes?.[DETAILS_DATA_KEY];
+    const about = isValidResourceURL(detailsData) ? '' : (detailsData || '');
     const [loading, setLoading] = useState(true);
     useEffect(() => {
-        if (isValidResourceURL(detailsUrl)) {
+        if (detailsData === undefined && isValidResourceURL(detailsUrl)) {
             setLoading(true);
             axios.get(detailsUrl)
                 .then(({ data }) => {
-                    setAbout(data);
+                    onChange({ [`attributes.${DETAILS_DATA_KEY}`]: data }, true);
                 })
                 .finally(() => {
                     setLoading(false);
@@ -60,7 +57,7 @@ function ResourceAbout({
         } else {
             setLoading(false);
         }
-    }, [detailsUrl]);
+    }, [detailsUrl, detailsData]);
 
     if (loading || (!about && !editing)) {
         return (

--- a/web/client/plugins/ResourcesCatalog/containers/ResourceAboutEditor.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceAboutEditor.jsx
@@ -12,6 +12,7 @@ import { Tabs, Tab, Checkbox } from 'react-bootstrap';
 import { htmlToDraftJSEditorState, draftJSEditorStateToHtml } from '../../../utils/EditorUtils';
 import Message from '../../../components/I18N/Message';
 import FlexBox from '../../../components/layout/FlexBox';
+import { DETAILS_DATA_KEY } from '../../../utils/GeostoreUtils';
 
 function ResourceAboutEditor({
     value,
@@ -31,7 +32,7 @@ function ResourceAboutEditor({
                         const previousHTML = draftJSEditorStateToHtml(editorState);
                         const newHTML = draftJSEditorStateToHtml(newEditorState);
                         if (newHTML !== previousHTML) {
-                            onChange({ 'attributes.details': newHTML });
+                            onChange({ [`attributes.${DETAILS_DATA_KEY}`]: newHTML });
                         }
                     }}
                     toolbar={{

--- a/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
@@ -23,6 +23,7 @@ import Text from '../../../components/layout/Text';
 import Spinner from '../../../components/layout/Spinner';
 import Message from '../../../components/I18N/Message';
 import tooltip from '../../../components/misc/enhancers/tooltip';
+import { THUMBNAIL_DATA_KEY } from '../../../utils/GeostoreUtils';
 
 const Button = tooltip(ButtonMS);
 
@@ -132,7 +133,7 @@ function ResourceDetails({
                 }
                 loading={loading}
                 onClose={() => onClose()}
-                onChangeThumbnail={(thumbnail) => handleOnChange({ attributes: { thumbnail } })}
+                onChangeThumbnail={(thumbnail) => handleOnChange({ [`attributes.${THUMBNAIL_DATA_KEY}`]: thumbnail })}
             />
             {error ? <Alert className="_margin-md _padding-sm" bsStyle="danger">
                 <Message msgId={`resourcesCatalog.resourceError.${error}`}/>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This Backport includes:

b9be56f81baa1fcff3de733d8ea63f4646f317d1
f38b5e7701e7457a0d1befcc93913e30ffd0bad4

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11147

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The details and thumbnail are correctly updated while saving a resource

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
