### PR TITLE
#11469: Rule Manager: GeoFence error message in open layers DD in add new rule

### DIFF
--- a/web/client/components/manager/rulesmanager/ruleseditor/EditMain.jsx
+++ b/web/client/components/manager/rulesmanager/ruleseditor/EditMain.jsx
@@ -13,24 +13,32 @@ import Message from '../../../I18N/Message';
 import Api from '../../../../api/geoserver/GeoFence';
 
 
-export default ({rule = {}, setOption = () => {}, active = true}) => {
+export default ({rule = {}, setOption = () => {}, active = true, gsInstancesList = []}) => {
     const {grant, layer, workspace} = rule;
     const showInfo = grant !== "DENY" && layer && !workspace;
     const isStandAloneGeofence = Api.getRuleServiceType() === 'geofence';
     let rulesSelectors = [];
     if (isStandAloneGeofence) {
-        rulesSelectors = [
-            <Selectors.GSInstance key="instance" selected={rule?.instance?.id} setOption={setOption}/>,
-            <>{ !!rule.id && (<Selectors.Priority key="priority" selected={rule.priority} setOption={setOption}/>) }</>,
-            <Selectors.Role key="rolename" selected={rule.rolename} setOption={setOption} />,
-            <Selectors.User key="username" selected={rule.username} setOption={setOption} />,
-            <Selectors.Ip key="ip-address" selected={rule.ipaddress} setOption={setOption}/>,
-            <Selectors.Service key="service" selected={rule.service} setOption={setOption}/>,
-            <Selectors.Request key="request" selected={rule.request} service={rule.service} setOption={setOption}/>,
-            <Selectors.Workspace key="workspace" selected={rule.workspace} setOption={setOption} gsInstanceURL={rule?.instance?.url} disabled={!rule?.instance?.id}/>,
-            <Selectors.Layer key="layer" selected={rule.layer} workspace={rule.workspace} setOption={setOption} gsInstanceURL={rule?.instance?.url} disabled={!rule?.instance?.id}/>,
-            <Selectors.ValidityPeriod key="validityPeriod" selectedStart={rule.validafter || rule.validAfter} selectedEnd={rule.validbefore || rule.validBefore} setOption={setOption} />,
-            <Selectors.Access key="access" selected={rule.grant} workspace={rule.workspace} setOption={setOption}/>];
+        // adding this condition to only render selectors if:
+        //   - An instance is selected AND instances list is loaded (to resolve URL for workspace/layer fetch)
+        //   - OR no instance is selected yet (allow user to pick one first)
+        if ((rule?.instance && gsInstancesList.length) || !rule?.instance) {
+            const instanceId = rule?.instance?.id;
+            const ruleInstance = gsInstancesList.find(gs => gs.id === instanceId) ?? rule?.instance;
+
+            rulesSelectors = [
+                <Selectors.GSInstance key="instance" selected={rule?.instance?.id} setOption={setOption}/>,
+                <>{ !!rule.id && (<Selectors.Priority key="priority" selected={rule.priority} setOption={setOption}/>) }</>,
+                <Selectors.Role key="rolename" selected={rule.rolename} setOption={setOption} />,
+                <Selectors.User key="username" selected={rule.username} setOption={setOption} />,
+                <Selectors.Ip key="ip-address" selected={rule.ipaddress} setOption={setOption}/>,
+                <Selectors.Service key="service" selected={rule.service} setOption={setOption}/>,
+                <Selectors.Request key="request" selected={rule.request} service={rule.service} setOption={setOption}/>,
+                <Selectors.Workspace key="workspace" selected={rule.workspace} setOption={setOption} gsInstanceURL={ruleInstance?.url} disabled={!ruleInstance?.id}/>,
+                <Selectors.Layer key="layer" selected={rule.layer} workspace={rule.workspace} setOption={setOption} gsInstanceURL={ruleInstance?.url} disabled={!ruleInstance?.id}/>,
+                <Selectors.ValidityPeriod key="validityPeriod" selectedStart={rule.validafter || rule.validAfter} selectedEnd={rule.validbefore || rule.validBefore} setOption={setOption} />,
+                <Selectors.Access key="access" selected={rule.grant} workspace={rule.workspace} setOption={setOption}/>];
+        }
     } else {
         rulesSelectors = [
             <>{ !!rule.id && (<Selectors.Priority key="priority" selected={rule.priority} setOption={setOption}/>) }</>,

--- a/web/client/components/manager/rulesmanager/ruleseditor/attributeselectors/GSInstance.jsx
+++ b/web/client/components/manager/rulesmanager/ruleseditor/attributeselectors/GSInstance.jsx
@@ -53,8 +53,19 @@ const GSInstanceSelector = (props, context) => {
                     clearable
                     options={gsInstancesList.map(gsI => ({label: gsI.name, value: gsI.id, url: gsI.url}))}
                     value={props.selected}
-                    onChange={({value, url, label}) => {
-                        props.setOption({key: "instance", value: value ?  {id: value, url, name: label} : undefined});
+                    onChange={(selectedOption) => {
+                        if (!selectedOption) {
+                            props.setOption({
+                                key: "instance",
+                                value: undefined
+                            });
+                        } else {
+                            const { value, url, label } = selectedOption;
+                            props.setOption({
+                                key: "instance",
+                                value: value ? { id: value, url, name: label } : undefined
+                            });
+                        }
                     }}
                     placeholder={getMessageById(context.messages, "rulesmanager.placeholders.gsInstances")} />
             </Col>

--- a/web/client/observables/rulesmanager.js
+++ b/web/client/observables/rulesmanager.js
@@ -12,7 +12,6 @@ import Rx from 'rxjs';
 import { RULE_SAVED, storeGSInstancesDDList } from '../actions/rulesmanager';
 import GeoFence from '../api/geoserver/GeoFence';
 import WMS from '../api/WMS';
-import ConfigUtils from '../utils/ConfigUtils';
 import { describeFeatureType } from './wfs';
 import { describeLayer, getLayerCapabilities } from './wms';
 import { getLayerOptions } from '../utils/WMSUtils';
@@ -120,8 +119,7 @@ export const updateRule = (rule, origRule) => {
 };
 export const createRule = (rule) => Rx.Observable.defer(() => GeoFence.addRule(rule));
 
-export const getStylesAndAttributes = (layer, workspace) => {
-    const {url} = ConfigUtils.getDefaults().geoFenceGeoServerInstance || {};
+export const getStylesAndAttributes = (layer, workspace, url) => {
     const name = `${workspace}:${layer}`;
     const l = {url: `${fixUrl(url)}wms`, name};
     return Rx.Observable.combineLatest(getLayerCapabilities(l)

--- a/web/client/plugins/manager/EditorEnhancer.js
+++ b/web/client/plugins/manager/EditorEnhancer.js
@@ -6,34 +6,113 @@ import { connect } from 'react-redux';
 import { changeDrawingStatus } from '../../actions/draw';
 import { error } from '../../actions/notifications';
 import ConfigUtils from '../../utils/ConfigUtils';
+import GeoFence from '../../api/geoserver/GeoFence';
 
 const sameLayer = ({activeRule: f1}, {activeRule: f2}) => f1.layer === f2.layer;
 const emitStop = stream$ => stream$.filter(() => false).startWith({});
 import { getStylesAndAttributes } from '../../observables/rulesmanager';
+import { gsInstancesDDListSelector } from '../../selectors/rulesmanager';
+import { storeGSInstancesDDList } from '../../actions/rulesmanager';
 const dataStreamFactory = prop$ => {
     return prop$.distinctUntilChanged((oP, nP) => sameLayer(oP, nP))
         .filter(({activeRule}) => activeRule.layer && activeRule.workspace)
-        .switchMap(({activeRule, optionsLoaded, onError = () => {}, setLoading}) => {
-            const {workspace, layer} = activeRule;
+        .switchMap(props => {
+            const {
+                activeRule,
+                optionsLoaded,
+                onError = () => {},
+                setLoading,
+                onExit,
+                instances = [], // from gsInstancesDDListSelector
+                handleStoreGSInstancesDDList
+            } = props;
+
+            const { workspace, layer, instance } = activeRule;
+
             setLoading(true);
             const geoFenceType = ConfigUtils.getDefaults().geoFenceServiceType;
-            const {url} = ConfigUtils.getDefaults().geoFenceGeoServerInstance || {};
-            // extract instance url in case (stand-alone geofence) and if not -> use the geoserver one
-            const urlService = geoFenceType === "geofence" ? (activeRule.instance?.url ?? "") : url;
-            return getStylesAndAttributes(layer, workspace, urlService).do(opts => optionsLoaded(opts))
+            // in case non stand-alone geofence
+            if (geoFenceType !== "geofence") {
+                return getStylesAndAttributes(layer, workspace).do(opts => optionsLoaded(opts))
+                    .catch(() => {
+                        setLoading(false);
+                        onError({
+                            title: "rulesmanager.errorTitle",
+                            message: "rulesmanager.errorLoading"
+                        });
+                        return Rx.Observable.of({});
+                    })
+                    .do(() => setLoading(false));
+            }
+            // in case stand-alone geofence
+            // if no GS instance is selected — nothing to load
+            if (!instance?.id) {
+                setLoading(false);
+                return Rx.Observable.of({});
+            }
+            const instancesLoaded = instances.length > 0;
+            // if already instances list loaded, proceed directly
+            if (instancesLoaded) {
+                const ruleInstance = instances.find(inst => inst.id === instance.id);
+                const urlService = ruleInstance?.url || "";
+                return getStylesAndAttributes(layer, workspace, urlService)
+                    .do(opts => optionsLoaded(opts))
+                    .catch(() => {
+                        setLoading(false);
+                        onError({
+                            title: "rulesmanager.errorTitle",
+                            message: "rulesmanager.errorLoading"
+                        });
+                        return Rx.Observable.of({});
+                    })
+                    .do(() => setLoading(false));
+            }
+            // Otherwise, fetch instances and wait
+            setLoading(true);
+
+            return Rx.Observable.fromPromise(
+                GeoFence.getGSInstancesForDD()
+                    .then(response => {
+                        handleStoreGSInstancesDDList(response.data);
+                        return response.data;
+                    })
+                    .catch(() => {
+                        throw new Error("Failed to load GS instances");
+                    })
+            )
+                .switchMap(fetchedInstances => {
+                    const ruleInstance = fetchedInstances.find(inst => inst.id === instance.id);
+                    const urlService = ruleInstance?.url || "";
+
+                    return getStylesAndAttributes(layer, workspace, urlService)
+                        .do(opts => optionsLoaded(opts))
+                        .catch(() => {
+                            setLoading(false);
+                            onError({
+                                title: "rulesmanager.errorTitle",
+                                message: "rulesmanager.errorLoading"
+                            });
+                            return Rx.Observable.of({});
+                        })
+                        .do(() => setLoading(false));
+                })
                 .catch(() => {
                     setLoading(false);
-                    return Rx.Observable.of(onError({
+                    onError({
                         title: "rulesmanager.errorTitle",
-                        message: "rulesmanager.errorLoading"
-                    }));
-                }).do(() => setLoading(false));
-        }).let(emitStop);
+                        message: "rulesmanager.errorLoadingGSInstances"
+                    });
+                    onExit();
+                    return Rx.Observable.of({});
+                });
+        })
+        .let(emitStop);
 };
 
-export default compose(connect(() => ({}), {
+export default compose(connect((state) => ({gsInstancesList: gsInstancesDDListSelector(state)}), {
     onChangeDrawingStatus: changeDrawingStatus,
-    onError: error
+    onError: error,
+    handleStoreGSInstancesDDList: storeGSInstancesDDList
 }),
 defaultProps({dataStreamFactory}),
 withStateHandlers(({activeRule: initRule}) => ({

--- a/web/client/plugins/manager/RulesEditor.jsx
+++ b/web/client/plugins/manager/RulesEditor.jsx
@@ -36,7 +36,8 @@ class RuleEditor extends React.Component {
         properties: PropTypes.array,
         loading: PropTypes.bool,
         cleanConstraints: PropTypes.func,
-        layer: PropTypes.object
+        layer: PropTypes.object,
+        gsInstancesList: PropTypes.array
     }
     static defaultProps = {
         activeEditor: "1",
@@ -45,7 +46,8 @@ class RuleEditor extends React.Component {
         onExit: () => {},
         onSave: () => {},
         onDelete: () => {},
-        type: ""
+        type: "",
+        gsInstancesList: []
     }
     constructor(props) {
         super(props);
@@ -54,7 +56,7 @@ class RuleEditor extends React.Component {
         };
     }
     render() {
-        const { loading, activeRule, layer, activeEditor, onNavChange, initRule, styles = [], setConstraintsOption, type, properties, disableDetails} = this.props;
+        const { loading, activeRule, layer, activeEditor, onNavChange, initRule, styles = [], setConstraintsOption, type, properties, disableDetails, gsInstancesList} = this.props;
         const {modalProps} = this.state || {};
         return (
             <BorderLayout
@@ -71,7 +73,7 @@ class RuleEditor extends React.Component {
                     rule={activeRule}
                     onNavChange={onNavChange}/>}
             >
-                <MainEditor key="main-editor" rule={activeRule} setOption={this.setOption} active={activeEditor === "1"}/>
+                <MainEditor key="main-editor" rule={activeRule} setOption={this.setOption} active={activeEditor === "1"} onExit={this.cancelEditing} gsInstancesList={gsInstancesList} />
                 <StylesEditor styles={styles} key="styles-editor" constraints={activeRule && activeRule.constraints} setOption={setConstraintsOption} active={activeEditor === "2"}/>
                 <FiltersEditor layer={layer} key="filters-editor" setOption={setConstraintsOption} constraints={activeRule && activeRule.constraints} active={activeEditor === "3"}/>
                 <AttributesEditor editedAttributes={this.state.editedAttributes} setEditedAttributes={this.handleSetEditedAttrbiutes.bind(this)} key="attributes-editor" active={activeEditor === "4"} attributes={properties} constraints={activeRule && activeRule.constraints} setOption={setConstraintsOption}/>

--- a/web/client/utils/RulesEditorUtils.js
+++ b/web/client/utils/RulesEditorUtils.js
@@ -6,6 +6,7 @@
   * LICENSE file in the root directory of this source tree.
   */
 import { isEqual, isEmpty } from 'lodash';
+import Api from '../api/geoserver/GeoFence';
 
 export const checkIp = /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.)){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\/([0-2]?[0-9]|3[0-2]))$/;
 export const checkIpV4Range = /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.)){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
@@ -15,6 +16,11 @@ export const isRulePristine = (currentRule, initRule) => {
 };
 
 export const isSaveDisabled = (currentRule, initRule) => {
+    const isStandAloneGeofence = Api.getRuleServiceType() === 'geofence';
+    if (isStandAloneGeofence) {
+        // for stand-alone geofence -> save btn is disable in case gs instance not selected
+        return (isRulePristine(currentRule, initRule) && initRule && initRule.hasOwnProperty("id")) || !currentRule.instance;
+    }
     return isRulePristine(currentRule, initRule) && initRule && initRule.hasOwnProperty("id");
 };
 export const areDetailsActive = (layer, {grant} = {}) => {

--- a/web/client/utils/__tests__/RulesEditorUtils-test.js
+++ b/web/client/utils/__tests__/RulesEditorUtils-test.js
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+
+import {
+    isRulePristine,
+    isSaveDisabled,
+    areDetailsActive,
+    isRuleValid,
+    askConfirm,
+    isGSInstancePristine,
+    isSaveGSInstanceDisabled
+} from '../RulesEditorUtils';
+import ConfigUtils from '../ConfigUtils';
+
+
+describe('RulesEditorUtils', () => {
+    describe('isRulePristine', () => {
+        it('should return true if currentRule equals initRule', () => {
+            const rule = { id: 1, name: "test" };
+            expect(isRulePristine(rule, rule)).toBe(true);
+        });
+
+        it('should return false if currentRule differs from initRule', () => {
+            const current = { id: 1, name: "test" };
+            const init = { id: 1, name: "changed" };
+            expect(isRulePristine(current, init)).toBe(false);
+        });
+    });
+
+    describe('isSaveDisabled for non stand-alone geofence', () => {
+        beforeEach(() => {
+            ConfigUtils.setConfigProp("geoFenceServiceType", "geoserver");
+        });
+        afterEach(() => {
+            ConfigUtils.removeConfigProp("geoFenceServiceType");
+        });
+        it('should return true if rule is pristine and has id (non-geofence)', () => {
+            const current = { id: 1, name: "test" };
+            const init = { id: 1, name: "test" };
+            expect(isSaveDisabled(current, init)).toBe(true);
+        });
+
+        it('should return false if rule is modified (non-geofence)', () => {
+            const current = { id: 1, name: "modified" };
+            const init = { id: 1, name: "original" };
+            expect(isSaveDisabled(current, init)).toBe(false);
+        });
+    });
+    describe('isSaveDisabled for stand-alone geofence', () => {
+        beforeEach(() => {
+            ConfigUtils.setConfigProp("geoFenceServiceType", "geofence");
+        });
+        afterEach(() => {
+            ConfigUtils.removeConfigProp("geoFenceServiceType");
+        });
+        it('should return true if rule is pristine and has id (standalone geofence) but NO instance', () => {
+            const current = { id: 1, name: "test" }; // no instance
+            const init = { id: 1, name: "test" };
+            expect(isSaveDisabled(current, init)).toBe(true);
+        });
+
+        it('should return false if rule is pristine and has id AND instance (standalone geofence)', () => {
+            const current = { id: 1, name: "test", instance: { id: "inst1" } };
+            const init = { id: 1, name: "test" };
+            expect(isSaveDisabled(current, init)).toBe(false); // NOT disabled because instance is selected
+        });
+
+        it('should return true if rule is pristine and has id AND instance is null/undefined (standalone geofence)', () => {
+            const current = { id: 1, name: "test", instance: null };
+            const init = { id: 1, name: "test" };
+            expect(isSaveDisabled(current, init)).toBe(true);
+        });
+    });
+
+    describe('areDetailsActive', () => {
+        it('should return true if layer exists and grant is not DENY', () => {
+            expect(areDetailsActive("someLayer", { grant: "ALLOW" })).toBe(true);
+        });
+
+        it('should return false if layer is falsy', () => {
+            expect(areDetailsActive(null, { grant: "ALLOW" })).toBe(false);
+        });
+
+        it('should return false if grant is DENY', () => {
+            expect(areDetailsActive("someLayer", { grant: "DENY" })).toBe(false);
+        });
+
+        it('should return true if grant is undefined', () => {
+            expect(areDetailsActive("someLayer", {})).toBe(true);
+        });
+    });
+
+    describe('isRuleValid', () => {
+        it('should return true if ipaddress is empty', () => {
+            expect(isRuleValid({})).toBe(true);
+            expect(isRuleValid({ ipaddress: "" })).toBe(true);
+        });
+
+        it('should return true if ipaddress is valid CIDR', () => {
+            expect(isRuleValid({ ipaddress: "192.168.1.1/24" })).toBe(true);
+        });
+
+        it('should return false if ipaddress is invalid', () => {
+            expect(isRuleValid({ ipaddress: "999.999.999.999/99" })).toBe(false);
+            expect(isRuleValid({ ipaddress: "invalid" })).toBe(false);
+        });
+
+        it('should return true if ipaddress is null', () => {
+            expect(isRuleValid({ ipaddress: null })).toBe(true);
+        });
+    });
+
+    describe('askConfirm', () => {
+        it('should return true if constraints exist and key is "workspace"', () => {
+            expect(askConfirm({ constraints: { type: "area" } }, "workspace", "ws1")).toBe(true);
+        });
+
+        it('should return true if constraints exist and key is "layer"', () => {
+            expect(askConfirm({ constraints: { type: "area" } }, "layer", "layer1")).toBe(true);
+        });
+
+        it('should return true if constraints exist and key is "grant" with value not "ALLOW"', () => {
+            expect(askConfirm({ constraints: { type: "area" } }, "grant", "DENY")).toBe(true);
+        });
+
+        it('should return false if constraints exist and key is "grant" with value "ALLOW"', () => {
+            expect(askConfirm({ constraints: { type: "area" } }, "grant", "ALLOW")).toBe(false);
+        });
+
+        it('should return true if constraints exist and key is "instance"', () => {
+            expect(askConfirm({ constraints: { type: "area" } }, "instance", { id: "inst1" })).toBe(true);
+        });
+
+        it('should return false if constraints is empty', () => {
+            expect(askConfirm({}, "workspace", "ws1")).toBe(false);
+        });
+
+        it('should return false if constraints is undefined', () => {
+            expect(askConfirm(undefined, "workspace", "ws1")).toBe(false);
+        });
+    });
+
+    describe('isGSInstancePristine', () => {
+        it('should return true if currentGSInstance equals initGSInstance', () => {
+            const inst = { id: "inst1", url: "http://localhost" };
+            expect(isGSInstancePristine(inst, inst)).toBe(true);
+        });
+
+        it('should return false if instances differ', () => {
+            const current = { id: "inst1", url: "http://localhost" };
+            const init = { id: "inst1", url: "http://remote" };
+            expect(isGSInstancePristine(current, init)).toBe(false);
+        });
+    });
+
+    describe('isSaveGSInstanceDisabled', () => {
+        it('should return true if pristine and has id', () => {
+            const current = { id: "inst1", url: "http://localhost" };
+            const init = { id: "inst1", url: "http://localhost" };
+            expect(isSaveGSInstanceDisabled(current, init)).toBe(true);
+        });
+
+        it('should return false if not pristine', () => {
+            const current = { id: "inst1", url: "http://changed" };
+            const init = { id: "inst1", url: "http://localhost" };
+            expect(isSaveGSInstanceDisabled(current, init)).toBe(false);
+        });
+
+        it('should return false if no id', () => {
+            const current = { url: "http://localhost" };
+            const init = { url: "http://localhost" };
+            expect(isSaveGSInstanceDisabled(current, init)).toBe(false);
+        });
+    });
+
+});


### PR DESCRIPTION
## Description
This PR includes fixing the issue by adding a missing part in **EditorEnhancer file**  which is a check to use the selected gs instance url in case stand-alone geofence instead of geoFenceGeoServerInstance one to be used in function **getStylesAndAttributes** in rulemananger that handles a **GetCapabilities** wms/wfs request 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11469


**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The user ables to add new rule in case stand-alone geofence without any issue or showing errors in opening layers dropdown list.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
To well test this, you should make sure with this in localConfig:
```
  "geoFencePath": "geofence/rest",
  "geoFenceUrl": "http://localhost:8087/",   // instead of 8087: here you should put your local deployed port
  "geoFenceServiceType": "geofence",
```

and 
```
"rulesmanager": [
   "Redirect",
   {
        "name": "BrandNavbar",
         "cfg": {
           "containerPosition": "header"
           }
        },
       "Home",
        "Login",
       "Language",
      "RulesDataGrid",
       "Notifications",
      {
        "name": "RulesEditor",
           "cfg": {
             "containerPosition": "columns",
             "disableDetails": true
         }
    }
 ]
```