### PR TITLE
[Backport 2025.01.xx] - #11270: fix - Layer groups visibility is not consistent with Map Visualization MapViews plugin (#11313)

### DIFF
--- a/web/client/epics/__tests__/mapviews-test.js
+++ b/web/client/epics/__tests__/mapviews-test.js
@@ -79,21 +79,23 @@ describe('mapviews epics', () => {
             type: 'FeatureCollection',
             features: [feature]
         });
-        testEpic(updateMapViewsLayers, 5, activateViews(true), actions => {
+        testEpic(updateMapViewsLayers, 6, activateViews(true), actions => {
             try {
-                expect(actions.length).toBe(5);
+                expect(actions.length).toBe(6);
                 expect(actions.map(({ type }) => type)).toEqual([
                     UPDATE_RESOURCES,
                     SET_PREVIOUS_VIEW,
                     REMOVE_ADDITIONAL_LAYER,
                     UPDATE_ADDITIONAL_LAYER,
+                    UPDATE_ADDITIONAL_LAYER,
                     UPDATE_ADDITIONAL_LAYER
                 ]);
 
-                expect(actions[3].options.visibility).toBe(false);
-                expect(actions[4].options.visibility).toBe(true);
-                expect(actions[4].options.style).toBeTruthy();
-                expect(actions[4].options.style).toEqual({
+                expect(actions[3].options.visibility).toBe(true);       // layer 01
+                expect(actions[4].options.visibility).toBe(false);      // layer 02
+                expect(actions[5].options.visibility).toBe(true);
+                expect(actions[5].options.style).toBeTruthy();
+                expect(actions[5].options.style).toEqual({
                     format: 'geostyler',
                     body: {
                         name: '',
@@ -169,7 +171,7 @@ describe('mapviews epics', () => {
                         ],
                         groups: [
                             {
-                                id: 'group_02',
+                                id: 'group_01',
                                 visibility: true
                             }
                         ]

--- a/web/client/utils/MapViewsUtils.js
+++ b/web/client/utils/MapViewsUtils.js
@@ -112,6 +112,33 @@ export const isViewLayerChanged = (viewLayer, mapLayer) => {
     || viewLayer.clippingPolygonUnion !== mapLayer.clippingPolygonUnion;
 };
 /**
+ * Recursively searches for a group by its ID in groups/nested groups structure
+ * @param {[] object} groups - Array of group objects to search through
+ * @param {string} targetId - The ID of the group to find
+ * @returns {object|null} The found group object, or null if not found
+ **/
+export const findGroupById = (groups, targetId) => {
+    for (const group of groups) {
+        if (group.id === targetId) {
+            return group;
+        }
+        // Check in nested nodes if they exist and are objects
+        if (group.nodes) {
+            for (const node of group.nodes) {
+                if (typeof node === 'object' && node.id === targetId) {
+                    return node;
+                }
+                // If node has nested nodes, search recursively
+                if (typeof node === 'object' && node.nodes) {
+                    const found = findGroupById([node], targetId);
+                    if (found) return found;
+                }
+            }
+        }
+    }
+    return null;
+};
+/**
  * pick view layer properties
  * @param {object} node layer object
  */

--- a/web/client/utils/__tests__/MapViewsUtils-test.js
+++ b/web/client/utils/__tests__/MapViewsUtils-test.js
@@ -16,7 +16,8 @@ import {
     isViewLayerChanged,
     pickViewLayerProperties,
     pickViewGroupProperties,
-    mergeViewGroups
+    mergeViewGroups,
+    findGroupById
 } from '../MapViewsUtils';
 
 describe('Test MapViewsUtils', () => {
@@ -444,5 +445,40 @@ describe('Test MapViewsUtils', () => {
             [{ id: '01', visibility: false, nodes: ['layer01', { id: '02', visibility: false }] }],
             { groups: [{ id: '02', visibility: true }] }
         ), true).toEqual([ { id: '01', visibility: false, nodes: [ 'layer01', { id: '02', visibility: false } ] } ]);
+    });
+    it('test findGroupById: should return null for empty groups array', () => {
+        expect(findGroupById([], 'test-id')).toBe(null);
+    });
+
+    it('test findGroupById: should return null when group is not found', () => {
+        const groups = [
+            { id: 'group1', name: 'Group 1' },
+            { id: 'group2', name: 'Group 2' }
+        ];
+        expect(findGroupById(groups, 'nonexistent')).toBe(null);
+    });
+
+    it('test findGroupById: should find group at top level', () => {
+        const groups = [
+            { id: 'group1', name: 'Group 1' },
+            { id: 'group2', name: 'Group 2' }
+        ];
+        const result = findGroupById(groups, 'group2');
+        expect(result).toEqual({ id: 'group2', name: 'Group 2' });
+    });
+
+    it('test findGroupById: should find group in nested nodes', () => {
+        const groups = [
+            {
+                id: 'group1',
+                name: 'Group 1',
+                nodes: [
+                    { id: 'subgroup1', name: 'Sub Group 1' },
+                    { id: 'subgroup2', name: 'Sub Group 2' }
+                ]
+            }
+        ];
+        const result = findGroupById(groups, 'subgroup2');
+        expect(result).toEqual({ id: 'subgroup2', name: 'Sub Group 2' });
     });
 });


### PR DESCRIPTION
**[Backport 2025.01.xx]** - #11270: fix - Layer groups visibility is not consistent with Map Visualization MapViews plugin (#11313)