### PR TITLE
#11353: fix - preserve cfg maxItems value when loading saved maps

### DIFF
--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -88,8 +88,8 @@ export const identifyLifecycle = compose(
             onInitPlugin({
                 enableInfoForSelectedLayers,
                 configuration: {
-                    maxItems
                 },
+                maxItems,
                 showAllResponses,
                 highlight: pluginCfg?.highlightEnabledFromTheStart || false
             });

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -254,9 +254,9 @@ describe('identify Epics', () => {
                 disabledAlwaysOn: false,
                 configuration: {
                     showEmptyMessageGFI: false,
-                    infoFormat: "text/plain",
-                    maxItems: 50
-                }
+                    infoFormat: "text/plain"
+                },
+                maxItems: 50
             },
             layers: {
                 flat: [{

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -365,14 +365,9 @@ function mapInfo(state = initState, action) {
         };
     }
     case MAP_CONFIG_LOADED: {
-        const mergedConfig = {...state.configuration, ...action.config.mapInfoConfiguration};
-        // **Note: always preserve cfg maxItems if it exists
-        if (state.configuration?.maxItems) {
-            mergedConfig.maxItems = state.configuration.maxItems;
-        }
         return {
             ...state,
-            configuration: mergedConfig
+            configuration: action.config.mapInfoConfiguration || state.configuration || {}
         };
     }
     case CHANGE_FORMAT: {

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -30,7 +30,8 @@ import {
     currentFeatureSelector,
     mapInfoEnabledSelector,
     mapInfoDisabledSelector,
-    enableInfoForSelectedLayersSelector
+    enableInfoForSelectedLayersSelector,
+    identifyOptionsSelector
 } from '../mapInfo';
 
 const QUERY_PARAMS = {
@@ -393,5 +394,29 @@ describe('Test mapinfo selectors', () => {
         const state = { mapInfo: { enableInfoForSelectedLayers: false}};
         const enableInfoForSelectedLayers = enableInfoForSelectedLayersSelector(state);
         expect(enableInfoForSelectedLayers).toBeFalsy();
+    });
+    it('test maxItems in identifyOptionsSelector if not configured', () => {
+        const state = { mapInfo: { enabled: true}};
+
+        const identifyInfoState = identifyOptionsSelector(state);
+        expect(identifyInfoState.maxItems).toEqual(10);
+    });
+    it('test maxItems in identifyOptionsSelector if configured', () => {
+        const state = { mapInfo: { maxItems: 15}};
+
+        const identifyInfoState = identifyOptionsSelector(state);
+        expect(identifyInfoState.maxItems).toEqual(15);
+    });
+    it('test maxItems in identifyOptionsSelector if not configured but previously existing in mapConfiguration', () => {
+        const state = { mapInfo: { configuration: {maxItems: 15}}};
+
+        const identifyInfoState = identifyOptionsSelector(state);
+        expect(identifyInfoState.maxItems).toEqual(10);
+    });
+    it('test maxItems in identifyOptionsSelector if configured with value different that the previously existing in mapConfiguration', () => {
+        const state = { mapInfo: { maxItems: 100, configuration: {maxItems: 15}}};
+
+        const identifyInfoState = identifyOptionsSelector(state);
+        expect(identifyInfoState.maxItems).toEqual(100);
     });
 });

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -102,7 +102,7 @@ export const identifyOptionsSelector = createStructuredSelector({
     map: mapSelector,
     point: clickPointSelector,
     currentLocale: currentLocaleSelector,
-    maxItems: (state) => get(state, "mapInfo.configuration.maxItems")
+    maxItems: (state) => get(state, "mapInfo.maxItems") ?? 10
 });
 
 export const isHighlightEnabledSelector = (state = {}) => state.mapInfo && state.mapInfo.highlight;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR handles always use cfg **maxItems** for Identify requests via:
- Prevent mapInfoConfiguration from overriding cfg maxItems
- Ensures all loaded maps use current configuration maxItems value

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11353
If user puts cfg **maxItems** into identify plugin with value for example 15, all new created maps will respect this value but the old ones will not.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
All maps [old and new] use the same **maxItems** limit from the cfg in Identify plugin if existing, providing consistent Identify request behavior across the entire application regardless of when the map was created or saved.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
