### PR TITLE
fix maven-war-plugin.version in root pom.xml

### DIFF
--- a/project/standard/templates/pom.xml
+++ b/project/standard/templates/pom.xml
@@ -14,6 +14,7 @@
         <tomcat.port>8080</tomcat.port>
         <tomcat.version>9.0.105</tomcat.version>
         <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
+        <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
         <!-- Spring Framework & Security (aligned) -->
         <spring.security.version>5.7.13</spring.security.version>
         <spring.version>5.3.39</spring.version>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -353,7 +353,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
-            <version>3.4.0</version>
+            <version>${maven-war-plugin.version}</version>
             <configuration>
                 <packagingExcludes>
                     WEB-INF/lib/*spring*5.3.18*.jar,


### PR DESCRIPTION
## Description
moved maven-war-plugin.version define in root pom.xml and referred in web/pom.xml
reported in review: https://github.com/geosolutions-it/MapStore2-C305/pull/6#discussion_r2301090839

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
