### PR TITLE
Update the style of the square buttons and add border radius in all buttons, inputs, selectors

### DIFF
--- a/web/client/components/I18N/LangBar.jsx
+++ b/web/client/components/I18N/LangBar.jsx
@@ -42,7 +42,7 @@ class LangBar extends React.Component {
                     pullRight
                     noCaret
                     id={this.props.id}
-                    className="square-button-md _border-transparent"
+                    className="square-button _border-transparent"
                     title={
                         <FlagButton
                             componentAsButton={false}

--- a/web/client/components/TOC/TOCItemsSettings.jsx
+++ b/web/client/components/TOC/TOCItemsSettings.jsx
@@ -89,7 +89,7 @@ const TOCItemSettings = (props) => {
                             {ToolbarComponent ?
                                 <ToolbarComponent buttons={toolbarButtons}/>
                                 : <Toolbar
-                                    btnDefaultProps={{ bsStyle: 'primary', className: 'square-button-md' }}
+                                    btnDefaultProps={{ bsStyle: 'primary', className: 'square-button' }}
                                     buttons={toolbarButtons}/>}
                         </Col>
                     </Row>,

--- a/web/client/components/TOC/fragments/LayerFields/Fields.jsx
+++ b/web/client/components/TOC/fragments/LayerFields/Fields.jsx
@@ -40,7 +40,7 @@ const Fields = ({fields = [], onLoadFields = () => {}, onChange = () => {}, onCl
         className="layer-fields"
         header={<div key="row-header" className="layer-fields-header">
             <div key="row-toolbar" className="layer-fields-toolbar">
-                <Toolbar key="toolbar" btnDefaultProps={{ className: 'square-button-md', bsStyle: 'primary', disabled: loading }}
+                <Toolbar key="toolbar" btnDefaultProps={{ className: 'square-button', bsStyle: 'primary', disabled: loading }}
                     buttons={[{
                         glyph: 'refresh',
                         disabled: loading,
@@ -53,7 +53,7 @@ const Fields = ({fields = [], onLoadFields = () => {}, onChange = () => {}, onCl
                             disabled={loading}
                             bsStyle="primary"
                             confirmContent={<Message msgId="layerProperties.fields.clearCustomizationConfirm"/>}
-                            className="square-button-md"
+                            className="square-button"
                             onClick={() => onClear()}>
                             <Glyphicon
                                 glyph="clear-brush" />

--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -173,7 +173,7 @@ export default class extends React.Component {
                                 <Button
                                     disabled={!!this.state.formatLoading}
                                     tooltipId="layerProperties.format.refresh"
-                                    className="square-button-md no-border format-refresh"
+                                    className="square-button no-border format-refresh"
                                     onClick={() => {this.onFormatOptionsFetch(this.props.element?.url);}}
                                     key="format-refresh">
                                     <Glyphicon glyph="refresh" />

--- a/web/client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx
+++ b/web/client/components/TOC/fragments/settings/VisibilityLimitsForm.jsx
@@ -260,7 +260,7 @@ function VisibilityLimitsForm({
                 <div style={{ flex: 1 }}>{title}</div>
                 <Toolbar
                     btnDefaultProps={{
-                        className: 'square-button-md no-border'
+                        className: 'square-button no-border'
                     }}
                     buttons={[
                         {

--- a/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
+++ b/web/client/components/TOC/fragments/settings/WMSCacheOptions.jsx
@@ -303,7 +303,7 @@ function WMSCacheOptions({
                             ? 'layerProperties.updateTileGrids'
                             : 'layerProperties.checkAvailableTileGridsInfo'
                         }
-                        className="square-button-md no-border format-refresh"
+                        className="square-button no-border format-refresh"
                         onClick={() => {
                             onTileMatrixSetsFetch({ ...layer, force: true }).then((value) => handleOnChange(value, layer.tileGridStrategy !== 'custom'));
                         }}
@@ -319,7 +319,7 @@ function WMSCacheOptions({
                         active={layer.tileGridStrategy === 'custom'}
                         glyph={layer.tileGridStrategy === 'custom' ? 'grid-custom' : 'grid-regular'}
                         bsStyle={layer.tileGridStrategy === 'custom' ? 'success' : 'primary'}
-                        className="square-button-md"
+                        className="square-button"
                         onClick={() => {
                             const newTileGridStrategy = layer.tileGridStrategy !== 'custom'
                                 ? 'custom'

--- a/web/client/components/TOC/fragments/settings/__tests__/ThematicLayer-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/ThematicLayer-test.jsx
@@ -228,7 +228,7 @@ describe('test ThematicLayer module component', () => {
         expect(domNode).toExist();
         expect(document.getElementsByClassName('thematic_layer').length).toBe(1);
         expect(document.getElementsByClassName('thematic_layer')[0].childNodes.length).toBe(1);
-        expect(domNode.getElementsByClassName('mapstore-switch-panel')[0].querySelector('button.square-button-sm')).toExist();
+        expect(domNode.getElementsByClassName('mapstore-switch-panel')[0].querySelector('button.square-button')).toExist();
     });
 
     it('tests ThematicLayer component with configured thematic thema style admin buttons for no admin', () => {
@@ -238,7 +238,7 @@ describe('test ThematicLayer module component', () => {
         expect(domNode).toExist();
         expect(document.getElementsByClassName('thematic_layer').length).toBe(1);
         expect(document.getElementsByClassName('thematic_layer')[0].childNodes.length).toBe(1);
-        expect(domNode.getElementsByClassName('mapstore-switch-panel')[0].querySelector('button.square-button-sm')).toNotExist();
+        expect(domNode.getElementsByClassName('mapstore-switch-panel')[0].querySelector('button.square-button')).toNotExist();
     });
 
     it('tests ThematicLayer component with configured thematic thema style toggle configuration', () => {
@@ -254,7 +254,7 @@ describe('test ThematicLayer module component', () => {
         expect(domNode).toExist();
         expect(document.getElementsByClassName('thematic_layer').length).toBe(1);
         expect(document.getElementsByClassName('thematic_layer')[0].childNodes.length).toBe(1);
-        const cfgButton = domNode.getElementsByClassName('mapstore-switch-panel')[0].querySelector('button.square-button-sm');
+        const cfgButton = domNode.getElementsByClassName('mapstore-switch-panel')[0].querySelector('button.square-button');
         TestUtils.Simulate.click(cfgButton);
         expect(spyConfigurationChange.calls.length).toBe(2);
     });

--- a/web/client/components/TOC/fragments/settings/__tests__/VisibilityLimitsForm-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/VisibilityLimitsForm-test.jsx
@@ -93,7 +93,7 @@ describe('VisibilityLimitsForm', () => {
             />, document.getElementById('container'));
         });
         expect(document.querySelector('.ms-visibility-limits-form')).toBeTruthy();
-        const buttons = document.querySelectorAll('.square-button-md');
+        const buttons = document.querySelectorAll('.square-button');
         expect(buttons.length).toBe(1);
     });
 

--- a/web/client/components/TOC/fragments/template/MetadataTemplate.jsx
+++ b/web/client/components/TOC/fragments/template/MetadataTemplate.jsx
@@ -49,7 +49,7 @@ class MetadataTemplate extends React.Component {
                 {content}
                 <Button
                     style={{margin: '4px 0 0 4px'}}
-                    className="square-button-md no-border"
+                    className="square-button no-border"
                     onClick={() => collapsePanel(id, !this.state.collapsed[id])}>
                     <Glyphicon glyph={this.state.collapsed[id] ? 'plus' : 'minus'}/>
                 </Button>

--- a/web/client/components/background/BackgroundDialog.jsx
+++ b/web/client/components/background/BackgroundDialog.jsx
@@ -189,7 +189,7 @@ export default class BackgroundDialog extends React.Component {
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                         <ControlLabel style={{ flex: 1 }}><Message msgId="backgroundDialog.additionalParameters" /></ControlLabel>
                         <Button
-                            className="square-button-md"
+                            className="square-button"
                             tooltipId="backgroundDialog.addAdditionalParameterTooltip"
                             style={{ borderColor: 'transparent' }}
                             onClick={() => {
@@ -238,7 +238,7 @@ export default class BackgroundDialog extends React.Component {
                                 additionalParameters: this.state.additionalParameters.filter((aa) => val.id !== aa.id)
                             })}
                             tooltipId="backgroundDialog.removeAdditionalParameterTooltip"
-                            className="square-button-md"
+                            className="square-button"
                             style={{ borderColor: 'transparent' }}>
                             <Glyphicon glyph="trash" />
                         </Button>

--- a/web/client/components/background/TerrainEditor.jsx
+++ b/web/client/components/background/TerrainEditor.jsx
@@ -101,7 +101,7 @@ function TerrainEditor({
             <FlexBox classNames={['_padding-lr-lg', '_padding-tb-md']} column gap="md">
                 <FlexBox centerChildrenVertically>
                     <FlexBox.Fill component={Text} fontSize="md" >{getMessageById(messages, "backgroundSelector.terrain.title")}</FlexBox.Fill>
-                    <Button className="square-button-md" onClick={onHide} borderTransparent gap="sm">
+                    <Button className="square-button" onClick={onHide} borderTransparent gap="sm">
                         <Glyphicon glyph="1-close" />
                     </Button>
                 </FlexBox>

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -189,7 +189,7 @@ class RecordItem extends React.Component {
                     <SplitButton
                         id="add-layer-button"
                         tooltipId="catalog.addToMap"
-                        className="square-button-md"
+                        className="square-button"
                         bsStyle="primary"
                         title={this.state.loading ? <Loader className={'ms-loader ms-loader-primary'}/> : <Glyphicon glyph="plus" />}
                         onClick={() => this.onAddToMap(record)}
@@ -212,7 +212,7 @@ class RecordItem extends React.Component {
                 )
             }] : [{
                 tooltipId: 'catalog.addToMap',
-                className: 'square-button-md',
+                className: 'square-button',
                 bsStyle: 'primary',
                 disabled: this.state.loading,
                 loading: this.state.loading,
@@ -282,7 +282,7 @@ class RecordItem extends React.Component {
                 tools={
                     <Toolbar
                         btnDefaultProps={{
-                            className: 'square-button-md',
+                            className: 'square-button',
                             bsStyle: 'primary'
                         }}
                         btnGroupProps={{

--- a/web/client/components/catalog/SharingLinks.jsx
+++ b/web/client/components/catalog/SharingLinks.jsx
@@ -37,7 +37,7 @@ class SharingLinks extends React.Component {
         </Popover>);
         return (
             <OverlayTrigger container={this.props.popoverContainer} positionLeft={150} placement="top" trigger="click" overlay={popover}>
-                <Button bsSize={buttonSize} className="square-button-md" bsStyle="primary">
+                <Button bsSize={buttonSize} className="square-button" bsStyle="primary">
                     <Glyphicon glyph="link"/>
                 </Button>
             </OverlayTrigger>

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -191,7 +191,7 @@ export default ({
                     disabled={props.formatsLoading || !canLoadInfo
                     }
                     tooltipId="catalog.format.refresh"
-                    className="square-button-md no-border"
+                    className="square-button no-border"
                     onClick={() => onFormatOptionsFetch(service.url, true)}
                     key="format-refresh">
                     <Glyphicon glyph="refresh" />

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -167,7 +167,7 @@ const pluginsToItems = ({
                     {!isRoot && parentIsEnabled && !isMandatory && <Button
                         style={{left: '-4px', position: 'relative'}}
                         key="checkbox"
-                        className="square-button-md no-border"
+                        className="square-button no-border"
                         onClick={(event) => {
                             event.stopPropagation();
                             if (!isMandatory) {

--- a/web/client/components/contextcreator/ConfigureThemes.jsx
+++ b/web/client/components/contextcreator/ConfigureThemes.jsx
@@ -202,7 +202,7 @@ function ConfigureThemes({
                                 </div>
                             }><Button
                                 disabled={!customVariablesEnabled}
-                                className="square-button-md no-border"
+                                className="square-button no-border"
                                 style={{ display: mostReadableTextColor ? 'block' : 'none' }}>
                                 <Glyphicon glyph="exclamation-mark"/>
                             </Button>
@@ -319,7 +319,7 @@ function ConfigureThemes({
                                 </div>
                             }><Button
                                 disabled={!customVariablesEnabled}
-                                className="square-button-md no-border"
+                                className="square-button no-border"
                                 style={{ display: mostReadablePrimaryContrastColor ? 'block' : 'none' }}>
                                 <Glyphicon glyph="exclamation-mark"/>
                             </Button>
@@ -436,7 +436,7 @@ function ConfigureThemes({
                                 </div>
                             }><Button
                                 disabled={!customVariablesEnabled}
-                                className="square-button-md no-border"
+                                className="square-button no-border"
                                 style={{ display: mostReadableSuccessContrastColor ? 'block' : 'none' }}>
                                 <Glyphicon glyph="exclamation-mark"/>
                             </Button>
@@ -516,7 +516,7 @@ function ConfigureThemes({
                                 </div>
                             }><Button
                                 disabled={!customVariablesEnabled}
-                                className="square-button-md no-border"
+                                className="square-button no-border"
                                 style={{ display: mostReadableSuccessPrimaryColor ? 'block' : 'none' }}>
                                 <Glyphicon glyph="exclamation-mark"/>
                             </Button>

--- a/web/client/components/data/featuregrid/Header.jsx
+++ b/web/client/components/data/featuregrid/Header.jsx
@@ -29,7 +29,7 @@ export default (props = {
             <div className="data-grid-top-toolbar-right">
                 {!props.hideCloseButton && <Button
                     onClick={props.onClose}
-                    className="square-button-md no-border featuregrid-top-toolbar-margin"
+                    className="square-button no-border featuregrid-top-toolbar-margin"
                 >
                     <Glyphicon glyph="1-close"/>
                 </Button>}

--- a/web/client/components/data/featuregrid/toolbars/TButton.jsx
+++ b/web/client/components/data/featuregrid/toolbars/TButton.jsx
@@ -17,7 +17,7 @@ const hideStyle = {
 };
 const normalStyle = {};
 const getStyle = (visible) => visible ? normalStyle : hideStyle;
-export const SimpleTButton = forwardRef(({ disabled, id, visible, onClick, glyph, active, className = "square-button-md", ...props }, ref) => {
+export const SimpleTButton = forwardRef(({ disabled, id, visible, onClick, glyph, active, className = "square-button", ...props }, ref) => {
     return (<Button ref={ref} {...props} bsStyle={active ? "success" : "primary"} disabled={disabled} id={`fg-${id}`}
         style={getStyle(visible)}
         className={className}

--- a/web/client/components/data/featuregrid/toolbars/TSplitButton.jsx
+++ b/web/client/components/data/featuregrid/toolbars/TSplitButton.jsx
@@ -14,7 +14,7 @@ import ContainerDimensions from 'react-container-dimensions';
 import './TSplitButton.less';
 import classnames from "classnames";
 
-export const SimpleTButton = forwardRef(({ disabled, id, visible, onClick, active, title, buttonClassName = "square-button-md",
+export const SimpleTButton = forwardRef(({ disabled, id, visible, onClick, active, title, buttonClassName = "square-button",
     menuStyle = {}, className, children, onMount = () => {}, ...props }, ref) => {
     const [isShown, setIsShown] = useState(false);
     useEffect(() => {

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -182,7 +182,7 @@ const standardButtons = {
         title={isSnappingLoading ? <Spinner spinnerName="ball-beat" overrideSpinnerClassName="spinner" key="loadingSpinner" noFadeIn /> : <Glyphicon glyph="magnet" />}
         tooltipPosition="top"
         className="snap-tool"
-        buttonClassName="square-button-md no-border"
+        buttonClassName="square-button no-border"
         menuStyle={{maxHeight: `calc(${Math.round(editorHeight * 100)}vh - 50px)`, overflowY: 'auto'}}
         active={!!snapping}
         pullLeft
@@ -265,7 +265,7 @@ const standardButtons = {
         glyph="viewport-filter"
         tooltipPosition="top"
         className="viewportFilter-tool"
-        buttonClassName="square-button-md no-border"
+        buttonClassName="square-button no-border"
         active={viewportFilter ?? pluginCfg?.filterByViewport}
         pullLeft
     />)

--- a/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
+++ b/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
@@ -306,13 +306,13 @@ describe('Featuregrid toolbar component', () => {
         ReactDOM.render(<Toolbar mode="EDIT" selectedCount={0} hasSupportedGeometry={false} />, document.getElementById("container"));
         const el = document.getElementsByClassName("featuregrid-toolbar")[0];
         expect(el).toExist();
-        expect(filter(document.getElementsByClassName("square-button-md"), function(b) { return isVisibleButton(b); }).length).toBe(2);
+        expect(filter(document.getElementsByClassName("square-button"), function(b) { return isVisibleButton(b); }).length).toBe(2);
         expect(isVisibleButton(document.getElementById("fg-add-feature"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-back-view"))).toBe(true);
         expect(isVisibleButton(document.getElementById("fg-grid-map-filter"))).toBe(true);
 
         ReactDOM.render(<Toolbar mode="EDIT" selectedCount={1} hasSupportedGeometry={false} />, document.getElementById("container"));
-        expect(filter(document.getElementsByClassName("square-button-md"), function(b) { return isVisibleButton(b); }).length).toBe(3);
+        expect(filter(document.getElementsByClassName("square-button"), function(b) { return isVisibleButton(b); }).length).toBe(3);
         expect(isVisibleButton(document.getElementById("fg-add-feature"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-draw-feature"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-delete-geometry"))).toBe(false);
@@ -322,7 +322,7 @@ describe('Featuregrid toolbar component', () => {
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
 
         ReactDOM.render(<Toolbar mode="EDIT" selectedCount={1} hasSupportedGeometry={false} hasChanges/>, document.getElementById("container"));
-        expect(filter(document.getElementsByClassName("square-button-md"), function(b) { return isVisibleButton(b); }).length).toBe(3);
+        expect(filter(document.getElementsByClassName("square-button"), function(b) { return isVisibleButton(b); }).length).toBe(3);
         expect(isVisibleButton(document.getElementById("fg-draw-feature"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-delete-geometry"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-save-feature"))).toBe(true);

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -145,7 +145,7 @@ export default props => {
                             format={format}
                         />
                         <Toolbar
-                            btnDefaultProps={{ bsStyle: 'primary', className: 'square-button-md' }}
+                            btnDefaultProps={{ bsStyle: 'primary', className: 'square-button' }}
                             buttons={getFeatureButtons(props)}
                             transitionProps={null}
                         />
@@ -170,7 +170,7 @@ export default props => {
                     </div>
                     <GeocodeViewer latlng={latlng} revGeocodeDisplayName={revGeocodeDisplayName} {...props}/>
                     <Toolbar
-                        btnDefaultProps={{ bsStyle: 'primary', className: 'square-button-md' }}
+                        btnDefaultProps={{ bsStyle: 'primary', className: 'square-button' }}
                         buttons={toolButtons}
                         transitionProps={null
                             /* transitions was causing a bad rendering of toolbar present in the identify panel

--- a/web/client/components/data/identify/SwipeHeader.jsx
+++ b/web/client/components/data/identify/SwipeHeader.jsx
@@ -38,15 +38,15 @@ class SwipeHeader extends React.Component {
     renderLeftButton = () => {
         const isDisabled = this.props.index === 0 ? true : false;
         return this.props.useButtons ?
-            <Button ref="left" disabled={isDisabled} className={this.props.btnClassName || "square-button-md no-border"} onClick={() => {this.props.onPrevious(); }}><Glyphicon glyph="back"/></Button> :
-            <a ref="left" disabled={isDisabled} className={this.props.btnClassName || "square-button-md"} onClick={() => {this.props.onPrevious(); }}><Glyphicon glyph="back" /></a>;
+            <Button ref="left" disabled={isDisabled} className={this.props.btnClassName || "square-button no-border"} onClick={() => {this.props.onPrevious(); }}><Glyphicon glyph="back"/></Button> :
+            <a ref="left" disabled={isDisabled} className={this.props.btnClassName || "square-button"} onClick={() => {this.props.onPrevious(); }}><Glyphicon glyph="back" /></a>;
     };
 
     renderRightButton = () => {
         const isDisabled = this.props.index === this.props.size - 1 ? true : false;
         return this.props.useButtons ?
-            <Button ref="right" disabled={isDisabled} className={this.props.btnClassName || "square-button-md no-border"} onClick={() => {this.props.onNext(); }}><Glyphicon glyph="next"/></Button> :
-            <a ref="right" disabled={isDisabled} className={this.props.btnClassName || "square-button-md"} onClick={() => {this.props.onNext(); }}><Glyphicon glyph="next" /></a>;
+            <Button ref="right" disabled={isDisabled} className={this.props.btnClassName || "square-button no-border"} onClick={() => {this.props.onNext(); }}><Glyphicon glyph="next"/></Button> :
+            <a ref="right" disabled={isDisabled} className={this.props.btnClassName || "square-button"} onClick={() => {this.props.onNext(); }}><Glyphicon glyph="next" /></a>;
     };
 
     render() {

--- a/web/client/components/data/identify/__tests__/GeocodeViewer-test.jsx
+++ b/web/client/components/data/identify/__tests__/GeocodeViewer-test.jsx
@@ -50,7 +50,7 @@ describe('GeocodeViewer', () => {
             lngCorrected={10}/>, document.getElementById("container"));
         const modalEditor = document.getElementsByClassName('ms-resizable-modal');
         expect(modalEditor.length).toBe(1);
-        const close = document.querySelector('button.square-button-md');
+        const close = document.querySelector('button.square-button');
         expect(close).toBeTruthy();
         TestUtils.Simulate.click(close);
         expect(spyHideRevGeocode).toHaveBeenCalled();

--- a/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
+++ b/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
@@ -106,7 +106,7 @@ describe("test IdentifyContainer", () => {
         const alertModal = document.getElementsByClassName('ms-resizable-modal');
         expect(alertModal.length).toBe(1);
 
-        const btns = alertModal[0].querySelectorAll('button.square-button-md');
+        const btns = alertModal[0].querySelectorAll('button.square-button');
         expect(btns.length).toBe(1);
 
         TestUtils.Simulate.click(btns[0]);

--- a/web/client/components/data/query/QueryPanelHeader.jsx
+++ b/web/client/components/data/query/QueryPanelHeader.jsx
@@ -6,16 +6,16 @@ import popoverTooltip from '../../misc/enhancers/popover';
 import Button from '../../misc/Button';
 import FlexBox from '../../layout/FlexBox';
 
-const AlertIcon = popoverTooltip((props) => (<div className="square-button-md _border-transparent" style={{display: 'flex'}} {...props}><Glyphicon glyph="exclamation-mark" className="text-danger"/></div>));
+const AlertIcon = popoverTooltip((props) => (<div className="square-button _border-transparent" style={{display: 'flex'}} {...props}><Glyphicon glyph="exclamation-mark" className="text-danger"/></div>));
 
 export default ({loadingError, onToggleQuery = () => {}, buttonStyle = "default"} = {}) => (<FlexBox centerChildrenVertically gap="sm" classNames={['_padding-sm']}>
     {loadingError && (<AlertIcon popover={{text: (<Message msgId="queryform.loadingError"/>)}}/>) || (
-        <div className="square-button-md _border-transparent" style={{display: 'flex'}}><Glyphicon glyph="filter"/></div>)}
+        <div className="square-button _border-transparent" style={{display: 'flex'}}><Glyphicon glyph="filter"/></div>)}
     <FlexBox.Fill />
     <Button
         id="toc-query-close-button"
         key="menu-button"
-        className="square-button-md _border-transparent"
+        className="square-button _border-transparent"
         bsStyle={buttonStyle}
         onClick={() => onToggleQuery()}>
         <Glyphicon glyph="1-close"/>

--- a/web/client/components/data/query/QueryToolbar.jsx
+++ b/web/client/components/data/query/QueryToolbar.jsx
@@ -161,7 +161,7 @@ class QueryToolbar extends React.Component {
             disabled: queryDisabled,
             noTooltipWhenDisabled: true,
             glyph: this.props.advancedToolbar && "ok" || this.props.queryBtnGlyph,
-            className: showTooltip ? "square-button-md showWarning" : "square-button-md",
+            className: showTooltip ? "square-button showWarning" : "square-button",
             id: "query-toolbar-query",
             onClick: this.search
         }];
@@ -212,7 +212,7 @@ class QueryToolbar extends React.Component {
         }
         return (
             <div className="container-fluid query-toolbar">
-                <Toolbar btnDefaultProps={{bsStyle: "primary", className: "square-button-md", tooltipPosition: "bottom"}} className="queryFormToolbar row-fluid pull-right" buttons={buttons} />
+                <Toolbar btnDefaultProps={{bsStyle: "primary", className: "square-button", tooltipPosition: "bottom"}} className="queryFormToolbar row-fluid pull-right" buttons={buttons} />
                 <Modal show={this.props.showGeneratedFilter ? true : false} bsSize="large">
                     <Modal.Header>
                         <Modal.Title>{this.props.resultTitle}</Modal.Title>

--- a/web/client/components/data/query/SpatialFilter.jsx
+++ b/web/client/components/data/query/SpatialFilter.jsx
@@ -48,7 +48,7 @@ class SpatialFilter extends React.Component {
         spatialPanelExpanded: true,
         showDetailsButton: true,
         clearFilterOptions: {
-            className: "square-button-sm no-border",
+            className: "square-button no-border",
             buttonStyle: "default"
         },
         showDetailsPanel: false,

--- a/web/client/components/geostory/builder/Builder.jsx
+++ b/web/client/components/geostory/builder/Builder.jsx
@@ -98,7 +98,7 @@ class Builder extends React.Component {
                 >
                     <Toolbar
                         btnDefaultProps={{
-                            className: "square-button-md",
+                            className: "square-button",
                             bsStyle: "primary"
                         }}
                         transitionProps={false}
@@ -108,7 +108,7 @@ class Builder extends React.Component {
                                 Element: () => (<WithConfirmButton
                                     glyph="trash"
                                     bsStyle= "primary"
-                                    className="square-button-md no-border"
+                                    className="square-button no-border"
                                     tooltipId="geostory.builder.delete"
                                     confirmTitle={<Message msgId="geostory.contentToolbar.removeConfirmTitle" />}
                                     disabled= {!isToolbarEnabled || !selected }
@@ -145,7 +145,7 @@ class Builder extends React.Component {
                                 Element: () => (<SettingsButton
                                     bsStyle= "primary"
                                     glyph="arrow-left"
-                                    className="square-button-md no-border"
+                                    className="square-button no-border"
                                     tooltipId="geostory.builder.settings.back"
                                     confirmTitle={<Message msgId="geostory.builder.settings.backConfirmTitle" />}
                                     confirmContent={<Message msgId="geostory.builder.settings.backConfirmBody" />}

--- a/web/client/components/geostory/builder/SectionsPreview.jsx
+++ b/web/client/components/geostory/builder/SectionsPreview.jsx
@@ -100,7 +100,7 @@ const previewContents = {
                         preview: <ConnectedIcon type={contentType} resourceId={content.resourceId}/>,
                         tools: <Toolbar
                             btnDefaultProps={{
-                                className: 'square-button-md no-border'
+                                className: 'square-button no-border'
                             }}
                             buttons={[
                                 {
@@ -149,7 +149,7 @@ const previewContents = {
                         preview: <ConnectedIcon type={contentType} resourceId={content.resourceId}/>,
                         tools: <Toolbar
                             btnDefaultProps={{
-                                className: 'square-button-md no-border'
+                                className: 'square-button no-border'
                             }}
                             buttons={[
                                 {
@@ -197,7 +197,7 @@ const previewContents = {
                         preview: <Icon type={contentType} />,
                         tools: <Toolbar
                             btnDefaultProps={{
-                                className: 'square-button-md no-border'
+                                className: 'square-button no-border'
                             }}
                             buttons={[
                                 {
@@ -301,7 +301,7 @@ const sectionToItem = ({
         selected: id === selected,
         tools: <Toolbar
             btnDefaultProps={{
-                className: 'square-button-md no-border'
+                className: 'square-button no-border'
             }}
             buttons={[
                 {

--- a/web/client/components/geostory/common/CustomThemePicker.jsx
+++ b/web/client/components/geostory/common/CustomThemePicker.jsx
@@ -118,7 +118,7 @@ function CustomThemePicker({
                         </>
                     }>
                     {mostReadableTextColor && <Button
-                        className="square-button-md no-border"
+                        className="square-button no-border"
                         style={{ display: mostReadableTextColor ? 'block' : 'none' }}>
                         <Glyphicon glyph="exclamation-mark"/>
                     </Button> || <div />}
@@ -214,7 +214,7 @@ export function CustomThemePickerMenuItem({
                     <div><Message msgId="geostory.contentToolbar.customizeThemeLabel"/></div>
                     <Button
                         tooltipId="geostory.contentToolbar.customizeThemeRemoveLabel"
-                        className="square-button-md no-border"
+                        className="square-button no-border"
                         onClick={(event) => {
                             event.stopPropagation();
                             handleUpdateTheme('');

--- a/web/client/components/geostory/common/MapEditor.jsx
+++ b/web/client/components/geostory/common/MapEditor.jsx
@@ -89,7 +89,7 @@ const MapEditor = ({
                             className: "ms-geostory-map-editor-toolbar"
                         }}
                         btnDefaultProps={{
-                            className: "square-button-md no-border",
+                            className: "square-button no-border",
                             bsStyle: "primary",
                             noTooltipWhenDisabled: true
                         }}

--- a/web/client/components/geostory/common/ToolbarDropdownButton.jsx
+++ b/web/client/components/geostory/common/ToolbarDropdownButton.jsx
@@ -27,7 +27,7 @@ export default function ToolbarDropdownButton({
     glyph = '',
     tooltipId,
     pullRight = false,
-    className = 'square-button-md no-border',
+    className = 'square-button no-border',
     disabled,
     noTooltipWhenDisabled = false,
     hideMenuItem = () => false,

--- a/web/client/components/geostory/common/__tests__/ToolbarDropdownButton-test.jsx
+++ b/web/client/components/geostory/common/__tests__/ToolbarDropdownButton-test.jsx
@@ -24,7 +24,7 @@ describe('ToolbarDropdownButton component', () => {
     it('ToolbarDropdownButton rendering with defaults', () => {
         ReactDOM.render(<ToolbarDropdownButton />, document.getElementById("container"));
         const container = document.getElementById('container');
-        const el = container.querySelector('.square-button-md.no-border');
+        const el = container.querySelector('.square-button.no-border');
         expect(el).toBeTruthy();
     });
     it('should hide dropdown when disabled', () => {
@@ -36,7 +36,7 @@ describe('ToolbarDropdownButton component', () => {
             }]}
         />, document.getElementById("container"));
         const container = document.getElementById('container');
-        const buttonNode = container.querySelector('.square-button-md.no-border');
+        const buttonNode = container.querySelector('.square-button.no-border');
         expect(buttonNode).toBeTruthy();
         let dropdownMenuNode = container.querySelector('.dropdown.open');
         expect(dropdownMenuNode).toBeFalsy();
@@ -76,7 +76,7 @@ describe('ToolbarDropdownButton component', () => {
             }]}
         />, document.getElementById("container"));
         const container = document.getElementById('container');
-        const buttonNode = container.querySelector('.square-button-md.no-border');
+        const buttonNode = container.querySelector('.square-button.no-border');
         expect(buttonNode).toBeTruthy();
         const glyph = buttonNode.querySelector('.glyphicon-large');
         expect(glyph).toBeTruthy();
@@ -93,7 +93,7 @@ describe('ToolbarDropdownButton component', () => {
             }]}
         />, document.getElementById("container"));
         const container = document.getElementById('container');
-        const buttonNode = container.querySelector('.square-button-md.no-border');
+        const buttonNode = container.querySelector('.square-button.no-border');
         expect(buttonNode).toBeTruthy();
         const glyphLarge = buttonNode.querySelector('.glyphicon-large');
         const glyphDef = buttonNode.querySelector('.glyphicon-small');

--- a/web/client/components/geostory/common/enhancers/map.jsx
+++ b/web/client/components/geostory/common/enhancers/map.jsx
@@ -86,7 +86,7 @@ export const handleToolbar = withHandlers({
 const ResetButton = (props) => (<ConfirmButton
     glyph="repeat"
     bsStyle= "primary"
-    className="square-button-md no-border"
+    className="square-button no-border"
     tooltipId="geostory.contentToolbar.resetMap"
     confirmTitle={<Message msgId="geostory.contentToolbar.resetMapConfirm" />}
     confirmContent={<Message msgId="geostory.contentToolbar.resetConfirmContent" />}

--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -12,7 +12,7 @@ import Toolbar from '../../misc/toolbar/Toolbar';
 import {SizeButtonToolbar, AlignButtonToolbar, ThemeButtonToolbar, DeleteButtonToolbar} from "./ToolbarButtons";
 import uuid from "uuid";
 
-const BUTTON_CLASSES = 'square-button-md no-border';
+const BUTTON_CLASSES = 'square-button no-border';
 const toolButtons = {
     size: (props) => ({
         renderButton: <SizeButtonToolbar {...props}/>

--- a/web/client/components/geostory/contents/ToolbarButtons.jsx
+++ b/web/client/components/geostory/contents/ToolbarButtons.jsx
@@ -16,7 +16,7 @@ import { CustomThemePickerMenuItem } from '../common/CustomThemePicker';
 import isObject from "lodash/isObject";
 import isString from "lodash/isString";
 const DeleteButton = withConfirm(ToolbarButton);
-const BUTTON_CLASSES = 'square-button-md no-border';
+const BUTTON_CLASSES = 'square-button no-border';
 const BUTTON_BSSTYLE = { primary: 'btn-primary', "default": 'btn-default'};
 
 const getToolbarSizeProps = (size, sizeType) => {

--- a/web/client/components/geostory/contents/carousel/Carousel.jsx
+++ b/web/client/components/geostory/contents/carousel/Carousel.jsx
@@ -182,7 +182,7 @@ const DraggableCarousel = draggableContainer(({
                         }
                     </div>
                     {isStartControlActive && <Button
-                        className="square-button-md no-border ms-geo-carousel-control"
+                        className="square-button no-border ms-geo-carousel-control"
                         style={{
                             ...controlStyle,
                             position: 'absolute'
@@ -191,7 +191,7 @@ const DraggableCarousel = draggableContainer(({
                         <Glyphicon glyph="chevron-left"/>
                     </Button>}
                     {isEndControlActive && <Button
-                        className="square-button-md no-border ms-geo-carousel-control"
+                        className="square-button no-border ms-geo-carousel-control"
                         style={{
                             ...controlStyle,
                             position: 'absolute',

--- a/web/client/components/geostory/layouts/Cascade.jsx
+++ b/web/client/components/geostory/layouts/Cascade.jsx
@@ -36,7 +36,7 @@ const ContainerDimensions = emptyState(
         title: <Message msgId="geostory.emptyTitle"/>,
         description: <Message msgId="geostory.emptyDescription"/>,
         content: <AddBar
-            addButtonClassName="square-button-md"
+            addButtonClassName="square-button"
             containerWidth={"100%"}
             containerHeight={"100%"}
             buttons={[{

--- a/web/client/components/geostory/navigation/Navigation.jsx
+++ b/web/client/components/geostory/navigation/Navigation.jsx
@@ -94,7 +94,7 @@ export default ({
                         isHomeButtonEnabled && (
                             <Home
                                 bsStyle="default"
-                                className="square-button-md no-border"
+                                className="square-button no-border"
                                 tooltipPosition="right"
                                 renderUnsavedMapChangesDialog={false}
                             />

--- a/web/client/components/geostory/navigation/ScrollMenu.jsx
+++ b/web/client/components/geostory/navigation/ScrollMenu.jsx
@@ -121,13 +121,13 @@ const ScrollMenu = ({
                 })}
             </div>
             {isStartControlActive && <Button
-                className="square-button-md no-border"
+                className="square-button no-border"
                 style={{ position: 'absolute' }}
                 onClick={() => moveToDeltaSize(deltaSwipeSize)}>
                 <Glyphicon glyph="chevron-left"/>
             </Button>}
             {isEndControlActive && <Button
-                className="square-button-md no-border"
+                className="square-button no-border"
                 style={{
                     position: 'absolute',
                     right: 0

--- a/web/client/components/layout/Button.jsx
+++ b/web/client/components/layout/Button.jsx
@@ -21,7 +21,7 @@ const Button = forwardRef(({
     return (
         <ButtonRB
             {...props}
-            className={`${square ? 'square-button-md' : ''}${className ? ` ${className}` : ''}${borderTransparent ? ' _border-transparent' : ''}`}
+            className={`${square ? 'square-button' : ''}${className ? ` ${className}` : ''}${borderTransparent ? ' _border-transparent' : ''}`}
             ref={ref}
             bsStyle={variant}
             bsSize={size}

--- a/web/client/components/layout/__tests__/Button-test.jsx
+++ b/web/client/components/layout/__tests__/Button-test.jsx
@@ -42,6 +42,6 @@ describe('Button component', () => {
         ReactDOM.render(<Button square ><span className="child" /></Button>, document.getElementById('container'));
         const button = document.querySelector('.btn');
         expect(button).toBeTruthy();
-        expect(button.getAttribute('class')).toBe('square-button-md btn btn-default');
+        expect(button.getAttribute('class')).toBe('square-button btn btn-default');
     });
 });

--- a/web/client/components/manager/rulesmanager/ruleseditor/GSInstance/Header.jsx
+++ b/web/client/components/manager/rulesmanager/ruleseditor/GSInstance/Header.jsx
@@ -33,7 +33,7 @@ export default ({
     }];
     return (<div className="ms-panel-header-container">
         <div className="ms-toolbar-container">
-            <Toolbar btnDefaultProps={{ className: 'square-button-md', bsStyle: 'primary', tooltipPosition: 'bottom'}} buttons={buttons}/>
+            <Toolbar btnDefaultProps={{ className: 'square-button', bsStyle: 'primary', tooltipPosition: 'bottom'}} buttons={buttons}/>
         </div>
         <div className={`loading-header ${loading ? 'ms-circle-loader-md' : ''}`}/>
         <Nav bsStyle="tabs" activeKey={activeTab} justified onSelect={onNavChange}>

--- a/web/client/components/manager/rulesmanager/ruleseditor/Header.jsx
+++ b/web/client/components/manager/rulesmanager/ruleseditor/Header.jsx
@@ -28,7 +28,7 @@ export default ({layer, rule = {}, onNavChange = () => {}, onExit = () => {}, di
     const detailsActive = !disableDetails && areDetailsActive(layer, rule);
     return (<div className="ms-panel-header-container">
         <div className="ms-toolbar-container">
-            <Toolbar btnDefaultProps={{ className: 'square-button-md', bsStyle: 'primary', tooltipPosition: 'bottom'}} buttons={buttons}/>
+            <Toolbar btnDefaultProps={{ className: 'square-button', bsStyle: 'primary', tooltipPosition: 'bottom'}} buttons={buttons}/>
         </div>
         <div className={`loading-header ${loading ? 'ms-circle-loader-md' : ''}`}/>
         <Nav bsStyle="tabs" activeKey={activeTab} justified onSelect={onNavChange}>

--- a/web/client/components/manager/rulesmanager/ruleseditor/StylesEditor.jsx
+++ b/web/client/components/manager/rulesmanager/ruleseditor/StylesEditor.jsx
@@ -31,7 +31,7 @@ export default enhancer(({styles = [], constraints = {}, setOption = () => {}, a
                 <Row className="ms-add-style">
                     <Col><Message msgId="rulesmanager.defstyle"/></Col>
                     <Col>
-                        <Button className="square-button-md no-border" onClick={() => {
+                        <Button className="square-button no-border" onClick={() => {
                             toggleModal("default");
                         }}>
                             <Glyphicon glyph="pencil" />
@@ -42,7 +42,7 @@ export default enhancer(({styles = [], constraints = {}, setOption = () => {}, a
                 <Row className="ms-add-style">
                     <Col><Message msgId="rulesmanager.avstyle"/></Col>
                     <Col>
-                        <Button className="square-button-md no-border" onClick={() => {
+                        <Button className="square-button no-border" onClick={() => {
                             toggleModal("availables");
                         }}>
                             <Glyphicon glyph="pencil" />

--- a/web/client/components/map/cesium/MeasurementSupport.jsx
+++ b/web/client/components/map/cesium/MeasurementSupport.jsx
@@ -163,7 +163,7 @@ function MeasurementSupport({
                             return (
                                 <Button
                                     key={type}
-                                    className="square-button-md"
+                                    className="square-button"
                                     bsStyle={measureType === type ? 'success' : 'primary'}
                                     tooltipId={`measureComponent.${camelCase(type)}Measure`}
                                     tooltipPosition="bottom"
@@ -177,7 +177,7 @@ function MeasurementSupport({
                     </ButtonGroup>
                     <ButtonGroup>
                         <Button
-                            className="square-button-md"
+                            className="square-button"
                             bsStyle="primary"
                             tooltipId="measureComponent.resetTooltip"
                             onClick={() => setClearId(clearId + 1)}
@@ -187,7 +187,7 @@ function MeasurementSupport({
                     </ButtonGroup>
                     <ButtonGroup>
                         <Button
-                            className="square-button-md"
+                            className="square-button"
                             bsStyle="primary"
                             tooltipId="measureComponent.exportToGeoJSON"
                             disabled={(measurement?.features?.length || 0) === 0}
@@ -200,7 +200,7 @@ function MeasurementSupport({
                             <Glyphicon glyph="ext-json" />
                         </Button>
                         {onAddAsLayer && <Button
-                            className="square-button-md"
+                            className="square-button"
                             bsStyle="primary"
                             tooltipId="measureComponent.addAsLayer"
                             disabled={(measurement?.features?.length || 0) === 0}

--- a/web/client/components/mapcatalog/MapCatalogPanel.jsx
+++ b/web/client/components/mapcatalog/MapCatalogPanel.jsx
@@ -104,7 +104,7 @@ const MapCatalogPanel = ({
         description: map.description,
         tools: <Toolbar
             btnDefaultProps={{
-                className: 'square-button-md'
+                className: 'square-button'
             }}
             buttons={[{
                 glyph: 'trash',
@@ -127,7 +127,7 @@ const MapCatalogPanel = ({
             }, {
                 glyph: 'share-alt',
                 bsStyle: 'primary',
-                className: 'square-button-md',
+                className: 'square-button',
                 tooltipId: 'mapCatalog.tooltips.share',
                 onClick: (e) => {
                     e.stopPropagation();

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -202,7 +202,7 @@ class CoordinatesEditor extends React.Component {
                         noCaret
                         title={<Glyphicon glyph="cog"/>}
                         pullRight
-                        className="square-button-md no-border"
+                        className="square-button no-border"
                         tooltip="Format">
                         {formats.map(({text, value}) => <MenuItem
                             active={this.props.format === value}
@@ -256,7 +256,7 @@ class CoordinatesEditor extends React.Component {
                     <div>
                         <Toolbar
                             btnGroupProps={{ className: 'pull-right' }}
-                            btnDefaultProps={{ className: 'square-button-md no-border'}}
+                            btnDefaultProps={{ className: 'square-button no-border'}}
                             buttons={buttons}/>
                     </div>
                 </div>

--- a/web/client/components/mapcontrols/measure/MeasureComponent.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureComponent.jsx
@@ -297,7 +297,7 @@ class MeasureComponent extends React.Component {
                         <ButtonToolbar>
                             <Toolbar
                                 btnDefaultProps={{
-                                    className: 'square-button-md',
+                                    className: 'square-button',
                                     bsStyle: 'primary'
                                 }}
                                 buttons={
@@ -331,7 +331,7 @@ class MeasureComponent extends React.Component {
                                 }/>
                             <Toolbar
                                 btnDefaultProps={{
-                                    className: 'square-button-md',
+                                    className: 'square-button',
                                     bsStyle: 'primary'
                                 }}
                                 buttons={
@@ -346,7 +346,7 @@ class MeasureComponent extends React.Component {
                                 }/>
                             <Toolbar
                                 btnDefaultProps={{
-                                    className: 'square-button-md',
+                                    className: 'square-button',
                                     bsStyle: 'primary'
                                 }}
                                 buttons={

--- a/web/client/components/mapcontrols/measure/MeasureToolbar.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureToolbar.jsx
@@ -33,7 +33,7 @@ function MeasureToolbar({
             </div>
             {onClose ?
                 <Button
-                    className="square-button-md no-border"
+                    className="square-button no-border"
                     onClick={(event) => {
                         event.stopPropagation();
                         onClose();

--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -282,7 +282,7 @@ export default ({
                             })),
                         {
                             glyph: removeIcon,
-                            className: "square-button-md no-border",
+                            className: "square-button no-border",
                             bsStyle: "default",
                             pullRight: true,
                             loading: !isUndefined(loading) && loading,
@@ -297,7 +297,7 @@ export default ({
                                 CoordinateOptions.removeIcon(activeTool, coordinate, onClearCoordinatesSearch, onChangeCoord))
                         }, {
                             glyph: searchIcon,
-                            className: "square-button-md no-border " +
+                            className: "square-button no-border " +
                             (isSearchClickable || activeTool !== "addressSearch" ? "magnifying-glass clickable" : "magnifying-glass"),
                             bsStyle: "default",
                             pullRight: true,
@@ -312,7 +312,7 @@ export default ({
                         }, {
                             tooltip: getError(error),
                             tooltipPosition: "bottom",
-                            className: "square-button-md no-border",
+                            className: "square-button no-border",
                             glyph: "warning-sign",
                             bsStyle: "danger",
                             glyphClassName: "searcherror",

--- a/web/client/components/mapcontrols/search/SearchBarMenu.jsx
+++ b/web/client/components/mapcontrols/search/SearchBarMenu.jsx
@@ -16,7 +16,7 @@ const DropdownButtonT = tooltip(DropdownButton);
 
 const defaultButtonConfig = {
     disabled: false,
-    className: "square-button-md",
+    className: "square-button",
     noCaret: true,
     idDropDown: uuidv1()
 };
@@ -24,7 +24,7 @@ const buttonConfig = {
     title: <Glyphicon glyph="menu-hamburger"/>,
     tooltipId: "search.changeSearchInputField",
     tooltipPosition: "bottom",
-    className: "square-button-md no-border",
+    className: "square-button no-border",
     pullRight: true
 };
 

--- a/web/client/components/mapcontrols/search/SearchResult.jsx
+++ b/web/client/components/mapcontrols/search/SearchResult.jsx
@@ -60,7 +60,7 @@ class SearchResult extends React.Component {
                     <div className="search-result-tools">
                         <Toolbar
                             btnDefaultProps={{
-                                className: 'square-button-md',
+                                className: 'square-button',
                                 bsStyle: 'primary'
                             }}
                             buttons={this.props.tools}/>

--- a/web/client/components/mapcontrols/searchbookmarkconfig/AddNewBookmark.jsx
+++ b/web/client/components/mapcontrols/searchbookmarkconfig/AddNewBookmark.jsx
@@ -95,7 +95,7 @@ const AddNewBookmark = (props) => {
                             overlay={
                                 <Tooltip id="search-bookmark-layer"><Message msgId={"search.b_layer_tooltip"}/></Tooltip>
                             }>
-                            <Button key="toggleLayer" bsStyle="primary" className="square-button-md btn btn-default no-border" onClick={toggleLayerVisibility}>
+                            <Button key="toggleLayer" bsStyle="primary" className="square-button btn btn-default no-border" onClick={toggleLayerVisibility}>
                                 <Glyphicon glyph={layerVisibilityReload ? "eye-open" : "eye-close"} />
                             </Button>
                         </OverlayTrigger>
@@ -105,7 +105,7 @@ const AddNewBookmark = (props) => {
                             overlay={
                                 <Tooltip id="search-bookmark-bbox"><Message msgId={"search.b_bbox_tooltip"}/></Tooltip>
                             }>
-                            <Button key="getBBox" bsStyle="primary" className="square-button-md btn btn-default no-border" onClick={applyCurrentBBox}>
+                            <Button key="getBBox" bsStyle="primary" className="square-button btn btn-default no-border" onClick={applyCurrentBBox}>
                                 <Glyphicon glyph="fit-cover" />
                             </Button>
                         </OverlayTrigger>

--- a/web/client/components/mapcontrols/searchbookmarkconfig/BookmarkList.js
+++ b/web/client/components/mapcontrols/searchbookmarkconfig/BookmarkList.js
@@ -52,7 +52,7 @@ const BookmarkList = (props) => {
                         tools={
                             <Toolbar
                                 btnDefaultProps={{
-                                    className: 'square-button-md no-border'
+                                    className: 'square-button no-border'
                                 }}
                                 btnGroupProps={{
                                     style: {

--- a/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
+++ b/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
@@ -46,7 +46,7 @@ export const CoordinateOptions = ({
             title: <Glyphicon glyph="cog"/>,
             tooltipId: "search.changeSearchInputField",
             tooltipPosition: "bottom",
-            className: "square-button-md no-border",
+            className: "square-button no-border",
             pullRight: true
         },
         menuOptions: [

--- a/web/client/components/maptemplates/MapTemplatesPanel.jsx
+++ b/web/client/components/maptemplates/MapTemplatesPanel.jsx
@@ -88,7 +88,7 @@ export default ({
             </div>,
         tools: <Toolbar
             btnDefaultProps={{
-                className: 'square-button-md'
+                className: 'square-button'
             }}
             buttons={[{
                 glyph: 'transfer',
@@ -109,7 +109,7 @@ export default ({
                 }
             }, {
                 glyph: template.favourite ? 'star' : 'star-empty',
-                className: 'square-button-md no-border',
+                className: 'square-button no-border',
                 tooltipId: template.favourite ? 'mapTemplates.favouriteRemove' : 'mapTemplates.favouriteAdd',
                 onClick: (e) => {
                     e.stopPropagation();

--- a/web/client/components/mapviews/MapViewItem.jsx
+++ b/web/client/components/mapviews/MapViewItem.jsx
@@ -56,7 +56,7 @@ function MapViewItem({
                 select {title} item
             </button>
             {onRemove && <Button
-                className="square-button-md"
+                className="square-button"
                 bsStyle={selected ? 'primary' : 'default'}
                 onClick={onRemove}
                 tooltipId="mapViews.removeView"

--- a/web/client/components/mapviews/MapViewsSupport.jsx
+++ b/web/client/components/mapviews/MapViewsSupport.jsx
@@ -384,7 +384,7 @@ function MapViewsSupport({
                                     <ButtonGroup>
                                         {(mapViewsStateHistory?.past?.length || 0) > 0 && <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             disabled={(mapViewsStateHistory?.past?.length || 0) === 0}
                                             onClick={() => handleHistory(UNDO_VIEWS_STATE)}
                                             tooltipId="mapViews.undoChanges"
@@ -394,7 +394,7 @@ function MapViewsSupport({
                                         </Button>}
                                         <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             onClick={handleCreateView.bind(null, undefined)}
                                             tooltipId="mapViews.addNewView"
                                             tooltipPosition="bottom"
@@ -425,7 +425,7 @@ function MapViewsSupport({
                             <div className="ms-map-views-header">
                                 {(selected?.description && !expanded) ?
                                     <Button
-                                        className="square-button-md no-border"
+                                        className="square-button no-border"
                                         style={{ borderRadius: '50%', marginRight: 4 }}
                                         onClick={() => setShowDescription(!showDescription)}
                                         tooltipId={showDescription ? 'mapViews.hideDescription' : 'mapViews.showDescription'}
@@ -449,7 +449,7 @@ function MapViewsSupport({
                                     {!play && <ButtonGroup>
                                         <Button
                                             bsStyle={expanded === 'list' ? 'success' : 'primary'}
-                                            className="square-button-md"
+                                            className="square-button"
                                             active={expanded === 'list'}
                                             onClick={() => setExpanded(expanded !== 'list' ? 'list' : '')}
                                             tooltipId={expanded === 'list' ? 'mapViews.hideViewsList' : 'mapViews.showViewsList'}
@@ -461,7 +461,7 @@ function MapViewsSupport({
                                     {(!play && edit) && <ButtonGroup>
                                         <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             disabled={expanded === 'settings'}
                                             onClick={handleCreateView.bind(null, undefined)}
                                             tooltipId={selected ? 'mapViews.addNewViewBelowSelected' : 'mapViews.addNewView'}
@@ -471,7 +471,7 @@ function MapViewsSupport({
                                         </Button>
                                         <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             disabled={!selected || expanded === 'settings'}
                                             onClick={handleCreateView.bind(null, selected)}
                                             tooltipId="mapViews.copyCurrentView"
@@ -481,7 +481,7 @@ function MapViewsSupport({
                                         </Button>
                                         <Button
                                             bsStyle={expanded === 'settings' ? 'success' : 'primary'}
-                                            className="square-button-md"
+                                            className="square-button"
                                             active={expanded === 'settings'}
                                             disabled={!selected}
                                             onClick={() => setExpanded(expanded !== 'settings' ? 'settings' : '')}
@@ -492,7 +492,7 @@ function MapViewsSupport({
                                         </Button>
                                         <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             disabled={(mapViewsStateHistory?.past?.length || 0) === 0}
                                             onClick={() => handleHistory(UNDO_VIEWS_STATE)}
                                             tooltipId="mapViews.undoChanges"
@@ -502,7 +502,7 @@ function MapViewsSupport({
                                         </Button>
                                         <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             disabled={(mapViewsStateHistory?.future?.length || 0) === 0}
                                             onClick={() => handleHistory(REDO_VIEWS_STATE)}
                                             tooltipId="mapViews.redoChanges"
@@ -514,7 +514,7 @@ function MapViewsSupport({
                                     <ButtonGroup>
                                         <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             onClick={() => handleSelectView(views[0])}
                                             disabled={currentIndex === 0 || play}
                                             tooltipId="mapViews.gotToFirstView"
@@ -524,7 +524,7 @@ function MapViewsSupport({
                                         </Button>
                                         <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             onClick={() => handleStepMove(-1)}
                                             disabled={!views[currentIndex - 1] || play}
                                             tooltipId="mapViews.gotToPreviousView"
@@ -534,7 +534,7 @@ function MapViewsSupport({
                                         </Button>
                                         <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             active={!!play}
                                             disabled={views?.length === 1}
                                             onClick={() => setPlay(!play)}
@@ -545,7 +545,7 @@ function MapViewsSupport({
                                         </Button>
                                         <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             onClick={() => handleStepMove(1)}
                                             disabled={!views[currentIndex + 1] || play}
                                             tooltipId="mapViews.gotToNextView"
@@ -555,7 +555,7 @@ function MapViewsSupport({
                                         </Button>
                                         <Button
                                             bsStyle="primary"
-                                            className="square-button-md"
+                                            className="square-button"
                                             onClick={() => handleSelectView(views[views?.length - 1])}
                                             disabled={currentIndex === views?.length - 1 || play}
                                             tooltipId="mapViews.gotToLastView"

--- a/web/client/components/mapviews/settings/LayersSection.jsx
+++ b/web/client/components/mapviews/settings/LayersSection.jsx
@@ -168,7 +168,7 @@ function LayersSection({
                     <Button
                         tooltipId="mapViews.linkAllNodes"
                         disabled={!view?.layers?.length && !view?.groups?.length}
-                        className="square-button-md"
+                        className="square-button"
                         bsStyle="primary"
                         onClick={() => {
                             onChange({
@@ -181,7 +181,7 @@ function LayersSection({
                     </Button>
                     <Button
                         tooltipId="mapViews.unlinkAllNodes"
-                        className="square-button-md"
+                        className="square-button"
                         bsStyle="primary"
                         disabled={areAllNodesUnlinked()}
                         onClick={() => {

--- a/web/client/components/mapviews/settings/Section.jsx
+++ b/web/client/components/mapviews/settings/Section.jsx
@@ -25,7 +25,7 @@ function Section({
         <>
             <div className="ms-map-views-section" >
                 <Button
-                    className="square-button-md no-border"
+                    className="square-button no-border"
                     onClick={handleExpand}
                     style={{ borderRadius: '50%', marginRight: 4 }}
                 >

--- a/web/client/components/mediaEditor/MediaList.jsx
+++ b/web/client/components/mediaEditor/MediaList.jsx
@@ -131,7 +131,7 @@ export default compose(
                     <Toolbar
                         btnDefaultProps={{
                             bsStyle: 'primary',
-                            className: 'square-button-md'
+                            className: 'square-button'
                         }}
                         buttons={buttons} />
                 </div>

--- a/web/client/components/mediaEditor/image/ImageForm.jsx
+++ b/web/client/components/mediaEditor/image/ImageForm.jsx
@@ -124,7 +124,7 @@ export default enhance(({
                     }}
                     btnDefaultProps={{
                         bsStyle: "primary",
-                        className: "square-button-md"
+                        className: "square-button"
                     }}
                     buttons={[{
                         glyph: "arrow-left",

--- a/web/client/components/mediaEditor/map/MapForm.jsx
+++ b/web/client/components/mediaEditor/map/MapForm.jsx
@@ -129,7 +129,7 @@ export const MapForm = ({
                     }}
                     btnDefaultProps={{
                         bsStyle: "primary",
-                        className: "square-button-md"
+                        className: "square-button"
                     }}
                     buttons={[{
                         glyph: "arrow-left",
@@ -142,7 +142,7 @@ export const MapForm = ({
                             disabled={!properties.name || !saveEnabled}
                             onClick={onSave}
                             bsStyle="primary"
-                            className="square-button-md"
+                            className="square-button"
                             confirmPredicate={saveEnabled && isResourceUsed}
                         />
                     },

--- a/web/client/components/mediaEditor/video/VideoForm.jsx
+++ b/web/client/components/mediaEditor/video/VideoForm.jsx
@@ -175,7 +175,7 @@ const VideoForm = ({
                         }}
                         btnDefaultProps={{
                             bsStyle: "primary",
-                            className: "square-button-md"
+                            className: "square-button"
                         }}
                         buttons={[{
                             glyph: "arrow-left",

--- a/web/client/components/misc/Filter.jsx
+++ b/web/client/components/misc/Filter.jsx
@@ -58,7 +58,7 @@ class Filter extends React.Component {
                         onChange={this.onFilter}
                         onFocus={this.props.onFocus}
                         type="text"/>
-                    <InputGroup.Addon className="square-button-md">
+                    <InputGroup.Addon className="square-button">
                         {this.props.loading ? <div className="toc-inline-loader"></div> : icon}
                     </InputGroup.Addon>
                 </InputGroup>

--- a/web/client/components/misc/Thumbnail.jsx
+++ b/web/client/components/misc/Thumbnail.jsx
@@ -137,7 +137,7 @@ const Thumbnail = forwardRef(({
     const toolbar = (
         <Toolbar
             btnDefaultProps={{
-                className: 'square-button-md no-border'
+                className: 'square-button no-border'
             }}
             buttons={toolbarButtons
                 ? toolbarButtons

--- a/web/client/components/misc/__tests__/ResizableModal-test.jsx
+++ b/web/client/components/misc/__tests__/ResizableModal-test.jsx
@@ -47,7 +47,7 @@ describe('ResizableModal component', () => {
         const modalEl = document.getElementById('ms-resizable-modal');
         expect(modalEl).toExist();
         expect(modalEl.style.display).toBe('flex');
-        let headButtons = document.getElementsByClassName('square-button-md');
+        let headButtons = document.getElementsByClassName('square-button');
         expect(headButtons.length).toBe(1);
         ReactTestUtils.Simulate.click(headButtons[0]);
         expect(spyonClose).toHaveBeenCalled();
@@ -58,7 +58,7 @@ describe('ResizableModal component', () => {
         const modalEl = document.getElementById('ms-resizable-modal');
         expect(modalEl).toExist();
         expect(modalEl.style.display).toBe('flex');
-        let headButtons = document.getElementsByClassName('square-button-md');
+        let headButtons = document.getElementsByClassName('square-button');
         expect(headButtons.length).toBe(2);
         expect(headButtons[0].querySelector('.glyphicon').getAttribute('class')).toBe('glyphicon glyphicon-resize-full');
 
@@ -67,12 +67,12 @@ describe('ResizableModal component', () => {
         expect(document.querySelector('.ms-fullscreen')).toExist();
 
         ReactDOM.render(<ResizableModal show showFullscreen fullscreenType="vertical"/>, document.getElementById("container"));
-        headButtons = document.getElementsByClassName('square-button-md');
+        headButtons = document.getElementsByClassName('square-button');
         expect(headButtons.length).toBe(2);
         expect(headButtons[0].querySelector('.glyphicon').getAttribute('class')).toBe('glyphicon glyphicon-resize-vertical');
 
         ReactDOM.render(<ResizableModal show showFullscreen fullscreenType="horizontal"/>, document.getElementById("container"));
-        headButtons = document.getElementsByClassName('square-button-md');
+        headButtons = document.getElementsByClassName('square-button');
         expect(headButtons.length).toBe(2);
         expect(headButtons[0].querySelector('.glyphicon').getAttribute('class')).toBe('glyphicon glyphicon-resize-horizontal');
 

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -117,7 +117,7 @@ class CoordinatesRow extends React.Component {
             {
                 buttonConfig: {
                     title: <Glyphicon glyph="cog"/>,
-                    className: "square-button-md no-border",
+                    className: "square-button no-border",
                     pullRight: true,
                     tooltipId: "identifyChangeCoordinateFormat"
                 },
@@ -147,7 +147,7 @@ class CoordinatesRow extends React.Component {
 
         // drag button cannot be a button since IE/Edge doesn't support drag operation on button
         const dragButton = (
-            <div role="button" className="square-button-md no-border btn btn-default"
+            <div role="button" className="square-button no-border btn btn-default"
                 style={{display: "inline-flex", alignItems: 'center', justifyContent: 'center', width: 'auto',
                     color: !this.props.isDraggableEnabled && "#999999",
                     pointerEvents: !this.props.isDraggableEnabled ? "none" : "auto",
@@ -254,7 +254,7 @@ class CoordinatesRow extends React.Component {
                 {this.props.showToolButtons && <div key="tools">
                     <Toolbar
                         btnGroupProps={{className: 'tools'}}
-                        btnDefaultProps={{className: 'square-button-md no-border'}}
+                        btnDefaultProps={{className: 'square-button no-border'}}
                         buttons={toolButtons}/>
                 </div>
                 }

--- a/web/client/components/misc/panels/PanelHeader.jsx
+++ b/web/client/components/misc/panels/PanelHeader.jsx
@@ -62,20 +62,20 @@ export default ({
     onFullscreen = () => {}
 }) => {
     const closeButton = !onClose ? null : (
-        <Button key="ms-header-close" className="ms-close square-button-md _border-transparent" onClick={onClose}>
+        <Button key="ms-header-close" className="ms-close square-button _border-transparent" onClick={onClose}>
             <Glyphicon glyph="1-close"/>
         </Button>
     );
     const glyphButton = showFullscreen ? (
         <Button
             key="ms-header-glyph"
-            className="square-button-md _border-transparent"
+            className="square-button _border-transparent"
             onClick={() => onFullscreen(!fullscreen)}>
             <Glyphicon glyph={fullscreenGlyph[position] && fullscreenGlyph[position][fullscreen] || 'resize-full'}/>
         </Button>) : glyph ?
         (<div
             key="ms-header-glyph"
-            className={`square-button-md _border-transparent`}>
+            className={`square-button _border-transparent`}>
             <Glyphicon glyph={glyph}/>
         </div>
         ) : null;

--- a/web/client/components/misc/panels/__tests__/DockPanel-test.jsx
+++ b/web/client/components/misc/panels/__tests__/DockPanel-test.jsx
@@ -77,7 +77,7 @@ describe("test DockPanel", () => {
 
     it('test fullscreen', () => {
         ReactDOM.render(<DockPanel open showFullscreen onClose={() => {}}/>, document.getElementById("container"));
-        const buttons = document.getElementsByClassName('square-button-md');
+        const buttons = document.getElementsByClassName('square-button');
         expect(buttons.length).toBe(2);
         expect(buttons[0].children[0].getAttribute('class')).toBe('glyphicon glyphicon-chevron-left');
         TestUtils.Simulate.click(buttons[0]);

--- a/web/client/components/misc/panels/__tests__/PanelHeader-test.jsx
+++ b/web/client/components/misc/panels/__tests__/PanelHeader-test.jsx
@@ -28,7 +28,7 @@ describe("test PanelHeader", () => {
         ReactDOM.render(<PanelHeader onClose={() => {}}/>, document.getElementById("container"));
         const domComp = document.getElementsByClassName('ms-header')[0];
         expect(domComp).toExist();
-        const buttons = document.getElementsByClassName('square-button-md');
+        const buttons = document.getElementsByClassName('square-button');
         expect(buttons.length).toBe(2);
         expect(buttons[1].children[0].getAttribute('class')).toBe('glyphicon glyphicon-1-close');
     });
@@ -37,7 +37,7 @@ describe("test PanelHeader", () => {
         ReactDOM.render(<PanelHeader additionalRows={<div className="custom-header-row"/>} onClose={() => {}}/>, document.getElementById("container"));
         const domComp = document.getElementsByClassName('ms-header')[0];
         expect(domComp).toExist();
-        const buttons = document.getElementsByClassName('square-button-md');
+        const buttons = document.getElementsByClassName('square-button');
         expect(buttons.length).toBe(2);
         expect(buttons[1].children[0].getAttribute('class')).toBe('glyphicon glyphicon-1-close');
         const customRow = document.getElementsByClassName('custom-header-row');
@@ -79,7 +79,7 @@ describe("test PanelHeader", () => {
         ReactDOM.render(<PanelHeader bsStyle="primary" onClose={() => {}}/>, document.getElementById("container"));
         const domComp = document.getElementsByClassName('ms-header')[0];
         expect(domComp).toExist();
-        const icon = document.querySelectorAll('div.square-button-md');
+        const icon = document.querySelectorAll('div.square-button');
         expect(icon.length).toBe(1);
         expect(icon[0].tagName.toLowerCase()).toBe('div');
     });

--- a/web/client/components/misc/switch/SwitchPanel.jsx
+++ b/web/client/components/misc/switch/SwitchPanel.jsx
@@ -15,7 +15,7 @@ import Button from '../../misc/Button';
 import LoadingView from '../LoadingView';
 import Toolbar from '../toolbar/Toolbar';
 
-const ErrorIcon = () => <Button className="square-button-sm no-border switch-error"><Glyphicon glyph="exclamation-mark" className="text-danger" /></Button>;
+const ErrorIcon = () => <Button className="square-button no-border switch-error"><Glyphicon glyph="exclamation-mark" className="text-danger" /></Button>;
 const LoadingIcon = () => <div className="switch-loading"><LoadingView size="small"/></div>;
 class SwitchPanel extends React.Component {
 
@@ -61,7 +61,7 @@ class SwitchPanel extends React.Component {
                     }}/> : null}
                 {this.props.error ? <ErrorIcon /> : null}
                 {this.props.loading ? <LoadingIcon /> : null}
-                {this.props.buttons.length > 0 && this.props.expanded && <Toolbar btnDefaultProps={{ className: 'square-button-sm no-border'}} buttons={this.props.buttons}/>}
+                {this.props.buttons.length > 0 && this.props.expanded && <Toolbar btnDefaultProps={{ className: 'square-button no-border'}} buttons={this.props.buttons}/>}
             </div>
         </div>);
     }

--- a/web/client/components/misc/switch/SwitchToolbar.jsx
+++ b/web/client/components/misc/switch/SwitchToolbar.jsx
@@ -35,7 +35,7 @@ class SwitchToolbar extends React.Component {
     render() {
         return (<Toolbar
             btnDefaultProps={{
-                className: 'square-button-md',
+                className: 'square-button',
                 bsStyle: 'primary'
             }}
             btnGroupProps={{

--- a/web/client/components/misc/toolbar/DropdownToolbarOptions.jsx
+++ b/web/client/components/misc/toolbar/DropdownToolbarOptions.jsx
@@ -17,7 +17,7 @@ const DropdownButtonT = tooltip(DropdownButton);
  * options for buttonConfig = {
  *        disabled: false,
  *        tooltipId,
- *        className: "square-button-md",
+ *        className: "square-button",
  *        glyph,
  *        noCaret: true,
  *        title: <Glyphicon glyph={glyph}/>,
@@ -28,7 +28,7 @@ const DropdownButtonT = tooltip(DropdownButton);
 
 const defaultButtonConfig = {
     disabled: false,
-    className: "square-button-md",
+    className: "square-button",
     noCaret: true,
     idDropDown: uuidv1()
 };

--- a/web/client/components/misc/transfer/Transfer.jsx
+++ b/web/client/components/misc/transfer/Transfer.jsx
@@ -20,7 +20,7 @@ import CardList from './TransferColumnCardList';
 const renderTools = (tools) => (
     <Toolbar
         btnDefaultProps={{
-            className: 'square-button-md',
+            className: 'square-button',
             bsStyle: 'primary'
         }}
         buttons={tools}/>
@@ -32,7 +32,7 @@ const renderMoveButtons = (moveButtons) => (
             <Button
                 key={id || idx}
                 bsStyle="primary"
-                className="square-button-md"
+                className="square-button"
                 disabled={disabled}
                 onClick={onClick}>
                 {label}

--- a/web/client/components/misc/transfer/TransferColumnCardList.jsx
+++ b/web/client/components/misc/transfer/TransferColumnCardList.jsx
@@ -40,7 +40,7 @@ const TransferColumnCardList = ({
                 tools={item.tools && item.tools.length > 0 ? <Toolbar
                     buttons={item.tools.map(tool => ({
                         ...tool,
-                        className: 'square-button-md no-border',
+                        className: 'square-button no-border',
                         onClick: (event) => {
                             event.stopPropagation();
                             if (tool.onClick) {

--- a/web/client/components/misc/transfer/__tests__/Transfer-test.jsx
+++ b/web/client/components/misc/transfer/__tests__/Transfer-test.jsx
@@ -80,7 +80,7 @@ describe('Transfer component', () => {
         expect(container.getElementsByClassName('ms2-transfer')[0]).toExist();
         const moveButtonsContainer = container.getElementsByClassName('btn-group-vertical')[0];
         expect(moveButtonsContainer).toExist();
-        const moveButtons = moveButtonsContainer.getElementsByClassName('square-button-md');
+        const moveButtons = moveButtonsContainer.getElementsByClassName('square-button');
         expect(moveButtons.length).toBe(4);
         expect(moveButtons[0].classList.contains('disabled')).toBe(false);
         expect(moveButtons[1].classList.contains('disabled')).toBe(true);
@@ -109,7 +109,7 @@ describe('Transfer component', () => {
         expect(container.getElementsByClassName('ms2-transfer')[0]).toExist();
         const moveButtonsContainer = container.getElementsByClassName('btn-group-vertical')[0];
         expect(moveButtonsContainer).toExist();
-        const moveButtons = moveButtonsContainer.getElementsByClassName('square-button-md');
+        const moveButtons = moveButtonsContainer.getElementsByClassName('square-button');
         expect(moveButtons.length).toBe(4);
         expect(moveButtons[0].classList.contains('disabled')).toBe(false);
         expect(moveButtons[1].classList.contains('disabled')).toBe(false);
@@ -128,7 +128,7 @@ describe('Transfer component', () => {
         expect(container.getElementsByClassName('ms2-transfer')[0]).toExist();
         const moveButtonsContainer = container.getElementsByClassName('btn-group-vertical')[0];
         expect(moveButtonsContainer).toExist();
-        const moveButtons = moveButtonsContainer.getElementsByClassName('square-button-md');
+        const moveButtons = moveButtonsContainer.getElementsByClassName('square-button');
         expect(moveButtons.length).toBe(4);
         expect(moveButtons[0].classList.contains('disabled')).toBe(true);
         expect(moveButtons[1].classList.contains('disabled')).toBe(true);

--- a/web/client/components/resources/modals/fragments/DetailsRow.jsx
+++ b/web/client/components/resources/modals/fragments/DetailsRow.jsx
@@ -46,7 +46,7 @@ export default ({
                             <div className="pull-right">
                                 {loading ? <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner" /> : null}
                                 {!loading && <Toolbar
-                                    btnDefaultProps={{ className: 'square-button-md no-border' }}
+                                    btnDefaultProps={{ className: 'square-button no-border' }}
                                     buttons={[
                                         {
                                             glyph: showPreview ? 'eye-open' : 'eye-close',

--- a/web/client/components/search/SearchBar.jsx
+++ b/web/client/components/search/SearchBar.jsx
@@ -48,14 +48,14 @@ export default ({
                     splitTools={false}
                     toolbarButtons={[{
                         glyph: removeIcon,
-                        className: "square-button-md no-border",
+                        className: "square-button no-border",
                         bsStyle: "default",
                         pullRight: true,
                         visible: searchText !== "",
                         onClick: () => onSearchReset()
                     }, {
                         glyph: searchIcon,
-                        className: "square-button-md no-border " +
+                        className: "square-button no-border " +
                             (isSearchClickable ? "magnifying-glass clickable" : "magnifying-glass"),
                         bsStyle: "default",
                         pullRight: true,

--- a/web/client/components/search/SearchBarToolbar.jsx
+++ b/web/client/components/search/SearchBarToolbar.jsx
@@ -36,7 +36,7 @@ export default ({
     <Toolbar
         btnGroupProps = {{ className: 'btn-group-menu-options'}}
         transitionProps = {null}
-        btnDefaultProps = {{ className: 'square-button-md', bsStyle: 'primary' }}
+        btnDefaultProps = {{ className: 'square-button', bsStyle: 'primary' }}
         {...toolbarProps}
         buttons={toolbarButtons}/>
     {children}

--- a/web/client/components/style/ThemaClassesEditor.jsx
+++ b/web/client/components/style/ThemaClassesEditor.jsx
@@ -131,7 +131,7 @@ class ThemaClassesEditor extends React.Component {
                 }
                 <DropdownButton
                     style={{flex: 0}}
-                    className="square-button-md no-border add-rule"
+                    className="square-button no-border add-rule"
                     noCaret
                     pullRight
                     title={<Glyphicon glyph="option-vertical"/>}

--- a/web/client/components/styleeditor/ClassificationLayerSettings.jsx
+++ b/web/client/components/styleeditor/ClassificationLayerSettings.jsx
@@ -98,7 +98,7 @@ function ClassificationLayerSettings({
                     <div className="ms-classification-layer-settings-title">
                         <Message msgId="styleeditor.customParams" />
                         <Button
-                            className="square-button-md no-border"
+                            className="square-button no-border"
                             onClick={() => onToggle()}
                         >
                             <Glyphicon
@@ -145,7 +145,7 @@ function ClassificationLayerSettings({
                 </div>}
         >
             <Button
-                className="square-button-md no-border"
+                className="square-button no-border"
                 tooltipId="toc.thematic.goToCfg">
                 <Glyphicon
                     glyph="cog"

--- a/web/client/components/styleeditor/FilterBuilder.jsx
+++ b/web/client/components/styleeditor/FilterBuilder.jsx
@@ -184,7 +184,7 @@ export function FilterBuilderPopover({
                 />
             }>
             <Button
-                className="square-button-md no-border"
+                className="square-button no-border"
                 active={isActive}
                 tooltipId="styleeditor.openFilterBuilder">
                 <Glyphicon

--- a/web/client/components/styleeditor/RulesEditor.jsx
+++ b/web/client/components/styleeditor/RulesEditor.jsx
@@ -210,7 +210,7 @@ const RulesEditor = forwardRef(({
                 <div className="ms-style-rules-editor-right">
                     <Toolbar
                         btnDefaultProps={{
-                            className: 'square-button-md no-border'
+                            className: 'square-button no-border'
                         }}
                         buttons={[
                             ...Object.keys(symbolizerBlock).map((kind) => {
@@ -336,7 +336,7 @@ const RulesEditor = forwardRef(({
                                         onChange={(values) => handleChanges({ values, ruleId }, true)}
                                     />}
                                     {!mandatory && <Button
-                                        className="square-button-md no-border"
+                                        className="square-button no-border"
                                         tooltipId="styleeditor.removeRule"
                                         onClick={() => handleRemove(ruleId)}>
                                         <Glyphicon

--- a/web/client/components/styleeditor/ScaleDenominator.jsx
+++ b/web/client/components/styleeditor/ScaleDenominator.jsx
@@ -153,7 +153,7 @@ export function ScaleDenominatorPopover({
                 />
             }>
             <Button
-                className="square-button-md no-border"
+                className="square-button no-border"
                 tooltipId="styleeditor.openScaleDenominator"
                 active={value.min !== undefined || value.max !== undefined}>
                 <Glyphicon

--- a/web/client/components/styleeditor/StyleToolbar.jsx
+++ b/web/client/components/styleeditor/StyleToolbar.jsx
@@ -62,7 +62,7 @@ const StyleToolbar = ({
     <div>
         <Toolbar
             btnDefaultProps={{
-                className: 'square-button-md',
+                className: 'square-button',
                 bsStyle: 'primary'
             }}
             buttons={[

--- a/web/client/components/styleeditor/VisualStyleEditor.jsx
+++ b/web/client/components/styleeditor/VisualStyleEditor.jsx
@@ -290,7 +290,7 @@ function VisualStyleEditor({
             toolbar={
                 <Toolbar
                     btnDefaultProps={{
-                        className: 'square-button-md no-border'
+                        className: 'square-button no-border'
                     }}
                     buttons={[
                         {
@@ -318,7 +318,7 @@ function VisualStyleEditor({
                         {
                             visible: !!error,
                             Element: () => <div
-                                className="square-button-md"
+                                className="square-button"
                                 style={{
                                     display: 'inline-flex',
                                     alignItems: 'center',
@@ -344,7 +344,7 @@ function VisualStyleEditor({
                             visible: !!(loading || updating),
                             Element: () =>
                                 <div
-                                    className="square-button-md"
+                                    className="square-button"
                                     style={{
                                         display: 'inline-flex',
                                         alignItems: 'center',

--- a/web/client/components/widgets/builder/BuilderHeader.jsx
+++ b/web/client/components/widgets/builder/BuilderHeader.jsx
@@ -23,13 +23,13 @@ import Text from '../../layout/Text';
 export default ({onClose = () => {}, children} = {}) =>
     (<FlexBox className="widgets-builder-header" column gap="sm" classNames={['_padding-sm']}>
         <FlexBox centerChildrenVertically >
-            <div className="square-button-md">
+            <div className="square-button">
                 <Glyphicon glyph="stats"/>
             </div>
             <FlexBox.Fill component={Text} fontSize="md" className="_padding-lr-sm">
                 <Message msgId="widgets.builder.header.title" />
             </FlexBox.Fill>
-            <Button onClick={() => onClose()} className="ms-close square-button-md _border-transparent">
+            <Button onClick={() => onClose()} className="ms-close square-button _border-transparent">
                 <Glyphicon glyph="1-close"/>
             </Button>
         </FlexBox>

--- a/web/client/components/widgets/builder/wizard/chart/ChartClassification.jsx
+++ b/web/client/components/widgets/builder/wizard/chart/ChartClassification.jsx
@@ -161,7 +161,7 @@ const CustomClassification = ({
                     <div className="ms-wizard-form-separator">
                         <Message msgId="widgets.builder.wizard.classAttributes.title" />
                         <Button
-                            className="no-border square-button-md"
+                            className="no-border square-button"
                             onClick={() => setOpen(false)}
                         >
                             <Glyphicon glyph="1-close"/>

--- a/web/client/components/widgets/builder/wizard/chart/ChartSwitcher.jsx
+++ b/web/client/components/widgets/builder/wizard/chart/ChartSwitcher.jsx
@@ -47,7 +47,7 @@ export default ({
             // Show info icon when widget width cannot contain Map Switcher
             return (<Button
                 tooltipId="widgets.chartSwitcher.infoOnHide"
-                className="square-button-md no-border"
+                className="square-button no-border"
                 key="info-sign">
                 <Glyphicon glyph="info-sign" />
             </Button>);

--- a/web/client/components/widgets/builder/wizard/chart/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/chart/Toolbar.jsx
@@ -43,7 +43,7 @@ export default ({
         <Toolbar btnDefaultProps={{
             bsStyle: "primary",
             bsSize: "sm",
-            className: "square-button-md"
+            className: "square-button"
         }}
         buttons={[{
             onClick: () => setPage(Math.max(0, step - 1)),

--- a/web/client/components/widgets/builder/wizard/common/layerselector/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/common/layerselector/Toolbar.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import Toolbar from '../../../../../misc/toolbar/Toolbar';
 
 export default ({ canProceed, selected, stepButtons = [], onProceed = () => {}} = {}) => (<Toolbar btnDefaultProps={{
-    className: "square-button-md",
+    className: "square-button",
     bsStyle: "primary",
     bsSize: "sm"
 }}

--- a/web/client/components/widgets/builder/wizard/counter/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/counter/Toolbar.jsx
@@ -41,7 +41,7 @@ const getSaveTooltipId = (step, {id} = {}) => {
 export default ({openFilterEditor = () => {}, step = 0, stepButtons = [], editorData = {}, valid, setPage = () => {}, onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
     bsStyle: "primary",
     bsSize: "sm",
-    className: "square-button-md"
+    className: "square-button"
 }}
 buttons={[{
     onClick: () => setPage(Math.max(0, step - 1)),

--- a/web/client/components/widgets/builder/wizard/legend/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/legend/Toolbar.jsx
@@ -36,7 +36,7 @@ const getSaveTooltipId = (step, {id} = {}) => {
 export default ({ step = 0, editorData = {}, valid, stepButtons = [], onFinish = () => { }, setPage = () => { }} = {}) => (<Toolbar btnDefaultProps={{
     bsStyle: "primary",
     bsSize: "sm",
-    className: "square-button-md"
+    className: "square-button"
 }}
 buttons={[{
     onClick: () => setPage(Math.max(0, step - 1)),

--- a/web/client/components/widgets/builder/wizard/map/MapCatalog.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapCatalog.jsx
@@ -39,7 +39,7 @@ const Title = ({title = ''}) => (<>{title}
         style={{marginLeft: 4}}
         tooltipPosition={"right"}
         tooltip={<HTML msgId="widgets.mapSwitcher.subTitle" />}
-        className="maps-subtitle square-button-md no-border"
+        className="maps-subtitle square-button no-border"
         key="info-sign">
         <Glyphicon glyph="info-sign" />
     </Button></>

--- a/web/client/components/widgets/builder/wizard/map/MapSwitcher.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapSwitcher.jsx
@@ -45,7 +45,7 @@ export default ({
             // Show info icon when widget width cannot contain Map Switcher
             return (<Button
                 tooltipId="widgets.mapSwitcher.infoOnHide"
-                className="square-button-md no-border"
+                className="square-button no-border"
                 key="info-sign">
                 <Glyphicon glyph="info-sign" />
             </Button>);

--- a/web/client/components/widgets/builder/wizard/map/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/map/Toolbar.jsx
@@ -26,7 +26,7 @@ export default ({ step = 0, buttons, tocButtons = [], stepButtons = [], dashBoar
     return (<Toolbar btnDefaultProps={{
         bsStyle: "primary",
         bsSize: "sm",
-        className: "square-button-md"
+        className: "square-button"
     }}
     buttons={buttons || [...(step === 0 ? tocButtons : []), {
         onClick: () => setPage(Math.max(step - 1, 0)),

--- a/web/client/components/widgets/builder/wizard/table/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/table/Toolbar.jsx
@@ -36,7 +36,7 @@ const getSaveTooltipId = (step, {id} = {}) => {
 export default ({ openFilterEditor = () => { }, step = 0, stepButtons = [], editorData = {}, setPage = () => {}, onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
     bsStyle: "primary",
     bsSize: "sm",
-    className: "square-button-md"
+    className: "square-button"
 }}
 buttons={[{
     onClick: () => setPage(Math.max(0, step - 1)),

--- a/web/client/components/widgets/builder/wizard/text/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/text/Toolbar.jsx
@@ -20,7 +20,7 @@ const getSaveTooltipId = (step, {id} = {}) => {
 export default ({ step = 0, editorData = {}, stepButtons = [], onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
     bsStyle: "primary",
     bsSize: "sm",
-    className: "square-button-md"
+    className: "square-button"
 }}
 buttons={[...stepButtons, {
     onClick: () => onFinish(Math.min(step + 1, 1)),

--- a/web/client/epics/maplayout.js
+++ b/web/client/epics/maplayout.js
@@ -78,7 +78,7 @@ export const updateMapLayoutEpic = (action$, store) =>
 
             // Calculating sidebar's rectangle to be used by dock panels
             const rightSidebars = head([
-                get(state, "controls.sidebarMenu.enabled") && {right: 40} || null
+                get(state, "controls.sidebarMenu.enabled") && {right: 30} || null
             ]) || {right: 0};
             const leftSidebars = head([
                 null

--- a/web/client/plugins/AddWidgetDashboard.jsx
+++ b/web/client/plugins/AddWidgetDashboard.jsx
@@ -45,7 +45,7 @@ class AddWidgetDashboard extends React.Component {
  			}}
             id={'ms-add-card-dashboard'}
             tooltipPosition={'left'}
-            btnDefaultProps={{ tooltipPosition: 'right', className: 'square-button-md', bsStyle: this.props.editing ? 'primary' : 'tray' }}/>);
+            btnDefaultProps={{ tooltipPosition: 'right', className: 'square-button', bsStyle: this.props.editing ? 'primary' : 'tray' }}/>);
     }
 }
 

--- a/web/client/plugins/Annotations/components/FeaturesEditor.jsx
+++ b/web/client/plugins/Annotations/components/FeaturesEditor.jsx
@@ -333,7 +333,7 @@ export function FeaturesEditor({
                 <div className="ms-features-editor-list-header">
                     <ButtonGroup>
                         <Button
-                            className="square-button-md no-border"
+                            className="square-button no-border"
                             onClick={() => {
                                 dispatch({ type: UNDO_ANNOTATIONS_FEATURES });
                             }}
@@ -342,7 +342,7 @@ export function FeaturesEditor({
                             <Glyphicon glyph="undo"/>
                         </Button>
                         <Button
-                            className="square-button-md no-border"
+                            className="square-button no-border"
                             onClick={() => {
                                 dispatch({ type: REDO_ANNOTATIONS_FEATURES });
                             }}
@@ -352,19 +352,19 @@ export function FeaturesEditor({
                         </Button>
                     </ButtonGroup>
                     <ButtonGroup>
-                        <Button tooltipId="annotations.titles.marker" className="square-button-md no-border" onClick={() => handleAddFeature('Point')}>
+                        <Button tooltipId="annotations.titles.marker" className="square-button no-border" onClick={() => handleAddFeature('Point')}>
                             <Glyphicon glyph="point-plus"/>
                         </Button>
-                        <Button tooltipId="annotations.titles.line" className="square-button-md no-border" onClick={() => handleAddFeature('LineString')}>
+                        <Button tooltipId="annotations.titles.line" className="square-button no-border" onClick={() => handleAddFeature('LineString')}>
                             <Glyphicon glyph="polyline-plus"/>
                         </Button>
-                        <Button tooltipId="annotations.titles.polygon" className="square-button-md no-border" onClick={() => handleAddFeature('Polygon')}>
+                        <Button tooltipId="annotations.titles.polygon" className="square-button no-border" onClick={() => handleAddFeature('Polygon')}>
                             <Glyphicon glyph="polygon-plus"/>
                         </Button>
-                        <Button tooltipId="annotations.titles.text" className="square-button-md no-border" onClick={() => handleAddFeature('Text', { label: defaultTextLabel || '' })}>
+                        <Button tooltipId="annotations.titles.text" className="square-button no-border" onClick={() => handleAddFeature('Text', { label: defaultTextLabel || '' })}>
                             <Glyphicon glyph="font-add"/>
                         </Button>
-                        <Button tooltipId="annotations.titles.circle" className="square-button-md no-border" onClick={() => handleAddFeature('Circle', { geodesic: !!geodesic?.Circle })}>
+                        <Button tooltipId="annotations.titles.circle" className="square-button no-border" onClick={() => handleAddFeature('Circle', { geodesic: !!geodesic?.Circle })}>
                             <Glyphicon glyph="1-circle-add"/>
                         </Button>
                     </ButtonGroup>
@@ -408,7 +408,7 @@ export function FeaturesEditor({
                                     <Button
                                         disabled={!validateFeature(feature)}
                                         bsStyle={isSelected ? 'primary' : 'default'}
-                                        className="square-button-md"
+                                        className="square-button"
                                         tooltipId="annotations.zoomToGeometry"
                                         onClick={(event) => {
                                             event.stopPropagation();
@@ -417,7 +417,7 @@ export function FeaturesEditor({
                                         <Glyphicon glyph="zoom-to" />
                                     </Button>
                                     <Button
-                                        className="square-button-md"
+                                        className="square-button"
                                         bsStyle={isSelected ? 'primary' : 'default'}
                                         tooltipId="annotations.removeGeometry"
                                         onClick={(event) => { event.stopPropagation(); handleRemoveFeature(id); }}

--- a/web/client/plugins/Annotations/containers/AnnotationsPanel.jsx
+++ b/web/client/plugins/Annotations/containers/AnnotationsPanel.jsx
@@ -54,7 +54,7 @@ function AnnotationsInfoViewer({
             <div>
                 <ButtonGroup>
                     <Button
-                        className="square-button-md"
+                        className="square-button"
                         bsStyle="primary"
                         tooltipId="annotations.edit"
                         onClick={() => onEdit(layer.id)}
@@ -62,7 +62,7 @@ function AnnotationsInfoViewer({
                         <Glyphicon glyph="pencil"/>
                     </Button>
                     <Button
-                        className="square-button-md"
+                        className="square-button"
                         bsStyle="primary"
                         tooltipId="annotations.remove"
                         onClick={() => setRemoveModal(true)}
@@ -70,7 +70,7 @@ function AnnotationsInfoViewer({
                         <Glyphicon glyph="trash"/>
                     </Button>
                     <Button
-                        className="square-button-md"
+                        className="square-button"
                         bsStyle="primary"
                         tooltipId="annotations.downloadcurrenttooltip"
                         onClick={() => onDownload([layer])}
@@ -211,7 +211,7 @@ function AnnotationsPanel({
             style={style}
         >
             <FlexBox centerChildrenVertically classNames={['_padding-sm']}>
-                <div className="square-button-md">
+                <div className="square-button">
                     <Glyphicon glyph="comment"/>
                 </div>
                 <FlexBox.Fill component={Text} fontSize="md" className="_padding-lr-sm">
@@ -219,7 +219,7 @@ function AnnotationsPanel({
                 </FlexBox.Fill>
                 <Button
                     onClick={(event) => handleClosePanel(event)}
-                    className="square-button-md _border-transparent"
+                    className="square-button _border-transparent"
                 >
                     <Glyphicon glyph="1-close"/>
                 </Button>
@@ -248,7 +248,7 @@ function AnnotationsPanel({
                     <Message msgId="settings"/>
                 </NavItem>
                 <Button
-                    className="square-button-md"
+                    className="square-button"
                     bsStyle="primary"
                     tooltipId="annotations.downloadcurrenttooltip"
                     disabled={!(validateFields() && validateFeatures())}

--- a/web/client/plugins/BurgerMenu.jsx
+++ b/web/client/plugins/BurgerMenu.jsx
@@ -235,7 +235,7 @@ export default createPlugin(
                 position: 8,
                 priority: 2,
                 target: 'right-menu',
-                Component: connect(() => ({ id: 'ms-burger-menu', className: 'square-button-md' }))(BurgerMenuPlugin)
+                Component: connect(() => ({ id: 'ms-burger-menu', className: 'square-button' }))(BurgerMenuPlugin)
             }
         }
     }

--- a/web/client/plugins/GeoStoryEditor.jsx
+++ b/web/client/plugins/GeoStoryEditor.jsx
@@ -73,7 +73,7 @@ const EditButton = connect(
     return isEditAllowed
         ? <Button
             id="edit-story"
-            className="square-button-md no-border"
+            className="square-button no-border"
             onClick={handleOnClick}
             tooltipId="geostory.navigation.edit"
             tooltipPosition="bottom">

--- a/web/client/plugins/Login.jsx
+++ b/web/client/plugins/Login.jsx
@@ -254,8 +254,8 @@ export default createPlugin('Login', {
             target: 'right-menu',
             position: 9,
             priority: 3,
-            // TODO: remove square-button-md as soon all square button size are aligned
-            Component: connect(() => ({ className: 'square-button-md' }))(ConnectedLoginPlugin)
+            // TODO: remove square-button as soon all square button size are aligned
+            Component: connect(() => ({ className: 'square-button' }))(ConnectedLoginPlugin)
         },
         SidebarMenu: {
             name: "login",

--- a/web/client/plugins/MapConnectionDashboard.jsx
+++ b/web/client/plugins/MapConnectionDashboard.jsx
@@ -40,7 +40,7 @@ class MapConnectionDashboard extends React.Component {
             onClick={()=>onShowConnections(!showConnections)}
             tooltipPosition={'left'}
             id={'ms-map-connection-card-dashboard'}
-            btnDefaultProps={{ tooltipPosition: 'bottom', className: 'square-button-md', bsStyle: 'primary' }}/>);
+            btnDefaultProps={{ tooltipPosition: 'bottom', className: 'square-button', bsStyle: 'primary' }}/>);
     }
 }
 

--- a/web/client/plugins/ResourcesCatalog/__tests__/ResourcesSearch-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/__tests__/ResourcesSearch-test.jsx
@@ -34,7 +34,7 @@ describe('ResourcesSearch Plugin', () => {
         ReactDOM.render(<Plugin />, document.getElementById("container"));
         const resourcesSearchNode = document.querySelector('.ms-resources-search');
         expect(resourcesSearchNode).toBeTruthy();
-        const buttons = document.querySelectorAll('.square-button-md');
+        const buttons = document.querySelectorAll('.square-button');
         expect(buttons.length).toBe(0);
     });
     it('should render with query', () => {
@@ -48,7 +48,7 @@ describe('ResourcesSearch Plugin', () => {
         ReactDOM.render(<Plugin />, document.getElementById("container"));
         const resourcesSearchNode = document.querySelector('.ms-resources-search');
         expect(resourcesSearchNode).toBeTruthy();
-        const button = document.querySelector('.square-button-md:has(.glyphicon-1-close)');
+        const button = document.querySelector('.square-button:has(.glyphicon-1-close)');
         expect(button).toBeTruthy();
         Simulate.click(button);
         expect(store.getState().resources.search.clear).toBe(true);
@@ -62,7 +62,7 @@ describe('ResourcesSearch Plugin', () => {
         ReactDOM.render(<Plugin items={[{ name: 'MyTool', Component: MyTool, target: 'toolbar' }]}/>, document.getElementById("container"));
         const resourcesSearchNode = document.querySelector('.ms-resources-search');
         expect(resourcesSearchNode).toBeTruthy();
-        const button = document.querySelector('.square-button-md:has(.glyphicon-heart)');
+        const button = document.querySelector('.square-button:has(.glyphicon-heart)');
         expect(button).toBeTruthy();
     });
 

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/MenuItem-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/MenuItem-test.jsx
@@ -68,9 +68,9 @@ describe('MenuItem component', () => {
                 glyph: 'heart'
             }}
         />, document.getElementById('container'));
-        const button = document.querySelector('.square-button-md');
+        const button = document.querySelector('.square-button');
         expect(button).toBeTruthy();
-        expect(button.getAttribute('class')).toBe('square-button-md _border-transparent btn btn-default');
+        expect(button.getAttribute('class')).toBe('square-button _border-transparent btn btn-default');
         expect(button.getAttribute('href')).toBe('/');
         expect(button.getAttribute('target')).toBe('_blank');
         expect(button.innerHTML).toBe('<span class="glyphicon glyphicon-heart"></span>');

--- a/web/client/plugins/RulesEditor.jsx
+++ b/web/client/plugins/RulesEditor.jsx
@@ -91,14 +91,14 @@ class RulesEditorComponent extends React.Component {
              return this.props.editing
                  ? <div className="rulesmanager-editor"><Editor disableDetails={this.props.disableDetails} loading={this.props.loading} enabled={this.props.editing} onClose={() => this.props.setEditing(false)} catalog={this.props.catalog}/></div>
                  : (<div className="ms-vertical-toolbar rules-editor re-toolbar" id={this.props.id}>
-                     <Toolbar loading={this.props.loading} transitionProps={false} btnGroupProps={{vertical: true}} btnDefaultProps={{ tooltipPosition: 'right', className: 'square-button-md', bsStyle: 'primary'}} />
+                     <Toolbar loading={this.props.loading} transitionProps={false} btnGroupProps={{vertical: true}} btnDefaultProps={{ tooltipPosition: 'right', className: 'square-button', bsStyle: 'primary'}} />
                  </div>);
          }
          // render for gs instances
          return this.props.editingGSInstance
              ? <div className="rulesmanager-editor"><GSInstanceEditorComp disableDetails={this.props.disableDetails} loading={this.props.loading} enabled={this.props.editingGSInstance} onClose={() => this.props.setEditing(false)} catalog={this.props.catalog}/></div>
              : (<div className="ms-vertical-toolbar rules-editor re-toolbar" id={this.props.id}>
-                 <Toolbar loading={this.props.loading} transitionProps={false} btnGroupProps={{vertical: true}} btnDefaultProps={{ tooltipPosition: 'right', className: 'square-button-md', bsStyle: 'primary'}} />
+                 <Toolbar loading={this.props.loading} transitionProps={false} btnGroupProps={{vertical: true}} btnDefaultProps={{ tooltipPosition: 'right', className: 'square-button', bsStyle: 'primary'}} />
              </div>);
      }
 }

--- a/web/client/plugins/SearchByBookmark.jsx
+++ b/web/client/plugins/SearchByBookmark.jsx
@@ -205,7 +205,7 @@ const searchByBookmarkConfig = (toggleConfig, enabled, activeTool) => ({
         }
     },
     glyph: "cog",
-    className: "square-button-md no-border ",
+    className: "square-button no-border ",
     tooltipId: "search.bookmarksettings",
     tooltipPosition: "bottom",
     bsStyle: "default",

--- a/web/client/plugins/SearchServicesConfig.jsx
+++ b/web/client/plugins/SearchServicesConfig.jsx
@@ -236,7 +236,7 @@ function SearchServiceButton({
         return (<Button
             bsStyle="default"
             pullRight
-            className="square-button-md no-border"
+            className="square-button no-border"
             tooltipId="search.searchservicesbutton"
             tooltipPosition="bottom"
             onClick={() => {

--- a/web/client/plugins/TOC/components/Toolbar.jsx
+++ b/web/client/plugins/TOC/components/Toolbar.jsx
@@ -10,7 +10,7 @@ import React, { useRef, useEffect, useState } from 'react';
 import { Glyphicon, Dropdown } from 'react-bootstrap';
 import TableOfContentItemButton from './TableOfContentItemButton';
 import { NodeTypes, ROOT_GROUP_ID, DEFAULT_GROUP_ID } from '../../../utils/LayersUtils';
-import { StatusTypes } from '../utils/TOCUtils';
+import { markEdgesForToolbar, StatusTypes } from '../utils/TOCUtils';
 
 /**
  * Toolbar component for the TOC
@@ -74,6 +74,7 @@ function Toolbar({
             const width = ref.current.clientWidth;
             const scrollWidth = ref.current.scrollWidth;
             const overflow = width < scrollWidth;
+            markEdgesForToolbar(ref.current);
             if (overflow) {
                 const sumUntilIndex = (arr, index) => arr.filter((val, idx) => idx <= index).reduce((acc, val) => acc + val, 0);
                 const newBreakpoint = [...ref.current.children]

--- a/web/client/plugins/TOC/utils/TOCUtils.js
+++ b/web/client/plugins/TOC/utils/TOCUtils.js
@@ -189,3 +189,35 @@ export const selectedNodesIdsToObject = (selectedNodesIds, layers, tree) => {
         return null;
     }).filter(selectedNode => !!selectedNode);
 };
+
+/**
+ * Determines if a DOM element is visible based on its computed style.
+ *
+ * @param {HTMLElement} btn - The DOM element to check for visibility.
+ * @returns {boolean} True if the element is visible; otherwise, false.
+ */
+const isVisible = (btn) => {
+    const style = window.getComputedStyle(btn);
+    return style.display !== 'none' && style.visibility !== 'hidden';
+};
+
+/**
+ * Marks the first and last visible button elements within the given element
+ * by adding 'is-first' and 'is-last' CSS classes, respectively.
+ * Removes these classes from all buttons before marking.
+ *
+ * @param {HTMLElement} el - The container element to search for button elements.
+ */
+export const markEdgesForToolbar = (el) => {
+    if (!el) return;
+    const buttons = Array.from(el.querySelectorAll('button'));
+    // filter out excluded + invisible
+    const eligible = buttons.filter((btn) => isVisible(btn));
+    // remove old markers
+    buttons.forEach((btn) => btn.classList.remove('is-first', 'is-last'));
+    // mark new first/last
+    if (eligible.length > 0) {
+        eligible[0].classList.add('is-first');
+        eligible[eligible.length - 1].classList.add('is-last');
+    }
+};

--- a/web/client/plugins/TOC/utils/__tests__/TOCUtils-test.js
+++ b/web/client/plugins/TOC/utils/__tests__/TOCUtils-test.js
@@ -15,7 +15,8 @@ import {
     getLabelName,
     getLayerErrorMessage,
     selectedNodesIdsToObject,
-    isSingleDefaultGroup
+    isSingleDefaultGroup,
+    markEdgesForToolbar
 } from '../TOCUtils';
 
 import { DEFAULT_GROUP_ID, NodeTypes } from '../../../../utils/LayersUtils';
@@ -142,5 +143,89 @@ describe('TOCUtils', () => {
             { id: 'layer01', node: { id: 'layer01', error: null }, type: NodeTypes.LAYER },
             { id: 'group01', node: { id: 'group01', nodes: layers }, type: NodeTypes.GROUP }
         ]);
+    });
+
+    describe('markEdgesForToolbar', () => {
+        let container;
+        beforeEach(() => {
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+
+        afterEach(() => {
+            document.body.removeChild(container);
+            container = null;
+        });
+
+        function createButton(visible = true) {
+            const btn = document.createElement('button');
+            if (!visible) {
+                btn.style.display = 'none';
+            }
+            return btn;
+        }
+
+        it('marks first and last visible buttons', () => {
+            const btn1 = createButton();
+            const btn2 = createButton();
+            const btn3 = createButton();
+            container.append(btn1, btn2, btn3);
+
+            markEdgesForToolbar(container);
+
+            expect(btn1.classList.contains('is-first')).toBe(true);
+            expect(btn3.classList.contains('is-last')).toBe(true);
+            expect(btn2.classList.contains('is-first')).toBe(false);
+            expect(btn2.classList.contains('is-last')).toBe(false);
+        });
+
+        it('removes previous markers before marking new ones', () => {
+            const btn1 = createButton();
+            const btn2 = createButton();
+            btn1.classList.add('is-first', 'is-last');
+            btn2.classList.add('is-first', 'is-last');
+            container.append(btn1, btn2);
+
+            markEdgesForToolbar(container);
+
+            expect(btn1.classList.contains('is-first')).toBe(true);
+            expect(btn1.classList.contains('is-last')).toBe(false);
+            expect(btn2.classList.contains('is-first')).toBe(false);
+            expect(btn2.classList.contains('is-last')).toBe(true);
+        });
+
+        it('ignores invisible buttons', () => {
+            const btn1 = createButton(false); // invisible
+            const btn2 = createButton();
+            const btn3 = createButton(false); // invisible
+            container.append(btn1, btn2, btn3);
+
+            markEdgesForToolbar(container);
+
+            expect(btn2.classList.contains('is-first')).toBe(true);
+            expect(btn2.classList.contains('is-last')).toBe(true);
+            expect(btn1.classList.contains('is-first')).toBe(false);
+            expect(btn1.classList.contains('is-last')).toBe(false);
+            expect(btn3.classList.contains('is-first')).toBe(false);
+            expect(btn3.classList.contains('is-last')).toBe(false);
+        });
+
+        it('does nothing if no visible buttons', () => {
+            const btn1 = createButton(false);
+            container.append(btn1);
+
+            markEdgesForToolbar(container);
+
+            expect(btn1.classList.contains('is-first')).toBe(false);
+            expect(btn1.classList.contains('is-last')).toBe(false);
+        });
+
+        it('returns early if no element provided', () => {
+            const spy = expect.spyOn(document, 'querySelectorAll');
+            markEdgesForToolbar(null);
+            markEdgesForToolbar(undefined);
+            expect(spy.calls.length).toBe(0);
+            spy.restore();
+        });
     });
 });

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -311,7 +311,7 @@ const TimelinePlugin = compose(
                 <div className="timeline-plugin-btn-group">
                     <Toolbar
                         btnDefaultProps={{
-                            className: 'square-button-md',
+                            className: 'square-button',
                             bsStyle: 'primary'
                         }}
                         buttons={[
@@ -358,7 +358,7 @@ const TimelinePlugin = compose(
 
                 <Button
                     onClick={() => setOptions({ ...options, collapsed: !collapsed })}
-                    className="square-button-sm ms-timeline-expand"
+                    className="square-button ms-timeline-expand"
                     bsStyle="primary"
                     tooltip={<Message msgId= {collapsed ? "timeline.expand" : "timeline.collapse"}/>}>
                     <Glyphicon glyph={collapsed ? 'chevron-up' : 'chevron-down'}/>

--- a/web/client/plugins/__tests__/Share-test.jsx
+++ b/web/client/plugins/__tests__/Share-test.jsx
@@ -74,7 +74,7 @@ describe('Share Plugin', () => {
         const { Plugin, actions } = getPluginForTest(SharePlugin, { controls });
         ReactDOM.render(<Plugin />, document.getElementById("container"));
         expect(document.getElementsByClassName('share-panel-modal-body')[0]).toExist();
-        const closeButton = document.querySelector('.square-button-md:has(.glyphicon-1-close)');
+        const closeButton = document.querySelector('.square-button:has(.glyphicon-1-close)');
         ReactTestUtils.Simulate.click(closeButton);
         expect(actions[0].type).toBe(TOGGLE_CONTROL);
         expect(actions[1].type).toBe(HIDE_MAPINFO_MARKER);

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -75,7 +75,7 @@ class Menu extends React.Component {
 
     renderButtons = () => {
         return this.props.children.map((child) => {
-            const button = (<Button key={child.props.eventKey} className={(child.props.buttonConfig && child.props.buttonConfig.buttonClassName) ? child.props.buttonConfig.buttonClassName : "square-button-md _border-transparent"} onClick={this.props.onChoose.bind(null, child.props.eventKey, this.props.activeKey === child.props.eventKey)} bsStyle={this.props.activeKey === child.props.eventKey ? 'default' : 'primary'}>
+            const button = (<Button key={child.props.eventKey} className={(child.props.buttonConfig && child.props.buttonConfig.buttonClassName) ? child.props.buttonConfig.buttonClassName : "square-button _border-transparent"} onClick={this.props.onChoose.bind(null, child.props.eventKey, this.props.activeKey === child.props.eventKey)} bsStyle={this.props.activeKey === child.props.eventKey ? 'default' : 'primary'}>
                 {child.props.glyph ? <Glyphicon glyph={child.props.glyph} /> : child.props.icon}
             </Button>);
             if (child.props.buttonConfig && child.props.buttonConfig.tooltip) {
@@ -97,13 +97,13 @@ class Menu extends React.Component {
                 <FlexBox.Fill>
                     {this.renderButtons()}
                 </FlexBox.Fill>
-                <Button className="square-button-md _border-transparent"  onClick={this.props.onToggle}>
+                <Button className="square-button _border-transparent"  onClick={this.props.onToggle}>
                     <Glyphicon glyph="1-close"/>
                 </Button>
             </FlexBox>)
             : (<FlexBox className="navHeader _padding-sm" centerChildrenVertically>
                 <FlexBox.Fill component={Text} fontSize="md" className="_padding-lr-sm">{this.props.title}</FlexBox.Fill>
-                <Button className="square-button-md _border-transparent"  onClick={this.props.onToggle}>
+                <Button className="square-button _border-transparent"  onClick={this.props.onToggle}>
                     <Glyphicon glyph="1-close"/>
                 </Button>
             </FlexBox>);

--- a/web/client/plugins/manager/ManagerMenu.jsx
+++ b/web/client/plugins/manager/ManagerMenu.jsx
@@ -81,7 +81,7 @@ function ManagerMenu({
             title={<Glyphicon glyph="1-menu-manage"/>}
             tooltipId="manager.managerMenu"
             tooltipPosition="bottom"
-            className="square-button-md"
+            className="square-button"
         >
             {title}
             {defaultItems.map((entry, key) => {

--- a/web/client/plugins/playback/Playback.jsx
+++ b/web/client/plugins/playback/Playback.jsx
@@ -82,7 +82,7 @@ export default playbackEnhancer(({
         { (status !== statusMap.PLAY && status !== statusMap.PAUSE) && showSettings && <Settings style={settingsStyle}/>}
         <Toolbar
             btnDefaultProps={{
-                className: 'square-button-md',
+                className: 'square-button',
                 bsStyle: 'primary'
             }}
             buttons={[

--- a/web/client/plugins/userExtensions/ExtensionsPanel.jsx
+++ b/web/client/plugins/userExtensions/ExtensionsPanel.jsx
@@ -49,7 +49,7 @@ const ExtensionList = emptyState(({ filteredItems, filterText }) => filterText &
                 tools: (
                     <Toolbar
                         btnDefaultProps={{
-                            className: 'square-button-md no-border'
+                            className: 'square-button no-border'
                         }}
                         buttons={[
                             {

--- a/web/client/plugins/widgetbuilder/ChartLayerSelector.jsx
+++ b/web/client/plugins/widgetbuilder/ChartLayerSelector.jsx
@@ -107,7 +107,7 @@ export default connect((state) =>({
                     style={{marginLeft: 4}}
                     tooltipPosition={"right"}
                     tooltip={<HTML msgId="widgets.chartSwitcher.subTitle" />}
-                    className="maps-subtitle square-button-md no-border"
+                    className="maps-subtitle square-button no-border"
                     key="info-sign">
                     <Glyphicon glyph="info-sign" />
                 </Button>

--- a/web/client/plugins/widgetbuilder/MapLayerSelector.jsx
+++ b/web/client/plugins/widgetbuilder/MapLayerSelector.jsx
@@ -35,7 +35,7 @@ export default ({ onClose = () => { }, setSelected = () => { }, onLayerChoice = 
         className="bg-body layer-selector"
         header={<BuilderHeader onClose={onClose}>
             <Toolbar btnDefaultProps={{
-                className: "square-button-md",
+                className: "square-button",
                 bsStyle: "primary",
                 bsSize: "sm"
             }}

--- a/web/client/themes/default/bootstrap-theme.less
+++ b/web/client/themes/default/bootstrap-theme.less
@@ -61,7 +61,7 @@
 // Button
 button.close {
     opacity: 1.0;
-    .square-button-md();
+    .square-button();
     &:first-child {
         font-family: "mapstore2";
         font-size: 0;
@@ -73,7 +73,7 @@ button.close {
 
     &:first-child:before {
         .glyphicon-1-close-content();
-        font-size: @icon-size-md;
+        font-size: @icon-size;
     }
 }
 

--- a/web/client/themes/default/bootstrap-variables.less
+++ b/web/client/themes/default/bootstrap-variables.less
@@ -57,9 +57,9 @@
 
 @padding-base-vertical: 4px;
 @padding-base-horizontal: 8px;
-@border-radius-base: 0;
-@border-radius-large: 0;
-@border-radius-small: 0;
+@border-radius-base: 4px;
+@border-radius-large: 4px;
+@border-radius-small: 4px;
 @component-active-color: @ms-primary-contrast;
 
 //== Tables

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -184,24 +184,24 @@ textarea {
 
     &.toolbar-btn-transition-enter-active {
         .square-btn-size {
-            width: @square-btn-medium-size;
+            width: @square-btn-size;
         }
 
         transition: all 0.3s;
-        padding-left: @padding-left-square-md;
-        padding-right: @padding-left-square-md;
+        padding-left: @padding-left-square;
+        padding-right: @padding-left-square;
         overflow: hidden;
     }
 }
 
 .toolbar-btn-transition-leave {
     .square-btn-size {
-        width: @square-btn-medium-size;
+        width: @square-btn-size;
     }
 
     transition: all 0.3s;
-    padding-left: @padding-left-square-md;
-    padding-right: @padding-left-square-md;
+    padding-left: @padding-left-square;
+    padding-right: @padding-left-square;
     overflow: hidden;
 
     &.toolbar-btn-transition-leave-active {
@@ -244,14 +244,14 @@ textarea {
 }
 .mapstore-filter {
     &.form-group {
-        margin: ((@square-btn-size - @square-btn-medium-size)/2) 0 0 0;
+        margin: ((@square-btn-size - @button-size-sm)/2) 0 0 0;
 
         .input-group {
-            height: @square-btn-medium-size;
+            height: @square-btn-size;
             width: 100%;
 
             input {
-                height: @square-btn-medium-size;
+                height: @square-btn-size;
             }
 
             .input-group-addon {
@@ -462,4 +462,18 @@ div:has(.security-popup-dialog) .modal-backdrop.in {
 }
 .security-popup-dialog {
     z-index: 3150;
+}
+
+.button-group-with-border-radius() {
+    button {
+        border-radius: 0;
+        &:first-child {
+            border-top-left-radius: @border-radius-base;
+            border-bottom-left-radius: @border-radius-base;
+        }
+        &:last-child {
+            border-top-right-radius: @border-radius-base;
+            border-bottom-right-radius: @border-radius-base;
+        }
+    }
 }

--- a/web/client/themes/default/less/context-creator.less
+++ b/web/client/themes/default/less/context-creator.less
@@ -197,6 +197,7 @@
                     width: 50%;
                     min-width: 200px;
                     margin-right: 18px;
+                    border-radius: @border-radius-base;
                 }
             }
         }

--- a/web/client/themes/default/less/doublecolumntransfer.less
+++ b/web/client/themes/default/less/doublecolumntransfer.less
@@ -41,7 +41,7 @@
             .ms2-transfer-title-area h4 {
                 display: flex;
                 overflow-wrap: anywhere;
-                min-height: @square-btn-medium-size;
+                min-height: @square-btn-size;
 
                 span {
                     flex: 1;

--- a/web/client/themes/default/less/dropdown-menu.less
+++ b/web/client/themes/default/less/dropdown-menu.less
@@ -27,7 +27,7 @@
 
 .dropdown-menu .glyphicon,
 .dropdown-menu .fa {
-    font-size: @icon-size-md;
+    font-size: @icon-size;
     margin-right: 15px;
     vertical-align: middle;
 }

--- a/web/client/themes/default/less/geostory-navigation.less
+++ b/web/client/themes/default/less/geostory-navigation.less
@@ -111,7 +111,7 @@
                 background-color: inherit;
                 .ms-geostory-navigation-navigable-items {
                     flex: 1;
-                    min-height: @square-btn-medium-size;
+                    min-height: @square-btn-size;
                     max-width: 50%;
                     background-color: inherit;
                     margin: 4px 0;

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -375,13 +375,13 @@
         .ms-over:not(.ms-dragging) {
             &.ms-above {
                 & > div {
-                    padding-bottom: @square-btn-medium-size;
+                    padding-bottom: @square-btn-size;
                     border-bottom: 2px solid @ms-primary;
                 }
             }
             &.ms-below {
                 & > div {
-                    padding-top: @square-btn-medium-size;
+                    padding-top: @square-btn-size;
                     border-top: 2px solid @ms-primary;
                 }
             }
@@ -428,7 +428,7 @@
 }
 
 .ms-sections-container-small-screen {
-    @ms-story-padding-small-screen: (@square-btn-medium-size / 2 + 8px);
+    @ms-story-padding-small-screen: (@square-btn-size / 2 + 8px);
     .ms-section .ms-section-background .ms-section-background-container .ms-media {
         /* alignment of content */
         .ms-story-align-center();
@@ -492,12 +492,12 @@
         &.ms-section-title .ms-content-text,
         &.ms-section-immersive .ms-content-column,
         &.ms-section-carousel .ms-content-column {
-            padding-right: (@square-btn-medium-size + 8px);
+            padding-right: (@square-btn-size + 8px);
         }
     }
 }
 .ms-sections-container-medium-screen {
-    @ms-story-padding-medium-screen: (@square-btn-medium-size * 1.5);
+    @ms-story-padding-medium-screen: (@square-btn-size * 1.5);
     .ms-section .ms-section-background .ms-section-background-container {
         /* size of content */
         &.ms-size-full .ms-media { width: @ms-story-size-full; }
@@ -665,7 +665,7 @@
                 .ms-content-toolbar {
                     display: flex;
                     padding: 0 16px;
-                    padding-top: (@square-btn-medium-size / 2);
+                    padding-top: (@square-btn-size / 2);
                     .btn-group {
                         margin-right: 0;
                         margin-left: auto;
@@ -707,7 +707,7 @@
             width: 550px;
             height: 50px;
             bottom: 220px;
-            left: -(@square-btn-medium-size / 2);
+            left: -(@square-btn-size / 2);
             font-weight: bold;
             &:before {
                 content: "";
@@ -829,15 +829,15 @@
             border-top: 1px solid @ms-story-bg-grey;
             border-right: 1px solid @ms-story-bg-grey;
             border-left: 1px solid @ms-story-bg-grey;
-            width: (@square-btn-medium-size + 2);
+            width: (@square-btn-size + 2);
             border-top-left-radius: 50%;
             margin-left: 50%;
             transform: translateX(-50%);
             border-top-right-radius: 50%;
             .btn {
                 /* override default style of bootstrap */
-                height: @square-btn-medium-size;
-                width: @square-btn-medium-size;
+                height: @square-btn-size;
+                width: @square-btn-size;
                 padding: 0;
                 outline: 0;
                 .no-border();
@@ -884,8 +884,8 @@
                 /* render the toolbar has a floating container at top left corner of title container */
                 .ms-content-toolbar {
                     position: absolute;
-                    margin-left: (-@square-btn-medium-size / 2);
-                    margin-top: (-@square-btn-medium-size * 0.6);
+                    margin-left: (-@square-btn-size / 2);
+                    margin-top: (-@square-btn-size * 0.6);
                     padding: 0;
                     z-index: 2;
                     .shadow-soft();
@@ -897,8 +897,8 @@
                 where the alignment effect is not visible without this improvement
                 */
                 &.ms-align-center .ms-content-body { margin-left: auto; margin-right: auto; }
-                &.ms-align-left .ms-content-body { margin-left: (@square-btn-medium-size + 8px); margin-right: auto; }
-                &.ms-align-right .ms-content-body { margin-left: auto; margin-right: (@square-btn-medium-size + 8px); }
+                &.ms-align-left .ms-content-body { margin-left: (@square-btn-size + 8px); margin-right: auto; }
+                &.ms-align-right .ms-content-body { margin-left: auto; margin-right: (@square-btn-size + 8px); }
                 /* text on full size should fill all the width of container */
                 &.ms-size-full {
                     width: 100%;
@@ -1055,8 +1055,8 @@
                     &>.ms-content-toolbar {
                         position: absolute;
                         z-index: 2;
-                        margin-left: (-@square-btn-medium-size / 2);
-                        margin-top: (-@square-btn-medium-size * 0.6);
+                        margin-left: (-@square-btn-size / 2);
+                        margin-top: (-@square-btn-size * 0.6);
                         padding: 0;
                         .shadow-soft();
                     }
@@ -1560,8 +1560,8 @@
                     height: 180px;
                     .ms-content-toolbar {
                         position: absolute;
-                        margin-left: (-@square-btn-medium-size / 2);
-                        margin-top: (-@square-btn-medium-size * 0.6);
+                        margin-left: (-@square-btn-size / 2);
+                        margin-top: (-@square-btn-size * 0.6);
                         padding: 0;
                         z-index: 2;
                         border-top: none;
@@ -1653,8 +1653,8 @@
 }
 
 .ms-expand-media-button {
-    height: @square-btn-medium-size;
-    width: @square-btn-medium-size;
+    height: @square-btn-size;
+    width: @square-btn-size;
     padding: 0;
     outline: 0;
     .shadow-soft();
@@ -1685,7 +1685,7 @@
     display: flex;
     align-items: center;
     margin: 4px 0;
-    min-height: @square-btn-medium-size;
+    min-height: @square-btn-size;
     & > div {
         display: flex;
         position: relative;
@@ -1780,7 +1780,7 @@
     display: flex;
     align-items: center;
     margin: 4px 0;
-    min-height: @square-btn-medium-size;
+    min-height: @square-btn-size;
     & > div {
         position: relative;
         align-items: center;

--- a/web/client/themes/default/less/get-feature.less
+++ b/web/client/themes/default/less/get-feature.less
@@ -234,7 +234,7 @@
         padding: 0 8px;
     }
     .ms-identify-swipe-header-arrow {
-        min-width: @square-btn-medium-size;
+        min-width: @square-btn-size;
     }
 }
 

--- a/web/client/themes/default/less/legacy-annotations.less
+++ b/web/client/themes/default/less/legacy-annotations.less
@@ -439,15 +439,15 @@
             }
 
             .geometry-card-preview {
-                width: @square-btn-medium-size;
-                height: @square-btn-medium-size;
+                width: @square-btn-size;
+                height: @square-btn-size;
                 margin: 8px;
                 display: flex;
                 align-items: center;
                 justify-content: center;
 
                 .glyphicon {
-                    font-size: (@square-btn-medium-size * 2 / 3);
+                    font-size: (@square-btn-size * 2 / 3);
                 }
             }
 

--- a/web/client/themes/default/less/loaders.less
+++ b/web/client/themes/default/less/loaders.less
@@ -55,8 +55,8 @@
         .mapstore-circle-loader-with-css-variables(12px, 100%, @theme-vars[loader-primary-color], @theme-vars[loader-primary-fade-color]);
     }
     .mapstore-inline-loader {
-        margin: @padding-left-square-md;
-        .mapstore-circle-loader-with-css-variables((@icon-size-md/10), @icon-size-md, @theme-vars[loader-primary-color], @theme-vars[loader-primary-fade-color]);
+        margin: @padding-left-square;
+        .mapstore-circle-loader-with-css-variables((@icon-size/10), @icon-size, @theme-vars[loader-primary-color], @theme-vars[loader-primary-fade-color]);
     }
 }
 

--- a/web/client/themes/default/less/map-search-bar.less
+++ b/web/client/themes/default/less/map-search-bar.less
@@ -136,7 +136,7 @@ div.MapSearchBar .form-control:focus {
     -moz-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
     box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
 
-    .square-button-md {
+    .square-button {
         .ms-loader {
             >div {
                 border-top-color: rgba(7, 138, 163, 0.2);

--- a/web/client/themes/default/less/map-toolbar.less
+++ b/web/client/themes/default/less/map-toolbar.less
@@ -17,6 +17,7 @@
 // **************
 .mapToolbar {
     box-shadow: -1px 1px 5px 1px rgba(94, 94, 94, 1);
+    border-radius: @border-radius-base;
 }
 
 .mapToolbar {

--- a/web/client/themes/default/less/maps-properties.less
+++ b/web/client/themes/default/less/maps-properties.less
@@ -259,7 +259,7 @@
                 margin-right: 20px;
             }
             .Select {
-                width: ~"calc(50% - @{square-btn-medium-size} - 5px)";
+                width: ~"calc(50% - @{square-btn-size} - 5px)";
                 margin-right: 5px;
                 margin-top: (@square-btn-size - 34px) / 2;
                 .Select-control {
@@ -276,7 +276,7 @@
             }
             button {
                 float: right;
-                margin-top: ((@square-btn-size - @square-btn-medium-size) / 2);
+                margin-top: ((@square-btn-size - @square-btn-size) / 2);
             }
             .ms-permission-title {
                 width: ~"calc(50% - 20px)";
@@ -299,13 +299,13 @@
         margin: 0;
 
         .m-label {
-            margin-top:(( @square-btn-size - @square-btn-medium-size) / 2);
-            height: @square-btn-medium-size;
-            line-height: @square-btn-medium-size;
+            margin-top:(( @square-btn-size - @square-btn-size) / 2);
+            height: @square-btn-size;
+            line-height: @square-btn-size;
         }
 
         .btn-group {
-            margin-top:(( @square-btn-size - @square-btn-medium-size) / 2);
+            margin-top:(( @square-btn-size - @square-btn-size) / 2);
         }
 
         .ms-details-sheet {
@@ -316,8 +316,8 @@
                 margin-top: 0;
             }
             strong {
-                height: @square-btn-medium-size;
-                line-height: @square-btn-medium-size;
+                height: @square-btn-size;
+                line-height: @square-btn-size;
                 font-weight: normal;
             }
             img {

--- a/web/client/themes/default/less/media-editor.less
+++ b/web/client/themes/default/less/media-editor.less
@@ -123,17 +123,7 @@
             width: 300px;
 
             .btn-group {
-                button {
-                    border-radius: 0;
-                    &:first-child {
-                        border-top-left-radius: @border-radius-base;
-                        border-bottom-left-radius: @border-radius-base;
-                    }
-                    &:last-child {
-                        border-top-right-radius: @border-radius-base;
-                        border-bottom-right-radius: @border-radius-base;
-                    }
-                }
+                .button-group-with-border-radius();
             }
         }
     }
@@ -157,17 +147,7 @@
             }
         }
         .btn-group {
-            button {
-                border-radius: 0;
-                &:first-child {
-                    border-top-left-radius: @border-radius-base;
-                    border-bottom-left-radius: @border-radius-base;
-                }
-                &:last-child {
-                    border-top-right-radius: @border-radius-base;
-                    border-bottom-right-radius: @border-radius-base;
-                }
-            }
+            .button-group-with-border-radius();
         }
     }
     .ms-mapForm {

--- a/web/client/themes/default/less/media-editor.less
+++ b/web/client/themes/default/less/media-editor.less
@@ -121,6 +121,20 @@
             z-index: 1;
             order: -1;
             width: 300px;
+
+            .btn-group {
+                button {
+                    border-radius: 0;
+                    &:first-child {
+                        border-top-left-radius: @border-radius-base;
+                        border-bottom-left-radius: @border-radius-base;
+                    }
+                    &:last-child {
+                        border-top-right-radius: @border-radius-base;
+                        border-bottom-right-radius: @border-radius-base;
+                    }
+                }
+            }
         }
     }
     // move service selector in top right corner
@@ -140,6 +154,19 @@
             .ms-mediaEditor-label {
                 flex: 1;
                 padding-right: 4px;
+            }
+        }
+        .btn-group {
+            button {
+                border-radius: 0;
+                &:first-child {
+                    border-top-left-radius: @border-radius-base;
+                    border-bottom-left-radius: @border-radius-base;
+                }
+                &:last-child {
+                    border-top-right-radius: @border-radius-base;
+                    border-bottom-right-radius: @border-radius-base;
+                }
             }
         }
     }

--- a/web/client/themes/default/less/modal.less
+++ b/web/client/themes/default/less/modal.less
@@ -44,6 +44,12 @@
     display: block;
 }
 
+.modal, .modal-dialog {
+    .modal-header .close {
+        border-radius: @border-radius-base;
+    }
+}
+
 .ms-resizable-modal {
     position: absolute;
     text-align: left;

--- a/web/client/themes/default/less/navbar.less
+++ b/web/client/themes/default/less/navbar.less
@@ -51,7 +51,7 @@ ol {
 
 .nav-body {
     position: absolute;
-    top: @nav-toc-top;
+    top: 40px;
     bottom: 0;
     overflow: auto;
     width: 100%;

--- a/web/client/themes/default/less/navbar.less
+++ b/web/client/themes/default/less/navbar.less
@@ -51,7 +51,7 @@ ol {
 
 .nav-body {
     position: absolute;
-    top: @square-btn-size;
+    top: @nav-toc-top;
     bottom: 0;
     overflow: auto;
     width: 100%;

--- a/web/client/themes/default/less/query-panel.less
+++ b/web/client/themes/default/less/query-panel.less
@@ -31,6 +31,12 @@
         .ms2-border-layout-body {
             .background-color-var(@theme-vars[main-bg]);
         }
+
+        .query-toolbar {
+            span {
+                .button-group-with-border-radius();
+            }
+        }
     }
 
     .mapstore-conditions-group {
@@ -134,11 +140,11 @@
     }
 
     .ms2-border-layout-body {
-        padding: @square-btn-small-size;
+        padding: @square-btn-size;
 
         .mapstore-switch-panel {
-            margin-bottom: @square-btn-small-size;
-            padding: 0 (@square-btn-small-size / 2);
+            margin-bottom: @square-btn-size;
+            padding: 0 (@square-btn-size / 2);
             border: none;
             .shadow-soft;
 
@@ -181,7 +187,7 @@
     }
 
     .mapstore-conditions-group {
-        padding-left: @square-btn-small-size;
+        padding-left: @square-btn-size;
         padding-right: 0;
         border-left-width: 1px;
         border-left-style: solid;

--- a/web/client/themes/default/less/react-select.less
+++ b/web/client/themes/default/less/react-select.less
@@ -184,8 +184,8 @@
 // **************
 @import '~react-select/less/select.less';
 @select-input-height: 30; // reduced height to align it to other inputs
-@select-input-border-radius: 0;
-@select-item-border-radius: 0;
+@select-input-border-radius: @border-radius-base;
+@select-item-border-radius: @border-radius-base;
 
 .Select {
     * {

--- a/web/client/themes/default/less/sidegrid.less
+++ b/web/client/themes/default/less/sidegrid.less
@@ -223,6 +223,19 @@
     .mapstore-side-card-right-container {
         display: flex;
         flex-direction: column;
+        .mapstore-side-card-tool {
+            button {
+                border-radius: 0;
+                &:first-child {
+                    border-top-left-radius: @border-radius-base;
+                    border-bottom-left-radius: @border-radius-base;
+                }
+                &:last-child {
+                    border-top-right-radius: @border-radius-base;
+                    border-bottom-right-radius: @border-radius-base;
+                }
+            }
+        }
     }
 
     &:hover {

--- a/web/client/themes/default/less/sidegrid.less
+++ b/web/client/themes/default/less/sidegrid.less
@@ -224,17 +224,7 @@
         display: flex;
         flex-direction: column;
         .mapstore-side-card-tool {
-            button {
-                border-radius: 0;
-                &:first-child {
-                    border-top-left-radius: @border-radius-base;
-                    border-bottom-left-radius: @border-radius-base;
-                }
-                &:last-child {
-                    border-top-right-radius: @border-radius-base;
-                    border-bottom-right-radius: @border-radius-base;
-                }
-            }
+            .button-group-with-border-radius();
         }
     }
 

--- a/web/client/themes/default/less/sliders.less
+++ b/web/client/themes/default/less/sliders.less
@@ -114,8 +114,8 @@
 
                     &:before,
                     &:after {
-                        height: @square-btn-small-size;
-                        width: @square-btn-small-size;
+                        height: @square-btn-size;
+                        width: @square-btn-size;
                         background: transparent;
                         left: 0;
                         top: 0;
@@ -220,7 +220,7 @@
                                 display: flex;
                                 align-items: center;
                                 justify-content: center;
-                                line-height: @square-btn-small-size;
+                                line-height: @square-btn-size;
                             }
                         }
                     }

--- a/web/client/themes/default/less/square-button.less
+++ b/web/client/themes/default/less/square-button.less
@@ -16,50 +16,28 @@
 // Layout
 // **************
 .square-button {
-    // // !important due to vertical btn-group eg. dashboard
-    // height: @square-btn-size;
-    // width: @square-btn-size;
-    // display: inline-flex;
-    // align-items: center;
-    // justify-content: center;
-    // outline: 0;
-    // padding: 0;
-    // .glyphicon {
-    //     margin: auto;
-    //     font-size: @icon-size;
-    // }
-    // .ms-loader {
-    //     height: @icon-size;
-    //     width: @icon-size;
-    //     margin: auto;
-    //     > div {
-    //         margin: auto;
-    //         .mapstore-circle-loader-with-css-variables(@icon-size / 10, @icon-size);
-            
-    //     }
-    // }
     // !important due to vertical btn-group eg. dashboard
     &.input-group-addon {
         display: flex;
     }
     &, .btn-group-vertical & {
-        height: @square-btn-medium-size;
-        width: @square-btn-medium-size;
+        height: @square-btn-size;
+        width: @square-btn-size;
         padding: 0;
         outline: 0;
     }
     .fa,
     .glyphicon {
         margin: auto;
-        font-size: @icon-size-md;
+        font-size: @icon-size;
     }
     .ms-loader {
-        height: @icon-size-md;
-        width: @icon-size-md;
+        height: @icon-size;
+        width: @icon-size;
         margin: auto;
         > div {
             margin: auto;
-            .mapstore-circle-loader-with-css-variables(@icon-size-md/10, @icon-size-md);
+            .mapstore-circle-loader-with-css-variables(@icon-size/10, @icon-size);
         }
     }
 
@@ -67,61 +45,14 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    font-size: @icon-size-md;
+    font-size: @icon-size;
 }
 
 .btn-group-vertical > .square-button {
     width: @square-btn-size;
 }
 
-.square-button-md {
-    // !important due to vertical btn-group eg. dashboard
-    &.input-group-addon {
-        display: flex;
-    }
-    &, .btn-group-vertical & {
-        height: @square-btn-medium-size;
-        width: @square-btn-medium-size;
-        padding: 0;
-        outline: 0;
-    }
-    .fa,
-    .glyphicon {
-        margin: auto;
-        font-size: @icon-size-md;
-    }
-    .ms-loader {
-        height: @icon-size-md;
-        width: @icon-size-md;
-        margin: auto;
-        > div {
-            margin: auto;
-            .mapstore-circle-loader-with-css-variables(@icon-size-md/10, @icon-size-md);
-        }
-    }
-
-    // TODO: check and remove all the above rules
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    font-size: @icon-size-md;
-}
-
-.square-button-sm {
-     &, .btn-group-vertical & {
-        height: @square-btn-small-size;
-        width: @square-btn-small-size ;
-        padding: 0;
-        outline: 0 ;
-     }
-    .fa,
-    .glyphicon {
-        margin: auto;
-        font-size: @icon-size-sm;
-    }
-}
-
-.dropdown.btn-group > .square-button-md+button.dropdown-toggle {
-    height: @square-btn-medium-size;
+.dropdown.btn-group > .square-button+button.dropdown-toggle {
+    height: @square-btn-size;
     padding: 2px;
 }

--- a/web/client/themes/default/less/square-button.less
+++ b/web/client/themes/default/less/square-button.less
@@ -16,28 +16,58 @@
 // Layout
 // **************
 .square-button {
+    // // !important due to vertical btn-group eg. dashboard
+    // height: @square-btn-size;
+    // width: @square-btn-size;
+    // display: inline-flex;
+    // align-items: center;
+    // justify-content: center;
+    // outline: 0;
+    // padding: 0;
+    // .glyphicon {
+    //     margin: auto;
+    //     font-size: @icon-size;
+    // }
+    // .ms-loader {
+    //     height: @icon-size;
+    //     width: @icon-size;
+    //     margin: auto;
+    //     > div {
+    //         margin: auto;
+    //         .mapstore-circle-loader-with-css-variables(@icon-size / 10, @icon-size);
+            
+    //     }
+    // }
     // !important due to vertical btn-group eg. dashboard
-    height: @square-btn-size;
-    width: @square-btn-size;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    outline: 0;
-    padding: 0;
+    &.input-group-addon {
+        display: flex;
+    }
+    &, .btn-group-vertical & {
+        height: @square-btn-medium-size;
+        width: @square-btn-medium-size;
+        padding: 0;
+        outline: 0;
+    }
+    .fa,
     .glyphicon {
         margin: auto;
-        font-size: @icon-size;
+        font-size: @icon-size-md;
     }
     .ms-loader {
-        height: @icon-size;
-        width: @icon-size;
+        height: @icon-size-md;
+        width: @icon-size-md;
         margin: auto;
         > div {
             margin: auto;
-            .mapstore-circle-loader-with-css-variables(@icon-size / 10, @icon-size);
-            
+            .mapstore-circle-loader-with-css-variables(@icon-size-md/10, @icon-size-md);
         }
     }
+
+    // TODO: check and remove all the above rules
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    font-size: @icon-size-md;
 }
 
 .btn-group-vertical > .square-button {

--- a/web/client/themes/default/less/style-editor.less
+++ b/web/client/themes/default/less/style-editor.less
@@ -439,10 +439,11 @@ Ported to CodeMirror by Peter Kroon
 .ms-color-selector {
     position: relative;
     display: flex;
-    height: @square-btn-medium-size;
+    height: @square-btn-size;
     width: 100%;
     border: 1px solid @ms-main-border-color;
     padding: 4px;
+    border-radius: @border-radius-base;
     .ms-popover {
         position: relative;
         display: flex;

--- a/web/client/themes/default/less/swipe.less
+++ b/web/client/themes/default/less/swipe.less
@@ -63,8 +63,8 @@
     }
 
     .ms-slider-arrows {
-        height: @square-btn-medium-size;
-        width: @square-btn-medium-size;
+        height: @square-btn-size;
+        width: @square-btn-size;
         padding: 0;
         border-width: 1px;
         border-style: solid;

--- a/web/client/themes/default/less/switch.less
+++ b/web/client/themes/default/less/switch.less
@@ -58,8 +58,8 @@
 .mapstore-switch-btn {
     position: relative;
     display: inline-block;
-    width: ((@square-btn-small-size * 2) - 8px); /* 60 */
-    height: @square-btn-small-size; /* 34 */
+    width: ((@button-size-sm * 2) - 8px); /* 60 */
+    height: @button-size-sm; /* 34 */
     .m-slider {
 
         position: absolute;
@@ -71,17 +71,18 @@
         opacity: 0.4;
         -webkit-transition: 0.4s;
         transition: 0.4s;
+        border-radius: 9999px;
 
         &:before {
             position: absolute;
             content: " ";
-            height: @square-btn-small-size - 8px;
-            width: @square-btn-small-size - 8px;
+            height: @button-size-sm - 8px;
+            width: @button-size-sm - 8px;
             left: 4px;
             bottom: 4px;
             -webkit-transition: 0.4s;
             transition: 0.4s;
-
+            border-radius: 9999px;
         }
     }
 
@@ -92,7 +93,7 @@
             + .m-slider {
                 opacity: 1.0;
                 &:before {
-                    transform: translateX(@square-btn-small-size - 8px);
+                    transform: translateX(@button-size-sm - 8px);
                 }
             }
         }

--- a/web/client/themes/default/less/switchpanel.less
+++ b/web/client/themes/default/less/switchpanel.less
@@ -37,23 +37,23 @@
         }
         .mapstore-switch-btn, .switch-error, .switch-loading {
             float: right;
-            margin: ((@square-btn-size - @square-btn-small-size) / 2) 0;
+            margin: ((@square-btn-size - @button-size-sm) / 2) 0;
         }
         .switch-loading {
-            width:  @square-btn-small-size;
-            height: @square-btn-small-size;
+            width:  @square-btn-size;
+            height: @square-btn-size;
         }
         .btn-group {
             float: right;
-            margin: (((@square-btn-size - @square-btn-small-size) / 2) - 2) 0;
-            margin-right: ((((@square-btn-size - @square-btn-small-size) / 2) - 2) / 2);
-            .square-button-sm {
+            margin: (((@square-btn-size - @button-size-sm) / 2) - 2) 0;
+            margin-right: ((((@square-btn-size - @button-size-sm) / 2) - 2) / 2);
+            .square-button {
                 padding: 0;
                 text-align: center;
-                padding-top: (@icon-size-md / 8);
-                margin-left: ((((@square-btn-size - @square-btn-small-size) / 2) - 2) / 2);
+                padding-top: (@icon-size / 8);
+                margin-left: ((((@square-btn-size - @button-size-sm) / 2) - 2) / 2);
                 span {
-                    font-size: @icon-size-md;
+                    font-size: @icon-size;
                 }
             }
         }
@@ -62,18 +62,18 @@
     .panel-body {
         .mapstore-block-width {
             .m-label {
-                height: @square-btn-medium-size;
-                line-height: @square-btn-medium-size;
+                height: @square-btn-size;
+                line-height: @square-btn-size;
                 width: 100%;
                 text-overflow: ellipsis;
-                margin-top: ((@square-btn-size - @square-btn-medium-size) / 2);
+                margin-top: ((@square-btn-size - @button-size-sm) / 2);
             }
             .rw-combobox {
                 margin-top: ((@square-btn-size - 34) / 2);
             }
 
             .btn-group {
-                margin-top: ((@square-btn-size - @square-btn-medium-size) / 2);
+                margin-top: ((@square-btn-size - @button-size-sm) / 2);
             }
         }
         padding: 0;

--- a/web/client/themes/default/less/timeline.less
+++ b/web/client/themes/default/less/timeline.less
@@ -384,6 +384,7 @@
         border-top-left-radius: 50%;
         border-top-right-radius: 50%;
         height: 20px;
+        width: 22px;
     }
 
     /* local mixin to highlight handlers on timeline, used on active and over */
@@ -656,17 +657,7 @@
         .shadow-soft;
         .timeline-plugin-btn-group {
             display: flex;
-            button {
-                border-radius: 0;
-                &:first-child {
-                    border-top-left-radius: @border-radius-base;
-                    border-bottom-left-radius: @border-radius-base;
-                }
-                &:last-child {
-                    border-top-right-radius: @border-radius-base;
-                    border-bottom-right-radius: @border-radius-base;
-                }
-            }
+            .button-group-with-border-radius();
         }
         h4 {
             margin-left: 8px;
@@ -948,7 +939,7 @@
     padding-right: 8px;
     border-right: 1px solid @ms-main-border-color;
     background-color: @ms-main-bg;
-    min-height: @square-btn-medium-size;
+    min-height: @square-btn-size;
     display: flex;
     align-items: center;
     .form-group {
@@ -1078,15 +1069,5 @@
             }
         }
     }
-    button {
-        border-radius: 0;
-        &:first-child {
-            border-top-left-radius: @border-radius-base;
-            border-bottom-left-radius: @border-radius-base;
-        }
-        &:last-child {
-            border-top-right-radius: @border-radius-base;
-            border-bottom-right-radius: @border-radius-base;
-        }
-    }
+    .button-group-with-border-radius();
 }

--- a/web/client/themes/default/less/timeline.less
+++ b/web/client/themes/default/less/timeline.less
@@ -380,6 +380,7 @@
         top: 0;
         right: 0;
         transform: translate(-50%, -100%);
+        border-radius: 0;
         border-top-left-radius: 50%;
         border-top-right-radius: 50%;
         height: 20px;
@@ -655,6 +656,17 @@
         .shadow-soft;
         .timeline-plugin-btn-group {
             display: flex;
+            button {
+                border-radius: 0;
+                &:first-child {
+                    border-top-left-radius: @border-radius-base;
+                    border-bottom-left-radius: @border-radius-base;
+                }
+                &:last-child {
+                    border-top-right-radius: @border-radius-base;
+                    border-bottom-right-radius: @border-radius-base;
+                }
+            }
         }
         h4 {
             margin-left: 8px;
@@ -1064,6 +1076,17 @@
                     margin-top: 0;
                 }
             }
+        }
+    }
+    button {
+        border-radius: 0;
+        &:first-child {
+            border-top-left-radius: @border-radius-base;
+            border-bottom-left-radius: @border-radius-base;
+        }
+        &:last-child {
+            border-top-right-radius: @border-radius-base;
+            border-bottom-right-radius: @border-radius-base;
         }
     }
 }

--- a/web/client/themes/default/less/toc-settings.less
+++ b/web/client/themes/default/less/toc-settings.less
@@ -12,7 +12,7 @@
 
 #ms-components-theme(@theme-vars) {
     .thematic_layer {
-        .square-button-sm.no-border[disabled] {
+        .square-button.no-border[disabled] {
             .color-var(@theme-vars[primary]);
             .background-color-var(@theme-vars[primary-contrast]);
         }
@@ -83,7 +83,7 @@
         margin-top: -338px;
     }
 
-    .square-button-sm.no-border[disabled] {
+    .square-button.no-border[disabled] {
         background-color: #FFFFFF;
         color: #5C9FB4;
         opacity: 0.5;
@@ -166,6 +166,10 @@
         .layer-fields-toolbar {
             text-align: center;
             margin: 15px;
+
+            span {
+                .button-group-with-border-radius();
+            }
         }
         .layer-fields-row-header {
             height: 25px;

--- a/web/client/themes/default/less/toc.less
+++ b/web/client/themes/default/less/toc.less
@@ -187,6 +187,29 @@
     .ms-toc-toolbar-dropdown {
         width: @square-btn-medium-size / 2;
     }
+    .ms-toc-toolbar-content {
+        button {
+            border-radius: 0;
+        }
+        div {
+            &:first-child {
+                button {
+                    &:first-child {
+                        border-top-left-radius: @border-radius-base;
+                        border-bottom-left-radius: @border-radius-base;
+                    }
+                }
+            }
+            &:last-child {
+                button {
+                    &:last-child {
+                        border-top-right-radius: @border-radius-base;
+                        border-bottom-right-radius: @border-radius-base;
+                    }
+                }
+            }
+        }
+    }
 }
 
 .ms-context-menu {

--- a/web/client/themes/default/less/toc.less
+++ b/web/client/themes/default/less/toc.less
@@ -158,8 +158,8 @@
         margin: 0;
     }
     .toc-toolbar-button {
-        width: @square-btn-medium-size;
-        height: @square-btn-medium-size;
+        width: @square-btn-size;
+        height: @square-btn-size;
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -168,8 +168,8 @@
     .dropdown-toggle {
         padding: 0;
         border: transparent;
-        height: @square-btn-medium-size;
-        width: @square-btn-medium-size;
+        height: @square-btn-size;
+        width: @square-btn-size;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -185,29 +185,20 @@
         }
     }
     .ms-toc-toolbar-dropdown {
-        width: @square-btn-medium-size / 2;
+        width: @square-btn-size / 2;
     }
     .ms-toc-toolbar-content {
         button {
             border-radius: 0;
         }
-        div {
-            &:first-child {
-                button {
-                    &:first-child {
-                        border-top-left-radius: @border-radius-base;
-                        border-bottom-left-radius: @border-radius-base;
-                    }
-                }
-            }
-            &:last-child {
-                button {
-                    &:last-child {
-                        border-top-right-radius: @border-radius-base;
-                        border-bottom-right-radius: @border-radius-base;
-                    }
-                }
-            }
+        div button { border-radius: 0; }
+        div button.is-first {
+            border-top-left-radius: @border-radius-base;
+            border-bottom-left-radius: @border-radius-base;
+        }
+        div button.is-last {
+            border-top-right-radius: @border-radius-base;
+            border-bottom-right-radius: @border-radius-base;
         }
     }
 }
@@ -421,7 +412,7 @@
 .wms-legend {
     .wms-json-legend-rule {
         display: flex;
-        margin-bottom: @padding-left-square-md;
+        margin-bottom: @padding-left-square;
         .ms-legend-icon {
             margin-right: 8px;
         }

--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -68,9 +68,26 @@
     .widgets-tray {
         .background-color-var(@theme-vars[main-bg]);
 
+        .ms2-border-layout-body {
+            button:not(.widgets-bar button) {
+                border-radius: 0;
+                &:first-child {
+                    border-top-left-radius: @border-radius-base;
+                    border-bottom-left-radius: @border-radius-base;
+                }
+                &:last-child {
+                    border-top-right-radius: @border-radius-base;
+                    border-bottom-right-radius: @border-radius-base;
+                }
+            }
+        }
+
         .widgets-bar {
             >span {
                 .border-right-color-var(@theme-vars[main-border-color]);
+            }
+            > span > button {
+                border-radius: 0;
             }
         }
     }
@@ -413,6 +430,17 @@
         right: 0;
         padding: 7px;
         margin-right: 13px;
+    }
+    span > button {
+        border-radius: 0;
+        &:first-child {
+            border-top-left-radius: @border-radius-base;
+            border-bottom-left-radius: @border-radius-base;
+        }
+        &:last-child {
+            border-top-right-radius: @border-radius-base;
+            border-bottom-right-radius: @border-radius-base;
+        }
     }
 }
 .dashboard-editor {

--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -86,7 +86,7 @@
             >span {
                 .border-right-color-var(@theme-vars[main-border-color]);
             }
-            > span > button {
+            > span > button.btn-tray {
                 border-radius: 0;
             }
         }
@@ -547,8 +547,8 @@
         padding: 0;
 
         .mapstore-switch-panel {
-            margin-bottom: @square-btn-small-size;
-            padding: 0 @square-btn-small-size / 2;
+            margin-bottom: @square-btn-size;
+            padding: 0 @square-btn-size / 2;
             border: none;
             .shadow-soft;
             .panel-title {

--- a/web/client/themes/default/less/wizard.less
+++ b/web/client/themes/default/less/wizard.less
@@ -151,6 +151,24 @@
     }
 }
 
+.ms-wizard-chart-selector,
+.ms-wizard.chart-options {
+    span:first-child > button {
+        border-top-left-radius: @border-radius-base;
+        border-bottom-left-radius: @border-radius-base;
+    }
+    span:last-child > button {
+        border-top-right-radius: @border-radius-base;
+        border-bottom-right-radius: @border-radius-base;
+    }
+    span > button {
+        border-radius: 0;
+    }
+    .input-group input.form-control {
+        border-radius: @border-radius-base !important;
+    }
+}
+
 .ms-wizard-chart-custom-classification {
     .shadow-soft();
     width: 450px;

--- a/web/client/themes/default/ms-variables.less
+++ b/web/client/themes/default/ms-variables.less
@@ -377,22 +377,13 @@
 @square-btn-size: 30px;
 @padding-left-square: floor(((@square-btn-size - @icon-size) / 2));
 
-@icon-size-md: 15px;
-@square-btn-medium-size: 30px;
-@padding-left-square-md: floor(((@square-btn-medium-size - @icon-size-md) / 2));
-
-@icon-size-sm: 15px;
-@square-btn-small-size: 30px;
-@padding-left-square-sm: floor(((@square-btn-small-size - @icon-size-sm) / 2));
-
 @grid-icon-size: 16px;
 @grid-btn-size: 32px;
 @grid-btn-padding-left: floor(((@grid-btn-size - @grid-icon-size) / 2));
 
 @card-height: 52px;
 
-@nav-toc-top: 40px;
-
+@button-size-sm: 22px;
 
 
 // ******************************************

--- a/web/client/themes/default/ms-variables.less
+++ b/web/client/themes/default/ms-variables.less
@@ -373,16 +373,16 @@
 // ******************************************
 @small-icon-size: 14px;
 
-@icon-size: 24px;
-@square-btn-size: 40px;
+@icon-size: 15px;
+@square-btn-size: 30px;
 @padding-left-square: floor(((@square-btn-size - @icon-size) / 2));
 
 @icon-size-md: 15px;
 @square-btn-medium-size: 30px;
 @padding-left-square-md: floor(((@square-btn-medium-size - @icon-size-md) / 2));
 
-@icon-size-sm: 14px;
-@square-btn-small-size: 22px;
+@icon-size-sm: 15px;
+@square-btn-small-size: 30px;
 @padding-left-square-sm: floor(((@square-btn-small-size - @icon-size-sm) / 2));
 
 @grid-icon-size: 16px;
@@ -390,6 +390,8 @@
 @grid-btn-padding-left: floor(((@grid-btn-size - @grid-icon-size) / 2));
 
 @card-height: 52px;
+
+@nav-toc-top: 40px;
 
 
 


### PR DESCRIPTION
## Description
This PR updates the style of the square buttons, and adds the border radius in button, inputs and selectors as per the requirement in #10954.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
The buttons were categorized in small, medium and default size. And the components did not have the border radius to them.
Fixes #10954 

**What is the new behavior?**
All the buttons are now categorized under `square-button` only. Other categories of square-button-md and square-button-sm are deprecated. Also, the border radius have been implemented in the button, inputs and select components.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information