### PR TITLE
Fix #11406 Pending changes prompt shows up after save as

### DIFF
--- a/web/client/plugins/ResourcesCatalog/SaveAs.jsx
+++ b/web/client/plugins/ResourcesCatalog/SaveAs.jsx
@@ -16,7 +16,7 @@ import Persistence from '../../api/persistence';
 import { setSelectedResource } from './actions/resources';
 import { mapSaveError, mapSaved, mapInfoLoaded, configureMap } from '../../actions/config';
 import { userSelector } from '../../selectors/security';
-import { push } from 'connected-react-router';
+import { replace } from 'connected-react-router';
 import { parseResourceProperties } from '../../utils/GeostoreUtils';
 import { getResourceInfo } from '../../utils/ResourcesUtils';
 import { storySaved, geostoryLoaded, setResource as setGeoStoryResource, setCurrentStory, saveGeoStoryError } from '../../actions/geostory';
@@ -53,7 +53,7 @@ function SaveAs({
     onSuccess,
     onError,
     user,
-    onPush,
+    onReplace,
     onNotification,
     component,
     menuItem
@@ -92,7 +92,7 @@ function SaveAs({
                     setName('');
                     const { viewerPath } = getResourceInfo(resource);
                     if (viewerPath) {
-                        onPush(viewerPath);
+                        onReplace(viewerPath);
                     }
                 })
                 .catch((error) => {
@@ -172,7 +172,7 @@ const saveAsConnect = connect(
     }),
     {
         onNotification: show,
-        onPush: push,
+        onReplace: replace,
         onSelect: setSelectedResource,
         onSuccess: (resourceType, resource, data) => {
             return (dispatch) => {

--- a/web/client/plugins/ResourcesCatalog/containers/PendingStatePrompt.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/PendingStatePrompt.jsx
@@ -45,24 +45,6 @@ function PendingStatePrompt({
         };
     }, []);
 
-    // disable the back button when there are pending changes
-    useEffect(() => {
-        let popState;
-        if (pendingStateProp) {
-            popState = () => {
-                window.history.go(1);
-            };
-            window.history.pushState(null, null, window.location.href);
-            window.addEventListener('popstate', popState);
-        }
-        return () => {
-            if (popState) {
-                window.removeEventListener('popstate', popState);
-                popState = undefined;
-            }
-        };
-    }, [pendingStateProp]);
-
     function handleCancel() {
         setShowModal(false);
     }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The push redirect action after save as has been replaced with a replace action that prevents to display the pending changes prompt. Also the block on the browser navigation button has been removed

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11406

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Pending changes prompt will not show up after creating a new resource

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
