### PR TITLE
Fix #11465 Problem with feedback mask and user permissions

### DIFF
--- a/web/client/components/misc/enhancers/__tests__/withMask-test.jsx
+++ b/web/client/components/misc/enhancers/__tests__/withMask-test.jsx
@@ -66,4 +66,10 @@ describe('withMask enhancer', () => {
         expect(document.querySelector('.ms2-mask')).toNotExist();
         expect(document.querySelector('.custom-class')).toExist();
     });
+    it('withMask with enablePortal', () => {
+        const Sink = withMask(undefined, undefined, { enablePortal: true })(() => <div id="test">test</div>);
+        ReactDOM.render(<div id="content"><Sink /></div>, document.getElementById("container"));
+        expect(document.querySelector('#content').children.length).toBe(0);
+        expect(document.body.children.length).toBe(2);
+    });
 });

--- a/web/client/components/misc/enhancers/withMask.js
+++ b/web/client/components/misc/enhancers/withMask.js
@@ -8,18 +8,24 @@
 import React from 'react';
 
 import { branch, nest } from 'recompose';
+import Portal from '../Portal';
 /**
  * Add a grayed out mask to a component.
  * @param {function} showMask gets props as argument and returns true if the enhancer should be applied
  * @param {*} maskContent the content of the mask
  */
