### PR TITLE
backport 2025.01.xx - Fix #11175 parsing WMS capabilities when no global SRS is present (#11177)

### DIFF
--- a/web/client/api/WMS.js
+++ b/web/client/api/WMS.js
@@ -7,7 +7,7 @@
  */
 
 import urlUtil from 'url';
-import { isArray, castArray, get } from 'lodash';
+import { uniq, isArray, castArray, get } from 'lodash';
 import xml2js from 'xml2js';
 import axios from '../libs/ajax';
 import { getConfigProp } from '../utils/ConfigUtils';
@@ -106,7 +106,7 @@ export const searchAndPaginate = (json = {}, startPosition, maxRecords, text) =>
     const root = json.Capability;
     const service = json.Service;
     const onlineResource = getOnlineResource(root);
-    const SRSList = root.Layer && castArray(root.Layer.SRS || root.Layer.CRS)?.map((crs) => crs.toUpperCase()) || [];
+    const SRSList = root.Layer && castArray(root.Layer.SRS || root.Layer.CRS || [])?.map((crs) => crs.toUpperCase()) || [];
     const credits = root.Layer && root.Layer.Attribution && extractCredits(root.Layer.Attribution);
     const getMapFormats = castArray(root?.Request?.GetMap?.Format || []);
     const getFeatureInfoFormats = castArray(root?.Request?.GetFeatureInfo?.Format || []);
@@ -124,14 +124,18 @@ export const searchAndPaginate = (json = {}, startPosition, maxRecords, text) =>
         },
         records: filteredLayers
             .filter((layer, index) => index >= startPosition - 1 && index < startPosition - 1 + maxRecords)
-            .map((layer) => ({
-                ...layer,
-                getMapFormats,
-                getFeatureInfoFormats,
-                onlineResource,
-                SRS: SRSList,
-                credits: layer.Attribution ? extractCredits(layer.Attribution) : credits
-            }))
+            .map((layer) => {
+                // WMS spec, chapter 7.1.4.7 (WMS 1.1.1) / 7.2.4.8 (WMS 1.3.0) (inheritance of layer properties) says about CRS/SRS properties: child inherits any value(s) supplied by parent and adds any values of its own.
+                const CRSLIST = uniq(SRSList.concat(castArray(layer.SRS || layer.CRS || [])?.map((crs) => crs.toUpperCase()) || []));
+                return {
+                    ...layer,
+                    getMapFormats,
+                    getFeatureInfoFormats,
+                    onlineResource,
+                    SRS: CRSLIST,
+                    credits: layer.Attribution ? extractCredits(layer.Attribution) : credits
+                };
+            })
     };
 };
 

--- a/web/client/api/__tests__/WMS-test.js
+++ b/web/client/api/__tests__/WMS-test.js
@@ -108,7 +108,7 @@ describe('Test correctness of the WMS APIs', () => {
                 expect(result.service).toBeTruthy();
                 expect(result.records[0].getMapFormats.length).toBe(20);
                 expect(result.numberOfRecordsMatched).toBe(5);
-                expect(result.records[0].SRS.length).toBe(3);
+                expect(result.records[0].SRS.length).toBe(4);
                 expect(result.layerOptions).toBeTruthy();
                 expect(result.layerOptions.version).toBe('1.3.0');
                 done();
@@ -168,7 +168,7 @@ describe('Test correctness of the WMS APIs', () => {
     it('GetRecords transform SRS List to uppercase', (done) => {
         API.getRecords('base/web/client/test-resources/wms/GetCapabilities-1.3.0-lowercase-espg.xml', 0, 2, '').then((result) => {
             try {
-                expect(result.records[0].SRS).toEqual(['EPSG:3857', 'EPSG:4326', 'CRS:84']);
+                expect(result.records[0].SRS).toEqual(['EPSG:3857', 'EPSG:4326', 'CRS:84', 'EPSG:26713']);
                 done();
             } catch (ex) {
                 done(ex);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport 2025.01.xx - Fix #11175 parsing WMS capabilities when no global SRS is present (#11177)