### PR TITLE
Button translation missing in featuregrid exit editing modal #11246

### DIFF
--- a/web/client/components/data/featuregrid/dialog/ConfirmFeatureClose.jsx
+++ b/web/client/components/data/featuregrid/dialog/ConfirmFeatureClose.jsx
@@ -12,7 +12,7 @@ export default ({
     onCancel={onClose}
     onConfirm={onConfirm}
     variant="danger"
-    confirmId={`featuregrid.yesButton"`}
+    confirmId={`featuregrid.yesButton`}
     cancelId={`featuregrid.noButton`}
     preventHide
     titleId={"featuregrid.featureClose"}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fixed the sytax typo

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

fixes #11246

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11246 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
No error on Confirm button text on warning modal of Feature grid.
<img width="805" alt="image" src="https://github.com/user-attachments/assets/3c5a1c93-787c-4101-ac34-9319abaecdaf" />

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
