### PR TITLE
[Backport 2025.01.xx] - #11353: fix - preserve cfg maxItems value when loading saved maps (#11354)

### DIFF
--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -88,8 +88,8 @@ export const identifyLifecycle = compose(
             onInitPlugin({
                 enableInfoForSelectedLayers,
                 configuration: {
-                    maxItems
                 },
+                maxItems,
                 showAllResponses,
                 highlight: pluginCfg?.highlightEnabledFromTheStart || false
             });

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -253,9 +253,9 @@ describe('identify Epics', () => {
                 disabledAlwaysOn: false,
                 configuration: {
                     showEmptyMessageGFI: false,
-                    infoFormat: "text/plain",
-                    maxItems: 50
-                }
+                    infoFormat: "text/plain"
+                },
+                maxItems: 50
             },
             layers: {
                 flat: [{

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -30,7 +30,8 @@ import {
     currentFeatureSelector,
     mapInfoEnabledSelector,
     mapInfoDisabledSelector,
-    enableInfoForSelectedLayersSelector
+    enableInfoForSelectedLayersSelector,
+    identifyOptionsSelector
 } from '../mapInfo';
 
 const QUERY_PARAMS = {
@@ -393,5 +394,29 @@ describe('Test mapinfo selectors', () => {
         const state = { mapInfo: { enableInfoForSelectedLayers: false}};
         const enableInfoForSelectedLayers = enableInfoForSelectedLayersSelector(state);
         expect(enableInfoForSelectedLayers).toBeFalsy();
+    });
+    it('test maxItems in identifyOptionsSelector if not configured', () => {
+        const state = { mapInfo: { enabled: true}};
+
+        const identifyInfoState = identifyOptionsSelector(state);
+        expect(identifyInfoState.maxItems).toEqual(10);
+    });
+    it('test maxItems in identifyOptionsSelector if configured', () => {
+        const state = { mapInfo: { maxItems: 15}};
+
+        const identifyInfoState = identifyOptionsSelector(state);
+        expect(identifyInfoState.maxItems).toEqual(15);
+    });
+    it('test maxItems in identifyOptionsSelector if not configured but previously existing in mapConfiguration', () => {
+        const state = { mapInfo: { configuration: {maxItems: 15}}};
+
+        const identifyInfoState = identifyOptionsSelector(state);
+        expect(identifyInfoState.maxItems).toEqual(10);
+    });
+    it('test maxItems in identifyOptionsSelector if configured with value different that the previously existing in mapConfiguration', () => {
+        const state = { mapInfo: { maxItems: 100, configuration: {maxItems: 15}}};
+
+        const identifyInfoState = identifyOptionsSelector(state);
+        expect(identifyInfoState.maxItems).toEqual(100);
     });
 });

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -102,7 +102,7 @@ export const identifyOptionsSelector = createStructuredSelector({
     map: mapSelector,
     point: clickPointSelector,
     currentLocale: currentLocaleSelector,
-    maxItems: (state) => get(state, "mapInfo.configuration.maxItems")
+    maxItems: (state) => get(state, "mapInfo.maxItems") ?? 10
 });
 
 export const isHighlightEnabledSelector = (state = {}) => state.mapInfo && state.mapInfo.highlight;


### PR DESCRIPTION
[Backport 2025.01.xx] - #11353: fix - preserve cfg maxItems value when loading saved maps (#1…