### PR TITLE
[Backport 2025.01.xx]: #11153: Persist Swipe Layer state after map refresh (#11158)

### DIFF
--- a/web/client/reducers/__tests__/swipe-test.js
+++ b/web/client/reducers/__tests__/swipe-test.js
@@ -9,6 +9,7 @@ import expect from 'expect';
 
 import { SET_ACTIVE, SET_SPY_TOOL_RADIUS, SET_MODE, SET_SWIPE_TOOL_DIRECTION  } from '../../actions/swipe';
 import swipe from '../swipe';
+import { MAP_CONFIG_LOADED } from '../../actions/config';
 
 describe('Swipe tool REDUCERS', () => {
     it('should activate tool', () => {
@@ -56,5 +57,19 @@ describe('Swipe tool REDUCERS', () => {
         };
         const state = swipe({}, action);
         expect(state.spy.radius).toBe(80);
+    });
+    it('test setting swipe data if map config loaded', () => {
+        const action = {
+            type: MAP_CONFIG_LOADED,
+            config: {
+                swipe: {
+                    active: true,
+                    mode: 'swipe',
+                    layerId: "layer01"
+                }
+            }
+        };
+        const state = swipe({}, action);
+        expect(state).toEqual(action.config.swipe);
     });
 });

--- a/web/client/reducers/swipe.js
+++ b/web/client/reducers/swipe.js
@@ -8,11 +8,16 @@
 
 
 import { SET_ACTIVE, SET_MODE, SET_SWIPE_TOOL_DIRECTION, SET_SPY_TOOL_RADIUS, SET_SWIPE_LAYER } from '../actions/swipe';
+import { MAP_CONFIG_LOADED } from '../actions/config';
 
 export default (state = {}, action) => {
     switch (action.type) {
     case SET_ACTIVE: {
         return { ...state, [action.prop]: action.active };
+    }
+    case MAP_CONFIG_LOADED: {
+        const swipeConfig = action.config.swipe || {};
+        return {...state, ...swipeConfig};
     }
     case SET_SWIPE_LAYER: {
         return { ...state, layerId: action.layerId };

--- a/web/client/selectors/__tests__/mapsave-test.js
+++ b/web/client/selectors/__tests__/mapsave-test.js
@@ -77,4 +77,9 @@ describe('Test mapsave selectors', () => {
         expect(retVal.custom).toExist();
         expect(retVal.custom.someProperty).toBe("some value");
     });
+    it('check swipe is selected', () => {
+        const retVal = mapOptionsToSaveSelector({...state, swipe: {mode: 'swipe', active: true, layerId: 'layer01'}});
+        expect(retVal.swipe).toBeTruthy();
+        expect(retVal.swipe.layerId).toEqual('layer01');
+    });
 });

--- a/web/client/selectors/__tests__/swipe-test.js
+++ b/web/client/selectors/__tests__/swipe-test.js
@@ -7,7 +7,7 @@
 */
 import expect from 'expect';
 
-import { layerSwipeSettingsSelector, spyModeSettingsSelector, swipeModeSettingsSelector} from '../swipe';
+import { layerSwipeSettingsSelector, spyModeSettingsSelector, swipeModeSettingsSelector, swipeSettingsSelector} from '../swipe';
 
 describe('SWIPE SELECTORS', () => {
     it('should test layerSwipeSettingsSelector', () => {
@@ -42,5 +42,17 @@ describe('SWIPE SELECTORS', () => {
         };
 
         expect(swipeModeSettingsSelector(state)).toEqual(state.swipe.swipe);
+    });
+    it('should test swipeSettingsSelector', () => {
+        const state = {
+            swipe: {
+                active: true,
+                swipe: {
+                    direction: "cut-vertical"
+                }
+            }
+        };
+
+        expect(swipeSettingsSelector(state)).toEqual(state.swipe);
     });
 });

--- a/web/client/selectors/swipe.js
+++ b/web/client/selectors/swipe.js
@@ -6,10 +6,14 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+import { registerCustomSaveHandler } from "./mapsave";
+
 export const layerSwipeSettingsSelector = (state) => state.swipe && state.swipe || { active: false };
 export const spyModeSettingsSelector = state => state?.swipe?.spy || { radius: 80 };
 export const swipeModeSettingsSelector = state => state?.swipe?.swipe || { direction: 'cut-vertical' };
 export const getSwipeLayerId = state => state?.swipe?.layerId;
+export const swipeSettingsSelector = state => state?.swipe;
+registerCustomSaveHandler('swipe', swipeSettingsSelector);
 
 export default {
     layerSwipeSettingsSelector,

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -867,7 +867,8 @@ export const compareMapChanges = (map1 = {}, map2 = {}) => {
         'map.bookmark_search_config',
         'map.text_serch_config',
         'map.zoom',
-        'widgetsConfig'
+        'widgetsConfig',
+        'swipe'
     ];
     const filteredMap1 = pick(cloneDeep(map1), pickedFields);
     const filteredMap2 = pick(cloneDeep(map2), pickedFields);

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -1984,7 +1984,8 @@ describe('Test the MapUtils', () => {
             },
             "catalogServices": {},
             "widgetsConfig": {},
-            "mapInfoConfiguration": {}
+            "mapInfoConfiguration": {},
+            "swipe": {}
         };
         expect(compareMapChanges(map1, map2)).toBeTruthy();
     });


### PR DESCRIPTION
[Backport 2025.01.xx]: #11153: Persist Swipe Layer state after map refresh (#11158)