-const maskEnhancer = (showMask, maskContent, { maskContainerStyle, maskStyle, className, white }) => (A) => nest(
-    (props) => (<div className={`ms2-mask-container ${className || ''} ${!showMask(props) && 'ms2-mask-empty' || ''}`} style={maskContainerStyle} >
-        {props.children}
-        {showMask(props) ? <div className={"ms2-mask" + (white ? " white-mask" : "")} style={maskStyle} >
-            {maskContent(props)}
-        </div> : null}
-    </div>),
+const maskEnhancer = (showMask, maskContent, { maskContainerStyle, maskStyle, className, white, enablePortal }) => (A) => nest(
+    (props) => {
+        const content = (
+            <div className={`ms2-mask-container ${className || ''} ${!showMask(props) && 'ms2-mask-empty' || ''}`} style={maskContainerStyle} >
+                {props.children}
+                {showMask(props) ? <div className={"ms2-mask" + (white ? " white-mask" : "")} style={maskStyle} >
+                    {maskContent(props)}
+                </div> : null}
+            </div>
+        );
+        return enablePortal ? <Portal>{content}</Portal> : content;
+    },
     A);
 
 /**
@@ -40,10 +46,11 @@ export default (
         white = false,
         maskContainerStyle = {},
         maskStyle = {},
-        className
+        className,
+        enablePortal = false
     } = {}
 ) => alwaysWrap
-    ? maskEnhancer(showMask, maskContent, { maskContainerStyle, maskStyle, className, white })
+    ? maskEnhancer(showMask, maskContent, { maskContainerStyle, maskStyle, className, white, enablePortal })
     : branch(
         showMask,
         maskEnhancer(() => true, maskContent, { maskContainerStyle, maskStyle, white })

--- a/web/client/plugins/FeedbackMask.jsx
+++ b/web/client/plugins/FeedbackMask.jsx
@@ -76,7 +76,8 @@ const FeedbackMaskPlugin = compose(
             </span>
             :
             <ResourceUnavailable {...props} homeButton={<HomeButton />} />, {
-            className: 'ms2-loading-mask'
+            className: 'ms2-loading-mask',
+            enablePortal: true
         })
 )(() => null);
 

--- a/web/client/plugins/FeedbackMask.jsx
+++ b/web/client/plugins/FeedbackMask.jsx
@@ -77,7 +77,10 @@ const FeedbackMaskPlugin = compose(
             :
             <ResourceUnavailable {...props} homeButton={<HomeButton />} />, {
             className: 'ms2-loading-mask',
-            enablePortal: true
+            // feedback mask with portal will be positioned as overlay on top of the page
+            // we are going to set zIndex to 1 to allow other dialog to show on top of it (eg. login)
+            enablePortal: true,
+            maskContainerStyle: { zIndex: 1 }
         })
 )(() => null);
 

--- a/web/client/plugins/ResourcesCatalog/selectors/__tests__/save-test.js
+++ b/web/client/plugins/ResourcesCatalog/selectors/__tests__/save-test.js
@@ -116,6 +116,19 @@ describe('ResourcesCatalog save selectors', () => {
             expect(result.data.initialPayload).toExist();
             expect(result.data.resourceType).toBe('MAP');
         });
+
+        it('should return canCopy true for new map', () => {
+            const result = getResourceWithDataInfoByType({
+                map: { }
+            }, { resourceType: 'MAP' });
+            expect(result.resource).toEqual({ canCopy: true, category: { name: 'MAP' } });
+        });
+        it('should return canCopy false for map with id but empty map info (map with no permissions)', () => {
+            const result = getResourceWithDataInfoByType({
+                map: { mapId: 1 }
+            }, { resourceType: 'MAP' });
+            expect(result.resource).toEqual({ canCopy: false, category: { name: 'MAP' } });
+        });
     });
 
     describe('getPendingChanges', () => {

--- a/web/client/plugins/ResourcesCatalog/selectors/save.js
+++ b/web/client/plugins/ResourcesCatalog/selectors/save.js
@@ -6,19 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { mapSelector } from '../../../selectors/map';
+import { mapIdSelector, mapSelector } from '../../../selectors/map';
 import { mapSaveDataSelector } from '../../../selectors/mapsave';
 import { dashboardResource as getDashboardResource, originalDataSelector } from '../../../selectors/dashboard';
 import { widgetsConfig } from '../../../selectors/widgets';
 import { getInitialSelectedResource, getSelectedResource } from './resources';
 import { currentStorySelector, hasPendingChanges, resourceSelector } from '../../../selectors/geostory';
 import { contextResourceSelector } from '../../../selectors/context';
-import { isEmpty, omit } from 'lodash';
+import { isEmpty, isNil, omit } from 'lodash';
 import { createSelector } from 'reselect';
-
-const defaultNewResource = (resourceType) => {
-    return { canCopy: true, category: { name: resourceType } };
-};
 
 const applyContextAttribute = (resource, contextId) => {
     const context = contextId !== undefined
@@ -38,7 +34,6 @@ const applyContextAttribute = (resource, contextId) => {
 const resourceTypeSelector = (_state, props) => props?.resourceType;
 const initialSelectedResourceSelector = (state, props) => getInitialSelectedResource(state, props);
 const selectedResourceSelector = (state, props) => getSelectedResource(state, props);
-const newResourceSelector = (_state, props) => defaultNewResource(props?.resourceType);
 
 const mapInfoSelector = createSelector(
     state => mapSelector(state),
@@ -52,13 +47,13 @@ export const getResourceInfoByTypeSelectorCreator = (excludeData) =>
             resourceTypeSelector,
             initialSelectedResourceSelector,
             selectedResourceSelector,
-            newResourceSelector,
 
             // MAP deps
             contextResourceSelector,
             mapInfoSelector,
             mapSaveDataSelector,
             mapConfigRawDataSelector,
+            mapIdSelector,
 
             // DASHBOARD deps
             getDashboardResource,
@@ -74,13 +69,13 @@ export const getResourceInfoByTypeSelectorCreator = (excludeData) =>
             resourceType,
             initialResource,
             resource,
-            newResource,
 
             // MAP
             contextResource,
             mapInfo,
             mapSaveData,
             mapConfigRawData,
+            mapId,
 
             // DASHBOARD
             dashboardResource,
@@ -93,6 +88,8 @@ export const getResourceInfoByTypeSelectorCreator = (excludeData) =>
             geoStoryPendingChanges
         ) => {
 
+            // mapId is nill in case of new maps
+            const newResource = { canCopy: isNil(mapId), category: { name: resourceType } };
             // pass resource type
             if (resourceType === 'MAP') {
                 const contextId = contextResource?.id !== undefined
@@ -100,7 +97,6 @@ export const getResourceInfoByTypeSelectorCreator = (excludeData) =>
                     : mapInfo?.context; // new map has context in info
 
                 const mapResource = omit(mapInfo, ['context']);
-
                 const mapInitialResource = applyContextAttribute(
                     isEmpty(mapResource) ? newResource : mapResource,
                     contextId


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR includes two fixes:

- ensure the feedback mask uses portal to be render on top of everything
- remove canCopy permissions to map with id but without info to hide SaveAs. This combination refers to inaccessible map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11465

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The feedback mask covers the page to prevent unwanted actions

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
