### PR TITLE
[Backport 2025.01.xx] Fix #11489 Number editor no use standard editor superclass (#11490)

### DIFF
--- a/web/client/components/data/featuregrid/editors/NumberEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/NumberEditor.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {isNumber} from 'lodash';
 import IntlNumberFormControl from '../../../I18N/IntlNumberFormControl';
+import { editors } from 'react-data-grid';
 
 const parsers = {
     "int": v => parseInt(v, 10),
@@ -24,7 +25,7 @@ const parsers = {
  * @prop {number} editorProps.minValue the lower boundary of valid numbers
  * @prop {number} editorProps.maxValue the upper boundary of valid numbers
  */
-export default class NumberEditor extends React.Component {
+export default class NumberEditor extends editors.SimpleTextEditor {
     static propTypes = {
         value: PropTypes.oneOfType([
             PropTypes.string,
@@ -46,7 +47,6 @@ export default class NumberEditor extends React.Component {
         super(props);
 
         this.state = {inputText: props.value?.toString?.() ?? ''};
-        this.inputRef = React.createRef();
     }
 
     state = {inputText: ''};
@@ -73,10 +73,6 @@ export default class NumberEditor extends React.Component {
         }
     }
 
-    getInputNode() {
-        return this.inputRef.current;
-    }
-
     render() {
         return (<IntlNumberFormControl
             {...this.props.inputProps}
@@ -84,12 +80,13 @@ export default class NumberEditor extends React.Component {
                 borderColor: 'red'
             }}
             value={this.state.inputText}
-            ref={(input)=>{this.inputRef = input;}}
             type="number"
             min={this.props.minValue}
             max={this.props.maxValue}
             className="form-control"
             defaultValue={this.props.value}
+            onKeyDown={this.props.onKeyDown}
+            onBlur={this.props.onBlur}
             onChange={(val) => {
                 this.setState({
                     inputText: val,

--- a/web/client/components/data/featuregrid/editors/__tests__/NumberEditor-test.jsx
+++ b/web/client/components/data/featuregrid/editors/__tests__/NumberEditor-test.jsx
@@ -9,9 +9,10 @@
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-dom/test-utils';
+import TestUtils, { act } from 'react-dom/test-utils';
 
 import NumberEditor from '../NumberEditor';
+import { fireEvent } from '@testing-library/react';
 
 let testColumn = {
     key: 'columnKey'
@@ -80,5 +81,27 @@ describe('FeatureGrid NumberEditor/IntegerEditor component', () => {
 
         expect(cmp.getValue().columnKey).toBe(1.4);
         expect(cmp.state.isValid).toBe(true);
+    });
+    it('numberEditor getInputNode', () => {
+        const spies = {
+            onBlur: () => {}
+        };
+        const spyOnBlur = expect.spyOn(spies, "onBlur");
+
+        const cmp = ReactDOM.render(<NumberEditor
+            onBlur={spies.onBlur}
+            onkeydown={spies.spyOnKeyDown}
+            value={1.1}
+            rowIdx={1}
+            maxValue={1.5}
+            column={testColumn}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        const inputNode = cmp.getInputNode();
+        expect(inputNode).toExist();
+        act(() => {
+            inputNode.focus();
+            fireEvent.blur(inputNode);
+        });
+        expect(spyOnBlur).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
[Backport 2025.01.xx] Fix #11489 Number editor no use standard editor superclass (#11490)