### PR TITLE
Fix style parser import of font-awsome

### DIFF
--- a/web/client/utils/styleparser/CesiumStyleParser.js
+++ b/web/client/utils/styleparser/CesiumStyleParser.js
@@ -12,10 +12,10 @@ import { needProxy, getProxyUrl } from '../ProxyUtils';
 import {
     resolveAttributeTemplate,
     geoStylerStyleFilter,
-    drawIcons,
     getImageIdFromSymbolizer,
     parseSymbolizerExpressions
 } from './StyleParserUtils';
+import { drawIcons } from './IconUtils';
 import { geometryFunctionsLibrary } from './GeometryFunctionsUtils';
 import EllipseGeometryLibrary from '@cesium/engine/Source/Core/EllipseGeometryLibrary';
 import CylinderGeometryLibrary from '@cesium/engine/Source/Core/CylinderGeometryLibrary';

--- a/web/client/utils/styleparser/IconUtils.js
+++ b/web/client/utils/styleparser/IconUtils.js
@@ -1,0 +1,71 @@
+import { isNil } from 'lodash';
+import { getConfigProp } from '../ConfigUtils';
+import { loadFontAwesome } from '../FontUtils';
+import {
+    geoStylerStyleFilter,
+    parseSymbolizerExpressions,
+    getImageFromSymbolizer,
+    getWellKnownNameImageFromSymbolizer
+} from './StyleParserUtils';
+
+
+/**
+ * prefetch all image or mark symbol in a geostyler style
+ * @param {object} geoStylerStyle geostyler style
+ * @returns {promise} all the prefetched images
+ */
+export const drawIcons = (geoStylerStyle, options) => {
+    const { rules = [] } = geoStylerStyle || {};
+    const symbolizers = rules.reduce((acc, rule) => {
+        const markIconSymbolizers = (rule?.symbolizers || []).filter(({ kind }) => ['Mark', 'Icon'].includes(kind));
+        const symbolizerHasExpression = markIconSymbolizers
+            .some(properties => Object.keys(properties).some(key => !!properties[key]?.name));
+        if (!symbolizerHasExpression) {
+            return [
+                ...acc,
+                ...markIconSymbolizers
+            ];
+        }
+        const features = options.features || [];
+        const supportedFeatures = rule.filter === undefined
+            ? features
+            : features.filter((feature) => geoStylerStyleFilter(feature, rule.filter));
+        return [
+            ...acc,
+            ...markIconSymbolizers.reduce((newSymbolizers, symbolizer) => {
+                return [
+                    ...newSymbolizers,
+                    ...(supportedFeatures || []).map((feature) => {
+                        const newSymbolizer = parseSymbolizerExpressions(symbolizer, feature);
+                        return {
+                            ...newSymbolizer,
+                            // exclude msMarkerIcon from parsing
+                            // the getImageFromSymbolizer is already taking into account this case
+                            ...(symbolizer?.image?.name === 'msMarkerIcon' && { image: symbolizer.image })
+                        };
+                    })
+                ];
+            }, [])
+        ];
+    }, []);
+    const marks = symbolizers.filter(({ kind }) => kind === 'Mark');
+    const icons = symbolizers.filter(({ kind }) => kind === 'Icon');
+    const loadFontAwesomeForIcons = getConfigProp("loadFontAwesomeForIcons");
+    // if undefined or true it will load it to preserve previous behaviour
+    const loadingPromise =  (isNil(loadFontAwesomeForIcons) || loadFontAwesomeForIcons) && icons?.length ? loadFontAwesome() : Promise.resolve();
+    return loadingPromise
+        .then(
+            () => new Promise((resolve) => {
+                if (marks.length > 0 || icons.length > 0) {
+                    Promise.all([
+                        ...marks.map(getWellKnownNameImageFromSymbolizer),
+                        ...icons.map(getImageFromSymbolizer)
+                    ]).then((images) => {
+                        resolve(images);
+                    });
+                } else {
+                    resolve([]);
+                }
+            })
+        );
+};

--- a/web/client/utils/styleparser/LeafletStyleParser.js
+++ b/web/client/utils/styleparser/LeafletStyleParser.js
@@ -12,10 +12,11 @@ import 'ol/geom/Polygon';
 import {
     resolveAttributeTemplate,
     geoStylerStyleFilter,
-    drawIcons,
     getImageIdFromSymbolizer,
     parseSymbolizerExpressions
 } from './StyleParserUtils';
+import { drawIcons } from './IconUtils';
+
 import { geometryFunctionsLibrary } from './GeometryFunctionsUtils';
 import { circleToPolygon } from '../DrawGeometryUtils';
 

--- a/web/client/utils/styleparser/OLStyleParser.js
+++ b/web/client/utils/styleparser/OLStyleParser.js
@@ -60,9 +60,10 @@ import {
     isGeoStylerStringFunction,
     isGeoStylerNumberFunction,
     geoStylerStyleFilter,
-    drawIcons,
     getImageIdFromSymbolizer
 } from './StyleParserUtils';
