### PR TITLE
Switch from rimraf to premove

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "redux-devtools-dock-monitor": "1.1.2",
     "redux-devtools-log-monitor": "1.3.0",
     "redux-mock-store": "1.2.2",
-    "rimraf": "2.5.2",
     "simple-git": "2.20.1",
     "style-loader": "2.0.0",
     "terser": "5.18.1",
@@ -110,7 +109,8 @@
     "webpack": "5.94.0",
     "webpack-bundle-size-analyzer": "2.0.2",
     "webpack-cli": "4.10.0",
-    "webpack-dev-server": "3.11.0"
+    "webpack-dev-server": "3.11.0",
+    "premove": "4.0.0"
   },
   "dependencies": {
     "@carnesen/redux-add-action-listener-enhancer": "0.0.1",
@@ -295,7 +295,7 @@
     "cleandoc": "npm run jsdoc:clean",
     "doctest": "npm run jsdoc:test",
     "jsdoc:build": "npm run jsdoc:check && docma -c build/docma-config.json --dest web/docs",
-    "jsdoc:clean": "rimraf web/docs && rimraf web/client/mapstore/docs",
+    "jsdoc:clean": "premove web/docs && premove web/client/mapstore/docs",
     "jsdoc:test": "docma -c build/docma-config.json --dest web/client/mapstore/docs && echo documentation is accessible from the mapstore/docs path when running npm start",
     "jsdoc:check": "node ./utility/doc/jsDocConfigCheck.js",
     "jsdoc:update": "node ./utility/doc/jsDocConfigUpdate.js",
@@ -303,7 +303,7 @@
     "doc:start": "mkdocs serve",
     "postinstall": "node utility/build/postInstall.js",
     "clean": "npm run fe:clean",
-    "fe:clean": "rimraf ./web/client/dist",
+    "fe:clean": "premove ./web/client/dist",
     "md": "markdownlint .",
     "md:fix": "markdownlint --fix .",
     "lint": "eslint web/client --ext .jsx,.js && npm run md && npm run json:check",

--- a/utility/projects/projectScripts.json
+++ b/utility/projects/projectScripts.json
@@ -16,7 +16,7 @@
   "continuoustest": "npm run test:watch",
 
   "postinstall": "node MapStore2/utility/build/postInstall.js",
-  "clean": "rimraf dist",
+  "clean": "premove dist",
   "lint": "eslint js --ext .jsx,.js",
   "updateDevDeps": "node updateDevDependencies.js"
 }


### PR DESCRIPTION
## Description
This PR replaces rimraf with premove. It works as a drop-in replacement and is a much lighter alternative to rimraf.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
We are using rimraf to delete the dist and jsdoc folders
#11473

**What is the new behavior?**
We will be using premove instead of rimraf to delete the dist and jsdoc folders

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
