### PR TITLE
Remove usage of object-assign

### DIFF
--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -1,4 +1,3 @@
-const assign = require('object-assign');
 const LoaderOptionsPlugin = require("webpack/lib/LoaderOptionsPlugin");
 const DefinePlugin = require("webpack/lib/DefinePlugin");
 const ProvidePlugin = require("webpack/lib/ProvidePlugin");
@@ -123,7 +122,7 @@ module.exports = (...args) => mapArgumentsToObject(args, ({
     devtool = DEV_TOOL
 }) => ({
     target: "web",
-    entry: assign({}, bundles, themeEntries),
+    entry: Object.assign({}, bundles, themeEntries),
     mode: prod ? "production" : "development",
     optimization: {
         nodeEnv: false, // we are already using DefinePlugin for process.env.NODE_ENV so we should set this to false to avoid conflicts
@@ -196,7 +195,7 @@ module.exports = (...args) => mapArgumentsToObject(args, ({
             zlib: false
         },
         extensions: [".js", ".jsx"],
-        alias: assign({}, {
+        alias: Object.assign({}, {
             // next libs are added because of this issue https://github.com/geosolutions-it/MapStore2/issues/4569
             proj4: '@geosolutions/proj4',
             "react-joyride": '@geosolutions/react-joyride'

--- a/build/testConfig.js
+++ b/build/testConfig.js
@@ -1,4 +1,3 @@
-const assign = require('object-assign');
 const nodePath = require('path');
 const webpack = require('webpack');
 const ProvidePlugin = require("webpack/lib/ProvidePlugin");
@@ -144,7 +143,7 @@ module.exports = ({browsers = [ 'ChromeHeadless' ], files, path, testFile, singl
                 https: false,
                 zlib: false
             },
-            alias: assign({}, {
+            alias: Object.assign({}, {
                 // next libs are added because of this issue https://github.com/geosolutions-it/MapStore2/issues/4569
                 proj4: '@geosolutions/proj4',
                 "react-joyride": '@geosolutions/react-joyride'

--- a/web/client/components/TOC/fragments/RefreshLayers.jsx
+++ b/web/client/components/TOC/fragments/RefreshLayers.jsx
@@ -9,7 +9,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Glyphicon, Alert } from 'react-bootstrap';
-import assign from 'object-assign';
 
 import Dialog from '../../misc/Dialog';
 import Portal from '../../misc/Portal';
@@ -93,7 +92,7 @@ class RefreshLayers extends React.Component {
     };
 
     updateOption = (opt, value) => {
-        const options = assign({}, this.props.options, {
+        const options = Object.assign({}, this.props.options, {
             [opt]: value
         });
         this.props.onUpdateOptions(options);

--- a/web/client/components/TOC/fragments/settings/ThematicLayer.jsx
+++ b/web/client/components/TOC/fragments/settings/ThematicLayer.jsx
@@ -7,7 +7,6 @@
  */
 
 import { isEqual, isObject } from 'lodash';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert, Checkbox, Col, ControlLabel, FormGroup, Grid, Row } from 'react-bootstrap';
@@ -167,7 +166,7 @@ class ThematicLayer extends React.Component {
             this.props.onChangeConfiguration(
                 this.props.layer,
                 false,
-                JSON.stringify(assign({}, this.props.layer.thematic, internalProperties), null, 4)
+                JSON.stringify(Object.assign({}, this.props.layer.thematic, internalProperties), null, 4)
             );
             if (this.hasConfiguration()) {
                 this.switchLayer(this.props.layer);
@@ -195,12 +194,12 @@ class ThematicLayer extends React.Component {
         // get current thematic style when configuration changes
         // add an attribute for every layer param
         const newParams = this.props.getThematicParameters(thematic.params || []).reduce((previous, param) => {
-            return assign(previous, {
+            return Object.assign(previous, {
                 [param.field]: param.defaultValue
             });
         }, {});
         // apply base initial parameters, layer params and current style (if any)
-        return assign({}, this.props.initialParams, {
+        return Object.assign({}, this.props.initialParams, {
             attribute: thematic.attribute || ''
         }, newParams, thematic.applied);
     };
@@ -480,15 +479,15 @@ class ThematicLayer extends React.Component {
         const newParams = this.props.removeThematicStyle(layer.params);
         this.props.onChange({
             params: newParams,
-            thematic: assign({}, layer.thematic, {
-                applied: assign({}, layer.thematic.current)
+            thematic: Object.assign({}, layer.thematic, {
+                applied: Object.assign({}, layer.thematic.current)
             })
         });
     };
 
     updateClassification = (classification) => {
-        this.props.onChange('thematic', assign({}, this.props.layer.thematic, {
-            current: assign({}, this.props.layer.thematic.current, {
+        this.props.onChange('thematic', Object.assign({}, this.props.layer.thematic, {
+            current: Object.assign({}, this.props.layer.thematic.current, {
                 classification
             })
         }));
@@ -520,12 +519,12 @@ class ThematicLayer extends React.Component {
     applyCfg = (cfg) => {
         try {
             const thematic = JSON.parse(cfg);
-            const newThema = assign({}, thematic, {
+            const newThema = Object.assign({}, thematic, {
                 current: this.getCurrentThema(thematic),
                 unconfigured: false
             });
             this.props.onChange('thematic', newThema);
-            this.props.onSwitchLayer(assign({}, this.props.layer, {
+            this.props.onSwitchLayer(Object.assign({}, this.props.layer, {
                 thematic: newThema
             }));
             this.props.onChangeConfiguration(this.props.layer, false, cfg);
@@ -549,7 +548,7 @@ class ThematicLayer extends React.Component {
     switchLayer = (layer) => {
         if (layer.thematic) {
             const newCurrent = this.getCurrentThema(layer.thematic);
-            this.props.onChange('thematic', assign({}, layer.thematic, {
+            this.props.onChange('thematic', Object.assign({}, layer.thematic, {
                 current: newCurrent
             }));
         }
@@ -557,9 +556,9 @@ class ThematicLayer extends React.Component {
     };
 
     restoreStyle = () => {
-        const layer = assign({}, this.props.layer, {
-            thematic: assign({}, this.props.layer.thematic, {
-                current: assign({}, this.props.layer.thematic.current, {
+        const layer = Object.assign({}, this.props.layer, {
+            thematic: Object.assign({}, this.props.layer.thematic, {
+                current: Object.assign({}, this.props.layer.thematic.current, {
                     classification: null
                 })
             })
@@ -569,11 +568,11 @@ class ThematicLayer extends React.Component {
     };
 
     applyStyle = (layer) => {
-        const newParams = assign({}, layer.params, this.props.getStyleParameters(layer, layer.thematic.current));
+        const newParams = Object.assign({}, layer.params, this.props.getStyleParameters(layer, layer.thematic.current));
         this.props.onChange({
             params: newParams,
-            thematic: assign({}, layer.thematic, {
-                applied: assign({}, layer.thematic.current)
+            thematic: Object.assign({}, layer.thematic, {
+                applied: Object.assign({}, layer.thematic.current)
             })
         });
         this.props.onApplyStyle();
@@ -584,16 +583,16 @@ class ThematicLayer extends React.Component {
     };
     updateStyle = (key, value, quiet) => {
         const layer = this.props.layer;
-        const currentStyle = assign({}, layer.thematic.current, {
+        const currentStyle = Object.assign({}, layer.thematic.current, {
             [key]: value
         });
-        const newThema = assign({}, layer.thematic, {
+        const newThema = Object.assign({}, layer.thematic, {
             current: currentStyle
         });
         this.props.onChange('thematic', newThema);
         if (this.needsToUpdateClassification(key)) {
-            const newParams = assign({}, this.props.getMetadataParameters(layer, currentStyle));
-            this.props.onClassify(assign({}, layer, {
+            const newParams = Object.assign({}, this.props.getMetadataParameters(layer, currentStyle));
+            this.props.onClassify(Object.assign({}, layer, {
                 thematic: newThema
             }), newParams);
         }

--- a/web/client/components/app/StandardAppComponent.jsx
+++ b/web/client/components/app/StandardAppComponent.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -19,7 +18,7 @@ import ThemeComp from '../theme/Theme';
 const Theme = connect((state) => ({
     theme: state.theme && state.theme.selectedTheme && state.theme.selectedTheme.id
 }), {}, (stateProps, dispatchProps, ownProps) => {
-    return assign({}, stateProps, dispatchProps, ownProps);
+    return Object.assign({}, stateProps, dispatchProps, ownProps);
 })(ThemeComp);
 
 class StandardAppComponent extends React.Component {

--- a/web/client/components/app/StandardContainer.jsx
+++ b/web/client/components/app/StandardContainer.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -18,7 +17,7 @@ import ThemeComp from '../theme/Theme';
 const Theme = connect((state) => ({
     theme: state.theme && state.theme.selectedTheme && state.theme.selectedTheme.id
 }), {}, (stateProps, dispatchProps, ownProps) => {
-    return assign({}, stateProps, dispatchProps, ownProps);
+    return Object.assign({}, stateProps, dispatchProps, ownProps);
 })(ThemeComp);
 
 class StandardContainer extends React.Component {

--- a/web/client/components/app/StandardRouter.jsx
+++ b/web/client/components/app/StandardRouter.jsx
@@ -17,12 +17,11 @@ import Localized from '../I18N/Localized';
 import Theme from '../theme/Theme';
 import {ErrorBoundary} from 'react-error-boundary';
 import ErrorBoundaryFallbackComponent from './ErrorFallBackComp';
-import assign from 'object-assign';
 
 const ThemeProvider = connect((state) => ({
     theme: state.theme?.selectedTheme?.id
 }), {}, (stateProps, dispatchProps, ownProps) => {
-    return assign({}, stateProps, dispatchProps, ownProps);
+    return Object.assign({}, stateProps, dispatchProps, ownProps);
 })(Theme);
 
 class StandardRouter extends React.Component {

--- a/web/client/components/background/BackgroundSelector.jsx
+++ b/web/client/components/background/BackgroundSelector.jsx
@@ -8,7 +8,6 @@
 
 import React, { lazy } from 'react';
 
-import assign from 'object-assign';
 import PreviewButton from './PreviewButton';
 import PreviewList from './PreviewList';
 import PreviewIcon from './PreviewIcon';
@@ -170,7 +169,7 @@ class BackgroundSelector extends React.Component {
         return {pagination, listSize, visibleIconsLength};
     };
     renderBackgroundSelector = () => {
-        const configuration = assign({
+        const configuration = Object.assign({
             side: 78,
             sidePreview: 104,
             frame: 3,

--- a/web/client/components/buttons/InfoButton.jsx
+++ b/web/client/components/buttons/InfoButton.jsx
@@ -9,7 +9,6 @@
 
 import './css/infoButton.css';
 
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Glyphicon} from 'react-bootstrap';
@@ -88,7 +87,7 @@ class InfoButton extends React.Component {
 
     render() {
         const dialog =
-            (<Dialog id="mapstore-about" style={assign({}, this.props.style, {display: this.state.isVisible ? "block" : "none"})}>
+            (<Dialog id="mapstore-about" style={Object.assign({}, this.props.style, {display: this.state.isVisible ? "block" : "none"})}>
                 <span role="header"><span className="modal-title about-panel-title">{this.props.title}</span><button onClick={this.close} className="about-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button></span>
                 <div role="body">{this.props.body}</div>
             </Dialog>)

--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -7,7 +7,6 @@
 */
 import { isNil, isEmpty } from 'lodash';
 
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -169,7 +168,7 @@ class Catalog extends React.Component {
     getServices = () => {
         return Object.keys(this.props.services).map(s => {
             const service = this.props.services[s];
-            return assign({}, {
+            return Object.assign({}, {
                 label: service.titleMsgId ? getMessageById(this.context.messages, service.titleMsgId) : service.title,
                 value: s
             });

--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -9,7 +9,6 @@
 import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import { findIndex, head } from 'lodash';
-import assign from 'object-assign';
 import { Glyphicon } from 'react-bootstrap';
 import Spinner from 'react-spinkit';
 
@@ -139,7 +138,7 @@ const DownloadDialog = ({
     const handleExport = () => {
         const selectedSrs = downloadOptions && downloadOptions.selectedSrs || defaultSrs || (head(srsList) || {}).name;
         const propertyName = getAttributesList(attributes, customAttributeSettings);
-        onExport(selectedLayer?.url, filterObj, assign({}, downloadOptions, {selectedSrs}, {propertyName}));
+        onExport(selectedLayer?.url, filterObj, Object.assign({}, downloadOptions, {selectedSrs}, {propertyName}));
     };
 
     const findValidFormats  = fmt => formats.filter(({validServices, type = 'vector'}) =>

--- a/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
@@ -12,7 +12,6 @@ import AttributeEditor from './AttributeEditor';
 import ControlledCombobox from '../../../misc/combobox/ControlledCombobox';
 import { forceSelection } from '../../../../utils/FeatureGridEditorUtils';
 import { head } from 'lodash';
-import assign from 'object-assign';
 /**
  * Editor that provides a DropDown menu of a list of elements passed.
  * @memberof components.data.featuregrid.editors
@@ -102,7 +101,7 @@ class DropDownEditor extends AttributeEditor {
             data = this.props.values.map(v => {return {label: v, value: v}; });
         }
 
-        const props = assign({}, {...this.props}, {
+        const props = Object.assign({}, {...this.props}, {
             data,
             defaultOption: this.props.defaultOption || head(this.props.values)
         });

--- a/web/client/components/data/query/AutocompleteFieldHOC.jsx
+++ b/web/client/components/data/query/AutocompleteFieldHOC.jsx
@@ -10,7 +10,6 @@
 import PropTypes from 'prop-types';
 
 import React from 'react';
-import assign from 'object-assign';
 import AutocompleteListItem from './AutocompleteListItem';
 import PagedCombobox from '../../misc/combobox/PagedCombobox';
 import { isLikeOrIlike } from '../../../utils/FilterUtils';
@@ -68,7 +67,7 @@ class AutocompleteFieldHOC extends React.Component {
         const numberOfPages = Math.ceil(this.props.filterField.fieldOptions.valuesCount / this.props.maxFeaturesWPS);
         const firstPage = this.props.filterField.fieldOptions.currentPage === 1 || !this.props.filterField.fieldOptions.currentPage;
         const lastPage = this.props.filterField.fieldOptions.currentPage === numberOfPages || !this.props.filterField.fieldOptions.currentPage;
-        return assign({}, this.props.pagination, {
+        return Object.assign({}, this.props.pagination, {
             paginated: options.length !== 0 && !(firstPage && options.length === 1),
             firstPage,
             lastPage,
@@ -78,7 +77,7 @@ class AutocompleteFieldHOC extends React.Component {
     };
 
     getTooltip = () => {
-        return assign({}, this.props.tooltip, {
+        return Object.assign({}, this.props.tooltip, {
             enabled: isLikeOrIlike(this.props.filterField.operator),
             id: "autocompleteField-tooltip" + this.props.filterField && this.props.filterField.rowId,
             message: (<HTML msgId="queryform.attributefilter.tooltipTextField"/>),

--- a/web/client/components/data/query/ComboField.jsx
+++ b/web/client/components/data/query/ComboField.jsx
@@ -7,7 +7,6 @@
  */
 import React from 'react';
 
-import assign from 'object-assign';
 import { getMessageById } from '../../../utils/LocaleUtils';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'react-bootstrap';
@@ -88,10 +87,10 @@ class ComboField extends React.Component {
     };
 
     render() {
-        let style = assign({}, {borderColor: "#dedede"}, this.props.style);
+        let style = Object.assign({}, {borderColor: "#dedede"}, this.props.style);
 
         if (this.props.fieldException) {
-            style = assign({}, style, {borderColor: "#FF0000"});
+            style = Object.assign({}, style, {borderColor: "#FF0000"});
         }
 
         const ListComponent = this.props.multivalue ? Multiselect : DropdownList;

--- a/web/client/components/data/query/FilterField.jsx
+++ b/web/client/components/data/query/FilterField.jsx
@@ -9,7 +9,6 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 import ComboField from './ComboField';
-import assign from 'object-assign';
 
 import localizedProps from '../../misc/enhancers/localizedProps';
 
@@ -59,7 +58,7 @@ class FilterField extends React.Component {
     renderValueField = (selectedAttribute) => {
         const valueElement = React.cloneElement(
             React.Children.toArray(this.props.children).filter((node) => node.props.attType === selectedAttribute.type)[0],
-            assign({
+            Object.assign({
                 fieldName: "value",
                 fieldRowId: this.props.filterField.rowId,
                 fieldValue: this.props.filterField.value,

--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -11,7 +11,6 @@ import PropTypes from 'prop-types';
 import { Row, Col } from 'react-bootstrap';
 import SwitchPanel from '../../misc/switch/SwitchPanel';
 import I18N from '../../I18N/I18N';
-import assign from 'object-assign';
 import { reprojectBbox, reproject, getUnits } from '../../../utils/CoordinatesUtils';
 import IntlNumberFormControl from '../../I18N/IntlNumberFormControl';
 
@@ -43,12 +42,12 @@ class GeometryDetails extends React.Component {
         if (this.props.type === "BBOX") {
 
             this.extent = this.getBBOXDimensions(geometry);
-            this.tempExtent = assign({}, this.extent);
+            this.tempExtent = Object.assign({}, this.extent);
 
         } else if (this.props.type === "Circle") {
 
             this.circle = this.getCircleDimensions(geometry);
-            this.tempCircle = assign({}, this.circle);
+            this.tempCircle = Object.assign({}, this.circle);
 
         }
     }

--- a/web/client/components/map/leaflet/Feature.jsx
+++ b/web/client/components/map/leaflet/Feature.jsx
@@ -9,7 +9,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {isEqual, isArray, castArray} from 'lodash';
-import assign from 'object-assign';
 import axios from 'axios';
 
 import {geometryToLayer} from '../../../utils/leaflet/Vector';
@@ -63,7 +62,7 @@ class FeatureComponent extends React.Component {
         if (props.features) {
             // supporting FeatureCollection
             props.features.forEach(f => {
-                let newProps = assign({}, props, {
+                let newProps = Object.assign({}, props, {
                     type: f.type,
                     geometry: f.geometry,
                     style: f.style && castArray(f.style) || undefined,

--- a/web/client/components/map/leaflet/Layer.jsx
+++ b/web/client/components/map/leaflet/Layer.jsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Layers from '../../../utils/leaflet/Layers';
-import assign from 'object-assign';
 import isEqual from 'lodash/isEqual';
 import isNil from 'lodash/isNil';
 class LeafletLayer extends React.Component {
@@ -148,7 +147,7 @@ class LeafletLayer extends React.Component {
     };
 
     generateOpts = (options, position, securityToken) => {
-        return assign({}, options, position ? {zIndex: position, srs: this.props.srs } : null, {
+        return Object.assign({}, options, position ? {zIndex: position, srs: this.props.srs } : null, {
             zoomOffset: -this.props.zoomOffset,
             onError: () => {
                 this.props.onCreationError(options);
@@ -199,7 +198,7 @@ class LeafletLayer extends React.Component {
             if (this.props.options.refresh && this.layer.setParams) {
                 let counter = 0;
                 this.refreshTimer = setInterval(() => {
-                    this.layer.setParams(assign({}, this.props.options.params, {_refreshCounter: counter++}));
+                    this.layer.setParams(Object.assign({}, this.props.options.params, {_refreshCounter: counter++}));
                 }, this.props.options.refresh);
             }
         }

--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ConfigUtils from '../../../utils/ConfigUtils';
 import {reprojectBbox, reproject} from '../../../utils/CoordinatesUtils';
-import assign from 'object-assign';
 import {
     getGoogleMercatorResolutions,
     EXTENT_TO_ZOOM_HOOK,
@@ -97,7 +96,7 @@ class LeafletMap extends React.Component {
         if (this.props.mapOptions && this.props.mapOptions.view && this.props.mapOptions.view.resolutions && this.props.mapOptions.view.resolutions.length > 0) {
             const scaleFun = L.CRS.EPSG3857.scale;
             const ratio = this.props.mapOptions.view.resolutions[0] / getGoogleMercatorResolutions(0, 23)[0];
-            this.crs = assign({}, L.CRS.EPSG3857, {
+            this.crs = Object.assign({}, L.CRS.EPSG3857, {
                 scale: (zoom) => {
                     return scaleFun.call(L.CRS.EPSG3857, zoom) / Math.pow(2, Math.round(Math.log2(ratio)));
                 }
@@ -108,7 +107,7 @@ class LeafletMap extends React.Component {
     componentDidMount() {
         const {limits = {}} = this.props;
         const maxBounds = limits.restrictedExtent && limits.crs && reprojectBbox(limits.restrictedExtent, limits.crs, "EPSG:4326");
-        let mapOptions = assign({}, this.props.interactive ? {} : {
+        let mapOptions = Object.assign({}, this.props.interactive ? {} : {
             dragging: false,
             touchZoom: false,
             scrollWheelZoom: false,
@@ -125,7 +124,7 @@ class LeafletMap extends React.Component {
             maxZoom: limits && limits.maxZoom || 23
         }, this.props.mapOptions, this.crs ? {crs: this.crs} : {});
         // it is not possible to use #<id> in a query selector if the id starts with a number
-        const map = L.map(this.getDocument().querySelector(`[id='${this.props.id}'] > .map-viewport`), assign({ zoomControl: false }, mapOptions) ).setView([this.props.center.y, this.props.center.x],
+        const map = L.map(this.getDocument().querySelector(`[id='${this.props.id}'] > .map-viewport`), Object.assign({ zoomControl: false }, mapOptions) ).setView([this.props.center.y, this.props.center.x],
             Math.round(this.props.zoom));
 
         this.map = map;

--- a/web/client/components/map/leaflet/Overview.jsx
+++ b/web/client/components/map/leaflet/Overview.jsx
@@ -4,7 +4,6 @@ var React = require('react');
 var MiniMap = require('leaflet-minimap');
 var L = require('leaflet');
 var Layers = require('../../../utils/leaflet/Layers');
-var assign = require('object-assign');
 require('./overview.css');
 
 const defaultOpt = { // For all configuration options refer to https://github.com/Norkart/Leaflet-MiniMap
@@ -37,7 +36,7 @@ class Overview extends React.Component {
     };
 
     componentDidMount() {
-        let opt = assign({}, defaultOpt, this.props.overviewOpt);
+        let opt = Object.assign({}, defaultOpt, this.props.overviewOpt);
         if (this.props.layers) {
             let lfLayers = [];
             this.props.layers.forEach((layerOpt) => {

--- a/web/client/components/map/openlayers/Layer.jsx
+++ b/web/client/components/map/openlayers/Layer.jsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Layers from '../../../utils/openlayers/Layers';
 import {normalizeSRS, reprojectBbox, getExtentFromNormalized, isBboxCompatible, getPolygonFromExtent} from '../../../utils/CoordinatesUtils';
-import assign from 'object-assign';
 import Rx from 'rxjs';
 import isNumber from 'lodash/isNumber';
 import isArray from 'lodash/isArray';
@@ -148,7 +147,7 @@ export default class OpenlayersLayer extends React.Component {
                 maxZoom: !isNil(minResolution) ? getZoomFromResolution(minResolution, resolutions) : undefined
             })
         };
-        return assign({}, options, isNumber(position) ? {zIndex: position} : null, {
+        return Object.assign({}, options, isNumber(position) ? {zIndex: position} : null, {
             srs,
             onError: () => {
                 this.props.onCreationError(options);
@@ -329,7 +328,7 @@ export default class OpenlayersLayer extends React.Component {
             if (options.refresh) {
                 let counter = 0;
                 this.refreshTimer = setInterval(() => {
-                    this.layer.getSource().updateParams(assign({}, options.params, {_refreshCounter: counter++}));
+                    this.layer.getSource().updateParams(Object.assign({}, options.params, {_refreshCounter: counter++}));
                 }, options.refresh);
             }
         }

--- a/web/client/components/map/openlayers/snapshot/GrabMap.jsx
+++ b/web/client/components/map/openlayers/snapshot/GrabMap.jsx
@@ -9,7 +9,6 @@
 import './snapshotMapStyle.css';
 import '../../../map/openlayers/plugins/index';
 
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -54,7 +53,7 @@ export default class GrabOlMap extends React.Component {
             let projection = this.props.config.projection || 'EPSG:3857';
             let me = this; // TODO find the reason why the arrow function doesn't get this object
             return layers.map((layer, index) => {
-                var options = assign({}, layer, {srs: projection}, layer.type === "wms" ? {forceProxy: !this.props.allowTaint} : {});
+                var options = Object.assign({}, layer, {srs: projection}, layer.type === "wms" ? {forceProxy: !this.props.allowTaint} : {});
                 return (<LLayer type={layer.type} position={index} key={layer.id || layer.name} options={options}>
                     {me.renderLayerContent(layer)}
                 </LLayer>);

--- a/web/client/components/mapcontrols/search/SearchResultList.jsx
+++ b/web/client/components/mapcontrols/search/SearchResultList.jsx
@@ -9,7 +9,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { find } from 'lodash';
-import assign from 'object-assign';
 
 import SearchResult from './SearchResult';
 import I18N from '../../I18N/I18N';
@@ -89,7 +88,7 @@ export default class SearchResultList extends React.Component {
         if (this.props.fitToMapSize && mapSize) {
             let maxWidth = mapSize.width - this.props.sizeAdjustment.width;
             let maxHeight = mapSize.height - this.props.sizeAdjustment.height;
-            containerStyle = assign({}, this.props.containerStyle, {
+            containerStyle = Object.assign({}, this.props.containerStyle, {
                 maxWidth,
                 maxHeight
             });
@@ -97,7 +96,7 @@ export default class SearchResultList extends React.Component {
         if (!this.props.results) {
             return null;
         } else if (this.props.results.length === 0) {
-            return <div className="search-result-list" style={assign({padding: "10px", textAlign: "center"}, containerStyle)}>{notFoundMessage}</div>;
+            return <div className="search-result-list" style={Object.assign({padding: "10px", textAlign: "center"}, containerStyle)}>{notFoundMessage}</div>;
         }
         return (
             <div className="search-result-list" style={containerStyle}>

--- a/web/client/components/mapcontrols/searchservicesconfig/ResultsProps.jsx
+++ b/web/client/components/mapcontrols/searchservicesconfig/ResultsProps.jsx
@@ -11,7 +11,6 @@ import React from 'react';
 import { get } from 'lodash';
 import { FormGroup, ControlLabel, FormControl, Label, Checkbox } from 'react-bootstrap';
 import Slider from 'react-nouislider';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
 import Message from '../../I18N/Message';
@@ -124,11 +123,11 @@ class ResultsProps extends React.Component {
 
     updateProp = (prop, path, event) => {
         const value = get(event, path || 'target.value');
-        this.props.onPropertyChange("service", assign({}, this.props.service, {[prop]: value}));
+        this.props.onPropertyChange("service", Object.assign({}, this.props.service, {[prop]: value}));
     };
 
     updatePriority = (val) => {
-        this.props.onPropertyChange("service", assign({}, this.props.service, {priority: parseFloat(val[0], 10)}));
+        this.props.onPropertyChange("service", Object.assign({}, this.props.service, {priority: parseFloat(val[0], 10)}));
     };
     updateLaunchInfoPanel = (val) => {
         // determine launchInfoPanel value

--- a/web/client/components/mapcontrols/searchservicesconfig/WFSOptionalProps.jsx
+++ b/web/client/components/mapcontrols/searchservicesconfig/WFSOptionalProps.jsx
@@ -11,7 +11,6 @@ import React from 'react';
 import { FormGroup, ControlLabel, FormControl, Label } from 'react-bootstrap';
 import Message from '../../I18N/Message';
 import Slider from 'react-nouislider';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 
 function validate() {
@@ -90,8 +89,8 @@ class WFSOptionalProps extends React.Component {
 
     updateProp = (prop, event) => {
         const value = event.target.value;
-        const options = assign({}, this.props.service.options, {[prop]: value});
-        this.props.onPropertyChange("service", assign({}, this.props.service, {options}));
+        const options = Object.assign({}, this.props.service.options, {[prop]: value});
+        this.props.onPropertyChange("service", Object.assign({}, this.props.service, {options}));
     };
 
     updateSliderProps = (props, val) => {

--- a/web/client/components/mapcontrols/searchservicesconfig/WFSServiceProps.jsx
+++ b/web/client/components/mapcontrols/searchservicesconfig/WFSServiceProps.jsx
@@ -9,7 +9,6 @@ import React from 'react';
 
 import { FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
 import Message from '../../I18N/Message';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 
 // const weburl = new RegExp(/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/);
@@ -85,18 +84,18 @@ class WFSServiceProps extends React.Component {
         if (prop === "queriableAttributes") {
             value = value.split(",");
         }
-        const options = assign({}, this.props.service.options, {[prop]: value} );
-        this.props.onPropertyChange("service", assign({}, this.props.service, {options}));
+        const options = Object.assign({}, this.props.service.options, {[prop]: value} );
+        this.props.onPropertyChange("service", Object.assign({}, this.props.service, {options}));
     };
 
     updateName = (event) => {
         const value = event.target.value;
-        this.props.onPropertyChange("service", assign({}, this.props.service, {name: value}));
+        this.props.onPropertyChange("service", Object.assign({}, this.props.service, {name: value}));
     };
 
     updateMaxFeatures = (val) => {
-        const options = assign({}, this.props.service.options, {maxFeatures: parseFloat(val[0], 10)});
-        this.props.onPropertyChange("service", assign({}, this.props.service, {options}));
+        const options = Object.assign({}, this.props.service.options, {maxFeatures: parseFloat(val[0], 10)});
+        this.props.onPropertyChange("service", Object.assign({}, this.props.service, {options}));
     };
 }
 

--- a/web/client/components/misc/Dialog.jsx
+++ b/web/client/components/misc/Dialog.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Draggable from 'react-draggable';
@@ -91,7 +90,7 @@ class Dialog extends React.Component {
         const dialog = this.props.draggable ? (<Draggable defaultPosition={this.props.start} bounds={this.props.bounds} handle=".draggable-header, .draggable-header *">
             {body}
         </Draggable>) : body;
-        let containerStyle = assign({}, this.props.style.display ? {display: this.props.style.display} : {}, this.props.backgroundStyle);
+        let containerStyle = Object.assign({}, this.props.style.display ? {display: this.props.style.display} : {}, this.props.backgroundStyle);
         return this.props.modal ?
             <div ref={(mask) => { this.mask = mask; }} onClick={this.onClickOut} style={containerStyle} className={"fade in modal " + this.props.containerClassName} role="dialog">
                 {dialog}

--- a/web/client/components/misc/Modal.jsx
+++ b/web/client/components/misc/Modal.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import { Modal } from 'react-bootstrap';
 
 import withContainer from './WithContainer';
@@ -30,7 +29,7 @@ class FixedModal extends Modal {
 }
 
 
-export default assign(withContainer(FixedModal), {
+export default Object.assign(withContainer(FixedModal), {
     Body: Modal.Body,
     Dialog: Modal.Dialog,
     Footer: Modal.Footer,

--- a/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
+++ b/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
@@ -7,7 +7,6 @@
  */
 
 import expect from 'expect';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -51,7 +50,7 @@ const plugins = {
     MyPlugin: My,
     OtherPlugin: My,
     ContainerPlugin: Container,
-    NoRootPlugin: assign(NoRootPlugin, { noRoot: true, Container: {
+    NoRootPlugin: Object.assign(NoRootPlugin, { noRoot: true, Container: {
         name: 'no-root-plugin',
         position: 1,
         priority: 1

--- a/web/client/components/print/MapPreview.jsx
+++ b/web/client/components/print/MapPreview.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Glyphicon } from 'react-bootstrap';
@@ -136,7 +135,7 @@ class MapPreview extends React.Component {
             return null;
         }
 
-        const style = assign({}, this.props.style, {
+        const style = Object.assign({}, this.props.style, {
             width: this.props.width + "px",
             height: this.props.height + "px"
         });
@@ -167,7 +166,7 @@ class MapPreview extends React.Component {
             >
                 {this.props.layers.map((layer, index) =>
                     (<Layer key={layer.id || layer.name} position={index} type={layer.type} srs={projection}
-                        options={assign({}, this.adjustResolution(layer), {srs: projection})}
+                        options={Object.assign({}, this.adjustResolution(layer), {srs: projection})}
                         env={this.props.env}
                     >
                         {this.renderLayerContent(layer, projection)}
@@ -188,10 +187,10 @@ class MapPreview extends React.Component {
     adjustResolution = (layer) => {
         const ratio = this.getRatio();
         const dpi = Math.round(96.0 / ratio);
-        return assign({}, layer, {
+        return Object.assign({}, layer, {
             ...(!isNil(layer?.minResolution) && { minResolution: layer.minResolution * ratio }),
             ...(!isNil(layer?.maxResolution) && { maxResolution: layer.maxResolution * ratio }),
-            params: assign({}, layer.params, {
+            params: Object.assign({}, layer.params, {
                 "format_options": "dpi:" + dpi,
                 "MAP.RESOLUTION": dpi
             })

--- a/web/client/components/search/SearchBarToolbar.jsx
+++ b/web/client/components/search/SearchBarToolbar.jsx
@@ -7,7 +7,6 @@
 */
 
 import React from 'react';
-import assign from 'object-assign';
 import Spinner from 'react-spinkit';
 
 import Toolbar from '../misc/toolbar/Toolbar';
@@ -23,7 +22,7 @@ const getSpinnerStyle = (splitTools) => {
         zIndex: 1,
         top: "13px"
     };
-    return assign({}, {position: "absolute"}, splitTools ? {...splittedStyle} : {...nonSplittedStyle});
+    return Object.assign({}, {position: "absolute"}, splitTools ? {...splittedStyle} : {...nonSplittedStyle});
 };
 
 export default ({

--- a/web/client/components/styleeditor/Editor.jsx
+++ b/web/client/components/styleeditor/Editor.jsx
@@ -7,7 +7,6 @@
  */
 
 import { debounce, endsWith, isEqual, isFunction, isObject, isString } from 'lodash';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Message from '../I18N/Message';
@@ -166,7 +165,7 @@ class Editor extends React.Component {
     getInlineWidget = ({ onClick = () => {}, token = {}, className = '', style = {} }) => {
         const inlineWidget = document.createElement('div');
         inlineWidget.setAttribute('class', `${className} ms-style-editor-inline-widget`);
-        assign(inlineWidget.style, style);
+        Object.assign(inlineWidget.style, style);
         inlineWidget.onclick = () => onClick({ ...token });
         return inlineWidget;
     };


### PR DESCRIPTION
## Description
I noticed that object-assign is still being used a few places, after we recently removed the dependency from package.json see #11036.

The test are however not failing, because we still have another dependency pulling in object-assign as a transitive dependency. 

This PR removes the the remaining usage of object-assign

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
https://github.com/geosolutions-it/MapStore2/issues/11218

**What is the current behavior?**
We are still using object-assign

#<issue>

**What is the new behavior?**
We remove the remaining usage of object-assign and replace it with Object.assign

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
