### PR TITLE
Extend the charts to show the current time

### DIFF
--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -579,6 +579,7 @@ export const toPlotly = (_props) => {
             }} : {}),
             hovermode: 'x unified',
             uirevision: true,
+            shapes: [...(layout?.shapes || [])],
             ...gridProperty
         },
         data: traces.filter((trace, idx) => !!dataProp[idx]).reduce((acc, {

--- a/web/client/components/widgets/builder/wizard/chart/ChartAxisOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/chart/ChartAxisOptions.jsx
@@ -265,7 +265,7 @@ function AxisOptions({
                     {!(options?.hide ?? false) && <InfoPopover bsStyle="info" text={<Message msgId="widgets.advanced.maxXAxisLabels" msgParams={{ max: MAX_X_AXIS_LABELS }} />} />}
                 </Checkbox>
             </FormGroup>}
-            <FormGroup className="form-group-flex"  style={{ marginBottom: 0 }}>
+            <FormGroup className="form-group-flex" style={{ marginBottom: 0 }}>
                 <Checkbox
                     disabled={options?.hide ?? false}
                     checked={options.angle !== undefined}
@@ -289,7 +289,7 @@ function AxisOptions({
                     <InputGroup.Addon>°</InputGroup.Addon>
                 </InputGroup>
             </FormGroup>
-            <FormGroup className="form-group-flex">
+            <FormGroup className="form-group-flex" style={{ marginBottom: 0 }}>
                 <Checkbox
                     checked={options?.hide ?? false}
                     onChange={(event) => { handleChange('hide', event?.target?.checked); }}
@@ -297,6 +297,14 @@ function AxisOptions({
                     <Message msgId="widgets.advanced.hideLabels" />
                 </Checkbox>
             </FormGroup>
+            {options.type === 'date' && <FormGroup className="form-group-flex">
+                <Checkbox
+                    checked={options?.showCurrentTime ?? false}
+                    onChange={(event) => { handleChange('showCurrentTime', event?.target?.checked); }}
+                >
+                    <Message msgId="widgets.advanced.showCurrentTime" />
+                </Checkbox>
+            </FormGroup>}
         </>
     );
 }

--- a/web/client/components/widgets/builder/wizard/chart/__tests__/ChartAxisOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/chart/__tests__/ChartAxisOptions-test.jsx
@@ -109,4 +109,29 @@ describe('ChartAxisOptions', () => {
         const checkboxInputNodes = document.querySelectorAll('input[type=\'checkbox\']');
         Simulate.change(checkboxInputNodes[1], { target: { checked: true }});
     });
+    it('should display the checkbox to display current time', (done) => {
+        ReactDOM.render(<ChartAxisOptions data={{
+            selectedChartId: 'chart-01',
+            charts: [{
+                chartId: 'chart-01',
+                traces: [{
+                    type: 'line'
+                }],
+                xAxisOpts: [{ id: 0, type: 'date' }]
+            }]
+        }}/>, document.getElementById('container'));
+        const checkboxNodes = document.querySelectorAll('.checkbox');
+        expect([...checkboxNodes].map(node => node.innerText)).toEqual([
+            // y
+            'widgets.advanced.xAxisAngle',
+            'widgets.advanced.hideLabels',
+
+            // x
+            'widgets.advanced.forceTicks',
+            'widgets.advanced.xAxisAngle',
+            'widgets.advanced.hideLabels',
+            'widgets.advanced.showCurrentTime'
+        ]);
+        done();
+    });
 });

--- a/web/client/components/widgets/widget/ChartWidget.jsx
+++ b/web/client/components/widgets/widget/ChartWidget.jsx
@@ -16,6 +16,7 @@ import {
 import ChartSwitcher from "../builder/wizard/chart/ChartSwitcher";
 import emptyTableState from "../../widgets/enhancers/emptyChartState";
 import loadingState from '../../misc/enhancers/loadingState';
+import { addCurrentTimeShapes } from '../../../utils/widgetUtils';
 const TableView = loadingState()(emptyTableState(TableViewComp));
 
 const renderHeaderLeftTopItem = ({ showTable, toggleTableView = () => {}} = {}) => {
@@ -45,9 +46,14 @@ const ChartWidget = ({
     toggleDeleteConfirm = () => {},
     updateProperty = () => { },
     selectionActive,
+    range = {},
     ...props}) => {
     const containerId = `widget-chart-${id}`;
     const width = document.getElementById(containerId)?.clientWidth;
+    const currentTimeShapes = addCurrentTimeShapes({ charts, selectedChartId }, range);
+    const layout = currentTimeShapes.length > 0 ? {
+        shapes: [...currentTimeShapes]
+    } : {};
     return (<WidgetContainer
         className={"chart-widget-view"}
         id={containerId}
@@ -74,7 +80,7 @@ const ChartWidget = ({
     >
         {showTable
             ? <TableView data={data} {...props}/>
-            : <ChartView id={id} isAnimationActive={!loading} loading={loading} data={data} traces={traces} iconFit {...props} />}
+            : <ChartView id={id} isAnimationActive={!loading} loading={loading} data={data} traces={traces} layout={layout} iconFit {...props} />}
     </WidgetContainer>
 
     );

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -43,6 +43,7 @@ import { widthProvider, heightProvider } from '../components/layout/enhancers/gr
 
 import WidgetsViewBase from '../components/widgets/view/WidgetsView';
 import {mapLayoutValuesSelector} from "../selectors/maplayout";
+import { currentTimeRangeSelector } from '../selectors/timeline';
 
 const WidgetsView =
 compose(
@@ -57,7 +58,8 @@ compose(
             state => state.browser && state.browser.mobile,
             getFloatingWidgets,
             getTblWidgetZoomLoader,
-            (id, widgets, layouts, maximized, dependencies, mapLayout, isMobileAgent, dropdownWidgets, recordZoomLoading) => ({
+            state => currentTimeRangeSelector(state),
+            (id, widgets, layouts, maximized, dependencies, mapLayout, isMobileAgent, dropdownWidgets, recordZoomLoading, range) => ({
                 id,
                 widgets,
                 layouts,
@@ -66,7 +68,8 @@ compose(
                 mapLayout,
                 isMobileAgent,
                 dropdownWidgets,
-                recordZoomLoading
+                recordZoomLoading,
+                range
             })
         ), {
             editWidget,

--- a/web/client/plugins/widgetbuilder/commons.js
+++ b/web/client/plugins/widgetbuilder/commons.js
@@ -24,6 +24,7 @@ import {
     getWidgetLayer,
     getChartWidgetLayers
 } from '../../selectors/widgets';
+import { currentTimeRangeSelector } from '../../selectors/timeline';
 
 export const wizardStateToProps = ( stateProps = {}, dispatchProps = {}, ownProps = {}) => ({
     ...ownProps,
@@ -44,13 +45,15 @@ export const wizardSelector = createSelector(
     getEditorSettings,
     getFloatingWidgets,
     isDashboardEditing,
-    (layer, layers, editorData, settings, widgets, dashBoardEditing) => ({
+    state => currentTimeRangeSelector(state),
+    (layer, layers, editorData, settings, widgets, dashBoardEditing, range) => ({
         layer,
         layers,
         editorData,
         settings,
         widgets,
-        dashBoardEditing
+        dashBoardEditing,
+        range
     })
 );
 export const dashboardSelector = createSelector(

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2358,7 +2358,8 @@
           "category": "Category",
           "log": "Log",
           "date": "Date"
-        }
+        },
+        "showCurrentTime": "Show current time on the axis"
       },
       "tray": {
         "title": "Widgets",

--- a/web/client/utils/widgetUtils.js
+++ b/web/client/utils/widgetUtils.js
@@ -1,0 +1,82 @@
+const createRectShape = (axisId, axisType, startTime, endTime, fill = {}) => {
+    const isX = axisType === 'x';
+    return {
+        type: 'rect',
+        xref: isX ? axisId : 'paper',
+        yref: isX ? 'paper' : axisId,
+        x0: isX ? startTime : 0,
+        x1: isX ? endTime : 1,
+        y0: isX ? 0 : startTime,
+        y1: isX ? 1 : endTime,
+        fillcolor: 'rgba(200, 200, 200, 0.4)',
+        line: { width: 0 },
+        ...fill
+    };
+};
+
+const createLineShape = (axisId, axisType, time, line = {}) => {
+    const isX = axisType === 'x';
+    return {
+        type: 'line',
+        xref: isX ? axisId : 'paper',
+        yref: isX ? 'paper' : axisId,
+        x0: isX ? time : 0,
+        x1: isX ? time : 1,
+        y0: isX ? 0 : time,
+        y1: isX ? 1 : time,
+        line: {
+            color: 'rgb(55, 128, 191)',
+            width: 3,
+            ...line
+        }
+    };
+};
+
+const addAxisShapes = (axisOpts, axisType, times) => {
+    const shapes = [];
+    const { startTime, endTime, hasBothDates } = times;
+
+    axisOpts.forEach((axis, index) => {
+        if (axis.type === 'date' && axis.showCurrentTime === true) {
+            const axisId = index === 0 ? axisType : `${axisType}${index + 1}`;
+            if (hasBothDates) {
+                shapes.push(createRectShape(axisId, axisType, startTime, endTime, {
+                    fillcolor: 'rgba(187, 196, 198, 0.4)'
+                }));
+            } else {
+                // Single dashed line
+                shapes.push(createLineShape(axisId, axisType, startTime, {
+                    color: '#3aba6f',
+                    dash: 'dash'
+                }));
+            }
+        }
+    });
+
+    return shapes;
+};
+
+export const addCurrentTimeShapes = (data, timeRange) => {
+    if (!timeRange.start && !timeRange.end) return [];
+    // Get the selected chart from the data structure
+    const selectedChart = (data?.charts || []).find((chart) => chart.chartId === data.selectedChartId);
+    if (!selectedChart) {
+        return [];
+    }
+
+    const xAxisOpts = selectedChart.xAxisOpts || [];
+    const yAxisOpts = selectedChart.yAxisOpts || [];
+
+    // Split the time range
+    const startTime = timeRange.start;
+    const endTime = timeRange.end;
+    const hasBothDates = startTime && endTime;
+
+    const times = { startTime, endTime, hasBothDates };
+
+    // Create shapes for both x and y axes
+    const xAxisShapes = addAxisShapes(xAxisOpts, 'x', times);
+    const yAxisShapes = addAxisShapes(yAxisOpts, 'y', times);
+
+    return [...xAxisShapes, ...yAxisShapes];
+};


### PR DESCRIPTION
## Description
This PR adds the functionality to display the current time in the charts, issue #11327. It adds the checkbox to display the current time in the Axes tab of the charts.
<img width="250" height="300" alt="image" src="https://github.com/user-attachments/assets/823e618d-9775-4fdc-918e-bfd3af7e63ed" />    <img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/36bce24a-2744-4535-bb3c-33a8bd6005b8" />

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
There is no option to add the current time in the chart.
Fixes #11326 

**What is the new behavior?**
````
1. UI to Show the current time on the axis.
2. When checked, the user can view the current time either single or range on the axis.
3. When saved, the same feature will be available in the chart widgets too.
````

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
