### PR TITLE
#10699: Attribute table crash when additional geometries in attributes

### DIFF
--- a/web/client/utils/FeatureTypeUtils.js
+++ b/web/client/utils/FeatureTypeUtils.js
@@ -70,6 +70,22 @@ const types = {
     'xsd:array': 'array'
 };
 
+// for multi-geom fields --> the primary geometry field type is gml:GeometryType like: gml:Point
+// and other geom fields type be xsd:GeometryType like: xsd:Point
+// ref for available geometry field types :https://docs.geoserver.geo-solutions.it/edu/en/complex_features/intro/index.html#id3
+export const notPrimaryGeometryFields = {
+    "xsd:Point": "Point",
+    "xsd:LineString": "LineString",
+    "xsd:Polygon": "Polygon",
+    "xsd:MultiPoint": "MultiPoint",
+    "xsd:MultiLineString": "MultiLineString",
+    "xsd:MultiPolygon": "MultiPolygon",
+    "xsd:GeometryCollection": "GeometryCollection",
+    "xsd:LinearRing": "LinearRing",
+    "xsd:Curve": "Curve",
+    "xsd:Surface": "Surface"
+};
+
 /**
  * Transforms the DescribeFeatureType response to an array of attributes.
  * @param {object} data JSON response of DescribeFeatureType
@@ -77,7 +93,7 @@ const types = {
  * @returns {object[]} attributes with `label`, `attribute`, `type`, `valueId`, `valueLabel`, `values`.
  */
 export const describeFeatureTypeToAttributes = (data, fields = []) => get(data, "featureTypes[0].properties")
-    .filter((attribute) => attribute.type.indexOf('gml:') !== 0 && types[attribute.type])
+    .filter((attribute) => (attribute.type.indexOf('gml:') !== 0 && types[attribute.type]) && (!notPrimaryGeometryFields[attribute.type]))
     .map((attribute) => {
         const field = find(fields, {name: attribute.name});
         return {

--- a/web/client/utils/__tests__/FeatureTypeUtils-test.js
+++ b/web/client/utils/__tests__/FeatureTypeUtils-test.js
@@ -55,4 +55,62 @@ describe('Test the FeatureTypeUtils', () => {
             values: []
         }]);
     });
+    it('describeFeatureTypeToAttributes with multi-geometry fields', () => {
+        const featureTypeData = {
+            featureTypes: [{
+                properties: [{
+                    name: "name",
+                    type: "xsd:string"
+                }, {
+                    "name": "the_geom",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "gml:Point",
+                    "localType": "Point"
+                }, {
+                    "name": "geom2",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "xsd:LineString",
+                    "localType": "LineString"
+                }, {
+                    "name": "geom3",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "xsd:Point",
+                    "localType": "Point"
+                }]
+            }]
+        };
+        const fields = [
+            {
+                name: "name",
+                alias: "alias"
+            },
+            {
+                name: "the_geom",
+                alias: "Point"
+            },
+            {
+                name: "geom2",
+                alias: "LineString"
+            },
+            {
+                name: "geom3",
+                alias: "Point"
+            }
+        ];
+        const attributes = describeFeatureTypeToAttributes(featureTypeData, fields);
+        expect(attributes).toEqual([{
+            label: "alias",
+            attribute: "name",
+            type: "string",
+            valueId: "id",
+            valueLabel: "name",
+            values: []
+        }]);
+    });
 });

--- a/web/client/utils/ogc/WFS/__tests__/base-test.js
+++ b/web/client/utils/ogc/WFS/__tests__/base-test.js
@@ -76,11 +76,43 @@ describe('WFS base utility functions', () => {
             "type": "xsd:number",
             "localType": "number"
         }];
+        const MULTI_GEOM_ATTRIBUTES = [{
+            "name": "the_geom",
+            "maxOccurs": 1,
+            "minOccurs": 0,
+            "nillable": true,
+            "type": "gml:MultiPolygon",
+            "localType": "MultiPolygon"
+        }, {
+            "name": "GEOM",
+            "maxOccurs": 1,
+            "minOccurs": 1,
+            "nillable": false,
+            "type": "xsd:Geometry",
+            "localType": "Geometry"
+        }, {
+            "name": "geom2",
+            "maxOccurs": 1,
+            "minOccurs": 0,
+            "nillable": true,
+            "type": "xsd:Point",
+            "localType": "Point"
+        }, {
+            "name": "geom3",
+            "maxOccurs": 1,
+            "minOccurs": 0,
+            "nillable": true,
+            "type": "xsd:LineString",
+            "localType": "LineString"
+        }];
         GEOM_ATTRIBUTES.forEach( a => {
             expect(isGeometryType(a)).toBe(true);
         });
         NOT_GEOM_ATTRIBUTES.forEach( a => {
             expect(isGeometryType(a)).toBe(false);
+        });
+        MULTI_GEOM_ATTRIBUTES.forEach( a => {
+            expect(isGeometryType(a)).toBe(true);
         });
         const geomProp = findGeometryProperty(describePois);
         expect(geomProp).toExist();

--- a/web/client/utils/ogc/WFS/base.js
+++ b/web/client/utils/ogc/WFS/base.js
@@ -10,6 +10,7 @@ import head from 'lodash/head';
 import get  from 'lodash/get';
 export {processOGCGeometry} from "../GML";
 import {processOGCGeometry} from "../GML";
+import { notPrimaryGeometryFields } from '../../FeatureTypeUtils';
 /**
  * Base utilities for WFS.
  * @name WFS
@@ -43,7 +44,8 @@ export const wfsToGmlVersion = (v = "1.1.0") => WFS_TO_GML[v];
  * @return {object[]}                     The array of featuretypes properties
  */
 export const getFeatureTypeProperties = (describeFeatureType) => get(describeFeatureType, "featureTypes[0].properties");
-export const isGeometryType = (pd) => pd.type.indexOf("gml:") === 0 || pd.type === "xsd:Geometry";
+
+export const isGeometryType = (pd) => pd.type.indexOf("gml:") === 0 || pd.type === "xsd:Geometry" || !!(notPrimaryGeometryFields[pd.type]);
 /**
  * Provides the first geometry type found
  * @param  {object} describeFeatureType the describeFeatureType object


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes: fixing the crash app issue due to multi geometry fields by 
- editing 'isGeometryType' util 
- editing 'describeFeatureTypeToAttributes' util


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10699

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The new bahavior is if there are some multi geometry fields in layer data and user wants to explore attribute table data --> the geometry field will be the first one on fetched fields and other geometry ones will be ignored

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
