### PR TITLE
#11395: Fix TOC group is not restored in correct position when it has no direct child layer

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -467,6 +467,38 @@ export const normalizeMap = (rawMap = {}) =>
  * @return function that filter by group
  */
 export const belongsToGroup = (gid) => l => (l.group || DEFAULT_GROUP_ID) === gid || (l.group || "").indexOf(`${gid}.`) === 0;
+
+/**
+ * Retrieves the store index of a group from a list of map layers.
+ *
+ * @param {Object} cur - The current group object whose store index is being searched.
+ * @param {Array} mapLayers - An array of layer objects, each containing a `group` and `storeIndex` property.
+ * @returns {number} - The store index of the group if found, otherwise `-1`.
+ */
+const getGroupStoreIndex = (cur, mapLayers) => {
+    // Create a map for quick lookup of group to storeIndex
+    const groupMap = new Map(mapLayers.map(el => [el.group, el.storeIndex]));
+    // Check direct match
+    if (groupMap.has(cur.id)) {
+        return groupMap.get(cur.id);
+    }
+    // Checks if a layer belongs to the descendants of the current group.
+    // If yes, return the storeIndex of the first matching layer as the storeIndex for the current group.
+    // Ensures that groups without direct child layers are assigned a storeIndex
+    // preventing them from always being placed at the end of the TOC.
+    for (const el of mapLayers) {
+        const groupParts = el.group.split('.');
+        for (let i = groupParts.length - 1; i > 0; i--) {
+            const parentGroup = groupParts.slice(0, i).join('.');
+            if (parentGroup === cur.id) {
+                return el.storeIndex;
+            }
+        }
+    }
+    // Return -1 if no match is found
+    return -1;
+};
+
 export const getLayersByGroup = (configLayers, configGroups) => {
     let i = 0;
     let mapLayers = configLayers.map((layer) => assign({}, layer, {storeIndex: i++}));
@@ -488,7 +520,7 @@ export const getLayersByGroup = (configLayers, configGroups) => {
                 group.nodes = getLayersId(groupId, mapLayers).concat(group.nodes)
                     .reduce((arr, cur) => {
                         isObject(cur)
-                            ? arr.push({node: cur, order: mapLayers.find((el) => el.group === cur.id)?.storeIndex})
+                            ? arr.push({node: cur, order: getGroupStoreIndex(cur, mapLayers)})
                             : arr.push({node: cur, order: mapLayers.find((el) => el.id === cur)?.storeIndex});
                         return arr;
                     }, []).sort((a, b) => b.order - a.order).map(e => e.node);

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -255,6 +255,87 @@ describe('LayersUtils', () => {
         ]);
     });
 
+    it('getLayersByGroup should return correctly ordered groups even without direct child layers', () => {
+        // Group Default.root.test does not have direct child layers, but it has child groups
+        const groups = [
+            {id: 'Default'},
+            {id: 'Default.root.test.childGroup001'},
+            {id: 'Default.root.test.childGroup002'},
+            {id: 'Default.root.test'},
+            {id: 'Default.root.custom'},
+            {id: 'Default.root'}
+        ];
+        const layers = [
+            {id: 'layer007', group: 'Default.root'},
+            {id: 'layer006', group: 'Default.root'},
+            {id: 'layer005', group: 'Default.root.custom'},
+            {id: 'layer004', group: 'Default.root.test.childGroup002'},
+            {id: 'layer003', group: 'Default.root.test.childGroup001'},
+            {id: 'layer002', group: 'Default.root'},
+            {id: 'layer001', group: 'Default.root'}
+        ];
+
+        const result = LayersUtils.getLayersByGroup(layers, groups);
+        const expectedGroups = [
+            {
+                "expanded": true,
+                "id": "Default",
+                "name": "Default",
+                "nodes": [
+                    {
+                        "expanded": true,
+                        "id": "Default.root",
+                        "name": "root",
+                        "nodes": [
+                            "layer001",
+                            "layer002",
+                            {
+                                "expanded": true,
+                                "id": "Default.root.test",
+                                "name": "test",
+                                "nodes": [
+                                    {
+                                        "expanded": true,
+                                        "id": "Default.root.test.childGroup001",
+                                        "name": "childGroup001",
+                                        "nodes": [
+                                            "layer003"
+                                        ],
+                                        "title": "childGroup001"
+                                    },
+                                    {
+                                        "expanded": true,
+                                        "id": "Default.root.test.childGroup002",
+                                        "name": "childGroup002",
+                                        "nodes": [
+                                            "layer004"
+                                        ],
+                                        "title": "childGroup002"
+                                    }
+                                ],
+                                "title": "test"
+                            },
+                            {
+                                "expanded": true,
+                                "id": "Default.root.custom",
+                                "name": "custom",
+                                "nodes": [
+                                    "layer005"
+                                ],
+                                "title": "custom"
+                            },
+                            "layer006",
+                            "layer007"
+                        ],
+                        "title": "root"
+                    }
+                ],
+                "title": "Default"
+            }
+        ];
+        expect(result).toEqual(expectedGroups);
+    });
+
     it('deep change in nested group', () => {
 
         const nestedGroups = [


### PR DESCRIPTION
Fix TOC groups without direct layers should be restored in correct position

- Fixed an issue where newly created groups without direct child layers, but containing subgroups with layers, were not displayed in the correct position after saving
- Added test cases to cover groups with only subgroups

On behalf of DB Systel GmbH

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11395

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Group without direct child layer is stored in correct position.
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
