### PR TITLE
fix FE unit tests failure due to change in PR 11236

### DIFF
--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -706,8 +706,8 @@ describe('PrintUtils', () => {
             done();
         }).catch(done);
     });
-    it('getMapfishPrintSpecification with editScale', () => {
-        const printSpec = getMapfishPrintSpecification({
+    it('getMapfishPrintSpecification with editScale', (done) => {
+        getMapfishPrintSpecification({
             ...testSpec,
             scaleZoom: 3,
             scales: [2030400, 1020020, 504060, 104020, 50406],
@@ -718,12 +718,14 @@ describe('PrintUtils', () => {
                     editScale: true
                 }
             }
-        });
-        expect(printSpec).toExist();
-        expect(printSpec.pages[0].scale).toBe(73957338.86364141);
+        }).then((printSpec) => {
+            expect(printSpec).toExist();
+            expect(printSpec.pages[0].scale).toBe(73957338.86364141);
+            done();
+        }).catch(done);
     });
-    it('getMapfishPrintSpecification with editScale = true and useFixedScales = true', () => {
-        const printSpec = getMapfishPrintSpecification({
+    it('getMapfishPrintSpecification with editScale = true and useFixedScales = true', (done) => {
+        getMapfishPrintSpecification({
             ...testSpec,
             scaleZoom: 3,
             scales: [2030400, 1020020, 504060, 104020, 50406],
@@ -735,9 +737,11 @@ describe('PrintUtils', () => {
                     useFixedScales: true
                 }
             }
-        });
-        expect(printSpec).toExist();
-        expect(printSpec.pages[0].scale).toBe(73957338.86364141);
+        }).then(printSpec => {
+            expect(printSpec).toExist();
+            expect(printSpec.pages[0].scale).toBe(73957338.86364141);
+            done();
+        }).catch(done);
     });
     it('from rgba to rgb', () => {
         const rgb = rgbaTorgb("rgba(255, 255, 255, 0.1)");


### PR DESCRIPTION
## Description
This PR includes only fixing unit tests failure happened due merge process of subsequent PRs'. 
The cause of the failing is a change implemented in return of **getMapfishPrintSpecification** in this PR --> returns **promise**: https://github.com/geosolutions-it/MapStore2/pull/11236 and it merged first before https://github.com/geosolutions-it/MapStore2/pull/11130 which contains additional unit tests [that failed] uses the previous version of **getMapfishPrintSpecification** that not return promise.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

Compendium fix #10839
