### PR TITLE
Fix #11468 Strange failure in one test context to investigate

### DIFF
--- a/web/client/observables/__tests__/geostore-test.js
+++ b/web/client/observables/__tests__/geostore-test.js
@@ -415,6 +415,74 @@ describe('geostore observables for resources management', () => {
             e => done(e)
         );
     });
+    it('createResource should skip invalid tags', done => {
+        const ID = 1;
+        const testResource = {
+            metadata: { name: 'A' },
+            data: {},
+            category: 'MAP',
+            tags: [{ id: '1' }, { tag: { id: '2' }, action: 'link'}]
+        };
+        const DummyAPI = {
+            createResource: testAndResolve(
+                (metadata, data, category) => {
+                    expect(metadata).toBe(testResource.metadata);
+                    expect(data).toBe(testResource.data);
+                    expect(category).toBe(testResource.category);
+                },
+                { data: ID }
+            ),
+            getResourcePermissions: testAndResolve(
+                (id) => {
+                    expect(id).toBe(ID);
+                },
+                []
+            ),
+            updateResourcePermissions: testAndResolve(
+                (id) => {
+                    expect(id).toBe(ID);
+                },
+                {}
+            ),
+            linkTagToResource: testAndResolve(
+                (tagId, resourceId) => {
+                    expect(tagId).toBe('2');
+                    expect(resourceId).toBe(ID);
+                },
+                {  }
+            )
+        };
+        createResource(testResource, DummyAPI).subscribe(
+            () => done(),
+            e => done(e)
+        );
+    });
+    it('updateResource should skip invalid tags', done => {
+        const ID = 10;
+        const testResource = {
+            id: ID,
+            tags: [{ id: '1' }, { tag: { id: '2' }, action: 'link'}]
+        };
+        const DummyAPI = {
+            putResourceMetadataAndAttributes: testAndResolve(
+                (id) => {
+                    expect(id).toBe(ID);
+                },
+                {}
+            ),
+            linkTagToResource: testAndResolve(
+                (tagId, resourceId) => {
+                    expect(tagId).toBe('2');
+                    expect(resourceId).toBe(ID);
+                },
+                {}
+            )
+        };
+        updateResource(testResource, DummyAPI).subscribe(
+            () => done(),
+            e => done(e)
+        );
+    });
     it('createResource with tags', done => {
         const ID = 10;
         const testResource = {

--- a/web/client/observables/geostore.js
+++ b/web/client/observables/geostore.js
@@ -288,6 +288,8 @@ export const createResource = ({ data, category, metadata, permission: configure
             Observable
                 .defer(() => Promise.all(
                     (tags || [])
+                        // exclude all tags that does not match the expected structure
+                        .filter((entry) => entry?.tag)
                         .map(({ tag, action }) => action === 'link'
                             ? API.linkTagToResource(tag.id, id)
                             : API.unlinkTagFromResource(tag.id, id)
@@ -311,7 +313,8 @@ export const createCategory = (category, API = GeoStoreDAO) =>
 
 export const updateResource = ({ id, data, permission, metadata, linkedResources = {}, tags } = {}, API = GeoStoreDAO) => {
     const linkedResourcesKeys = Object.keys(linkedResources);
-
+    // exclude all tags that does not match the expected structure
+    const parsedTags = (tags || []).filter((entry) => entry?.tag);
     // Step 1: Update metadata and data
     return Observable.defer(() => API.putResourceMetadataAndAttributes(id, metadata))
         .switchMap(res =>
@@ -333,9 +336,9 @@ export const updateResource = ({ id, data, permission, metadata, linkedResources
                 )
                 : Observable.of(-1),
             // Update tags
-            tags && tags.length > 0
+            parsedTags.length > 0
                 ? Observable.defer(() => Promise.all(
-                    tags.map(({ tag, action }) =>
+                    parsedTags.map(({ tag, action }) =>
                         action === 'link'
                             ? API.linkTagToResource(tag.id, id)
                             : API.unlinkTagFromResource(tag.id, id)

--- a/web/client/selectors/__tests__/contextcreator-test.js
+++ b/web/client/selectors/__tests__/contextcreator-test.js
@@ -211,4 +211,36 @@ describe('contextcreator selectors', () => {
         expect(hideUploadExtensionSelector({ security: { user: { role: 'ADMIN' } } })).toBe(false);
         expect(hideUploadExtensionSelector({ security: { user: { role: 'ADMIN' } } }, { hideUploadExtension: true })).toBe(true);
     });
+    it('exclude tags from generateContextResource', () => {
+        const source = {
+            map: {
+                present: {
+                    center: [20, 21],
+                    maxExtent: [0, 0, 0, 0],
+                    projection: 'EPSG:4326',
+                    units: 'meters',
+                    mapInfoControl: {},
+                    zoom: 10,
+                    mapOptions: {},
+                    layers: [],
+                    groups: [],
+                    backgrounds: [],
+                    text_search_config: undefined,
+                    bookmark_search_config: undefined
+                }
+            },
+            contextcreator: {
+                plugins: [{ name: 'Map' }],
+                customVariablesEnabled: true,
+                resource: {
+                    id: 1,
+                    name: 'Map',
+                    tags: [{ id: '1' }]
+                }
+            }
+        };
+        const generatedSource = generateContextResource(source);
+        expect(generatedSource.metadata.name).toBe('Map');
+        expect(generatedSource.tags).toBeFalsy();
+    });
 });

--- a/web/client/selectors/contextcreator.js
+++ b/web/client/selectors/contextcreator.js
@@ -88,7 +88,9 @@ export const generateContextResource = (state) => {
         userPlugins
     };
     return resource && resource.id ? {
-        ...omit(resource, 'name', 'description'),
+        // tags are associated information and they are not directly manage inside the context editor
+        // we are omitting them until the workflow for context will be similar to other resources viewer
+        ...omit(resource, 'name', 'description', 'tags'),
         data: newContext,
         metadata: {
             name: resource && resource.name,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR improves parsing on tags properties inside the create and update workflows. The context viewer has a different save workflow and tags were included inside the payload causing the update error. The tags should only be included when linking/unlinking them and that's not the case for the update workflow of the context resource.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11468

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
