### PR TITLE
#11397: Fix TOC layer-settings description disappears when switching between tabs

### DIFF
--- a/web/client/utils/WMSUtils.js
+++ b/web/client/utils/WMSUtils.js
@@ -72,7 +72,7 @@ export const getLayerOptions = function(capabilities) {
     return isObject(capabilities)
         ? {
             capabilities,
-            description: capabilities.Abstract,
+            ...(capabilities.Abstract && capabilities.Abstract !== '' && { description: capabilities.Abstract }),
             boundingBox: capabilities?.EX_GeographicBoundingBox
                 ? {
                     minx: capabilities.EX_GeographicBoundingBox?.westBoundLongitude,

--- a/web/client/utils/__tests__/WMSUtils-test.js
+++ b/web/client/utils/__tests__/WMSUtils-test.js
@@ -43,6 +43,33 @@ describe('Test the WMSUtils', () => {
                 availableStyles: [{ name: 'generic' }]
             });
     });
+    it('test getLayerOptions with empty or no Abstract', () => {
+        expect(getLayerOptions()).toEqual({});
+        const capabilities = {
+            Style: { Name: 'generic' },
+            LatLonBoundingBox: {$: { minx: -180, miny: -90, maxx: 180, maxy: 90 }}
+        };
+
+        const capabilities2 = {
+            Style: { Name: 'generic' },
+            Abstract: '',
+            LatLonBoundingBox: {$: { minx: -180, miny: -90, maxx: 180, maxy: 90 }}
+        };
+        // should not contain description if Abstract is undefined
+        expect(getLayerOptions(capabilities))
+            .toEqual({
+                capabilities,
+                boundingBox: { minx: -180, miny: -90, maxx: 180, maxy: 90 },
+                availableStyles: [{ name: 'generic' }]
+            });
+        // should not contain description if Abstract is empty string
+        expect(getLayerOptions(capabilities2))
+            .toEqual({
+                capabilities: capabilities2,
+                boundingBox: { minx: -180, miny: -90, maxx: 180, maxy: 90 },
+                availableStyles: [{ name: 'generic' }]
+            });
+    });
     it('test getTileGridFromLayerOptions', () => {
         const tileGrids = [
             {


### PR DESCRIPTION
fix(TOC layer-settings): preserve description when switching between tabs

- Fixed an issue where a layer’s description shown in the General tab disappeared after navigating to the Style tab and back
- Prevent overwriting description if capabilities.Abstract is empty or undefined
- Add test to verify description persistence when Abstract is missing

On behalf of DB Systel GmbH

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11397

**What is the new behavior?**
Layer’s description will not disappear after navigating to the Style tab and back

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
