### PR TITLE
#11209

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -258,15 +258,17 @@ export function parseCreditRemovingTagsOrSymbol(creditText = "") {
  * @memberof utils.PrintUtils
  */
 export const getLayersCredits = (layers) => {
-    const layerCredits = layers.filter(lay => lay?.credits?.title).map((layer) => {
-        const layerCreditTitle = layer?.credits?.title || '';
+    let layerCredits = layers.filter(lay => lay?.credits?.title || lay?.attribution).map((layer) => {
+        const layerCreditTitle = layer?.credits?.title || layer?.attribution || '';
         const hasOrSymbol = layerCreditTitle.includes('|');
         const hasHtmlTag = layerCreditTitle.includes('<');
         const layerCredit = (hasHtmlTag || hasOrSymbol)
             ? parseCreditRemovingTagsOrSymbol(layerCreditTitle)
             : layerCreditTitle;
         return layerCredit;
-    }).join(' | ');
+    });
+    const uniqueCredits = [...new Set(layerCredits)];
+    layerCredits = uniqueCredits.join(' | ');
     return layerCredits;
 };
 

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -1107,6 +1107,44 @@ describe('PrintUtils', () => {
                     credits: {
                         title: 'Attribution layer 03 @ | polygon layer'
                     }
+                },
+                {
+                    center: [22, 33],
+                    name: "duplicate layer 05 with same credits",
+                    credits: {
+                        title: 'Attribution layer 03 @ | polygon layer'
+                    }
+                }];
+                const reqLayersCreditTxt = getLayersCredits(layersArr);
+                expect(reqLayersCreditTxt).toEqual('OSM Simple Light Rendering GeoSolutions Data © OpenStreetMap contributors, ODbL | Attribution layer 02 | Attribution layer 03 @ polygon layer');
+            });
+            it("test getLayersAttribution", () => {
+                const layersArr = [{
+                    center: [10, 20],
+                    name: "layer 01",
+                    attribution: 'OSM Simple Light | Rendering <a href="https://www.geo-solutions.it/">GeoSolutions</a> | Data © <a href="http://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="http://www.openstreetmap.org/copyright">ODbL</a>'
+                },
+                {
+                    center: [10, 30],
+                    name: "layer 02",
+                    attribution: 'Attribution layer 02'
+                }, {
+                    center: [20, 30],
+                    name: "layer 03"
+                }, {
+                    center: [40, 45],
+                    name: "layer 04",
+                    attribution: ''
+                },
+                {
+                    center: [22, 33],
+                    name: "layer 05",
+                    attribution: 'Attribution layer 03 @ | polygon layer'
+                },
+                {
+                    center: [22, 33],
+                    name: "duplicate layer 05 with same attribution",
+                    attribution: 'Attribution layer 03 @ | polygon layer'
                 }];
                 const reqLayersCreditTxt = getLayersCredits(layersArr);
                 expect(reqLayersCreditTxt).toEqual('OSM Simple Light Rendering GeoSolutions Data © OpenStreetMap contributors, ODbL | Attribution layer 02 | Attribution layer 03 @ polygon layer');


### PR DESCRIPTION
fix(print): include attribution in output and remove duplicate credits
- Added support for including attribution field in print output
- Avoid duplicate credit entries in printed results
- Add unit tests for both cases

On behalf of DB Systel GmbH

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->


- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
[#11209 ](https://github.com/geosolutions-it/MapStore2/issues/11209)

**What is the new behavior?**
1. Copyright information from the attribution field will be printed.
2. Duplicate copyright entries will be printed only once.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
