### PR TITLE
[Backport 2025.01.xx] Fix #11146 Edit permission to everyone should not be set (#11150)

### DIFF
--- a/web/client/plugins/ResourcesCatalog/components/Permissions.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/Permissions.jsx
@@ -265,7 +265,7 @@ function Permissions({
                                 <PermissionsRow
                                     {...entry}
                                     onChange={editing ? handleUpdateEntry.bind(null, entry.id) : null}
-                                    options={permissionOptions?.default}
+                                    options={permissionOptions?.[`entry.name.${entry.name}`] || permissionOptions?.default}
                                 >
                                     {entry.permissions !== 'owner' && editing ?
                                         <>

--- a/web/client/plugins/ResourcesCatalog/components/PermissionsRow.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/PermissionsRow.jsx
@@ -33,6 +33,7 @@ function PermissionsRow({
         ? (
             <Select
                 clearable={clearable}
+                disabled={options?.length < 2}
                 options={options.map(({ value, labelId, label }) => ({ value, label: label ? <span>{label}</span> : <Message msgId={labelId} />}))}
                 value={permissions}
                 onChange={(option) => onChange({ permissions: option?.value || '' })}

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/Permissions-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/Permissions-test.jsx
@@ -27,4 +27,51 @@ describe('Permissions component', () => {
         const permissions = document.querySelector('.ms-permissions');
         expect(permissions).toBeTruthy();
     });
+
+    it('should provide different list of permission based on entry name', () => {
+        ReactDOM.render(<Permissions
+            editing
+            compactPermissions={{
+                entries: [
+                    {
+                        type: 'group',
+                        id: 1,
+                        name: 'everyone',
+                        permissions: 'view'
+                    },
+                    {
+                        type: 'group',
+                        id: 2,
+                        name: 'custom-group',
+                        permissions: 'view'
+                    }
+                ]
+            }}
+            permissionOptions={{
+                'entry.name.everyone': [
+                    {
+                        value: 'view',
+                        labelId: 'resourcesCatalog.viewPermission'
+                    }
+                ],
+                'default': [
+                    {
+                        value: 'view',
+                        labelId: 'resourcesCatalog.viewPermission'
+                    },
+                    {
+                        value: 'edit',
+                        labelId: 'resourcesCatalog.editPermission'
+                    }
+                ]
+            }}
+        />, document.getElementById('container'));
+        const permissions = document.querySelector('.ms-permissions');
+        expect(permissions).toBeTruthy();
+        const permissionsRows = document.querySelectorAll('.ms-permissions-row');
+        expect(permissionsRows.length).toBe(2);
+        expect([...permissionsRows].map(row => row.innerText)).toEqual(['everyone\nresourcesCatalog.viewPermission', 'custom-group\nresourcesCatalog.viewPermission']);
+        const disabled = permissionsRows[0].querySelector('.is-disabled');
+        expect(disabled).toBeTruthy();
+    });
 });

--- a/web/client/plugins/ResourcesCatalog/containers/ResourcePermissions.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourcePermissions.jsx
@@ -118,6 +118,12 @@ function ResourcePermissions({
                 });
             }}
             permissionOptions={{
+                'entry.name.everyone': [
+                    {
+                        value: 'view',
+                        labelId: 'resourcesCatalog.viewPermission'
+                    }
+                ],
                 'default': [
                     {
                         value: 'view',


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds the possibility to configure specific permissions option based on the entry name.

![image](https://github.com/user-attachments/assets/c0e72d74-a75b-4727-b659-f38873467534)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11146

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The permissions for the default everyone group are not editable and forced to view permissions

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
