### PR TITLE
fix #1153: Persist Swipe Layer state after map refresh 

### DIFF
--- a/web/client/actions/__tests__/swipe-test.js
+++ b/web/client/actions/__tests__/swipe-test.js
@@ -15,7 +15,9 @@ import {
     SET_ACTIVE,
     SET_MODE,
     SET_SWIPE_TOOL_DIRECTION,
-    SET_SPY_TOOL_RADIUS
+    SET_SPY_TOOL_RADIUS,
+    SET_SWIPE_SLIDER_OPTIONS,
+    setSwipeSliderOps
 } from '../swipe';
 
 describe('Test correctness of the swipe actions', () => {
@@ -52,5 +54,16 @@ describe('Test correctness of the swipe actions', () => {
         expect(action).toExist();
         expect(action.type).toBe(SET_SPY_TOOL_RADIUS);
         expect(action.radius).toBe(80);
+    });
+    it('should set swipe slider options', () => {
+        const action1 = setSwipeSliderOps({pos: {x: 0, y: 0}});
+        expect(action1).toExist();
+        expect(action1.type).toEqual(SET_SWIPE_SLIDER_OPTIONS);
+        expect(action1.options).toEqual({pos: {x: 0, y: 0}});
+        // in reset
+        const action2 = setSwipeSliderOps({});
+        expect(action2).toExist();
+        expect(action2.type).toEqual(SET_SWIPE_SLIDER_OPTIONS);
+        expect(action2.options).toEqual({});
     });
 });

--- a/web/client/actions/swipe.js
+++ b/web/client/actions/swipe.js
@@ -11,6 +11,7 @@ const SET_MODE = "SWIPE:SET_MODE";
 const SET_SWIPE_TOOL_DIRECTION = "SWIPE:SET_SWIPE_TOOL_DIRECTION";
 const SET_SPY_TOOL_RADIUS = "SWIPE:SET_SPY_TOOL_RADIUS";
 const SET_SWIPE_LAYER = "SWIPE:SET_SWIPE_LAYER";
