### PR TITLE
Fix #11404 Problem with user permissions still involving the "Save As"

### DIFF
--- a/web/client/plugins/ResourcesCatalog/SaveAs.jsx
+++ b/web/client/plugins/ResourcesCatalog/SaveAs.jsx
@@ -10,14 +10,14 @@ import React, { useState } from 'react';
 import { createPlugin } from "../../utils/PluginsUtils";
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import { isEmpty, omit } from 'lodash';
+import { isEmpty } from 'lodash';
 import { getPendingChanges } from './selectors/save';
 import Persistence from '../../api/persistence';
 import { setSelectedResource } from './actions/resources';
 import { mapSaveError, mapSaved, mapInfoLoaded, configureMap } from '../../actions/config';
 import { userSelector } from '../../selectors/security';
 import { push } from 'connected-react-router';
-import { parseResourceProperties } from '../../utils/GeostoreUtils';
+import { parseResourceProperties, parseClonedResourcePayload } from '../../utils/GeostoreUtils';
 import { getResourceInfo } from '../../utils/ResourcesUtils';
 import { storySaved, geostoryLoaded, setResource as setGeoStoryResource, setCurrentStory, saveGeoStoryError } from '../../actions/geostory';
 import { dashboardSaveError, dashboardSaved, dashboardLoaded } from '../../actions/dashboard';
@@ -25,19 +25,6 @@ import { convertDependenciesMappingForCompatibility } from '../../utils/WidgetsU
 import { show } from '../../actions/notifications';
 import InputControl from './components/InputControl';
 import ConfirmDialog from '../../components/layout/ConfirmDialog';
-
-function parseResourcePayload(resource, { name, resourceType } = {}) {
-    return {
-        ...resource,
-        permission: undefined,
-        category: resourceType,
-        metadata: {
-            ...resource?.metadata,
-            name,
-            attributes: omit(resource?.metadata?.attributes || {}, ['thumbnail', 'details'])
-        }
-    };
-}
 
 /**
  * Plugin to create/clone a resource. Saves the new resource using the persistence API.
@@ -73,7 +60,7 @@ function SaveAs({
             const api = Persistence.getApi();
             const contextId = saveResource?.metadata?.attributes?.context;
             Promise.all([
-                api.createResource(parseResourcePayload(saveResource, { name, resourceType })).toPromise()
+                api.createResource(parseClonedResourcePayload(saveResource, { name, resourceType })).toPromise()
                     .then((resourceId) => api.getResource(resourceId, { includeAttributes: true, withData: false }).toPromise()),
                 contextId !== undefined
                     ? api.getResource(contextId, { withData: false }).toPromise()

--- a/web/client/utils/GeostoreUtils.js
+++ b/web/client/utils/GeostoreUtils.js
@@ -271,3 +271,23 @@ export const parseResourceProperties = (resource, context) => {
         }
     };
 };
+/**
+ * Prepare a cloned resource replacing and removing attributes and properties
+ * @param {object} resource Resource properties.
+ * @param {object} overrides additional properties
+ * @param {string} overrides.name resource name
+ * @param {string} overrides.resourceType resource type
+ * @return {object} parsed cloned resource
+ */
+export function parseClonedResourcePayload(resource, { name, resourceType } = {}) {
+    return {
+        ...resource,
+        permission: undefined,
+        category: resourceType,
+        metadata: {
+            ...resource?.metadata,
+            name,
+            attributes: omit(resource?.metadata?.attributes || {}, ['thumbnail', 'details', 'owner'])
+        }
+    };
+}

