### PR TITLE
[Backport 2025.01.xx]: Fixes #11154 Max zoom level configuration from localConfig for Coordinate Search(#11159)

### DIFF
--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -696,4 +696,65 @@ describe("test the SearchBar", () => {
         expect(spyOnZoomToExtent.calls.length).toBe(1);
         expect(spyOnZoomToExtent.calls[0].arguments[0]).toEqual([ 5, 10, 20, 30 ]);
     });
+
+    it("test maxZoomLevel for Coordinate search", (done) => {
+        const coordinateSearchOptions = {maxZoomLevel: 15};
+
+        const store = {
+            dispatch: () => {},
+            subscribe: () => {},
+            getState: () => ({search: {coordinate: {lat: 15, lon: 15}}})
+        };
+        ReactDOM.render(
+            <Provider store={store}>
+                <SearchBar
+                    format="decimal"
+                    activeSearchTool="coordinatesSearch"
+                    showOptions
+                    onZoomToPoint={(point, zoom) => {
+                        expect(zoom).toEqual(15);
+                        done();
+                    }}
+                    coordinate={{lat: 15, lon: 15}}
+                    typeAhead={false}
+                    defaultZoomLevel={coordinateSearchOptions?.maxZoomLevel}
+                />
+            </Provider>
+            , document.getElementById("container")
+        );
+        const container = document.getElementById('container');
+        const buttons = container.querySelectorAll('.glyphicon-search');
+        expect(buttons.length).toBe(1);
+        TestUtils.Simulate.click(buttons[0]);
+    });
+
+    it("test default maxZoomLevel for Coordinate search", (done) => {
+
+        const store = {
+            dispatch: () => {},
+            subscribe: () => {},
+            getState: () => ({search: {coordinate: {lat: 15, lon: 15}}})
+        };
+        ReactDOM.render(
+            <Provider store={store}>
+                <SearchBar
+                    format="decimal"
+                    activeSearchTool="coordinatesSearch"
+                    showOptions
+                    onZoomToPoint={(point, zoom) => {
+                        // default zoom level is 12
+                        expect(zoom).toEqual(12);
+                        done();
+                    }}
+                    coordinate={{lat: 15, lon: 15}}
+                    typeAhead={false}
+                />
+            </Provider>
+            , document.getElementById("container")
+        );
+        const container = document.getElementById('container');
+        const buttons = container.querySelectorAll('.glyphicon-search');
+        expect(buttons.length).toBe(1);
+        TestUtils.Simulate.click(buttons[0]);
+    });
 });

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -159,6 +159,8 @@ const SearchResultList = connect(selector, {
  * @prop {object} cfg.resultsStyle custom style for search results
  * @prop {bool} cfg.fitResultsToMapSize true by default, fits the result list to the mapSize (can be disabled, for custom uses)
  * @prop {searchService[]} cfg.searchOptions.services a list of services to perform search.
+ * @prop {object} cfg.coordinateSearchOptions options for the coordinate search
+ * @prop {number} [cfg.coordinateSearchOptions.maxZoomLevel=12] the max zoom level for the coordinate search
  * a **nominatim** search service look like this:
  * ```
  * {
@@ -377,6 +379,7 @@ const SearchPlugin = connect((state) => ({
             searchOptions={this.getCurrentServices()}
             placeholder={this.getServiceOverrides("placeholder")}
             placeholderMsgId={this.getServiceOverrides("placeholderMsgId")}
+            defaultZoomLevel={this.props.coordinateSearchOptions?.maxZoomLevel || 12}
         />);
         return (
             !this.searchFitToTheScreen() ?


### PR DESCRIPTION
Fixes #11154 Max zoom level configuration from localConfig for Coordinate Search(#11159)