### PR TITLE
#10930: fix Annotation circle editing causing MapStore to crash

### DIFF
--- a/web/client/components/I18N/IntlNumberFormControl.jsx
+++ b/web/client/components/I18N/IntlNumberFormControl.jsx
@@ -57,7 +57,7 @@ class IntlNumberFormControl extends React.Component {
             const groupSeparator = formatParts?.find(part => part.type === 'group').value;
             let isFormattedCurrentVal = currentValue && groupSeparator && (currentValue.includes(groupSeparator));
             let isFormattedPrevVal = prevValue && groupSeparator && (prevValue.includes(groupSeparator));
-            if ((isFormattedCurrentVal || isFormattedPrevVal)) {
+            if ((isFormattedCurrentVal || isFormattedPrevVal) && this.state && this.state.inputRef) {
                 let currentValueLength = currentValue.length;           // length of current value
                 let prevValueLength = prevValue.length;                 // length of prev value
                 let groupSeparatorPrevValue   = prevValueLength  - prevValue.replaceAll(groupSeparator, "").length;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR includes fixing app crash during annotation circle editing. 

The problem was the `IntlNumberFormControl` component was prone to crashing under certain conditions, specifically when `this.state.inputRef` was `null` or `undefined` within the `componentDidUpdate` lifecycle method here: https://github.com/geosolutions-it/MapStore2/blob/f34f22cfa98ba6c46e42c7926fc4c62cae43bd02/web/client/components/I18N/IntlNumberFormControl.jsx#L48 due to change input values from outside the input not by noraml way by focus to input and change value manually. 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10930 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
No crash for app during annotation circle editing will happen

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
