### PR TITLE
Thousands separator is always active while Mapstore is in French #10639

### DIFF
--- a/web/client/components/I18N/IntlNumberFormControl.jsx
+++ b/web/client/components/I18N/IntlNumberFormControl.jsx
@@ -31,7 +31,8 @@ class IntlNumberFormControl extends React.Component {
         disabled: PropTypes.bool,
         onBlur: PropTypes.func,
         onKeyDown: PropTypes.func,
-        onKeyUp: PropTypes.func
+        onKeyUp: PropTypes.func,
+        inputClassName: PropTypes.string
     }
     static contextTypes = {
         intl: PropTypes.object
@@ -127,7 +128,7 @@ class IntlNumberFormControl extends React.Component {
                     allow !== null && e.preventDefault();
                 }}
                 componentClass={"input"}
-                className="form-control intl-numeric"
+                className={`form-control intl-numeric ${this.props?.inputClassName || ''}`}
                 locale={this.context && this.context.intl && this.context.intl.locale || "en-US"}
             />
         );

--- a/web/client/components/data/query/NumberField.jsx
+++ b/web/client/components/data/query/NumberField.jsx
@@ -12,9 +12,7 @@ import PropTypes from 'prop-types';
 import { Tooltip } from 'react-bootstrap';
 import OverlayTrigger from '../../misc/OverlayTrigger';
 import { getMessageById } from '../../../utils/LocaleUtils';
-import numberLocalizer from 'react-widgets/lib/localizers/simple-number';
-numberLocalizer();
-import { NumberPicker } from 'react-widgets';
+import IntlNumberFormControl from '../../I18N/IntlNumberFormControl';
 
 class NumberField extends React.Component {
     static propTypes = {
@@ -75,21 +73,27 @@ class NumberField extends React.Component {
             <div className="query-field">
                 <div className="query-field-value">
                     {lowLabel}
-                    <NumberPicker
+                    <IntlNumberFormControl
                         disabled={this.props.operator === "isNull"}
-                        style={style}
+                        style={style ? {input: style} : {}}
                         value={this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : null}
-                        onChange={(value) => !isNaN(value) && this.changeNumber({lowBound: value, upBound: this.props.fieldValue && (this.props.fieldValue.upBound !== null && this.props.fieldValue.upBound !== undefined ) ? this.props.fieldValue.upBound : null})}
+                        onChange={(value) => {
+                            !isNaN(value) && value !== "" && this.changeNumber({lowBound: value, upBound: this.props.fieldValue && (this.props.fieldValue.upBound !== null && this.props.fieldValue.upBound !== undefined ) ? this.props.fieldValue.upBound : null});
+                        }}
+                        inputClassName="rw-input"
                         {...this.props.options}
                     />
                 </div>
                 <div className="query-field-value">
                     {upLabel}
-                    <NumberPicker
+                    <IntlNumberFormControl
                         disabled={this.props.operator === "isNull"}
-                        style={style}
+                        style={style ? {input: style} : {}}
                         value={this.props.fieldValue && (this.props.fieldValue.upBound !== null && this.props.fieldValue.upBound !== undefined ) ? this.props.fieldValue.upBound : null}
-                        onChange={(value) => !isNaN(value) && this.changeNumber({upBound: value, lowBound: this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : null})}
+                        onChange={(value) => {
+                            !isNaN(value) && value !== "" && this.changeNumber({upBound: value, lowBound: this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : null});
+                        }}
+                        inputClassName="rw-input"
                         {...this.props.options}
                     />
                 </div>
@@ -97,11 +101,14 @@ class NumberField extends React.Component {
             :
             <div>
                 {label}
-                <NumberPicker
+                <IntlNumberFormControl
                     disabled={this.props.operator === "isNull"}
-                    style={style}
+                    style={style ? {input: style} : {}}
                     value={this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : this.props.fieldValue}
-                    onChange={(value) => !isNaN(value) && this.changeNumber(value)}
+                    onChange={(value) => {
+                        !isNaN(value) && value !== "" && this.changeNumber(value);
+                    }}
+                    inputClassName="rw-input"
                     {...this.props.options}
                 />
             </div>

--- a/web/client/components/data/query/__tests__/NumberField-test.jsx
+++ b/web/client/components/data/query/__tests__/NumberField-test.jsx
@@ -11,6 +11,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
 import NumberField from '../NumberField';
+import { IntlProvider } from 'react-intl';
 
 describe('NumberField', () => {
     beforeEach((done) => {
@@ -109,4 +110,45 @@ describe('NumberField', () => {
         TestUtils.Simulate.change(input[0], {target: {value: '7'}});
         expect(spyOnUpdateField).toHaveBeenCalled();
     });
+
+    it("check if the number is rendered in correct language format", () => {
+        // Test with different locales to ensure numbers are formatted correctly
+        const testCases = [
+            { locale: "it-IT", value: 1234.56, expected: "1.234,56" }, // Italiano
+            { locale: "en-US", value: 1234.56, expected: "1,234.56" }, // English
+            { locale: "fr-FR", value: 1234.56, expected: /1\s234,56/ }, // Français (regex for space)
+            { locale: "de-DE", value: 1234.56, expected: "1.234,56" }, // Deutsch
+            { locale: "es-ES", value: 1234.56, expected: "1234,56" }   // Español
+        ];
+
+        testCases.forEach(({ locale, value, expected }) => {
+            const conf = {
+                fieldRowId: 846,
+                operator: "=",
+                fieldValue: value,
+                type: "number"
+            };
+
+            const cmp = ReactDOM.render(
+                <IntlProvider locale={locale} messages={{}}>
+                    <NumberField {...conf} />
+                </IntlProvider>,
+                document.getElementById("container")
+            );
+            expect(cmp).toExist();
+
+            const node = ReactDOM.findDOMNode(cmp);
+            const inputs = node.getElementsByTagName("input");
+            expect(inputs.length).toBe(1);
+
+            // Check that the number is formatted according to the locale
+            if (locale === 'fr-FR') {
+                expect(inputs[0].value).toMatch(expected); // Handles regex patterns for flexible matching (e.g., French locale space variations)
+            } else {
+                expect(inputs[0].value).toBe(expected);
+            }
+
+        });
+    });
+
 });


### PR DESCRIPTION

## Description
Now, the display of numbers will automatically adapt to the language the user selects.

Examples of sample formats for different languages:
```
1,234.56 in English (en-US)
1.234,56 in Italian (it-IT) and German (de-DE)
1 234,56 in French (fr-FR) (note: uses a non-breaking space)
1234,56 in Spanish (es-ES)
```

**Please check if the PR fulfills these requirements **
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
fixes https://github.com/geosolutions-it/MapStore2/issues/10639
fixes https://github.com/geosolutions-it/MapStore2/issues/10640

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10639
#10640

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
- Number formats according to the language selected.
     ![image](https://github.com/user-attachments/assets/2864c837-6caf-4780-aa7b-59da8ef5e0ca)
- Decimal value will not disappear as before

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Now, the React widget's `NumberPicker` has been replaced by `IntlNumberFormControl`.
To maintain the consistent style, the className of the React widget's 'rw-input` has been used.