### PR TITLE
Halo not printed for annotation text with halo #11336

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
         <!-- MapStore‑specific -->
         <geostore-webapp.version>2.4-SNAPSHOT</geostore-webapp.version>
-        <print-lib.version>2.3.3</print-lib.version>
+        <print-lib.version>2.3.4</print-lib.version>
         <http_proxy.version>1.6-SNAPSHOT</http_proxy.version>
 
         <!-- Commons extras -->

--- a/web/client/utils/styleparser/PrintStyleParser.js
+++ b/web/client/utils/styleparser/PrintStyleParser.js
@@ -121,15 +121,13 @@ const symbolizerToPrintMSStyle = (symbolizer, feature, layer, originalSymbolizer
             fontColor: symbolizer.color,
             fontOpacity: 1 * globalOpacity,
             label: resolveAttributeTemplate(feature, symbolizer.label, ''),
-            // does not work
-            // the halo color cover the text
-            /*
+            // Halo information
             ...(symbolizer.haloWidth > 0 && {
                 labelOutlineColor: symbolizer.haloColor,
                 labelOutlineOpacity: 1 * globalOpacity,
-                labelOutlineWidth: symbolizer.haloWidth
+                labelOutlineWidth: symbolizer.haloWidth,
+                labelOutlineMode: 'halo'
             }),
-            */
             // hide default point
             fillOpacity: 0,
             pointRadius: 0,

--- a/web/client/utils/styleparser/__tests__/PrintStyleParser-test.js
+++ b/web/client/utils/styleparser/__tests__/PrintStyleParser-test.js
@@ -306,11 +306,56 @@ describe('PrintStyleParser', () => {
                 fontColor: '#000000',
                 fontOpacity: 1,
                 label: 'Hello World!',
+                labelOutlineColor: '#ffffff',
+                labelOutlineOpacity: 1,
+                labelOutlineWidth: 2,
+                labelOutlineMode: 'halo',
                 fillOpacity: 0,
                 pointRadius: 0,
                 strokeOpacity: 0,
                 strokeWidth: 0
             });
+        });
+
+        it('should write a style function with text symbolizer including halo (outline)', () => {
+            const style = {
+                name: '',
+                rules: [
+                    {
+                        filter: undefined,
+                        name: '',
+                        symbolizers: [
+                            {
+                                kind: 'Text',
+                                label: 'Test Label',
+                                color: '#123456',
+                                haloColor: '#abcdef',
+                                haloWidth: 3,
+                                size: 20
+                            }
+                        ]
+                    }
+                ]
+            };
+            const layer = {
+                features: [
+                    {
+                        "type": "Feature",
+                        "properties": {},
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [0, 0]
+                        }
+                    }
+                ]
+            };
+            const printFeaturesWithStyle = parser.writeStyle(style, true)({ layer });
+            expect(printFeaturesWithStyle.length).toBe(1);
+            const msStyle = printFeaturesWithStyle[0].properties.ms_style;
+            expect(msStyle.labelOutlineColor).toBe('#abcdef');
+            expect(msStyle.labelOutlineOpacity).toBe(1);
+            expect(msStyle.labelOutlineWidth).toBe(3);
+            expect(msStyle.labelOutlineMode).toBe('halo');
         });
 
         it('should write a style function with circle symbolizer', () => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)




<!-- add here the ReadTheDocs link (if needed) -->
fixes #11336

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11336


**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Halo style is not applied to the print.
<img width="666" height="477" alt="image" src="https://github.com/user-attachments/assets/478ce9ac-598f-460b-9eaf-46a2be15e525" />

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
