### PR TITLE
#11120: Skip dependency filter generation when filter parts are empty

### DIFF
--- a/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
@@ -199,6 +199,23 @@ describe('widgets dependenciesToFilter enhancer', () => {
         />, document.getElementById("container"));
     });
 
+    it('dependenciesToFilter with empty filter parts', (done) => {
+        const Sink = dependenciesToFilter(createSink(props => {
+            expect(props).toExist();
+            expect(props.filter).toBe(undefined);
+            done();
+        }));
+        const layer = { ...layerFilter, layerFilter: { } };
+        ReactDOM.render(<Sink
+            mapSync
+            layer={layer}
+            options={{aggregateFunction: "Count",
+                aggregationAttribute: "SUB_REGION",
+                groupByAttributes: undefined
+            }}
+        />, document.getElementById("container"));
+    });
+
     it('dependenciesToFilter with empty layerFilter', (done) => {
 
         const Sink = dependenciesToFilter(createSink(props => {

--- a/web/client/components/widgets/enhancers/dependenciesToFilter.js
+++ b/web/client/components/widgets/enhancers/dependenciesToFilter.js
@@ -84,11 +84,10 @@ const createFilterProps = ({ mapSync, geomProp = "the_geom", dependencies = {}, 
         };
     }
     // this will contain only an ogc filter based on current and other filters (cql excluded)
-    const ogcFilter = isEmpty(newFilterObj) && isEmpty(layerFilter) ? undefined
-        : filter(and(
-            ...(layerFilter ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : []),
-            ...(newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : [])
-        ));
+    const ogcLayerFilter = layerFilter ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : [];
+    const ogcNewFilterObj = newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : [];
+    const ogcFilter = isEmpty(ogcLayerFilter) && isEmpty(ogcNewFilterObj) ? undefined
+        : filter(and(...ogcLayerFilter, ...ogcNewFilterObj));
     return { filter: ogcFilter };
 };
 


### PR DESCRIPTION
## Description
This PR fixes an issue where certain filter parts being empty resulted in an empty OGC filter being sent

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- https://github.com/geosolutions-it/MapStore2/pull/11244#issuecomment-3027654042

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
