### PR TITLE
Missing flag when choosing catalan #11268

### DIFF
--- a/web/client/translations/data.ca-ES.json
+++ b/web/client/translations/data.ca-ES.json
@@ -1,5 +1,5 @@
 {
-  "locale": "ca-es",
+  "locale": "ca-ES",
   "messages": {
     "Language": "Llengua",
     "msgId0": "{name} va fer {numPhotos,plural, =0 {no photos} = 1 {one photo} Altres {# photos}} a {takenDate,date,long}.",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

fixes #11268

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11268
The flag was missing on the flag selector while choosing "Catalan"

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The flag will also appear for "Catalan".
<img width="130" height="67" alt="image" src="https://github.com/user-attachments/assets/121b4ab5-6e45-45a4-b45c-65819d872266" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
- on `web/client/translations/data.ca-ES.json` locale should be  "ca-ES", not "ca-es"
   - image is named as  `ca-ES`
- for test, add this to `supportedLocales` on `localConfig`
  ```
      "ca": {
            "code": "ca-ES",
            "description": "Catalan"
          }
   ```