### PR TITLE
Fix: #11403 In Dashboard , When table widget is connected to map and saved the app crashes

### DIFF
--- a/web/client/epics/widgets.js
+++ b/web/client/epics/widgets.js
@@ -67,7 +67,7 @@ const updateDependencyMap = (active, targetId, { dependenciesMap, mappings}) => 
         if (includes(dimensionDependencies, k)) {
             return {
                 ...ov,
-                [k]: `${depToTheWidget}.${mappings[k]}`
+                [k]: targetId === "map" ? `dimension.${mappings[k]}` : `${depToTheWidget}.${mappings[k]}`
             };
         }
         if (!endsWith(targetId, "map") && includes(tableDependencies, k)) {


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
In Dashboard , After we create a empty map and connect the table widget to the Map. The app crashes

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11403 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Now we can connect the table widget with Map in Dashboard without any issue.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
