### PR TITLE
[Backport 2024.02.xx] #11120: Fix - Counter widget error when connected to a Table in dashboard

### DIFF
--- a/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
@@ -187,6 +187,36 @@ describe('widgets dependenciesToFilter enhancer', () => {
     });
 
     it('dependenciesToFilter with empty layerFilter', (done) => {
+        const Sink = dependenciesToFilter(createSink(props => {
+            expect(props).toExist();
+            expect(props.filter).toBe(undefined);
+            done();
+        }));
+        const layer = { ...layerFilter, layerFilter: { } };
+        ReactDOM.render(<Sink
+            mapSync
+            layer={layer}
+        />, document.getElementById("container"));
+    });
+
+    it('dependenciesToFilter with empty filter parts', (done) => {
+        const Sink = dependenciesToFilter(createSink(props => {
+            expect(props).toExist();
+            expect(props.filter).toBe(undefined);
+            done();
+        }));
+        const layer = { ...layerFilter, layerFilter: { } };
+        ReactDOM.render(<Sink
+            mapSync
+            layer={layer}
+            options={{aggregateFunction: "Count",
+                aggregationAttribute: "SUB_REGION",
+                groupByAttributes: undefined
+            }}
+        />, document.getElementById("container"));
+    });
+
+    it('dependenciesToFilter with empty layerFilter', (done) => {
 
         const Sink = dependenciesToFilter(createSink(props => {
             expect(props).toExist();

--- a/web/client/components/widgets/enhancers/dependenciesToFilter.js
+++ b/web/client/components/widgets/enhancers/dependenciesToFilter.js
@@ -84,11 +84,11 @@ const createFilterProps = ({ mapSync, geomProp = "the_geom", dependencies = {}, 
         };
     }
     // this will contain only an ogc filter based on current and other filters (cql excluded)
-    return {
-        filter: filter(and(
-            ...(layerFilter ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : []),
-            ...(newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : [])))
-    };
+    const ogcLayerFilterParts = layerFilter ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : [];
+    const ogcNewFilterObjParts = newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : [];
+    const ogcFilter = isEmpty(ogcLayerFilterParts) && isEmpty(ogcNewFilterObjParts) ? undefined
+        : filter(and(...ogcLayerFilterParts, ...ogcNewFilterObjParts));
+    return { filter: ogcFilter };
 };
 
 const TRACE_PROPS = ['mapSync', 'dependencies', 'dependenciesMap', 'widgets'];

--- a/web/client/plugins/widgetbuilder/ChartBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/ChartBuilder.jsx
@@ -124,6 +124,7 @@ export default chooseLayerEnhancer(({ enabled, onClose = () => { }, exitButton, 
                     toggleLayerSelector={props.toggleLayerSelector}
                     errors={props.errors}
                     dashboardEditing={props.dashboardEditing}
+                    widgets={props.widgets}
                 />
             </BuilderHeader>}
         >

--- a/web/client/plugins/widgetbuilder/CounterBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/CounterBuilder.jsx
@@ -85,6 +85,7 @@ export default chooseLayerEnhancer(({ enabled, onClose = () => { }, exitButton, 
             editorData={editorData}
             toggleConnection={toggleConnection}
             availableDependencies={availableDependencies}
+            widgets={props.widgets}
             onClose={onClose} /></BuilderHeader>}
     >
         {enabled ? <Builder formOptions={{

--- a/web/client/plugins/widgetbuilder/TableBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/TableBuilder.jsx
@@ -96,6 +96,7 @@ export default chooseLayerEnhancer(({ enabled, onClose = () => { }, editorData =
                     exitButton={exitButton}
                     toggleConnection={toggleConnection}
                     availableDependencies={availableDependencies}
+                    widgets={props.widgets}
                     onClose={onClose} />
                 {get(editorData, "options.propertyName.length") === 0 ? <InfoPopover
                     trigger={false}

--- a/web/client/plugins/widgetbuilder/enhancers/connection/__tests__/withConnectButton-test.js
+++ b/web/client/plugins/widgetbuilder/enhancers/connection/__tests__/withConnectButton-test.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import expect from 'expect';
+import withConnectButton from '../withConnectButton';
+
+const getStepButtons = (props = {}) => {
+    const enhancer = withConnectButton()((p) => p);
+    const enhanced = enhancer(props);
+    return enhanced.stepButtons;
+};
+
+describe('withConnectButton enhancer', () => {
+    it('should set isTableOnlyWidget true and correct tooltip for table widget', () => {
+        const widgets = [
+            { id: 'w1', widgetType: 'table' },
+            { id: 'w2', widgetType: 'chart' }
+        ];
+        const availableDependencies = ['widgets["w1"].layer'];
+        const stepButtons = getStepButtons({
+            availableDependencies,
+            widgets,
+            canConnect: true,
+            connected: false
+        });
+        expect(stepButtons.length).toBe(1);
+        expect(stepButtons[stepButtons.length - 1].tooltipId).toBe('widgets.builder.wizard.connectToTheTable');
+    });
+
+    it('should set correct tooltip for map connection', () => {
+        const widgets = [
+            { id: 'w2', widgetType: 'chart' }
+        ];
+        const availableDependencies = ['widgets["w2"].layer'];
+        const stepButtons = getStepButtons({
+            availableDependencies,
+            widgets,
+            canConnect: true,
+            connected: false
+        });
+        expect(stepButtons[stepButtons.length - 1].tooltipId).toBe('widgets.builder.wizard.connectToTheMap');
+    });
+
+    it('should set correct tooltip for multi dependency', () => {
+        const widgets = [
+            { id: 'w1', widgetType: 'table' },
+            { id: 'w2', widgetType: 'chart' }
+        ];
+        const availableDependencies = ['widgets["w1"].layer', 'widgets["w2"].layer'];
+        const stepButtons = getStepButtons({
+            availableDependencies,
+            widgets,
+            canConnect: true,
+            connected: false
+        });
+        expect(stepButtons[stepButtons.length - 1].tooltipId).toBe('widgets.builder.wizard.connectToAMap');
+    });
+    it('should render when dependencies return empty dependency id', () => {
+        const widgets = [
+            { id: 'w1', widgetType: 'table' },
+            { id: 'w2', widgetType: 'chart' }
+        ];
+        const availableDependencies = ['layer'];
+        const stepButtons = getStepButtons({
+            availableDependencies,
+            widgets,
+            canConnect: true,
+            connected: false
+        });
+        expect(stepButtons[stepButtons.length - 1].tooltipId).toBe('widgets.builder.wizard.connectToTheMap');
+    });
+});

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2139,6 +2139,7 @@
                     "useTheSelectedLayer": "Verwende die ausgewählte Ebene",
                     "connectToAMap": "Stellen Sie eine Verbindung zu einem anderen Widget her",
                     "connectToTheMap": "Verbinden Sie sich mit der Karte",
+                    "connectToTheTable": "Verbinden Sie sich mit der Tabelle",
                     "selectMapToConnect": "Wählen Sie das zu verbindende Widget aus",
                     "clearConnection": "Verbindung löschen",
                     "disableConnectToMap": "Vorgang nicht verfügbar",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2101,6 +2101,7 @@
                     "useTheSelectedLayer": "Use the selected layer",
                     "connectToAMap": "Connect to another widget",
                     "connectToTheMap": "Connect to the map",
+                    "connectToTheTable": "Connect to the table",
                     "selectMapToConnect": "Select the widget to connect",
                     "clearConnection": "Clear connection",
                     "disableConnectToMap": "Operation unavailable",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -249,7 +249,7 @@
                 "incompatibleFilterWarning": "Los filtros de leyenda son incompatibles con el filtro de capa activo, o no hay características visibles dentro de la vista del mapa. Haga clic en restablecer para borrar los filtros de leyenda",
                 "resetLegendFilter": "Restablecer",
                 "noLegendData": "No hay elementos de leyenda para mostrar"
-            } 
+            }
         },
         "localizedInput": {
           "localize": "Localizar cadena...",
@@ -2101,6 +2101,7 @@
                     "useTheSelectedLayer": "Usar la capa seleccionada",
                     "connectToAMap": "Conectarse a otro widget",
                     "connectToTheMap": "Conectar al mapa",
+                    "connectToTheTable": "Conectar a la tabla",
                     "selectMapToConnect": "Seleccione el widget para conectarse",
                     "clearConnection": "Borrar conexión",
                     "disableConnectToMap": "Operación no disponible",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2101,6 +2101,7 @@
                     "useTheSelectedLayer": "Utiliser la couche sélectionnée",
                     "connectToAMap": "Se connecter à un autre widget",
                     "connectToTheMap": "Connectez-vous à la carte",
+                    "connectToTheTable": "Connect to the table",
                     "selectMapToConnect": "Sélectionnez le widget pour vous connecter",
                     "clearConnection": "Effacer la connexion",
                     "disableConnectToMap": "Opération indisponible",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2098,6 +2098,7 @@
                     "useTheSelectedLayer": "Usa il livello selezionato",
                     "connectToAMap": "Connetti ad un altro widget",
                     "connectToTheMap": "Collegati alla mappa",
+                    "connectToTheTable": "Connetti alla tabella",
                     "selectMapToConnect": "Seleziona il widget da connettere",
                     "clearConnection": "Disconnetti",
                     "disableConnectToMap": "Operazione non disponibile",


### PR DESCRIPTION
### Issues
- #11120: Fix - Counter widget error when connected to a Table in dashboard (#11244)
- #11120: Skip dependency filter generation when filter parts are empty (#11271)
- #11282: Fix - Chart builder in map viewer is not working (#11283)