### PR TITLE
gs-stable CORS policy issue on QA #11234

### DIFF
--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -55,11 +55,6 @@
       "method": "bearer"
     },
     {
-      "urlPattern": "http(s)?\\:\\/\\/gs-stable\\.(geo-solutions\\.it|geosolutionsgroup\\.com)(\\:443|\\:80)?\\/geoserver/.*",
-      "authkeyParamName": "authkey",
-      "method": "authkey"
-    },
-    {
       "urlPattern": ".*rest/config.*",
       "method": "bearer"
     }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
As sending the authkey(configured in localConfig) throws an error on the qa server, as mentioned here  #11234. So, reverting the change by removing the authkey rule from authenticationRules.

**Please check if the PR fulfills these requirements **
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

fixes #11234


**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Error from services(gs-stable) when authkey is sent.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
No errror as no authkey is being be sent.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
