### PR TITLE
Fix the widget support for the WFS layer with no geom

### DIFF
--- a/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
@@ -28,7 +28,8 @@ import {
     resultQuickFiltersAndDependenciesQF,
     resultQuickFiltersAndDependenciesFilter,
     resultSpatialAndQuickFilters,
-    resultLayerFilter
+    resultLayerFilter,
+    resultFilterForEmptyGeom
 } from '../../../../test-resources/widgets/dependenciesToFiltersData';
 
 describe('widgets dependenciesToFilter enhancer', () => {
@@ -254,6 +255,27 @@ describe('widgets dependenciesToFilter enhancer', () => {
                 }}],
                 viewport: { "bounds": { "minx": "-1", "miny": "-1", "maxx": "1", "maxy": "1" }, "crs": "EPSG:4326", "rotation": 0 }
             }}  />, document.getElementById("container"));
+
+    });
+
+    it('dependenciesToFilter with empty geomProp', (done) => {
+        const Sink = dependenciesToFilter(createSink(props => {
+            expect(props).toExist();
+            expect(props.filter).toBe(resultFilterForEmptyGeom);
+            done();
+        }));
+        ReactDOM.render(<Sink
+            mapSync
+            layer={{
+                name: "test",
+                id: "test"
+            }}
+            dependencies={{
+                layers: [{id: "test", params: {
+                    cql_filter: "prop = 'value'"
+                }}],
+                viewport: { "bounds": { "minx": "-1", "miny": "-1", "maxx": "1", "maxy": "1" }, "crs": "EPSG:4326", "rotation": 0 }
+            }} filter={inputFilterObjSpatial} />, document.getElementById("container"));
 
     });
 });

--- a/web/client/components/widgets/enhancers/dependenciesToFilter.js
+++ b/web/client/components/widgets/enhancers/dependenciesToFilter.js
@@ -37,7 +37,7 @@ const shouldMapOrKeys = ({ mapSync, geomProp, dependencies = {}, layer, quickFil
         || getLayerFilter(layer) !== getLayerFilter(nextProps.layer);
 };
 
-const createFilterProps = ({ mapSync, geomProp = "the_geom", dependencies = {}, filter: filterObj, layer, quickFilters, options } = {}) => {
+const createFilterProps = ({ mapSync, geomProp, dependencies = {}, filter: filterObj, layer, quickFilters, options } = {}) => {
     const viewport = dependencies.viewport;
     const fb = filterBuilder({ gmlVersion: "3.1.1" });
     const toFilter = fromObject(fb);
@@ -80,7 +80,7 @@ const createFilterProps = ({ mapSync, geomProp = "the_geom", dependencies = {}, 
                 ...cqlFilterRules,
                 ...(layerFilter  && !layerFilter.disabled ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : []),
                 ...(newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : []),
-                property(geomProp).intersects(geom)))
+                ...(geomProp ? [property(geomProp).intersects(geom)] : [])))
         };
     }
     // this will contain only an ogc filter based on current and other filters (cql excluded)

--- a/web/client/test-resources/widgets/dependenciesToFiltersData.js
+++ b/web/client/test-resources/widgets/dependenciesToFiltersData.js
@@ -200,3 +200,4 @@ export const resultSpatialFilterMultiple =
     + "</ogc:Or></ogc:And></ogc:Filter>";
 
 export const resultLayerFilter = `<ogc:Filter><ogc:And><ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>STATE_NAME</ogc:PropertyName><ogc:Literal>Arizona</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Or></ogc:And></ogc:Filter>`;
+export const resultFilterForEmptyGeom = `<ogc:Filter><ogc:And><ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo><ogc:Intersects><ogc:PropertyName>geometry</ogc:PropertyName><gml:Polygon srsName="EPSG:4326"><gml:exterior><gml:LinearRing><gml:posList>1 1 1 2 2 2 2 1 1 1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogc:Intersects></ogc:And></ogc:Filter>`


### PR DESCRIPTION
## Description
https://github.com/geosolutions-it/MapStore2/pull/11377
Continuing from this PR. This PR adds the support of the widget for the WFS layer with no geom.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
As there is no geometry in the WFS layer when the widget is added to the map, it tries to filter the data, but due to not having the geometry field, the error message is displayed.

Fixes https://github.com/geosolutions-it/MapStore2/issues/11376

**What is the new behavior?**
This PR adds the support to create the chart with other fields even when there is no geometry for the WFS layer.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information