### PR TITLE
[Backport 2025.01.xx] Fix #11459 unload resources at logout (#11480)

### DIFF
--- a/web/client/plugins/ResourcesCatalog/DeleteResource.jsx
+++ b/web/client/plugins/ResourcesCatalog/DeleteResource.jsx
@@ -16,6 +16,7 @@ import { searchResources } from './actions/resources';
 import { getPendingChanges } from './selectors/save';
 import { push } from 'connected-react-router';
 import useIsMounted from '../../hooks/useIsMounted';
+import { userSelector } from '../../selectors/security';
 
 /**
  * Plugin to delete a resource
@@ -26,6 +27,7 @@ import useIsMounted from '../../hooks/useIsMounted';
  * @prop {string} cfg.redirectTo optional redirect path after delete completion
  */
 function DeleteResource({
+    user,
     resource,
     component,
     onRefresh,
@@ -65,7 +67,7 @@ function DeleteResource({
                 }));
         }
     }
-    if (!(resource?.id && resource?.canDelete)) {
+    if (!(user && resource?.id && resource?.canDelete)) {
         return null;
     }
     return (
@@ -101,7 +103,8 @@ const deleteResourcesConnect = connect(
             }
             const pendingChanges = getPendingChanges(state, { resourceType: 'MAP', ...props });
             return pendingChanges?.resource;
-        }
+        },
+        user: userSelector
     }),
     {
         onRefresh: searchResources.bind(null, { refresh: true }),

--- a/web/client/plugins/ResourcesCatalog/ResourcesGrid.jsx
+++ b/web/client/plugins/ResourcesCatalog/ResourcesGrid.jsx
@@ -36,6 +36,7 @@ import {
     getSelectedResource
 } from './selectors/resources';
 
+import resourcesEpics from './epics/resources';
 /**
  * This plugins allows to render a resources grid, it could be configured multiple times in the localConfig with different id
  * @memberof plugins
@@ -481,7 +482,7 @@ const ResourcesGridPlugin = connect(
 export default createPlugin('ResourcesGrid', {
     component: ResourcesGridPlugin,
     containers: {},
-    epics: {},
+    epics: resourcesEpics,
     reducers: {
         resources: resourcesReducer
     }

--- a/web/client/plugins/ResourcesCatalog/actions/resources.js
+++ b/web/client/plugins/ResourcesCatalog/actions/resources.js
@@ -9,6 +9,8 @@
 export const UPDATE_RESOURCES = 'RESOURCES:UPDATE_RESOURCES';
 export const UPDATE_RESOURCE = 'RESOURCES:UPDATE_RESOURCE';
 export const LOADING_RESOURCES = 'RESOURCES:LOADING_RESOURCES';
+export const UNLOAD_RESOURCES = 'RESOURCES:UNLOAD_RESOURCES';
+
 export const UPDATE_RESOURCES_METADATA = 'RESOURCES:UPDATE_RESOURCES_METADATA';
 export const SET_SHOW_FILTERS_FORM = 'RESOURCES:SET_SHOW_FILTERS_FORM';
 export const SET_SHOW_DETAILS = 'RESOURCES:SET_SHOW_DETAILS';
@@ -48,6 +50,12 @@ export function loadingResources(loading, id) {
         type: LOADING_RESOURCES,
         loading,
         id
+    };
+}
+
+export function unloadResources() {
+    return {
+        type: UNLOAD_RESOURCES
     };
 }
 

--- a/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
@@ -9,7 +9,7 @@
 import React, { useRef } from 'react';
 import url from 'url';
 import PropTypes from 'prop-types';
-import isEmpty from 'lodash/isEmpty';
+import {isEmpty, isNull} from 'lodash';
 import { Alert, Glyphicon } from 'react-bootstrap';
 
 import useRequestResource from '../hooks/useRequestResource';
@@ -120,22 +120,24 @@ function ResourceDetails({
                 editing={editing}
                 tools={
                     <FlexBox centerChildrenVertically gap="sm">
-                        {!isSpecificResourceType && editing ? <Button
-                            tooltipId="resourcesCatalog.apply"
-                            className={isEmpty(pendingChanges?.changes) ? undefined : 'ms-notification-circle warning'}
-                            disabled={isEmpty(pendingChanges?.changes)}
-                            onClick={() => handleUpdateResource(pendingChanges.saveResource)}
-                        >
-                            <Glyphicon glyph="floppy-disk" />
-                        </Button> : null}
-                        {canEditResource ? <Button
-                            tooltipId="resourcesCatalog.editResourceProperties"
-                            square
-                            variant={editing ? 'success' : undefined}
-                            onClick={() => onToggleEditing()}
-                        >
-                            <Glyphicon glyph="edit" />
-                        </Button> : null}
+                        {!isNull(user) && <>
+                            {!isSpecificResourceType && editing ? <Button
+                                tooltipId="resourcesCatalog.apply"
+                                className={isEmpty(pendingChanges?.changes) ? undefined : 'ms-notification-circle warning'}
+                                disabled={isEmpty(pendingChanges?.changes)}
+                                onClick={() => handleUpdateResource(pendingChanges.saveResource)}
+                            >
+                                <Glyphicon glyph="floppy-disk" />
+                            </Button> : null}
+                            {canEditResource ? <Button
+                                tooltipId="resourcesCatalog.editResourceProperties"
+                                square
+                                variant={editing ? 'success' : undefined}
+                                onClick={() => onToggleEditing()}
+                            >
+                                <Glyphicon glyph="edit" />
+                            </Button> : null}
+                        </>}
                     </FlexBox>
                 }
                 loading={loading}

--- a/web/client/plugins/ResourcesCatalog/epics/__tests__/resources-test.js
+++ b/web/client/plugins/ResourcesCatalog/epics/__tests__/resources-test.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+
+import { SET_SHOW_DETAILS, UNLOAD_RESOURCES } from '../../actions/resources';
+
+import { unloadCatalogResourcesOnAuthentication } from '../resources';
+
+import { testEpic } from '../../../../epics/__tests__/epicTestUtils';
+import { loginSuccess, logout } from '../../../../actions/security';
+
+describe('resources Epics', () => {
+    it('unloadResources on logout epic', (done) => {
+        testEpic(unloadCatalogResourcesOnAuthentication, 2, logout(), ([showDetailsAction, unloadResourcesAction]) => {
+            try {
+                expect(showDetailsAction).toBeTruthy();
+                expect(showDetailsAction.type).toBe(SET_SHOW_DETAILS);
+                expect(showDetailsAction.show).toBe(false);
+                expect(unloadResourcesAction).toBeTruthy();
+                expect(unloadResourcesAction.type).toBe(UNLOAD_RESOURCES);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }, {});
+    });
+    it('unloadResources on login success epic', (done) => {
+        testEpic(unloadCatalogResourcesOnAuthentication, 2, loginSuccess(), ([showDetailsAction, unloadResourcesAction]) => {
+            try {
+                expect(showDetailsAction).toBeTruthy();
+                expect(showDetailsAction.type).toBe(SET_SHOW_DETAILS);
+                expect(showDetailsAction.show).toBe(false);
+                expect(unloadResourcesAction).toBeTruthy();
+                expect(unloadResourcesAction.type).toBe(UNLOAD_RESOURCES);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }, {});
+    });
+});

--- a/web/client/plugins/ResourcesCatalog/epics/resources.js
+++ b/web/client/plugins/ResourcesCatalog/epics/resources.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import Rx from 'rxjs';
+
+import { LOGOUT, LOGIN_SUCCESS } from '../../../actions/security';
+
+import { setShowDetails, unloadResources } from '../actions/resources';
+
+export const unloadCatalogResourcesOnAuthentication = (actions$) =>
+    actions$.ofType(LOGOUT, LOGIN_SUCCESS)
+        .switchMap(() => {
+            return Rx.Observable.of(
+                setShowDetails(false),
+                unloadResources()
+            );
+        });
+
+export default { unloadCatalogResourcesOnAuthentication };

--- a/web/client/plugins/ResourcesCatalog/reducers/resources.js
+++ b/web/client/plugins/ResourcesCatalog/reducers/resources.js
@@ -14,6 +14,7 @@ import uuid from 'uuid/v1';
 import {
     UPDATE_RESOURCES,
     LOADING_RESOURCES,
+    UNLOAD_RESOURCES,
     UPDATE_RESOURCE,
     UPDATE_RESOURCES_METADATA,
     SET_SHOW_FILTERS_FORM,
@@ -158,6 +159,13 @@ function resources(state = defaultState, action) {
             ...state,
             resourceTypes: action.resourceTypes
         };
+    case UNLOAD_RESOURCES:
+        return {
+            ...state,
+            initialSelectedResource: undefined,
+            selectedResource: undefined
+        };
+
     default:
         return state;
     }


### PR DESCRIPTION
fix issue #11459 

Define new actions, reducers, epic in the plugin `ResourcesCatalog`.
around the action LOGOUT, introduce new action UNLOAD_RESOURCES triggered to clear the state section that refers to the selected resource for unlogged users, clear this state sections:
`resources.initialSelectedResource`
`resources.selectedResource`
This new feature fixes some issues related to inconsistency state for non-logged in users.

Includes also a patch that hides the edit/save button in the info panel for non-logged users (this is based on the user's logged condition because the `canEdit` field is not enough to hide the button, the resource `canCopy` field for public resources override the canEdit condition (see details in the linked issues)
(previous exposed here: https://github.com/geosolutions-it/MapStore2/issues/11459#issuecomment-3284476005)

- added new epic `unloadResources` in ResourcesCatalog
- added unit test for resources epic
- hide save button in infopanel for no-logged users

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11459


**What is the new behavior?**

Hides the correct items after on logout.

https://github.com/user-attachments/assets/ee429695-a3e0-4793-b34a-60a3462cdef7



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
