### PR TITLE
Remove unused devDependency karma-ie-launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "karma-coverage": "2.2.0",
     "karma-coveralls": "2.1.0",
     "karma-firefox-launcher": "2.1.2",
-    "karma-ie-launcher": "1.0.0",
     "karma-junit-reporter": "2.0.1",
     "karma-mocha": "2.0.1",
     "karma-mocha-reporter": "2.2.5",


### PR DESCRIPTION
## Description
This PR removes the karma-ie-launcher devDependency from package.json

The devDependency can safely be removed as it is not being used anywhere. 
IE11 is not mentioned as a supported browser.
The browser is no longer supported by Microsoft, and the end of life was 3 years ago.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
The dependency is not being used anywhere, but it still listed in package.json

#<issue>
https://github.com/geosolutions-it/MapStore2/issues/11220

**What is the new behavior?**
Remove the dependency from package.sjon

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