+import { drawIcons } from './IconUtils';
+
 import isString from 'lodash/isString';
 import { geometryFunctionsLibrary } from './GeometryFunctionsUtils';
 

--- a/web/client/utils/styleparser/PrintStyleParser.js
+++ b/web/client/utils/styleparser/PrintStyleParser.js
@@ -12,10 +12,11 @@ import {
     resolveAttributeTemplate,
     geoStylerStyleFilter,
     drawWellKnownNameImageFromSymbolizer,
-    drawIcons,
     parseSymbolizerExpressions,
     getCachedImageById
 } from './StyleParserUtils';
+import { drawIcons } from './IconUtils';
+
 import { geometryFunctionsLibrary } from './GeometryFunctionsUtils';
 import { circleToPolygon } from '../DrawGeometryUtils';
 

--- a/web/client/utils/styleparser/__tests__/IconUtils-test.js
+++ b/web/client/utils/styleparser/__tests__/IconUtils-test.js
@@ -1,0 +1,52 @@
+import expect from 'expect';
+import { drawIcons } from '../IconUtils';
+
+describe('IconUtils', () => {
+    it('should preload images and marker from a style', (done) => {
+        const geoStylerStyle = {
+            name: '',
+            rules: [
+                {
+                    filter: undefined,
+                    name: '',
+                    symbolizers: [
+                        {
+                            kind: 'Mark',
+                            wellKnownName: 'Circle',
+                            color: '#ff0000',
+                            fillOpacity: 0.5,
+                            strokeColor: '#00ff00',
+                            strokeOpacity: 0.25,
+                            strokeWidth: 3,
+                            radius: 16,
+                            rotate: 90
+                        }
+                    ]
+                },
+                {
+                    filter: undefined,
+                    name: '',
+                    symbolizers: [
+                        {
+                            kind: 'Icon',
+                            image: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+                            opacity: 0.5,
+                            size: 32,
+                            rotate: 90
+                        }
+                    ]
+                }
+            ]
+        };
+        drawIcons(geoStylerStyle)
+            .then((images) => {
+                try {
+                    expect(images[0].id).toEqual('Circle:#ff0000:0.5:#00ff00:0.25::3:16');
+                    expect(images[1].id).toEqual('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+    });
+});

--- a/web/client/utils/styleparser/__tests__/PrintStyleParser-test.js
+++ b/web/client/utils/styleparser/__tests__/PrintStyleParser-test.js
@@ -8,7 +8,7 @@
 
 import expect from 'expect';
 import PrintStyleParser from '../PrintStyleParser';
-import { drawIcons } from '../StyleParserUtils';
+import { drawIcons } from './IconUtils';
 const parser = new PrintStyleParser();
 
 describe('PrintStyleParser', () => {

--- a/web/client/utils/styleparser/__tests__/StyleParserUtils-test.js
+++ b/web/client/utils/styleparser/__tests__/StyleParserUtils-test.js
@@ -9,7 +9,6 @@
 import expect from 'expect';
 import {
     getImageIdFromSymbolizer,
-    drawIcons,
     geoStylerStyleFilter,
     getWellKnownNameImageFromSymbolizer,
     parseSymbolizerExpressions,
@@ -45,53 +44,7 @@ describe("StyleParserUtils ", () => {
 
     });
 
-    it('should preload images and marker from a style', (done) => {
-        const geoStylerStyle = {
-            name: '',
-            rules: [
-                {
-                    filter: undefined,
-                    name: '',
-                    symbolizers: [
-                        {
-                            kind: 'Mark',
-                            wellKnownName: 'Circle',
-                            color: '#ff0000',
-                            fillOpacity: 0.5,
-                            strokeColor: '#00ff00',
-                            strokeOpacity: 0.25,
-                            strokeWidth: 3,
-                            radius: 16,
-                            rotate: 90
-                        }
-                    ]
-                },
-                {
-                    filter: undefined,
-                    name: '',
-                    symbolizers: [
-                        {
-                            kind: 'Icon',
-                            image: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
-                            opacity: 0.5,
-                            size: 32,
-                            rotate: 90
-                        }
-                    ]
-                }
-            ]
-        };
-        drawIcons(geoStylerStyle)
-            .then((images) => {
-                try {
-                    expect(images[0].id).toEqual('Circle:#ff0000:0.5:#00ff00:0.25::3:16');
-                    expect(images[1].id).toEqual('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==');
-                } catch (e) {
-                    done(e);
-                }
-                done();
-            });
-    });
+
     it('should preload images and marker from a style that use property expressions', (done) => {
         const geoStylerStyle = {
             name: '',


### PR DESCRIPTION
## Description

Font awsome is included in StyleUtils, included in FilterUtils, that at the end are included by Extensions. This makes Extensions fail in build because there is not a support for font. 
This causes both 
- a build failure
- a transitive dependency that may import font-awsome in extensions increasing a lot the bundle size without a specific reason. 

For this reason, this PR separates the `drawIcon` function from the general parsing / filtering utilities.
This makes the default extension build. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
