### PR TITLE
Remove es6-promise dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,6 @@
     "dxf-writer": "1.18.4",
     "earcut": "2.2.4",
     "embed-video": "2.0.4",
-    "es6-promise": "2.3.0",
     "esri-leaflet": "3.0.12",
     "eventlistener": "0.0.1",
     "file-saver": "1.3.3",

--- a/web/client/actions/locale.js
+++ b/web/client/actions/locale.js
@@ -7,7 +7,6 @@
  */
 
 import { castArray, merge } from 'lodash';
-import { Promise } from 'es6-promise';
 
 import axios from '../libs/ajax';
 import { error } from './notifications';

--- a/web/client/components/TOC/fragments/__tests__/LayerMetadataModal-test.jsx
+++ b/web/client/components/TOC/fragments/__tests__/LayerMetadataModal-test.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Promise } from 'es6-promise';
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/web/client/components/TOC/fragments/template/__tests__/MetadataTemplate-test.jsx
+++ b/web/client/components/TOC/fragments/template/__tests__/MetadataTemplate-test.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Promise} from 'es6-promise';
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/web/client/components/data/template/jsx/__tests__/Template-test.jsx
+++ b/web/client/components/data/template/jsx/__tests__/Template-test.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Promise} from 'es6-promise';
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/web/client/components/import/SelectShape.jsx
+++ b/web/client/components/import/SelectShape.jsx
@@ -14,7 +14,6 @@ import Spinner from 'react-spinkit';
 import { getMessageById } from '../../utils/LocaleUtils';
 import JSZip from 'jszip';
 import { readZip, recognizeExt, MIME_LOOKUPS } from '../../utils/FileUtils';
-import { Promise } from 'es6-promise';
 
 class SelectShape extends React.Component {
     static propTypes = {

--- a/web/client/components/import/ShapefileUploadAndStyle.jsx
+++ b/web/client/components/import/ShapefileUploadAndStyle.jsx
@@ -30,7 +30,6 @@ import {
 } from '../../utils/FileUtils';
 import Button from '../misc/Button';
 import SelectShape from './SelectShape';
-import { Promise } from 'es6-promise';
 
 class ShapeFileUploadAndStyle extends React.Component {
     static propTypes = {

--- a/web/client/components/import/style/StylePanel.jsx
+++ b/web/client/components/import/style/StylePanel.jsx
@@ -9,7 +9,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid, Row, Col, Alert, ButtonToolbar } from 'react-bootstrap';
-import { Promise } from 'es6-promise';
 
 import Message from '../../I18N/Message';
 import { getMessageById } from '../../../utils/LocaleUtils';

--- a/web/client/components/map/openlayers/VectorStyle.js
+++ b/web/client/components/map/openlayers/VectorStyle.js
@@ -27,7 +27,6 @@ import CircleStyle from 'ol/style/Circle';
 import {Stroke, Fill, Text, Style} from 'ol/style';
 import {Point, LineString} from 'ol/geom';
 
-import {Promise} from 'es6-promise';
 import axios from '../../../libs/ajax';
 
 import {

--- a/web/client/components/resources/modals/enhancers/__tests__/handlePermission-test.jsx
+++ b/web/client/components/resources/modals/enhancers/__tests__/handlePermission-test.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Promise } from 'es6-promise';
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import url from 'url';
 import axios from 'axios';
 import { castArray, isArray, isObject, endsWith, isNil, get, mergeWith } from 'lodash';
-import { Promise } from 'es6-promise';
 import isMobile from 'ismobilejs';
 import {mergeConfigsPatch} from "@mapstore/patcher";
 

--- a/web/client/utils/ElevationUtils.js
+++ b/web/client/utils/ElevationUtils.js
@@ -9,7 +9,6 @@
 import axios from '../libs/ajax';
 
 import LRUCache from 'lrucache';
-import { Promise } from 'es6-promise';
 const DEFAULT_SIZE = 100;
 let elevationTiles = new LRUCache(DEFAULT_SIZE);
 

--- a/web/client/utils/FileUtils.js
+++ b/web/client/utils/FileUtils.js
@@ -13,7 +13,6 @@ import toBlob from 'canvas-to-blob';
 import shp from 'shpjs';
 import tj from '@mapbox/togeojson';
 import JSZip from 'jszip';
-import { Promise } from 'es6-promise';
 const parser = new DOMParser();
 import { hint as geojsonhint } from '@mapbox/geojsonhint/lib/object';
 import { toMapConfig } from './ogc/WMC';


### PR DESCRIPTION
## Description
This PR removes the es6-promise npm dependency. The dependency implements a polyfill for Promise. Promise has been available in all modern browsers for a long time, which means we can safely remove it.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11456

**What is the new behavior?**
Promise will no longer get polyfilled

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
