### PR TITLE
fix 11441 build failure updating cesium 1.133.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "bootstrap": "3.4.1",
     "buffer": "6.0.3",
     "canvas-to-blob": "0.0.0",
-    "cesium": "1.131.0",
+    "cesium": "1.133.1",
     "chroma-js": "1.3.7",
     "classnames": "2.2.5",
     "codemirror": "5.65.16",


### PR DESCRIPTION
## Description
fix #11441 this cesium upgrade prevent build fail:


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
 
## Other useful information

The upgrade from 1.131.0 to 1.133.1
introduce 1 deprecation and 1 potential breaking change which does not concern the current version of MS which does not seem to use this part(ITwinData), Below are the most important references from the Cesium changelog.
```
## 1.132
Deprecated
Updated all of the ITwinData.* functions to accept an options parameter instead of individual arguments to avoid confusion with multiple optional arguments. There is a fallback to the old signature that will be removed in 1.133 #12778

## 1.133

### Breaking Changes
Removed the argument fallback in ITwinData.* functions. Instead, use the new options argument signature. #12778
https://github.com/CesiumGS/cesium/issues/12778

```

 [https://github.com/CesiumGS/cesium/issues/12778](https://github.com/CesiumGS/cesium/issues/12778)
