### PR TITLE
#11237: Allow the possibility to control the resource detail tab selection

### DIFF
--- a/web/client/plugins/ResourcesCatalog/ResourceDetails.jsx
+++ b/web/client/plugins/ResourcesCatalog/ResourceDetails.jsx
@@ -14,6 +14,7 @@ import resourcesReducer from './reducers/resources';
 import {
     resetSelectedResource,
     searchResources,
+    setDetailPanelTab,
     setSelectedResource,
     setShowDetails,
     updateSelectedResource
@@ -22,7 +23,8 @@ import {
     getSelectedResource,
     getMonitoredStateSelector,
     getRouterLocation,
-    getShowDetails
+    getShowDetails,
+    getDetailPanelTab
 } from './selectors/resources';
 import { getPendingChanges } from './selectors/save';
 import ResourcePermissions from './containers/ResourcePermissions';
@@ -318,14 +320,16 @@ const resourceDetailsConnect = connect(
         user: userSelector,
         monitoredState: getMonitoredStateSelector,
         location: getRouterLocation,
-        show: getShowDetails
+        show: getShowDetails,
+        selectedTab: getDetailPanelTab
     }),
     {
         onSelect: setSelectedResource,
         onChange: updateSelectedResource,
         onSearch: searchResources,
         onReset: resetSelectedResource,
-        onShow: setShowDetails
+        onShow: setShowDetails,
+        onSelectTab: setDetailPanelTab
     }
 );
 

--- a/web/client/plugins/ResourcesCatalog/actions/__tests__/resources-test.js
+++ b/web/client/plugins/ResourcesCatalog/actions/__tests__/resources-test.js
@@ -26,7 +26,9 @@ import {
     RESET_SELECTED_RESOURCE,
     resetSelectedResource,
     SET_SHOW_DETAILS,
-    setShowDetails
+    setShowDetails,
+    SET_DETAIL_PANEL_TAB,
+    setDetailPanelTab
 } from '../resources';
 import expect from 'expect';
 
@@ -110,6 +112,12 @@ describe('resources actions', () => {
             type: SET_SHOW_DETAILS,
             show: true,
             id: 'catalog'
+        });
+    });
+    it('setDetailPanelTab', () => {
+        expect(setDetailPanelTab('tab1')).toEqual({
+            type: SET_DETAIL_PANEL_TAB,
+            tab: 'tab1'
         });
     });
 });

--- a/web/client/plugins/ResourcesCatalog/actions/resources.js
+++ b/web/client/plugins/ResourcesCatalog/actions/resources.js
@@ -17,6 +17,7 @@ export const UPDATE_SELECTED_RESOURCE = 'RESOURCES:UPDATE_SELECTED_RESOURCE';
 export const SEARCH_RESOURCES = 'RESOURCES:SEARCH_RESOURCES';
 export const RESET_SEARCH_RESOURCES = 'RESOURCES:RESET_SEARCH_RESOURCES';
 export const RESET_SELECTED_RESOURCE = 'RESOURCES:RESET_SELECTED_RESOURCE';