+const SET_SWIPE_SLIDER_OPTIONS = "SWIPE:SET_SWIPE_SLIDER_OPTIONS";
 
 /**
 * Sets the status of boolean values of the swipe redux state
@@ -80,6 +81,18 @@ function setSwipeLayer( layerId) {
         layerId
     };
 }
+/**
+* Sets the swipe slider options
+* @memberof actions.swipe
+* @param {object}  options swipe slider options
+* @return {object} of type `SET_SWIPE_SLIDER_OPTIONS` with slider options
+*/
+function setSwipeSliderOps(options) {
+    return {
+        type: SET_SWIPE_SLIDER_OPTIONS,
+        options
+    };
+}
 
 export {
     setActive,
@@ -87,9 +100,11 @@ export {
     setSwipeToolDirection,
     setSpyToolRadius,
     setSwipeLayer,
+    setSwipeSliderOps,
     SET_ACTIVE,
     SET_MODE,
     SET_SWIPE_TOOL_DIRECTION,
     SET_SPY_TOOL_RADIUS,
-    SET_SWIPE_LAYER
+    SET_SWIPE_LAYER,
+    SET_SWIPE_SLIDER_OPTIONS
 };

--- a/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
@@ -11,20 +11,24 @@ import Draggable from 'react-draggable';
 
 import EffectSupport from './EffectSupport';
 
-const VSlider = ({ type, map, widthRef }) => {
+const VSlider = ({ type, map, widthRef, swipeSliderOptions, onSetSwipeSliderOptions }) => {
 
-    const [pos, setPos] = useState();
+    const [pos, setPos] = useState(swipeSliderOptions?.pos);
     const [showArrows, setShowArrows] = useState(true);
 
     // reset the slider positon to prevent misalignment between handler and cut positions
     const onWindowResize = () => {
-        setPos({x: 0, y: 0});
+        const posToSet = {x: 0, y: 0};
+        setPos(posToSet);
+        onSetSwipeSliderOptions({pos: posToSet});
         widthRef.current = map.getProperties().size[0] / 2;
     };
 
     const onDragVerticalHandler = (e, ui) => {
         widthRef.current += ui.deltaX;
-        setPos({x: ui.x, y: ui.y});
+        const posToSet = {x: ui.x, y: ui.y};
+        setPos(posToSet);
+        onSetSwipeSliderOptions({pos: posToSet});
         map.render();
     };
 
@@ -71,19 +75,23 @@ const VSlider = ({ type, map, widthRef }) => {
     );
 };
 
-const HSlider = ({ type, map, heightRef }) => {
+const HSlider = ({ type, map, heightRef, swipeSliderOptions, onSetSwipeSliderOptions }) => {
 
-    const [pos, setPos] = useState();
+    const [pos, setPos] = useState(swipeSliderOptions?.pos);
     const [showArrows, setShowArrows] = useState(true);
 
     const onWindowResize = () => {
-        setPos({x: 0, y: 0});
+        const posToSet = {x: 0, y: 0};
+        setPos(posToSet);
+        onSetSwipeSliderOptions({pos: posToSet});
         heightRef.current = map.getProperties().size[1] / 2;
     };
 
     const onDragHorizontalHandler = (e, ui) => {
         heightRef.current += ui.deltaY;
-        setPos({x: ui.x, y: ui.y});
+        const posToSet = {x: ui.x, y: ui.y};
+        setPos(posToSet);
+        onSetSwipeSliderOptions({pos: posToSet});
         map.render();
     };
 
@@ -135,14 +143,14 @@ const HSlider = ({ type, map, heightRef }) => {
  * @props {object} map the map object
  * @props {layer} the layer object
  */
-const SliderSwipeSupport = ({ map, layer, type = "cut-vertical", active }) => {
+const SliderSwipeSupport = ({ map, layer, type = "cut-vertical", active, swipeSliderOptions = {}, onSetSwipeSliderOptions }) => {
     const heightRef = useRef();
     const widthRef = useRef();
     if (layer && active) {
         return (
             <>
-                {type === "cut-vertical" && (<VSlider widthRef={widthRef} map={map} type={type} />)}
-                {type === "cut-horizontal" && (<HSlider heightRef={heightRef} map={map} type={type} />)}
+                {type === "cut-vertical" && (<VSlider swipeSliderOptions={swipeSliderOptions} onSetSwipeSliderOptions={onSetSwipeSliderOptions} widthRef={widthRef} map={map} type={type} />)}
+                {type === "cut-horizontal" && (<HSlider swipeSliderOptions={swipeSliderOptions} onSetSwipeSliderOptions={onSetSwipeSliderOptions} heightRef={heightRef} map={map} type={type} />)}
                 <EffectSupport
                     map={map}
                     layer={layer}

--- a/web/client/plugins/Swipe.jsx
+++ b/web/client/plugins/Swipe.jsx
@@ -10,13 +10,14 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import { layerSwipeSettingsSelector, swipeModeSettingsSelector, spyModeSettingsSelector, getSwipeLayerId } from '../selectors/swipe';
+import { layerSwipeSettingsSelector, swipeModeSettingsSelector, spyModeSettingsSelector, getSwipeLayerId, swipeSliderSettingsSelector } from '../selectors/swipe';
 import swipe from '../reducers/swipe';
 import epics from '../epics/swipe';
 import {
     setActive,
     setMode,
-    setSwipeLayer
+    setSwipeLayer,
+    setSwipeSliderOps
 } from '../actions/swipe';
 
 import { createPlugin } from '../utils/PluginsUtils';
@@ -27,27 +28,31 @@ import SpyGlassSupport from '../components/map/openlayers/swipe/SpyGlassSupport'
 import SwipeButton from './swipe/SwipeButton';
 
 
-export const Support = ({ mode, map, layer, active, swipeModeSettings, spyModeSettings }) => {
+export const Support = ({ mode, map, layer, active, swipeModeSettings, spyModeSettings, swipeSliderOptions, onSetSwipeSliderOptions }) => {
     if (mode === "spy") {
         return <SpyGlassSupport map={map} layer={layer} active={active} radius={spyModeSettings.radius} />;
     }
-    return <SliderSwipeSupport map={map} layer={layer} active={active} type={swipeModeSettings.direction} />;
+    return <SliderSwipeSupport map={map} layer={layer} active={active} type={swipeModeSettings.direction} swipeSliderOptions={swipeSliderOptions} onSetSwipeSliderOptions={onSetSwipeSliderOptions} />;
 };
 
 const swipeSupportSelector = createSelector([
     getSwipeLayerId,
     layerSwipeSettingsSelector,
     swipeModeSettingsSelector,
-    spyModeSettingsSelector
-], (layer, swipeSettings, swipeModeSettings, spyModeSettings) => ({
+    spyModeSettingsSelector,
+    swipeSliderSettingsSelector
+], (layer, swipeSettings, swipeModeSettings, spyModeSettings, swipeSliderOptions) => ({
     layer,
     active: swipeSettings.active || false,
     swipeModeSettings,
     spyModeSettings,
-    mode: swipeSettings?.mode || "swipe"
+    mode: swipeSettings?.mode || "swipe",
+    swipeSliderOptions
 }));
 
-const MapSwipeSupport = connect(swipeSupportSelector, null)(Support);
+const MapSwipeSupport = connect(swipeSupportSelector, {
+    onSetSwipeSliderOptions: setSwipeSliderOps
+})(Support);
 
 const tocToolsSelector = createSelector(getSwipeLayerId, layerSwipeSettingsSelector, (swipeLayerId, swipeSettings) => ({swipeLayerId, swipeSettings}));
 

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -50,8 +50,8 @@ export const plugins = {
     MetadataInfoPlugin: MetadataInfo,
     SearchServicesConfigPlugin: SearchServicesConfig,
     SecurityPopupPlugin: SecurityPopup,
+    SwipePlugin: Swipe,     // switched from async to sync load to keep Swipe persistence for contexts
     TOCPlugin: TOC,
-    SwipePlugin: Swipe,
 
     // ### DYNAMIC PLUGINS ### //
     // product plugins

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -20,6 +20,7 @@ import UserSession from "../plugins/UserSession";
 import FeatureEditor from '../plugins/FeatureEditor';
 import MetadataInfo from '../plugins/MetadataInfo';
 import TOC from '../plugins/TOC';
+import Swipe from "../plugins/Swipe";
 import * as resourcesCatalogPlugins from '../plugins/ResourcesCatalog';
 import SearchServicesConfig from "../plugins/SearchServicesConfig";
 import SecurityPopup from "../plugins/SecurityPopup";
@@ -50,6 +51,7 @@ export const plugins = {
     SearchServicesConfigPlugin: SearchServicesConfig,
     SecurityPopupPlugin: SecurityPopup,
     TOCPlugin: TOC,
+    SwipePlugin: Swipe,
 
     // ### DYNAMIC PLUGINS ### //
     // product plugins
@@ -121,7 +123,6 @@ export const plugins = {
     SnapshotPlugin: toModulePlugin('Snapshot', () => import(/* webpackChunkName: 'plugins/snapshot' */ '../plugins/Snapshot')),
     StreetView: toModulePlugin('StreetView', () => import(/* webpackChunkName: 'plugins/streetView' */ '../plugins/StreetView')),
     StyleEditor: toModulePlugin('StyleEditor', () => import(/* webpackChunkName: 'plugins/styleEditor' */ '../plugins/StyleEditor')),
-    SwipePlugin: toModulePlugin('Swipe', () => import(/* webpackChunkName: 'plugins/swipe' */ '../plugins/Swipe')),
     TOCItemsSettingsPlugin: toModulePlugin('TOCItemsSettings', () => import(/* webpackChunkName: 'plugins/TOCItemsSettings' */ '../plugins/TOCItemsSettings')),
     ThematicLayerPlugin: toModulePlugin('ThematicLayer', () => import(/* webpackChunkName: 'plugins/thematicLayer' */ '../plugins/ThematicLayer')),
     ThemeSwitcherPlugin: toModulePlugin('ThemeSwitcher', () => import(/* webpackChunkName: 'plugins/themeSwitcher' */ '../plugins/ThemeSwitcher')),

--- a/web/client/reducers/__tests__/swipe-test.js
+++ b/web/client/reducers/__tests__/swipe-test.js
@@ -7,7 +7,7 @@
  */
 import expect from 'expect';
 
-import { SET_ACTIVE, SET_SPY_TOOL_RADIUS, SET_MODE, SET_SWIPE_TOOL_DIRECTION  } from '../../actions/swipe';
+import { SET_ACTIVE, SET_SPY_TOOL_RADIUS, SET_MODE, SET_SWIPE_TOOL_DIRECTION, SET_SWIPE_SLIDER_OPTIONS  } from '../../actions/swipe';
 import swipe from '../swipe';
 import { MAP_CONFIG_LOADED } from '../../actions/config';
 
@@ -30,6 +30,12 @@ describe('Swipe tool REDUCERS', () => {
         };
         const state = swipe({}, action);
         expect(state.active).toBe(false);
+        // reset sliderOptions in case deacvtivate tool
+        const state2 = swipe({
+            sliderOptions: {pos: {x: 1, y: 10}}
+        }, action);
+        expect(state.active).toBe(false);
+        expect(state2.sliderOptions).toEqual({});
     });
 
     it('should set tool mode', () => {
@@ -48,6 +54,12 @@ describe('Swipe tool REDUCERS', () => {
         };
         const state = swipe({}, action);
         expect(state.swipe.direction).toBe("cut-vertical");
+        // reset sliderOptions in case change direction
+        const state2 = swipe({
+            sliderOptions: {pos: {x: 1, y: 10}}
+        }, action);
+        expect(state2.swipe.direction).toEqual("cut-vertical");
+        expect(state2.sliderOptions).toEqual({});
     });
 
     it('should set spy radius', () => {
@@ -71,5 +83,13 @@ describe('Swipe tool REDUCERS', () => {
         };
         const state = swipe({}, action);
         expect(state).toEqual(action.config.swipe);
+    });
+    it('test seting swipe slider options', () => {
+        const action = {
+            type: SET_SWIPE_SLIDER_OPTIONS,
+            options: {pos: {x: 1, y: 10}}
+        };
+        const state = swipe({}, action);
+        expect(state.sliderOptions).toEqual({pos: {x: 1, y: 10}});
     });
 });

--- a/web/client/reducers/swipe.js
+++ b/web/client/reducers/swipe.js
@@ -40,9 +40,10 @@ export default (state = {}, action) => {
         return { ...state, spy: newSpySetting };
     }
     case SET_SWIPE_SLIDER_OPTIONS: {
-        return { ...state, sliderOptions: {
-            ...action.options
-        } };
+        return {
+            ...state,
+            sliderOptions: action.options
+        };
     }
     default:
         return state;

--- a/web/client/reducers/swipe.js
+++ b/web/client/reducers/swipe.js
@@ -7,20 +7,20 @@
  */
 
 
-import { SET_ACTIVE, SET_MODE, SET_SWIPE_TOOL_DIRECTION, SET_SPY_TOOL_RADIUS, SET_SWIPE_LAYER } from '../actions/swipe';
+import { SET_ACTIVE, SET_MODE, SET_SWIPE_TOOL_DIRECTION, SET_SPY_TOOL_RADIUS, SET_SWIPE_LAYER, SET_SWIPE_SLIDER_OPTIONS } from '../actions/swipe';
 import { MAP_CONFIG_LOADED } from '../actions/config';
 
 export default (state = {}, action) => {
     switch (action.type) {
     case SET_ACTIVE: {
-        return { ...state, [action.prop]: action.active };
+        return { ...state, [action.prop]: action.active, sliderOptions: {} };
     }
     case MAP_CONFIG_LOADED: {
         const swipeConfig = action.config.swipe || {};
         return {...state, ...swipeConfig};
     }
     case SET_SWIPE_LAYER: {
-        return { ...state, layerId: action.layerId };
+        return { ...state, layerId: action.layerId, sliderOptions: {} };
     }
     case SET_MODE: {
         return { ...state, mode: action.mode };
@@ -30,7 +30,7 @@ export default (state = {}, action) => {
             ...state.swipe,
             direction: action.direction
         };
-        return { ...state, swipe: newSwipeSetting };
+        return { ...state, swipe: newSwipeSetting, sliderOptions: {} };
     }
     case SET_SPY_TOOL_RADIUS: {
         const newSpySetting = {
@@ -38,6 +38,11 @@ export default (state = {}, action) => {
             radius: action.radius
         };
         return { ...state, spy: newSpySetting };
+    }
+    case SET_SWIPE_SLIDER_OPTIONS: {
+        return { ...state, sliderOptions: {
+            ...action.options
+        } };
     }
     default:
         return state;

--- a/web/client/selectors/__tests__/swipe-test.js
+++ b/web/client/selectors/__tests__/swipe-test.js
@@ -7,7 +7,7 @@
 */
 import expect from 'expect';
 
-import { layerSwipeSettingsSelector, spyModeSettingsSelector, swipeModeSettingsSelector, swipeSettingsSelector} from '../swipe';
+import { layerSwipeSettingsSelector, spyModeSettingsSelector, swipeModeSettingsSelector, swipeSettingsSelector, swipeSliderSettingsSelector} from '../swipe';
 
 describe('SWIPE SELECTORS', () => {
     it('should test layerSwipeSettingsSelector', () => {
@@ -54,5 +54,17 @@ describe('SWIPE SELECTORS', () => {
         };
 
         expect(swipeSettingsSelector(state)).toEqual(state.swipe);
+    });
+    it('should test swipeSliderSettingsSelector', () => {
+        const state = {
+            swipe: {
+                active: true,
+                sliderOptions: {
+                    pos: {x: 1, y: 10}
+                }
+            }
+        };
+
+        expect(swipeSliderSettingsSelector(state)).toEqual(state.swipe.sliderOptions);
     });
 });

--- a/web/client/selectors/swipe.js
+++ b/web/client/selectors/swipe.js
@@ -12,6 +12,7 @@ export const layerSwipeSettingsSelector = (state) => state.swipe && state.swipe 
 export const spyModeSettingsSelector = state => state?.swipe?.spy || { radius: 80 };
 export const swipeModeSettingsSelector = state => state?.swipe?.swipe || { direction: 'cut-vertical' };
 export const getSwipeLayerId = state => state?.swipe?.layerId;
+export const swipeSliderSettingsSelector = state => state?.swipe?.sliderOptions || {};
 export const swipeSettingsSelector = state => state?.swipe;
 registerCustomSaveHandler('swipe', swipeSettingsSelector);
 
@@ -19,5 +20,6 @@ export default {
     layerSwipeSettingsSelector,
     spyModeSettingsSelector,
     swipeModeSettingsSelector,
-    getSwipeLayerId
+    getSwipeLayerId,
+    swipeSliderSettingsSelector
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes fixing:
- handle storing position of swipe
- fix issue of not reflecting the stored swipe for map in context

The issue of map context was: the swipe component was loading late after loading [context and its map] info so the swipe state not initiating until toc and swipe compoenent mount and this causes an issue of not reflecting the stored swipe on map context after map loading.

The reason:  the Swipe is loaded as async plugin in this 
```  toModulePlugin('Swipe', () => import(/* webpackChunkName: 'plugins/swipe' */ '../plugins/Swipe')) ```
so to fix this issue, I made it loading sync in **web/client/product/plugins.js**.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
https://github.com/geosolutions-it/MapStore2/issues/11153#issuecomment-3027213236

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The Swipe persistence is now working for map contexts and the Swipe position is persisted: when you refresh the map it is now keeping the stored position.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
