### PR TITLE
[Backport 2025.01.xx]: #11164: make bar chart legend clickable by items (#11167)

### DIFF
--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -570,7 +570,13 @@ export const toPlotly = (_props) => {
             autosize: false,
             height,
             width,
-            ...(types.includes('pie') && isModeBarVisible && { legend: {x: 1.05, y: 0.5} }), // Position legend to right and centered vertically
+            // for pie: Position legend to right and centered vertically
+            // for bar: use groupclick to be for item toggle by overriding the default 'togglegroup' with 'toggleitem'
+            // ** see: https://plotly.com/javascript/reference/layout/#layout-legend-groupclick
+            ...((types.includes('pie') && isModeBarVisible) ? { legend: {x: 1.05, y: 0.5} } : types.includes('bar') ? {legend: {
+                "tracegroupgap": 10,
+                "groupclick": "toggleitem"
+            }} : {}),
             hovermode: 'x unified',
             uirevision: true,
             ...gridProperty


### PR DESCRIPTION
[Backport 2025.01.xx]: #11164: make bar chart legend clickable by items (#11167)