### PR TITLE
[Backport 2025.01.xx]: fixes  #11269 Cannot exit the filter configuration panel during the setup of a widget for dashboards (#11287)

### DIFF
--- a/web/client/components/data/query/QueryBuilder.jsx
+++ b/web/client/components/data/query/QueryBuilder.jsx
@@ -204,6 +204,7 @@ class QueryBuilder extends React.Component {
                 storedFilter={this.props.storedFilter}
                 advancedToolbar={this.props.advancedToolbar}
                 loadingError={this.props.loadingError}
+                queryBtnGlyph="ok"
             /></div>);
         const { spatialMethodOptions, toolsOptions, spatialOperations} = this.props;
         return this.props.attributes.length > 0 ?

--- a/web/client/plugins/querypanel/SpatialFilterMap.jsx
+++ b/web/client/plugins/querypanel/SpatialFilterMap.jsx
@@ -6,10 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
+import { createPortal } from 'react-dom';
 
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import Portal from '../../components/misc/Portal';
 
 import withContainer from '../../components/misc/WithContainer';
 
@@ -42,18 +42,58 @@ export const MapComponent = connect(
         onMapReady: initQueryPanel
     } )(MapWithDraw);
 
+/**
+ * SpatialFilterMap Component
+ *
+ * Renders a map component for spatial filtering in the query panel.
+ * The component uses createPortal to render the map in a specific container
+ * to ensure proper layout and positioning.
+ *
+ * @param {Object} props - Component props
+ * @param {boolean} props.useEmbeddedMap - Whether to use embedded map mode
+ * @param {boolean} props.hideSpatialFilter - Whether to hide the spatial filter
+ * @param {boolean} props.queryPanelEnabled - Whether the query panel is enabled
+ * @param {string} [props.targetContainerSelector=null] - CSS selector for the target container where the map should be rendered (optional, defaults to withContainer HOC's container)
+ * @param {Element} [props.container] - Fallback container element (provided by withContainer HOC)
+ * @param {...Object} props - Additional props passed to MapComponent
+ *
+ * @example
+ * // Basic usage with default container (from withContainer HOC)
+ * <SpatialFilterMap
+ *   useEmbeddedMap={true}
+ *   hideSpatialFilter={false}
+ *   queryPanelEnabled={true}
+ * />
+ *
+ * @example
+ * // Dashboard usage with custom container selector
+ * <SpatialFilterMap
+ *   useEmbeddedMap={true}
+ *   hideSpatialFilter={false}
+ *   queryPanelEnabled={true}
+ *   targetContainerSelector="#page-dashboard > .ms2-border-layout-body"
+ * />
+ */
 export default withContainer((props) => {
     const {
         container,
         useEmbeddedMap,
         hideSpatialFilter,
-        queryPanelEnabled
+        queryPanelEnabled,
+        targetContainerSelector
     } = props;
+
+    // Use custom selector if provided, otherwise fall back to withContainer HOC's container
+    const targetContainer = targetContainerSelector
+        ? document.querySelector(targetContainerSelector) || container
+        : container;
+
     return useEmbeddedMap && !hideSpatialFilter && queryPanelEnabled ?
-        (<Portal container={container}>
+        createPortal(
             <div className="mapstore-query-map">
                 <MapComponent {...props}/>
-            </div>
-        </Portal>)
+            </div>,
+            targetContainer
+        )
         : null;
 });

--- a/web/client/plugins/querypanel/index.js
+++ b/web/client/plugins/querypanel/index.js
@@ -35,7 +35,9 @@ const standardItems = {
     map: [{
         id: "spatialFilterMap",
         plugin: SpatialFilterMap,
-        cfg: {},
+        cfg: {
+            targetContainerSelector: "#page-dashboard > .ms2-border-layout-body"
+        },
         position: 1
     }]
 };

--- a/web/client/themes/default/less/dashboard.less
+++ b/web/client/themes/default/less/dashboard.less
@@ -25,6 +25,9 @@
     #home-button {
         float: right;
     }
+    > .ms2-border-layout-body {
+        position: relative;
+    }
 
     #mapstore-navbar-container {
         margin-bottom: 0;

--- a/web/client/themes/default/less/query-panel.less
+++ b/web/client/themes/default/less/query-panel.less
@@ -234,7 +234,7 @@
 .mapstore-query-map {
     position: absolute;
     top: 0;
-    z-index: 1000;
+    z-index: 2000;
     /* left: 0; */
     bottom: 0;
     right: 0;


### PR DESCRIPTION
[Backport 2025.01.xx]: fixes  #11269 Cannot exit the filter configuration panel during the setup of a widget for dashboards (#11287)