### PR TITLE
Support of getfeatureinfo when time changes and info popup is open

### DIFF
--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -1709,7 +1709,8 @@ describe('identify Epics', () => {
         const state = {
             map: {present: {...TEST_MAP_STATE.present, resolution: 100000}},
             mapInfo: {
-                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } }
+                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } },
+                showMarker: true
             },
             layers: {
                 flat: [
@@ -1745,7 +1746,8 @@ describe('identify Epics', () => {
         const state = {
             map: {present: {...TEST_MAP_STATE.present, resolution: 100000}},
             mapInfo: {
-                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } }
+                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } },
+                showMarker: true
             },
             layers: {
                 flat: [

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -40,7 +40,8 @@ import {
     isMapPopup, isHighlightEnabledSelector,
     itemIdSelector, overrideParamsSelector, filterNameListSelector,
     currentEditFeatureQuerySelector, mapTriggerSelector, enableInfoForSelectedLayersSelector,
-    responsesSelector
+    responsesSelector,
+    showMarkerSelector
 } from '../selectors/mapInfo';
 import { centerToMarkerSelector, getSelectedLayers, layersSelector, queryableLayersSelector, queryableSelectedLayersSelector, rawGroupsSelector, selectedNodesSelector } from '../selectors/layers';
 import { modeSelector, getAttributeFilters, isFeatureGridOpen } from '../selectors/featuregrid';
@@ -451,7 +452,9 @@ export const handleGetFeatureInfoForTimeParamsChange = (action$, {getState}) =>
         .filter(({ params = {} }) => {
             // Only process if params is time and there's a click point in map
             const state = getState();
-            return includes(Object.keys(params), "time") && clickPointSelector(state);
+            return includes(Object.keys(params), "time")
+            && clickPointSelector(state)
+            && showMarkerSelector(state);
         })
         // recover old parameters of last featureInfoClick and re-trigger the action
         .withLatestFrom(action$.ofType(FEATURE_INFO_CLICK), ({}, lastAction) => ({


### PR DESCRIPTION
## Description
This PR fixes issue #11327. It adds the condition to call the getFeatureInfo for layers in the Info popup when the time changes and the info popup is open.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
If the feature info popup is closed and the time is changed from the timeline, it again opens the feature info popup.
Fixes #11327

**What is the new behavior?**
When the time changes and the feature info popup is open, only then the request for the getFeatureInfo is made, hence updating the information for that time.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information