### PR TITLE
Fix #11304 Improving timeline layout 

### DIFF
--- a/web/client/actions/widgets.js
+++ b/web/client/actions/widgets.js
@@ -43,6 +43,7 @@ export const TOGGLE_COLLAPSE = "WIDGET:TOGGLE_COLLAPSE";
 export const TOGGLE_COLLAPSE_ALL = "WIDGET:TOGGLE_COLLAPSE_ALL";
 export const TOGGLE_MAXIMIZE = "WIDGET:TOGGLE_MAXIMIZE";
 export const TOGGLE_TRAY = "WIDGET:TOGGLE_TRAY";
+export const EXPAND_TRAY = "WIDGET:EXPAND_TRAY";
 
 /**
  * Intent to create a new Widgets
@@ -320,3 +321,9 @@ export const toggleMaximize = (widget, target = DEFAULT_TARGET) => ({
  * @param {boolean} value true the tray is present, false if it is not present
  */
 export const toggleTray = value => ({ type: TOGGLE_TRAY, value});
+
+/**
+ * Toggles the content of the widgets tray.
+ * @param {boolean} value true the widget tray is expanded, false if it is not expanded
+ */
+export const expandTray = value => ({ type: EXPAND_TRAY, value});

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -30,7 +30,8 @@ import {
     TOGGLE_TRAY,
     toggleCollapse,
     REPLACE,
-    WIDGETS_REGEX
+    WIDGETS_REGEX,
+    EXPAND_TRAY
 } from '../actions/widgets';
 import { REFRESH_SECURITY_LAYERS, CLEAR_SECURITY } from '../actions/security';
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -59,7 +60,8 @@ const emptyState = {
         settings: {
             step: 0
         }
-    }
+    },
+    expanded: true
 };
 
 
@@ -446,6 +448,9 @@ function widgetsReducer(state = emptyState, action) {
     }
     case TOGGLE_TRAY: {
         return set('tray', action.value, state);
+    }
+    case EXPAND_TRAY: {
+        return set('expanded', action.value, state);
     }
     default:
         return state;

--- a/web/client/selectors/widgets.js
+++ b/web/client/selectors/widgets.js
@@ -193,3 +193,5 @@ export const getTblWidgetZoomLoader = state => {
     let tableWidgets = (getFloatingWidgets(state) || []).filter(({ widgetType } = {}) => widgetType === "table");
     return tableWidgets?.find(t=>t.dependencies?.zoomLoader) ? true : false;
 };
+
+export const getExpandedTray = state => get(state, "widgets.expanded");


### PR DESCRIPTION
## Description
This PR fixes issue #11304. It improves the space between the Baselayer switcher and the Timeline plugin, and fixes the overlapping issue with the Widget tray when the Timeline Plugin is expanded.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
Fix #11304
- There is quite a space between the background switcher and the timeline.
- When the timeline is expanded, it overlaps with the widget tray.
  <img width="1457" height="227" alt="image" src="https://github.com/user-attachments/assets/72156957-c76e-4e9a-a8a3-e2f38b14d63a" />

**What is the new behavior?**
- The layout of the timeline is shifted near the baselayer switcher to reduce the space between them.
- Similarly, the timeline only expands up to the widget tray when it is expanded. Hence, resolving the overlapping issue.
  <img width="1528" height="176" alt="image" src="https://github.com/user-attachments/assets/d5984ebb-a6f6-4a2e-87fe-1a3688c2e41e" />

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
