### PR TITLE
Fix : #11400 Added quickFilters also  when exporting data from TableWiget

### DIFF
--- a/web/client/selectors/layerdownload.js
+++ b/web/client/selectors/layerdownload.js
@@ -11,6 +11,7 @@ import { createSelector } from 'reselect';
 import { isFeatureGridOpen } from './featuregrid';
 import { getSelectedLayer } from './layers';
 import { wfsFilter } from './query';
+import { composeFilterObject } from '../components/widgets/enhancers/utils';
 
 import { getTableWidgets } from './widgets';
 
@@ -40,7 +41,12 @@ export const wfsFilterSelector = createSelector(
     ) => {
         const selectedLayer = mapLayer || downloadLayer;
         const widget = tableWidgets.filter(w => w.id === downloadLayer?.widgetId)[0];
-        return featureGridOpen ? wfsFilterObj || widget?.filter : selectedLayer?.name ? widget?.filter || {
+        const options = tableWidgets.filter(w => w.id === downloadLayer?.widgetId)[0]?.options;
+        let updatedFilter = widget?.filter;
+        if (widget?.filter && widget?.quickFilters) {
+            updatedFilter = composeFilterObject(widget.filter, widget.quickFilters, options);
+        }
+        return featureGridOpen ? wfsFilterObj || updatedFilter : selectedLayer?.name ? updatedFilter || {
             featureTypeName: selectedLayer.name,
             filterType: 'OGC',
             ogcVersion: '1.1.0'


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

When exporting the data from the TableWidget , quickFilters are also included

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md



**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [x] Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11400 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

When exporting the data now , both the quick filter and filter configured in the widget is included.

<img width="402" height="455" alt="Screenshot 2025-08-25 at 14 26 27" src="https://github.com/user-attachments/assets/e250cd5f-e4d9-4d83-bd71-6712e38d0444" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
