### PR TITLE
#11328: Fix YAML config issues for printing: North arrow URL format and A2 north arrow positioning

### DIFF
--- a/java/printing/resources/geoserver/print/config.yaml
+++ b/java/printing/resources/geoserver/print/config.yaml
@@ -1309,13 +1309,13 @@ layouts:
               failOnBrokenUrl: false
         - !columns
           absoluteX: 834
-          absoluteY: 198
+          absoluteY: 140
           width: 40
           items:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42
@@ -1426,14 +1426,14 @@ layouts:
               backgroundColor: #ffffff
               failOnBrokenUrl: false
         - !columns
-          absoluteX: 834
-          absoluteY: 198
+          absoluteX: 1170
+          absoluteY: 220
           width: 40
           items:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42
@@ -1499,14 +1499,14 @@ layouts:
           absoluteX: 42
           absoluteY: 1400
         - !columns
-          absoluteX: 834
-          absoluteY: 198
+          absoluteX: 1100
+          absoluteY: 140
           width: 40
           items:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42
@@ -1590,14 +1590,14 @@ layouts:
           absoluteX: 42
           absoluteY: 990
         - !columns
-          absoluteX: 834
-          absoluteY: 198
+          absoluteX: 1580
+          absoluteY: 230
           width: 40
           items:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42
@@ -1663,14 +1663,14 @@ layouts:
           absoluteX: 42
           absoluteY: 1400
         - !columns
-          absoluteX: 834
-          absoluteY: 198
+          absoluteX: 1100
+          absoluteY: 140
           width: 40
           items:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42
@@ -1791,14 +1791,14 @@ layouts:
           absoluteX: 42
           absoluteY: 990
         - !columns
-          absoluteX: 834
-          absoluteY: 198
+          absoluteX: 1580
+          absoluteY: 220
           width: 40
           items:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes editing in config.yaml file of the printing:
- fix url issue for north arrow for A2
- edit north arrow position to be proper for A2


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11328 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now the A2 prints is working well with north arrow appearance and its position on print pages.
* a2_landscape_with_legend_in_separate_page_new_fixed
<img width="1053" height="317" alt="a2_landscape_with_legend_in_separate_page_new_fixed" src="https://github.com/user-attachments/assets/d4eb97e1-20e7-4b34-9559-8105dc797555" />


* a2_portrait_with_legend_in_separate_page_new_fixed
<img width="1042" height="258" alt="a2_portrait_with_legend_in_separate_page_new_fixed" src="https://github.com/user-attachments/assets/9e5e8dfc-0b41-4b3c-b2cd-5b3c544a4aad" />

* a2_landscape_with_legend_new_fixed
<img width="1035" height="315" alt="a2_landscape_with_legend_new_fixed" src="https://github.com/user-attachments/assets/48e79a47-2e02-46fa-a165-385eb1cc5c34" />

* a2_portrait_with_legend_new_fixed
<img width="1067" height="286" alt="a2_portrait_with_legend_new_fixed" src="https://github.com/user-attachments/assets/45563a4f-9c5e-409b-a436-b94548e3534c" />

* a2_portrait_new_fixed

![Upload
<img width="953" height="243" alt="a2_portrait_new_fixed" src="https://github.com/user-attachments/assets/2f1436a7-90f2-4261-9001-c9437cd34999" />

* a2_landscape_new_fixed

<img width="1070" height="312" alt="a2_landscape_new_fixed" src="https://github.com/user-attachments/assets/13fd0015-3be3-4086-a9ae-5c6d151c19ee" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
