### PR TITLE
Remove intersection-observer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
     "html-to-draftjs": "npm:@geosolutions/html-to-draftjs@1.5.1",
     "html-to-image": "1.11.11",
     "immutable": "4.0.0-rc.12",
-    "intersection-observer": "0.7.0",
     "intl": "1.2.2",
     "ismobilejs": "0.5.0",
     "json-2-csv": "5.5.1",

--- a/web/client/components/misc/enhancers/withIntersectionObserver.js
+++ b/web/client/components/misc/enhancers/withIntersectionObserver.js
@@ -7,7 +7,6 @@
  */
 import React from "react";
 import { InView } from 'react-intersection-observer';
-import "intersection-observer";
 
 /**
  * Enhancer that adds IntersectionObserver functionalities to trigger appear or disappear events in a scroll context.


### PR DESCRIPTION
## Description
This PR removes the intersection-observer dependency, which is a polyfill for a the Intersection Observer API. The polyfill is no longer needed as all modern browsers support this functionality.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11449

**What is the new behavior?**
We will no longer npm install intersection-observer dependency

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
