### PR TITLE
#11369: Enhance non hyperlink query field to have spacing

### DIFF
--- a/web/client/plugins/ResourcesCatalog/components/DetailsInfo.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/DetailsInfo.jsx
@@ -191,16 +191,21 @@ function DetailsInfoFields({ fields, formatHref, editing, onChange, query = {}, 
                 return (
                     <DetailsInfoField key={filedIndex} field={field}>
                         {(values) => values.map((value, idx) => (
-                            <ALink key={idx} href={enableFilters ? formatHref({
-                                query: field.queryTemplate
-                                    ? Object.keys(field.queryTemplate)
-                                        .reduce((acc, key) => ({
-                                            ...acc,
-                                            [key]: replaceTemplateString(value, field.queryTemplate[key])
-                                        }), {})
-                                    : field.query,
-                                pathname: field.pathname
-                            }) : undefined}>{field.valueKey ? value[field.valueKey] : value}</ALink>
+                            <ALink
+                                key={idx}
+                                fallbackComponent="span"
+                                href={enableFilters ? formatHref({
+                                    query: field.queryTemplate
+                                        ? Object.keys(field.queryTemplate)
+                                            .reduce((acc, key) => ({
+                                                ...acc,
+                                                [key]: replaceTemplateString(value, field.queryTemplate[key])
+                                            }), {})
+                                        : field.query,
+                                    pathname: field.pathname
+                                }) : undefined}>
+                                {field.valueKey ? value[field.valueKey] : value}
+                            </ALink>
                         ))}
                     </DetailsInfoField>
                 );


### PR DESCRIPTION
## Description
This PR adds fallback component to query field that is not hyperlink to space the text properly

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #11369

**What is the new behavior?**
The texts of query type non hyperlink are spaced properly
<img width="513" height="67" alt="image" src="https://github.com/user-attachments/assets/46bf67ed-fe4e-4a6e-8a56-9ac7c7bef088" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