--- a/web/client/utils/__tests__/GeostoreUtils-test.js
+++ b/web/client/utils/__tests__/GeostoreUtils-test.js
@@ -13,206 +13,233 @@ import {
     computePendingChanges,
     parseResourceProperties,
     THUMBNAIL_DATA_KEY,
-    DETAILS_DATA_KEY
+    DETAILS_DATA_KEY,
+    parseClonedResourcePayload
 } from '../GeostoreUtils';
 import expect from 'expect';
 
 describe('GeostoreUtils', () => {
-    describe('test geostore resource', () => {
-        it('parseNODATA', () => {
-            expect(parseNODATA('NODATA')).toBe('');
-            expect(parseNODATA('/resource/1')).toBe('/resource/1');
+    it('parseNODATA', () => {
+        expect(parseNODATA('NODATA')).toBe('');
+        expect(parseNODATA('/resource/1')).toBe('/resource/1');
+    });
+    it('getGeostoreResourceTypesInfo', () => {
+        expect(getGeostoreResourceTypesInfo({
+            id: '1',
+            name: 'Map',
+            category: {
+                name: 'MAP'
+            },
+            attributes: {
+                thumbnail: '/thumb/2'
+            }
+        })).toEqual({ title: 'Map', icon: { glyph: '1-map' }, thumbnailUrl: '/thumb/2', viewerPath: '/viewer/1', viewerUrl: '#/viewer/1' });
+        expect(getGeostoreResourceTypesInfo({
+            id: '1',
+            name: 'Map',
+            category: {
+                name: 'MAP'
+            },
+            attributes: {
+                thumbnail: 'NODATA'
+            }
+        })).toEqual({ title: 'Map', icon: { glyph: '1-map' }, thumbnailUrl: '', viewerPath: '/viewer/1', viewerUrl: '#/viewer/1' });
+        expect(getGeostoreResourceTypesInfo({
+            id: '1',
+            name: 'Map',
+            category: {
+                name: 'MAP'
+            },
+            attributes: {
+                thumbnail: '/thumb/2'
+            },
+            '@extras': {}
+        }, {
+            name: 'context'
+        })).toEqual({ title: 'Map', icon: { glyph: '1-map' }, thumbnailUrl: '/thumb/2', viewerPath: '/context/context/1', viewerUrl: '#/context/context/1' });
+
+        expect(getGeostoreResourceTypesInfo({
+            id: '1',
+            name: 'Dashboard',
+            category: {
+                name: 'DASHBOARD'
+            },
+            attributes: {
+                thumbnail: '/thumb/2'
+            }
+        })).toEqual({ title: 'Dashboard', icon: { glyph: 'dashboard' }, thumbnailUrl: '/thumb/2', viewerPath: '/dashboard/1', viewerUrl: '#/dashboard/1' });
+
+        expect(getGeostoreResourceTypesInfo({
+            id: '1',
+            name: 'GeoStory',
+            category: {
+                name: 'GEOSTORY'
+            },
+            attributes: {
+                thumbnail: '/thumb/2'
+            }
+        })).toEqual({ title: 'GeoStory', icon: { glyph: 'geostory' }, thumbnailUrl: '/thumb/2', viewerPath: '/geostory/1', viewerUrl: '#/geostory/1' });
+        expect(getGeostoreResourceTypesInfo({
+            id: '1',
+            name: 'custom',
+            category: {
+                name: 'CONTEXT'
+            },
+            attributes: {
+                thumbnail: '/thumb/2'
+            }
+        })).toEqual({ title: 'custom', icon: { glyph: 'context' }, thumbnailUrl: '/thumb/2', viewerPath: '/context/custom', viewerUrl: '#/context/custom' });
+    });
+    it('getGeostoreResourceStatus', () => {
+        expect(getGeostoreResourceStatus()).toEqual({ items: [] });
+        expect(getGeostoreResourceStatus({
+            advertised: false
+        })).toEqual({ items: [{ type: 'icon', tooltipId: 'resourcesCatalog.unadvertised', glyph: 'eye-close' }] });
+        expect(getGeostoreResourceStatus({}, {
+            name: 'Context'
+        })).toEqual({ items: [{ type: 'icon', glyph: 'context', tooltipId: 'resourcesCatalog.mapUsesContext', tooltipParams: { contextName: 'Context' } }] });
+    });
+    it('computePendingChanges', () => {
+        expect(computePendingChanges({ id: 1, name: 'Title', category: { name: 'MAP' } }, { id: 1, name: 'Title', category: { name: 'MAP' } })).toEqual(
+            {
+                initialResource: { id: 1, name: 'Title', category: { name: 'MAP' } },
+                resource: { id: 1, name: 'Title', category: { name: 'MAP' } },
+                saveResource: { id: 1, permission: undefined, category: 'MAP', metadata: { id: 1, name: 'Title', attributes: {} } },
+                changes: {}
+            }
+        );
+
+        expect(computePendingChanges({ id: 1, name: 'Title', category: { name: 'MAP' } }, { id: 1, name: 'New Title', category: { name: 'MAP' } })).toEqual(
+            {
+                initialResource: { id: 1, name: 'Title', category: { name: 'MAP' } },
+                resource: { id: 1, name: 'New Title', category: { name: 'MAP' } },
+                saveResource: { id: 1, permission: undefined, category: 'MAP', metadata: { id: 1, name: 'New Title', attributes: {} } },
+                changes: {
+                    name: 'New Title'
+                }
+            }
+        );
+
+        expect(computePendingChanges({ id: 1, name: 'Title', category: { name: 'MAP' } }, { id: 1, name: 'Title', category: { name: 'MAP' } }, { pending: true, payload: { map: {} } })).toEqual(
+            {
+                initialResource: { id: 1, name: 'Title', category: { name: 'MAP' } },
+                resource: { id: 1, name: 'Title', category: { name: 'MAP' } },
+                saveResource: { id: 1, permission: undefined, category: 'MAP', metadata: { id: 1, name: 'Title', attributes: {} }, data: { map: {} } },
+                changes: { data: true }
+            }
+        );
+    });
+    it('computePendingChanges with details', () => {
+        let computedChanges = computePendingChanges(
+            { id: 1, name: 'Title', attributes: { details: '/details'  }, category: { name: 'MAP' } },
+            { id: 1, name: 'Title', attributes: { [DETAILS_DATA_KEY]: '' }, category: { name: 'MAP' } });
+        expect(computedChanges.initialResource).toEqual({ id: 1, name: 'Title', attributes: { details: '/details' }, category: { name: 'MAP' } });
+        expect(computedChanges.resource).toEqual({ id: 1, name: 'Title', attributes: { [DETAILS_DATA_KEY]: '' }, category: { name: 'MAP' } });
+        expect(computedChanges.saveResource).toEqual({
+            id: 1,
+            permission: undefined,
+            category: 'MAP',
+            metadata: { id: 1, name: 'Title', attributes: { details: '/details' } },
+            linkedResources: { details: { category: 'DETAILS', value: '/details', data: 'NODATA' } }
         });
-        it('getGeostoreResourceTypesInfo', () => {
-            expect(getGeostoreResourceTypesInfo({
-                id: '1',
-                name: 'Map',
-                category: {
-                    name: 'MAP'
-                },
+        expect(computedChanges.changes).toEqual({ linkedResources: { details: { category: 'DETAILS', value: '/details', data: 'NODATA' } } });
+
+        computedChanges = computePendingChanges(
+            { id: 1, name: 'Title', attributes: {  }, category: { name: 'MAP' } },
+            { id: 1, name: 'Title', attributes: { [DETAILS_DATA_KEY]: '/details' }, category: { name: 'MAP' } });
+        expect(computedChanges.initialResource).toEqual({ id: 1, name: 'Title', attributes: { }, category: { name: 'MAP' } });
+        expect(computedChanges.resource).toEqual({ id: 1, name: 'Title', attributes: { [DETAILS_DATA_KEY]: '/details' }, category: { name: 'MAP' } });
+        expect(computedChanges.saveResource).toEqual({
+            id: 1,
+            permission: undefined,
+            category: 'MAP',
+            metadata: { id: 1, name: 'Title', attributes: {} },
+            linkedResources: { details: { category: 'DETAILS', value: 'NODATA', data: '/details' } }
+        });
+        expect(computedChanges.changes).toEqual({ linkedResources: { details: { category: 'DETAILS', value: 'NODATA', data: '/details' } } });
+    });
+    it('computePendingChanges with thumbnail', () => {
+        let computedChanges = computePendingChanges(
+            { id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } },
+            { id: 1, name: 'Title', attributes: { [THUMBNAIL_DATA_KEY]: '' }, category: { name: 'MAP' } });
+        expect(computedChanges.initialResource).toEqual({ id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } });
+        expect(computedChanges.resource).toEqual({ id: 1, name: 'Title', attributes: { [THUMBNAIL_DATA_KEY]: '' }, category: { name: 'MAP' } });
+        expect(computedChanges.changes.linkedResources.thumbnail.value).toBe('/thumb');
+        expect(computedChanges.changes.linkedResources.thumbnail.data).toBe('NODATA');
+
+        computedChanges = computePendingChanges(
+            { id: 1, name: 'Title', attributes: {}, category: { name: 'MAP' } },
+            { id: 1, name: 'Title', attributes: { [THUMBNAIL_DATA_KEY]: '/thumb' }, category: { name: 'MAP' } });
+        expect(computedChanges.initialResource).toEqual({ id: 1, name: 'Title', attributes: { }, category: { name: 'MAP' } });
+        expect(computedChanges.resource).toEqual({ id: 1, name: 'Title', attributes: { [THUMBNAIL_DATA_KEY]: '/thumb' }, category: { name: 'MAP' } });
+        expect(computedChanges.changes.linkedResources.thumbnail.value).toBe('NODATA');
+        expect(computedChanges.changes.linkedResources.thumbnail.data).toBe('/thumb');
+        const tailsParts = computedChanges.changes.linkedResources.thumbnail.tail.split('&');
+        expect(tailsParts[0]).toBe('/raw?decode=datauri');
+        expect(tailsParts[1].includes('v=')).toBe(true);
+    });
+    it('computePendingChanges with tags', () => {
+        const computed = computePendingChanges(
+            { id: 1, name: 'Title', category: { name: 'MAP' }, tags: [{ id: '01' }, { id: '02' }] },
+            { id: 1, name: 'Title', category: { name: 'MAP' }, tags: [{ id: '02' }, { id: '03' }] }
+        );
+        expect(computed.saveResource.tags).toEqual(computed.changes.tags);
+        expect(computed.saveResource.tags).toEqual([
+            { tag: { id: '01' }, action: 'unlink' },
+            { tag: { id: '03' }, action: 'link' }
+        ]);
+    });
+
+    it('computePendingChanges with empty attributes in initial resource', () => {
+        const computed = computePendingChanges(
+            { },
+            { attributes: { featured: true } }
+        );
+        expect(computed.changes).toEqual({ attributes: { featured: true } });
+    });
+
+    it('should parse the detailsSettings of resource', () => {
+        let resource = parseResourceProperties({ attributes: { detailsSettings: "{\"showAsModal\":false,\"showAtStartup\":false}" } });
+        expect(resource?.attributes?.detailsSettings).toEqual({ showAsModal: false, showAtStartup: false });
+        resource = parseResourceProperties(resource);
+        expect(resource?.attributes?.detailsSettings).toEqual({ showAsModal: false, showAtStartup: false });
+    });
+    it('should parse the extras of resource', () => {
+        let resource = parseResourceProperties({ id: "1", "@extras": {name: "test"}, category: { name: "MAP" } });
+        expect(resource?.["@extras"]).toBeTruthy();
+        expect(resource?.["@extras"].name).toEqual("test");
+        expect(resource?.["@extras"].info.icon.glyph).toEqual("1-map");
+        expect(resource?.["@extras"].info.icon.glyph).toEqual("1-map");
+        expect(resource?.["@extras"].info.viewerUrl).toEqual("#/viewer/1");
+        resource = parseResourceProperties({ id: "1", "@extras": {name: "test"}, category: { name: "MAP" } }, {name: "context-name"});
+        expect(resource?.["@extras"].info.viewerUrl).toEqual("#/context/context-name/1");
+    });
+    it('parseClonedResourcePayload', () => {
+        const resource = {
+            id: 1,
+            permission: [],
+            metadata: {
+                name: 'Old title',
+                description: 'Description',
                 attributes: {
-                    thumbnail: '/thumb/2'
+                    featured: true,
+                    thumbnail: '/path',
+                    details: '/path',
+                    owner: 'admin'
                 }
-            })).toEqual({ title: 'Map', icon: { glyph: '1-map' }, thumbnailUrl: '/thumb/2', viewerPath: '/viewer/1', viewerUrl: '#/viewer/1' });
-            expect(getGeostoreResourceTypesInfo({
-                id: '1',
-                name: 'Map',
-                category: {
-                    name: 'MAP'
-                },
+            }
+        };
+        expect(parseClonedResourcePayload(resource, { name: 'New title', resourceType: 'MAP' })).toEqual({
+            id: 1,
+            permission: undefined,
+            category: 'MAP',
+            metadata: {
+                name: 'New title',
+                description: 'Description',
                 attributes: {
-                    thumbnail: 'NODATA'
+                    featured: true
                 }
-            })).toEqual({ title: 'Map', icon: { glyph: '1-map' }, thumbnailUrl: '', viewerPath: '/viewer/1', viewerUrl: '#/viewer/1' });
-            expect(getGeostoreResourceTypesInfo({
-                id: '1',
-                name: 'Map',
-                category: {
-                    name: 'MAP'
-                },
-                attributes: {
-                    thumbnail: '/thumb/2'
-                },
-                '@extras': {}
-            }, {
-                name: 'context'
-            })).toEqual({ title: 'Map', icon: { glyph: '1-map' }, thumbnailUrl: '/thumb/2', viewerPath: '/context/context/1', viewerUrl: '#/context/context/1' });
-
-            expect(getGeostoreResourceTypesInfo({
-                id: '1',
-                name: 'Dashboard',
-                category: {
-                    name: 'DASHBOARD'
-                },
-                attributes: {
-                    thumbnail: '/thumb/2'
-                }
-            })).toEqual({ title: 'Dashboard', icon: { glyph: 'dashboard' }, thumbnailUrl: '/thumb/2', viewerPath: '/dashboard/1', viewerUrl: '#/dashboard/1' });
-
-            expect(getGeostoreResourceTypesInfo({
-                id: '1',
-                name: 'GeoStory',
-                category: {
-                    name: 'GEOSTORY'
-                },
-                attributes: {
-                    thumbnail: '/thumb/2'
-                }
-            })).toEqual({ title: 'GeoStory', icon: { glyph: 'geostory' }, thumbnailUrl: '/thumb/2', viewerPath: '/geostory/1', viewerUrl: '#/geostory/1' });
-            expect(getGeostoreResourceTypesInfo({
-                id: '1',
-                name: 'custom',
-                category: {
-                    name: 'CONTEXT'
-                },
-                attributes: {
-                    thumbnail: '/thumb/2'
-                }
-            })).toEqual({ title: 'custom', icon: { glyph: 'context' }, thumbnailUrl: '/thumb/2', viewerPath: '/context/custom', viewerUrl: '#/context/custom' });
-        });
-        it('getGeostoreResourceStatus', () => {
-            expect(getGeostoreResourceStatus()).toEqual({ items: [] });
-            expect(getGeostoreResourceStatus({
-                advertised: false
-            })).toEqual({ items: [{ type: 'icon', tooltipId: 'resourcesCatalog.unadvertised', glyph: 'eye-close' }] });
-            expect(getGeostoreResourceStatus({}, {
-                name: 'Context'
-            })).toEqual({ items: [{ type: 'icon', glyph: 'context', tooltipId: 'resourcesCatalog.mapUsesContext', tooltipParams: { contextName: 'Context' } }] });
-        });
-        it('computePendingChanges', () => {
-            expect(computePendingChanges({ id: 1, name: 'Title', category: { name: 'MAP' } }, { id: 1, name: 'Title', category: { name: 'MAP' } })).toEqual(
-                {
-                    initialResource: { id: 1, name: 'Title', category: { name: 'MAP' } },
-                    resource: { id: 1, name: 'Title', category: { name: 'MAP' } },
-                    saveResource: { id: 1, permission: undefined, category: 'MAP', metadata: { id: 1, name: 'Title', attributes: {} } },
-                    changes: {}
-                }
-            );
-
-            expect(computePendingChanges({ id: 1, name: 'Title', category: { name: 'MAP' } }, { id: 1, name: 'New Title', category: { name: 'MAP' } })).toEqual(
-                {
-                    initialResource: { id: 1, name: 'Title', category: { name: 'MAP' } },
-                    resource: { id: 1, name: 'New Title', category: { name: 'MAP' } },
-                    saveResource: { id: 1, permission: undefined, category: 'MAP', metadata: { id: 1, name: 'New Title', attributes: {} } },
-                    changes: {
-                        name: 'New Title'
-                    }
-                }
-            );
-
-            expect(computePendingChanges({ id: 1, name: 'Title', category: { name: 'MAP' } }, { id: 1, name: 'Title', category: { name: 'MAP' } }, { pending: true, payload: { map: {} } })).toEqual(
-                {
-                    initialResource: { id: 1, name: 'Title', category: { name: 'MAP' } },
-                    resource: { id: 1, name: 'Title', category: { name: 'MAP' } },
-                    saveResource: { id: 1, permission: undefined, category: 'MAP', metadata: { id: 1, name: 'Title', attributes: {} }, data: { map: {} } },
-                    changes: { data: true }
-                }
-            );
-        });
-        it('computePendingChanges with details', () => {
-            let computedChanges = computePendingChanges(
-                { id: 1, name: 'Title', attributes: { details: '/details'  }, category: { name: 'MAP' } },
-                { id: 1, name: 'Title', attributes: { [DETAILS_DATA_KEY]: '' }, category: { name: 'MAP' } });
-            expect(computedChanges.initialResource).toEqual({ id: 1, name: 'Title', attributes: { details: '/details' }, category: { name: 'MAP' } });
-            expect(computedChanges.resource).toEqual({ id: 1, name: 'Title', attributes: { [DETAILS_DATA_KEY]: '' }, category: { name: 'MAP' } });
-            expect(computedChanges.saveResource).toEqual({
-                id: 1,
-                permission: undefined,
-                category: 'MAP',
-                metadata: { id: 1, name: 'Title', attributes: { details: '/details' } },
-                linkedResources: { details: { category: 'DETAILS', value: '/details', data: 'NODATA' } }
-            });
-            expect(computedChanges.changes).toEqual({ linkedResources: { details: { category: 'DETAILS', value: '/details', data: 'NODATA' } } });
-
-            computedChanges = computePendingChanges(
-                { id: 1, name: 'Title', attributes: {  }, category: { name: 'MAP' } },
-                { id: 1, name: 'Title', attributes: { [DETAILS_DATA_KEY]: '/details' }, category: { name: 'MAP' } });
-            expect(computedChanges.initialResource).toEqual({ id: 1, name: 'Title', attributes: { }, category: { name: 'MAP' } });
-            expect(computedChanges.resource).toEqual({ id: 1, name: 'Title', attributes: { [DETAILS_DATA_KEY]: '/details' }, category: { name: 'MAP' } });
-            expect(computedChanges.saveResource).toEqual({
-                id: 1,
-                permission: undefined,
-                category: 'MAP',
-                metadata: { id: 1, name: 'Title', attributes: {} },
-                linkedResources: { details: { category: 'DETAILS', value: 'NODATA', data: '/details' } }
-            });
-            expect(computedChanges.changes).toEqual({ linkedResources: { details: { category: 'DETAILS', value: 'NODATA', data: '/details' } } });
-        });
-        it('computePendingChanges with thumbnail', () => {
-            let computedChanges = computePendingChanges(
-                { id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } },
-                { id: 1, name: 'Title', attributes: { [THUMBNAIL_DATA_KEY]: '' }, category: { name: 'MAP' } });
-            expect(computedChanges.initialResource).toEqual({ id: 1, name: 'Title', attributes: { thumbnail: '/thumb' }, category: { name: 'MAP' } });
-            expect(computedChanges.resource).toEqual({ id: 1, name: 'Title', attributes: { [THUMBNAIL_DATA_KEY]: '' }, category: { name: 'MAP' } });
-            expect(computedChanges.changes.linkedResources.thumbnail.value).toBe('/thumb');
-            expect(computedChanges.changes.linkedResources.thumbnail.data).toBe('NODATA');
-
-            computedChanges = computePendingChanges(
-                { id: 1, name: 'Title', attributes: {}, category: { name: 'MAP' } },
-                { id: 1, name: 'Title', attributes: { [THUMBNAIL_DATA_KEY]: '/thumb' }, category: { name: 'MAP' } });
-            expect(computedChanges.initialResource).toEqual({ id: 1, name: 'Title', attributes: { }, category: { name: 'MAP' } });
-            expect(computedChanges.resource).toEqual({ id: 1, name: 'Title', attributes: { [THUMBNAIL_DATA_KEY]: '/thumb' }, category: { name: 'MAP' } });
-            expect(computedChanges.changes.linkedResources.thumbnail.value).toBe('NODATA');
-            expect(computedChanges.changes.linkedResources.thumbnail.data).toBe('/thumb');
-            const tailsParts = computedChanges.changes.linkedResources.thumbnail.tail.split('&');
-            expect(tailsParts[0]).toBe('/raw?decode=datauri');
-            expect(tailsParts[1].includes('v=')).toBe(true);
-        });
-        it('computePendingChanges with tags', () => {
-            const computed = computePendingChanges(
-                { id: 1, name: 'Title', category: { name: 'MAP' }, tags: [{ id: '01' }, { id: '02' }] },
-                { id: 1, name: 'Title', category: { name: 'MAP' }, tags: [{ id: '02' }, { id: '03' }] }
-            );
-            expect(computed.saveResource.tags).toEqual(computed.changes.tags);
-            expect(computed.saveResource.tags).toEqual([
-                { tag: { id: '01' }, action: 'unlink' },
-                { tag: { id: '03' }, action: 'link' }
-            ]);
-        });
-
-        it('computePendingChanges with empty attributes in initial resource', () => {
-            const computed = computePendingChanges(
-                { },
-                { attributes: { featured: true } }
-            );
-            expect(computed.changes).toEqual({ attributes: { featured: true } });
-        });
-
-        it('should parse the detailsSettings of resource', () => {
-            let resource = parseResourceProperties({ attributes: { detailsSettings: "{\"showAsModal\":false,\"showAtStartup\":false}" } });
-            expect(resource?.attributes?.detailsSettings).toEqual({ showAsModal: false, showAtStartup: false });
-            resource = parseResourceProperties(resource);
-            expect(resource?.attributes?.detailsSettings).toEqual({ showAsModal: false, showAtStartup: false });
-        });
-        it('should parse the extras of resource', () => {
-            let resource = parseResourceProperties({ id: "1", "@extras": {name: "test"}, category: { name: "MAP" } });
-            expect(resource?.["@extras"]).toBeTruthy();
-            expect(resource?.["@extras"].name).toEqual("test");
-            expect(resource?.["@extras"].info.icon.glyph).toEqual("1-map");
-            expect(resource?.["@extras"].info.icon.glyph).toEqual("1-map");
-            expect(resource?.["@extras"].info.viewerUrl).toEqual("#/viewer/1");
-            resource = parseResourceProperties({ id: "1", "@extras": {name: "test"}, category: { name: "MAP" } }, {name: "context-name"});
-            expect(resource?.["@extras"].info.viewerUrl).toEqual("#/context/context-name/1");
+            }
         });
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds logic to exclude the `owner` attribute while saving a resource.
Permission requests are failing if the `owner` attribute is different from the current editing user (see related issue #4634)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11404

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Removed the `owner` attribute from cloned resources

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
