### PR TITLE
Cannot exit the filter configuration panel during the setup of a widget for dashboards #11269

### DIFF
--- a/web/client/components/data/query/QueryBuilder.jsx
+++ b/web/client/components/data/query/QueryBuilder.jsx
@@ -204,6 +204,7 @@ class QueryBuilder extends React.Component {
                 storedFilter={this.props.storedFilter}
                 advancedToolbar={this.props.advancedToolbar}
                 loadingError={this.props.loadingError}
+                queryBtnGlyph="ok"
             /></div>);
         const { spatialMethodOptions, toolsOptions, spatialOperations} = this.props;
         return this.props.attributes.length > 0 ?

--- a/web/client/plugins/querypanel/SpatialFilterMap.jsx
+++ b/web/client/plugins/querypanel/SpatialFilterMap.jsx
@@ -6,10 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
+import { createPortal } from 'react-dom';
 
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import Portal from '../../components/misc/Portal';
 
 import withContainer from '../../components/misc/WithContainer';
 
@@ -42,18 +42,58 @@ export const MapComponent = connect(
         onMapReady: initQueryPanel
     } )(MapWithDraw);
 
+/**
+ * SpatialFilterMap Component
+ *
+ * Renders a map component for spatial filtering in the query panel.
+ * The component uses createPortal to render the map in a specific container
+ * to ensure proper layout and positioning.
+ *
+ * @param {Object} props - Component props
+ * @param {boolean} props.useEmbeddedMap - Whether to use embedded map mode
+ * @param {boolean} props.hideSpatialFilter - Whether to hide the spatial filter
+ * @param {boolean} props.queryPanelEnabled - Whether the query panel is enabled
+ * @param {string} [props.targetContainerSelector=null] - CSS selector for the target container where the map should be rendered (optional, defaults to withContainer HOC's container)
+ * @param {Element} [props.container] - Fallback container element (provided by withContainer HOC)
+ * @param {...Object} props - Additional props passed to MapComponent
+ *
+ * @example
+ * // Basic usage with default container (from withContainer HOC)
+ * <SpatialFilterMap
+ *   useEmbeddedMap={true}
+ *   hideSpatialFilter={false}
+ *   queryPanelEnabled={true}
+ * />
+ *
+ * @example
+ * // Dashboard usage with custom container selector
+ * <SpatialFilterMap
+ *   useEmbeddedMap={true}
+ *   hideSpatialFilter={false}
+ *   queryPanelEnabled={true}
+ *   targetContainerSelector="#page-dashboard > .ms2-border-layout-body"
+ * />
+ */
 export default withContainer((props) => {
     const {
         container,
         useEmbeddedMap,
         hideSpatialFilter,
-        queryPanelEnabled
+        queryPanelEnabled,
+        targetContainerSelector
     } = props;
+
+    // Use custom selector if provided, otherwise fall back to withContainer HOC's container
+    const targetContainer = targetContainerSelector
+        ? document.querySelector(targetContainerSelector) || container
+        : container;
+
     return useEmbeddedMap && !hideSpatialFilter && queryPanelEnabled ?
-        (<Portal container={container}>
+        createPortal(
             <div className="mapstore-query-map">
                 <MapComponent {...props}/>
-            </div>
-        </Portal>)
+            </div>,
+            targetContainer
+        )
         : null;
 });

--- a/web/client/plugins/querypanel/index.js
+++ b/web/client/plugins/querypanel/index.js
@@ -35,7 +35,9 @@ const standardItems = {
     map: [{
         id: "spatialFilterMap",
         plugin: SpatialFilterMap,
-        cfg: {},
+        cfg: {
+            targetContainerSelector: "#page-dashboard > .ms2-border-layout-body"
+        },
         position: 1
     }]
 };

--- a/web/client/themes/default/less/dashboard.less
+++ b/web/client/themes/default/less/dashboard.less
@@ -25,6 +25,9 @@
     #home-button {
         float: right;
     }
+    > .ms2-border-layout-body {
+        position: relative;
+    }
 
     #mapstore-navbar-container {
         margin-bottom: 0;

--- a/web/client/themes/default/less/query-panel.less
+++ b/web/client/themes/default/less/query-panel.less
@@ -234,7 +234,7 @@
 .mapstore-query-map {
     position: absolute;
     top: 0;
-    z-index: 1000;
+    z-index: 2000;
     /* left: 0; */
     bottom: 0;
     right: 0;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
On  the Dashboard, Query panel and Query Map were overlapping/hiding the brandNavbar. Top position was adjusted for both of them for dashboard

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

fixes #11269 
**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11269
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
- On the Dashboard page, while performing filter, query panel and map will not overlap/hide brandnavbar.
- Search icon is changed to tick icon
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/eb89e0da-6b88-42eb-b0b2-5e50ef4a64de" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
