### PR TITLE
#11165: Option to deny app context for normal users

### DIFF
--- a/web/client/api/ResourcesCatalog.js
+++ b/web/client/api/ResourcesCatalog.js
@@ -17,11 +17,11 @@ const applyDoubleQuote = value => `"${value}"`;
 const getFilter = ({
     q,
     user,
-    query
+    query,
+    categories
 }) => {
     const f = castArray(query.f || []);
     const ctx = castArray(query['filter{ctx.in}'] || []);
-    const categories = ['MAP', 'DASHBOARD', 'GEOSTORY', 'CONTEXT'];
     const creators = castArray(query['filter{creator.in}'] || []);
     const groups = castArray(query['filter{group.in}'] || []);
     const tags = castArray(query['filter{tag.in}'] || []).map(tag => {
@@ -142,7 +142,7 @@ const getFilter = ({
 export const requestResources = ({
     params,
     config
-} = {}, { user } = {}) => {
+} = {}, { user } = {}, categoriesDict) => {
 
     const {
         page = 1,
@@ -154,10 +154,13 @@ export const requestResources = ({
     const sortBy = sort.replace('-', '');
     const sortOrder = sort.includes('-') ? 'desc' : 'asc';
     const f = castArray(query.f || []);
+    const categories = user && user?.role ? categoriesDict[user.role] : categoriesDict.COMMON;
+
     return searchListByAttributes(getFilter({
         q,
         user,
-        query
+        query,
+        categories
     }),
     {
         ...config,

--- a/web/client/plugins/ResourcesCatalog/ResourcesGrid.jsx
+++ b/web/client/plugins/ResourcesCatalog/ResourcesGrid.jsx
@@ -58,6 +58,8 @@ import {
  * @prop {string} cfg.footerNodeSelector optional valid query selector for the footer in the page, used to set the position of the panel
  * @prop {string} cfg.targetSelector optional valid query selector for a node used to mount the plugin root component
  * @prop {string} cfg.openInNewTab optional boolean to open the resource in a new tab. Sets the link target to `_blank` when set to `true`
+ * @prop {string} cfg.categories configration categories dictionary list based on user role to be used in browsing resources like Map, Dashboard, Geostory, context
+ * it contains 3 main keys: ADMIN for admin users, USER for normal users and COMMON for guest users
  * @prop {object[]} items this property contains the items injected from the other plugins,
  * using the `containers` option in the plugin that want to inject new menu items.
  * The supported targets are:
@@ -410,6 +412,11 @@ function ResourcesGrid({
             }
         ]
     },
+    categories = {
+        "ADMIN": ["MAP", "DASHBOARD", "GEOSTORY", "CONTEXT"],
+        "USER": ["MAP", "DASHBOARD", "GEOSTORY"],
+        "COMMON": ["MAP", "DASHBOARD", "GEOSTORY"]
+    },
     ...props
 }, context) {
 
@@ -432,7 +439,7 @@ function ResourcesGrid({
         <ConnectedResourcesGrid
             {...props}
             order={order}
-            requestResources={(...args) => getCatalogResources(...args).toPromise()}
+            requestResources={(...args) => getCatalogResources(...args, categories).toPromise()}
             configuredItems={configuredItems}
             metadata={metadata}
             formatHref={handleFormatHref}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
In this PR, we introduce a new cfg called 'cateogries' for plugin 'ResourcesGrid' to control *whe*browse resources** in the new home page, it is a dictionary contains resources for ADMIN, USER, COMMON for example:
```
{
        "name": "ResourcesGrid",
        "cfg": {
          "id": "catalog",
          "titleId": "resources.contents.title",
          "queryPage": true,
          "categories":  {
            "ADMIN": ["MAP", "DASHBOARD", "GEOSTORY", "CONTEXT"],
            "USER": ["MAP", "DASHBOARD", "GEOSTORY"],
            "COMMON": ["MAP", "DASHBOARD", "GEOSTORY"]
          },
          "menuItems": ...menu items ist
          }
}
```
each array is the available resources to browse for user and COMMON is for guest user [Anonymous user]. So this is for browse contexts point in requirements if we provide a list without **CONTEXT** the shown/fetched resouces will be only the provided ones.

For **Edit a context**:
There is an option to provide **disablePluginIf** to the plugin **EditContext** like: 
```
{
        "name": "EditContext",
        "cfg": {
          "disablePluginIf": "{state('userrole') !== 'ADMIN'}"
        }
      },
```
For **Create a context**: 
There is an option to provide **disableIf** for the last item of **items** into **menuItems** in **cfg** of **ResourcesGrid** of catalog like:
```
{
        "name": "ResourcesGrid",
        "cfg": {
          "id": "catalog",
          "titleId": "resources.contents.title",
          "queryPage": true,
          "categories":  {
            "ADMIN": ["MAP", "DASHBOARD", "GEOSTORY", "CONTEXT"],
            "USER": ["MAP", "DASHBOARD", "GEOSTORY"],
            "COMMON": ["MAP", "DASHBOARD", "GEOSTORY"]
          },
          "menuItems": [
            {
              "labelId": "resourcesCatalog.addResource",
              "disableIf": "{!state('userrole')}",
              "type": "dropdown",
              "variant": "primary",
              "size": "sm",
              "responsive": true,
              "noCaret": true,
              "items": [
                {
                  "labelId": "resourcesCatalog.createMap",
                  "type": "link",
                  "href": "#/viewer/new"
                },
                {
                  "labelId": "resourcesCatalog.createDashboard",
                  "type": "link",
                  "href": "#/dashboard/"
                },
                {
                  "labelId": "resourcesCatalog.createGeoStory",
                  "type": "link",
                  "href": "#/geostory/newgeostory/"
                },
                {
                  "labelId": "resourcesCatalog.createContext",
                  "type": "link",
                  "href": "#/context-creator/new",
                  "disableIf": "{state('userrole') !== 'ADMIN'}"    // here to hide create new context for non admin users
                }
              ]
            }
          ]
        }
      },
```

For **filter by context**:
There is an option to provide **fields** into **cfg** of plugin **ResourcesFiltersForm** providing **disableIf** for the fields related to filter context like:
```
{
        "name": "ResourcesFiltersForm",
        "cfg": {
          "resourcesGridId": "catalog",
           "fields": [
              {
                  "type": "search"
              },
              {
                  "type": "group",
                  "labelId": "resourcesCatalog.customFiltersTitle",
                  "items": [
                      {
                          "id": "my-resources",
                          "labelId": "resourcesCatalog.myResources",
                          "type": "filter",
                          "disableIf": "{!state('userrole')}"
                      },
                      {
                          "id": "favorite",
                          "labelId": "resourcesCatalog.favorites",
                          "type": "filter",
                          "disableIf": "{!state('userrole')}"
                      },
                      {
                          "id": "map",
                          "labelId": "resourcesCatalog.mapsFilter",
                          "type": "filter"
                      },
                      {
                          "id": "dashboard",
                          "labelId": "resourcesCatalog.dashboardsFilter",
                          "type": "filter"
                      },
                      {
                          "id": "geostory",
                          "labelId": "resourcesCatalog.geostoriesFilter",
                          "type": "filter"
                      },
                      {
                          "id": "context",
                          "labelId": "resourcesCatalog.contextsFilter",
                          "type": "filter",
                          "disableIf": "{state('userrole') !== 'ADMIN'}"    // here to hide the context checkbox filter for non admin users
                      }
                  ]
              },
              {
                  "type": "divider"
              },
              {
                  "type": "select",
                  "facet": "group",
                  "disableIf": "{!state('userrole')}"
              },
              {
                  "type": "select",
                  "facet": "tag"
              },
              {
                  "type": "select",
                  "facet": "context",
                  "disableIf": "{state('userrole') !== 'ADMIN'}"      // here to hide the filter maps by context DD for non admin user
              },
              {
                  "type": "date-range",
                  "filterKey": "creation",
                  "labelId": "resourcesCatalog.creationFilter"
              }
          ]
        }
      },
```
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11165 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
We can manage the browse resources in new home page using by the new cfg 'categories' into plugin 'ResourcesGrid'. To manage hiding edit/create/filter context from new home page UI, we can do that using disableIf, disablePluginIf like the clarification above.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
