### PR TITLE
fix #11153: fix keeping slider swipe position after saving resource

### DIFF
--- a/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
@@ -13,19 +13,25 @@ import EffectSupport from './EffectSupport';
 
 const VSlider = ({ type, map, widthRef, swipeSliderOptions, onSetSwipeSliderOptions }) => {
 
-    const [pos, setPos] = useState(swipeSliderOptions?.pos);
+    const [pos, setPos] = useState(swipeSliderOptions?.pos || {x: 0, y: 0});
     const [showArrows, setShowArrows] = useState(true);
 
     // reset the slider positon to prevent misalignment between handler and cut positions
     const onWindowResize = () => {
-        const posToSet = {x: 0, y: 0};
-        setPos(posToSet);
-        onSetSwipeSliderOptions({pos: posToSet});
-        widthRef.current = map.getProperties().size[0] / 2;
+        // Only reset if no saved position exists
+        if (!swipeSliderOptions?.pos) {
+            const posToSet = {x: 0, y: 0};
+            setPos(posToSet);
+            onSetSwipeSliderOptions({pos: posToSet});
+            widthRef.current = map.getProperties().size[0] / 2;
+        } else {
+            // Keep saved position but update widthRef for new map size
+            widthRef.current = map.getProperties().size[0] / 2 + swipeSliderOptions.pos.x;
+        }
     };
 
     const onDragVerticalHandler = (e, ui) => {
-        widthRef.current += ui.deltaX;
+        widthRef.current = map.getProperties().size[0] / 2 + ui.x;
         const posToSet = {x: ui.x, y: ui.y};
         setPos(posToSet);
         onSetSwipeSliderOptions({pos: posToSet});
@@ -40,7 +46,13 @@ const VSlider = ({ type, map, widthRef, swipeSliderOptions, onSetSwipeSliderOpti
     }, [ type ]);
 
     useEffect(() => {
-        widthRef.current = map.getProperties().size[0] / 2;
+        // Initialize based on saved position from swipe state or default to center
+        const currentMapSize = map.getProperties().size;
+        if (swipeSliderOptions?.pos) {
+            widthRef.current = currentMapSize[0] / 2 + swipeSliderOptions.pos.x;
+        } else {
+            widthRef.current = currentMapSize[0] / 2;
+        }
     }, [ type ]);
 
     return (
@@ -77,18 +89,24 @@ const VSlider = ({ type, map, widthRef, swipeSliderOptions, onSetSwipeSliderOpti
 
 const HSlider = ({ type, map, heightRef, swipeSliderOptions, onSetSwipeSliderOptions }) => {
 
-    const [pos, setPos] = useState(swipeSliderOptions?.pos);
+    const [pos, setPos] = useState(swipeSliderOptions?.pos || {x: 0, y: 0});
     const [showArrows, setShowArrows] = useState(true);
 
     const onWindowResize = () => {
-        const posToSet = {x: 0, y: 0};
-        setPos(posToSet);
-        onSetSwipeSliderOptions({pos: posToSet});
-        heightRef.current = map.getProperties().size[1] / 2;
+        // Only reset if no saved position exists
+        if (!swipeSliderOptions?.pos) {
+            const posToSet = {x: 0, y: 0};
+            setPos(posToSet);
+            onSetSwipeSliderOptions({pos: posToSet});
+            heightRef.current = map.getProperties().size[1] / 2;
+        } else {
+            // Keep saved position but update heightRef for new map size
+            heightRef.current = map.getProperties().size[1] / 2 + swipeSliderOptions.pos.y;
+        }
     };
 
     const onDragHorizontalHandler = (e, ui) => {
-        heightRef.current += ui.deltaY;
+        heightRef.current = map.getProperties().size[1] / 2 + ui.y;
         const posToSet = {x: ui.x, y: ui.y};
         setPos(posToSet);
         onSetSwipeSliderOptions({pos: posToSet});
@@ -103,7 +121,12 @@ const HSlider = ({ type, map, heightRef, swipeSliderOptions, onSetSwipeSliderOpt
     }, [ type ]);
 
     useEffect(() => {
-        heightRef.current = map.getProperties().size[1] / 2;
+        // Initialize based on saved position from swipe state or default to center
+        if (swipeSliderOptions?.pos) {
+            heightRef.current = map.getProperties().size[1] / 2 + swipeSliderOptions.pos.y;
+        } else {
+            heightRef.current = map.getProperties().size[1] / 2;
+        }
     }, [ type ]);
 
     return (<Draggable

--- a/web/client/reducers/swipe.js
+++ b/web/client/reducers/swipe.js
@@ -13,14 +13,14 @@ import { MAP_CONFIG_LOADED } from '../actions/config';
 export default (state = {}, action) => {
     switch (action.type) {
     case SET_ACTIVE: {
-        return { ...state, [action.prop]: action.active, sliderOptions: {} };
+        return { ...state, [action.prop]: action.active, ...(action.active === false && { sliderOptions: {} }) };
     }
     case MAP_CONFIG_LOADED: {
         const swipeConfig = action.config.swipe || {};
         return {...state, ...swipeConfig};
     }
     case SET_SWIPE_LAYER: {
-        return { ...state, layerId: action.layerId, sliderOptions: {} };
+        return { ...state, layerId: action.layerId };
     }
     case SET_MODE: {
         return { ...state, mode: action.mode };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes the issue of not keeping slider swipe position after saving and make refresh page for vertical/horizontal swipe.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
https://github.com/geosolutions-it/MapStore2/pull/11276#issuecomment-3032155484

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Slider swipe position after saving resource is kept for horizontal/vertical slider.

https://github.com/user-attachments/assets/8ea9ee95-b9e5-41c3-81c5-2887d5e770fe


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
