### PR TITLE
#11279: Fix - Error during WPS export via LayerDownload in specific scenarios

### DIFF
--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -78,7 +78,6 @@ const DownloadDialog = ({
     const selectedLayer = mapLayer || downloadLayer || {};
 
     const [showLoader, setShowLoader] = useState(false);
-    // const [loadedLayer, setLoadedLayer] = useState(layer);
 
     const checkWPSAvailability = (layerToCheck, selectedService) => {
         setShowLoader(true);
@@ -125,12 +124,6 @@ const DownloadDialog = ({
         }
     }, [enabled, selectedLayer, defaultSelectedService]); // equivalent componentDidUpdate
 
-    // useEffect(() => {
-    //     return () => {
-    //         onClearDownloadOptions(defaultSelectedService);
-    //     };
-    // }, []);
-
     const renderIcon = () => {
         return loading ? <div style={{"float": "left"}}><Spinner spinnerName="circle" noFadeIn/></div> : <Glyphicon glyph="download" />;
     };
@@ -154,6 +147,8 @@ const DownloadDialog = ({
 
     const formatsAvailable = service === 'wfs' ? wfsFormatsList : validWPSFormats;
 
+    const serviceNotAvailable = !wfsAvailable && !wpsAvailable;
+
     return enabled ? (<Portal>
         <Dialog id="mapstore-export" draggable={false} modal>
             <span role="header">
@@ -161,14 +156,11 @@ const DownloadDialog = ({
                 <button onClick={onClose} className="settings-panel-close close">{closeGlyph ? <Glyphicon glyph={closeGlyph}/> : <span>×</span>}</button>
             </span>
             <div role="body">
-                {showLoader ?
-                    <Loader size={100} style={{margin: '0 auto'}}/> :
-
-                    !wpsAvailable && !wfsAvailable ?
-
-                        <EmptyView title={<Message msgId="layerdownload.noSupportedServiceFound"/>}/> :
-
-                        <DownloadOptions
+                {showLoader
+                    ? <Loader size={100} style={{margin: '0 auto'}}/>
+                    : serviceNotAvailable
+                        ? <EmptyView title={<Message msgId="layerdownload.noSupportedServiceFound"/>}/>
+                        : <DownloadOptions
                             attributes={attributes}
                             cropDataSetVisible={cropDataSetVisible}
                             customAttributesSettings={customAttributeSettings}
@@ -191,10 +183,10 @@ const DownloadDialog = ({
                             wfsAvailable={wfsAvailable}
                             wpsAdvancedOptionsVisible={!selectedLayer?.search?.url}
                             wpsAvailable={wpsAvailable}
-                        />}
+                        />
+                }
             </div>
-
-            {!checkingWPSAvailability && <div role="footer">
+            {!checkingWPSAvailability && !serviceNotAvailable && <div role="footer">
                 <Button
                     bsStyle="primary"
                     className="download-button"

--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -147,7 +147,7 @@ const DownloadDialog = ({
 
     const formatsAvailable = service === 'wfs' ? wfsFormatsList : validWPSFormats;
 
-    const serviceNotAvailable = !wfsAvailable && !wpsAvailable;
+    const noSupportedServiceFound = !wfsAvailable && !wpsAvailable;
 
     return enabled ? (<Portal>
         <Dialog id="mapstore-export" draggable={false} modal>
@@ -158,7 +158,7 @@ const DownloadDialog = ({
             <div role="body">
                 {showLoader
                     ? <Loader size={100} style={{margin: '0 auto'}}/>
-                    : serviceNotAvailable
+                    : noSupportedServiceFound
                         ? <EmptyView title={<Message msgId="layerdownload.noSupportedServiceFound"/>}/>
                         : <DownloadOptions
                             attributes={attributes}
@@ -186,7 +186,7 @@ const DownloadDialog = ({
                         />
                 }
             </div>
-            {!checkingWPSAvailability && !serviceNotAvailable && <div role="footer">
+            {!checkingWPSAvailability && !noSupportedServiceFound && <div role="footer">
                 <Button
                     bsStyle="primary"
                     className="download-button"

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -78,7 +78,7 @@ class DownloadOptions extends React.Component {
     }
 
     componentDidMount = () => {
-        this.props.onClearDownloadOptions(this.props.defaultSelectedService);
+        this.props.onClearDownloadOptions(this.props.service || this.props.defaultSelectedService);
         const format = get(this.props, "downloadOptions.selectedFormat") || get(head(this.props.formats), "name");
         const srs = get(this.props, "downloadOptions.selectedSrs") || get(this.props, "defaultSrs") || get(head(this.props.srsList), "name");
         const filter = get(this.props, "layer.layerFilter"); // This will miss the widget filter
@@ -90,7 +90,6 @@ class DownloadOptions extends React.Component {
     };
 
     componentWillReceiveProps = (newProps) => {
-        // this.props.onClearDownloadOptions();
         if ( !isEqual( this.props.formats, newProps.formats)) {
             const format = get(newProps, "downloadOptions.selectedFormat") || get(head(newProps.formats), "name");
             newProps.onChange("selectedFormat", format);

--- a/web/client/components/data/download/__tests__/DownloadDialog-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadDialog-test.jsx
@@ -68,4 +68,20 @@ describe('Test for DownloadDialog component', () => {
         const selectors = dialog.querySelectorAll('.Select');
         expect(selectors.length).toBe(1);
     });
+    it('should render serviceNotAvailable', (done) => {
+        const selectedLayer = {
+            type: 'wms',
+            visibility: true,
+            id: 'mapstore:states__7'
+        };
+        ReactDOM.render(<DownloadDialog enabled service="wps" wpsAvailable={false} mapLayer={selectedLayer} />, document.getElementById("container"));
+        setTimeout(() => {
+            const dialog = document.querySelector('.empty-state-container');
+            expect(dialog).toBeTruthy();
+            expect(dialog.textContent).toBe('layerdownload.noSupportedServiceFound');
+            const button = document.querySelector('.download-button');
+            expect(button).toBeFalsy();
+            done();
+        }, 0);
+    });
 });

--- a/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
@@ -57,4 +57,10 @@ describe('Test for DownloadOptions component', () => {
         const selectors = form.querySelectorAll('.Select');
         expect(selectors.length).toBe(1);
     });
+    it('should update service when available', () => {
+        const action = { onClearDownloadOptions: () => {} };
+        const onClearDownloadOptionsSpy = expect.spyOn(action, 'onClearDownloadOptions');
+        ReactDOM.render(<DownloadOptions service="wfs" defaultSelectedService="wps" onClearDownloadOptions={action.onClearDownloadOptions} />, document.getElementById("container"));
+        expect(onClearDownloadOptionsSpy).toHaveBeenCalledWith('wfs');
+    });
 });

--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -29,7 +29,7 @@ export const cqlToOgc = (cqlFilter, fOpts) => {
     return toFilter(read(cqlFilter));
 };
 
-import { get, isNil, isArray, find, findIndex, isString, flatten } from 'lodash';
+import { get, isNil, isArray, find, findIndex, isString, flatten, isEmpty } from 'lodash';
 import { INTERACTIVE_LEGEND_ID } from './LegendUtils';
 import { geoStylerStyleFilter } from './styleparser/StyleParserUtils';
 let FilterUtils;
@@ -1287,10 +1287,11 @@ export const mergeFiltersToOGC = (opts = {}, ...filters) =>  {
     });
     const toFilter = fromObject(fb);
 
+    const filtersToProcess = filters.filter(filter => !!filter && (isString(filter) || isFilterValid(filter) && !filter.disabled));
+    if (isEmpty(filtersToProcess)) return "";
+
     const filterString = fb.filter(fb.and(
-        ...flatten(filters
-            .filter(filter => !!filter && (isString(filter) || isFilterValid(filter) && !filter.disabled))
-            .map(filter => isString(filter) ? [toFilter(read(filter))] : toOGCFilterParts(filter, ogcVersionOpt, nsPlaceholder)))
+        ...flatten(filtersToProcess.map(filter => isString(filter) ? [toFilter(read(filter))] : toOGCFilterParts(filter, ogcVersionOpt, nsPlaceholder)))
     ));
 
     if (addXmlnsToRoot) {


### PR DESCRIPTION
## Description
This PR fixes the error during WPS export when using Layer download in specific scenario

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #11279 

**What is the new behavior?**
WPS download operation works correctly in the following scenario
- when empty filer
- hide export button when WPS or WFS not supported for the layer
- when service supports only wfs, then call is made with correct service type

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