+export const SET_DETAIL_PANEL_TAB = 'RESOURCES:SET_DETAIL_PANEL_TAB';
 
 export function updateResources(resources, id) {
     return {
@@ -101,5 +102,12 @@ export function setShowDetails(show, id) {
         type: SET_SHOW_DETAILS,
         show,
         id
+    };
+}
+
+export function setDetailPanelTab(tab) {
+    return {
+        type: SET_DETAIL_PANEL_TAB,
+        tab
     };
 }

--- a/web/client/plugins/ResourcesCatalog/components/DetailsInfo.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/DetailsInfo.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import castArray from 'lodash/castArray';
 import isEmpty from 'lodash/isEmpty';
 import moment from 'moment';
@@ -284,6 +284,8 @@ function DetailsInfo({
     tabs = [],
     tabComponents: tabComponentsProp,
     className,
+    onSelectTab,
+    selectedTab,
     ...props
 }) {
 
@@ -301,12 +303,18 @@ function DetailsInfo({
                 Component: tabComponents[tab.type] || tabComponents.tab
             }))
         .filter(tab => !isEmpty(tab?.items));
-    const [selectedTabId, onSelect] = useState(filteredTabs?.[0]?.id);
+
+    useEffect(() => {
+        return () => {
+            onSelectTab(filteredTabs?.[0]?.id);
+        };
+    }, []);
+
     return (
         <Tabs
             className={`ms-details-info tabs-underline${className ? ` ${className}` : ''}`}
-            selectedTabId={selectedTabId}
-            onSelect={onSelect}
+            selectedTabId={selectedTab ?? filteredTabs?.[0]?.id}
+            onSelect={onSelectTab}
             tabs={filteredTabs.map(({Component, ...tab} = {}) => ({
                 title: <DetailInfoFieldLabel field={tab} />,
                 eventKey: tab?.id,

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/DetailsInfo-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/DetailsInfo-test.jsx
@@ -131,4 +131,53 @@ describe('DetailsInfo component', () => {
             })
             .catch(done);
     });
+    it('should render tabs items and test onSelectTab', (done) => {
+        ReactDOM.render(<DetailsInfo
+            editing
+            tabs={[
+                {
+                    type: 'tab',
+                    id: 'info',
+                    labelId: 'Info',
+                    items: [
+                        {
+                            type: 'boolean',
+                            editable: true,
+                            labelId: 'Advertised',
+                            path: 'advertised',
+                            value: false
+                        }
+                    ]
+                },
+                {
+                    type: 'tab',
+                    id: 'info2',
+                    labelId: 'Info2',
+                    items: [
+                        {
+                            type: 'text',
+                            editable: true,
+                            labelId: 'Name',
+                            path: 'name',
+                            value: 'Resource Name'
+                        }
+                    ]
+                }
+            ]}
+            onSelectTab={(tab) => {
+                try {
+                    expect(tab).toEqual('info');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }}
+            selectedTab="info2"
+        />, document.getElementById('container'));
+        const detailsInfo = document.querySelector('.ms-details-info');
+        expect(detailsInfo).toBeTruthy();
+        const tabLink = document.querySelector('.ms-details-info li a');
+        Simulate.click(tabLink);
+    });
 });
+

--- a/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
@@ -49,7 +49,9 @@ function ResourceDetails({
     updateRequest,
     facets,
     resourceType,
-    enableFilters
+    enableFilters,
+    onSelectTab,
+    selectedTab
 }) {
 
     const parsedConfig = useParsePluginConfigExpressions(monitoredState, { tabs });
@@ -151,6 +153,8 @@ function ResourceDetails({
                 onChange={handleOnChange}
                 resource={resource || {}}
                 enableFilters={enableFilters}
+                onSelectTab={onSelectTab}
+                selectedTab={selectedTab}
             /> : null}
             {(updating || loading) ? <FlexBox centerChildren classNames={['_absolute', '_fill', '_overlay', '_corner-tl']}>
                 <Text fontSize="xxl">

--- a/web/client/plugins/ResourcesCatalog/reducers/__tests__/resources-test.js
+++ b/web/client/plugins/ResourcesCatalog/reducers/__tests__/resources-test.js
@@ -17,7 +17,8 @@ import {
     searchResources,
     resetSearchResources,
     resetSelectedResource,
-    setShowDetails
+    setShowDetails,
+    setDetailPanelTab
 } from '../../actions/resources';
 import expect from 'expect';
 
@@ -77,5 +78,9 @@ describe('resources reducer', () => {
     it('setShowDetails', () => {
         expect(resources({}, setShowDetails(true)))
             .toEqual({ showDetails: true });
+    });
+    it('setDetailPanelTab', () => {
+        expect(resources({}, setDetailPanelTab('tab1')))
+            .toEqual({ detailPanelTab: 'tab1' });
     });
 });

--- a/web/client/plugins/ResourcesCatalog/reducers/resources.js
+++ b/web/client/plugins/ResourcesCatalog/reducers/resources.js
@@ -22,7 +22,8 @@ import {
     SEARCH_RESOURCES,
     RESET_SEARCH_RESOURCES,
     RESET_SELECTED_RESOURCE,
-    SET_SHOW_DETAILS
+    SET_SHOW_DETAILS,
+    SET_DETAIL_PANEL_TAB
 } from '../actions/resources';
 
 import { parseResourceProperties } from '../../../utils/GeostoreUtils';
@@ -146,6 +147,10 @@ function resources(state = defaultState, action) {
     case RESET_SEARCH_RESOURCES:
         return setStateById(state, action, {
             search: null
+        });
+    case SET_DETAIL_PANEL_TAB:
+        return setStateById(state, action, {
+            detailPanelTab: action.tab
         });
     default:
         return state;

--- a/web/client/plugins/ResourcesCatalog/selectors/__tests__/resources-test.js
+++ b/web/client/plugins/ResourcesCatalog/selectors/__tests__/resources-test.js
@@ -18,7 +18,8 @@ import {
     getShowDetails,
     getCurrentPage,
     getSearch,
-    getCurrentParams
+    getCurrentParams,
+    getDetailPanelTab
 } from '../resources';
 import expect from 'expect';
 
@@ -78,5 +79,9 @@ describe('resources selectors', () => {
         expect(getCurrentParams()).toBe(undefined);
         expect(getCurrentParams({ resources: { sections: { catalog: { params: { page: 2 } } } } }, { id: 'catalog' })).toEqual({ page: 2 });
         expect(getCurrentParams({ resources: { sections: { catalog: { params: { page: 3 } } } } }, { resourcesGridId: 'catalog' })).toEqual({ page: 3 });
+    });
+    it('getDetailPanelTab', () => {
+        expect(getDetailPanelTab()).toBe(undefined);
+        expect(getDetailPanelTab({ resources: { detailPanelTab: 'tab1' } })).toEqual('tab1');
     });
 });

--- a/web/client/plugins/ResourcesCatalog/selectors/resources.js
+++ b/web/client/plugins/ResourcesCatalog/selectors/resources.js
@@ -43,6 +43,7 @@ export const getSelectedResource = (state, props) => getSelectedResourceState(st
 export const getShowDetails = (state, props) => !!getStatePart(state, props)?.showDetails;
 export const getCurrentParams = (state, props) => getStatePart(state, props)?.params;
 export const getCurrentPage = (state, props) => getCurrentParams(state, props)?.page ?? 1;
+export const getDetailPanelTab = (state, props) => getStatePart(state, props)?.detailPanelTab;
 export const getSearch = (state) => state?.resources?.search || null;
 
 export const getMonitoredStateSelector =  state => getMonitoredState(state, getConfigProp('monitorState'));


### PR DESCRIPTION
## Description
This PR allows the possibility to control the resource detail tab selection to allow tab control from downstream projects

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #11237

**What is the new behavior?**
Tab selection and its handlers have been moved out of the component, with the state now managed in the store

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
