### PR TITLE
[Backport 2025.01.xx]: Fix : #11400 Added quickFilters also  when exporting data from TablWidget (#11401)

### DIFF
--- a/web/client/selectors/__tests__/layerdownload-test.js
+++ b/web/client/selectors/__tests__/layerdownload-test.js
@@ -13,6 +13,7 @@ import {
     wfsFilterSelector
 } from '../layerdownload';
 
+
 describe('Test layers selectors', () => {
     it('test downloadLayerSelector', () => {
         let layer = downloadLayerSelector({layerdownload: {downloadLayer: {id: "ws:layer_1"}}});
@@ -59,6 +60,36 @@ describe('Test layers selectors', () => {
                 filterType: 'OGC',
                 ogcVersion: '1.1.0'
             });
+        });
+        it('featureGridOpen false, quickFilter added along with default filterObj', () => {
+            let filter = {
+                featureTypeName: "name",
+                filterType: 'OGC',
+                ogcVersion: '1.1.0',
+                filterFields: []
+            };
+            let quickFilters = {
+                "states": {
+                    attribute: "states",
+                    operator: "ilike",
+                    rawValue: "a",
+                    type: "string",
+                    value: "a"
+                }
+            };
+            let options = {
+                propertyName: ["states"]
+            };
+            let result = wfsFilterSelector({
+                featuregrid: {open: false},
+                layerdownload: {downloadLayer: {widgetId: "id", name: "name"}},
+                widgets: {containers: {floating: {widgets: [{id: "id", widgetType: "table", quickFilters, filter, options}]}}}
+            });
+            expect(result).toExist();
+            expect(result.filterFields.length).toBe(1);
+            expect(result.filterFields[0].value).toBe('a');
+            expect(result.filterFields[0].operator).toBe('ilike');
+            expect(result.filterFields[0].attribute).toBe('states');
         });
     });
 

--- a/web/client/selectors/layerdownload.js
+++ b/web/client/selectors/layerdownload.js
@@ -11,6 +11,7 @@ import { createSelector } from 'reselect';
 import { isFeatureGridOpen } from './featuregrid';
 import { getSelectedLayer } from './layers';
 import { wfsFilter } from './query';
+import { composeFilterObject } from '../components/widgets/enhancers/utils';
 
 import { getTableWidgets } from './widgets';
 
@@ -40,7 +41,12 @@ export const wfsFilterSelector = createSelector(
     ) => {
         const selectedLayer = mapLayer || downloadLayer;
         const widget = tableWidgets.filter(w => w.id === downloadLayer?.widgetId)[0];
-        return featureGridOpen ? wfsFilterObj || widget?.filter : selectedLayer?.name ? widget?.filter || {
+        const options = tableWidgets.filter(w => w.id === downloadLayer?.widgetId)[0]?.options;
+        let updatedFilter = widget?.filter;
+        if (widget?.filter && widget?.quickFilters) {
+            updatedFilter = composeFilterObject(widget.filter, widget.quickFilters, options);
+        }
+        return featureGridOpen ? wfsFilterObj || updatedFilter : selectedLayer?.name ? updatedFilter || {
             featureTypeName: selectedLayer.name,
             filterType: 'OGC',
             ogcVersion: '1.1.0'


### PR DESCRIPTION


* Fix : #11400 Added quickFilters also  when exporting data from TableWiget.

* Added unit test for quick filter when exporting the layer data

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11400 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Allow exporting including Header filter

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
