### PR TITLE
Remove resize-observer-polyfill dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,7 +256,6 @@
     "redux-thunk": "0.1.0",
     "redux-undo": "0.5.0",
     "reselect": "4.0.0",
-    "resize-observer-polyfill": "1.5.0",
     "rxjs": "5.1.1",
     "screenfull": "4.0.0",
     "shpjs": "3.4.2",

--- a/web/client/components/misc/enhancers/withResizeSpy.js
+++ b/web/client/components/misc/enhancers/withResizeSpy.js
@@ -11,7 +11,6 @@ import React from 'react';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
-import ResizeObserver from 'resize-observer-polyfill';
 
 /**
  * Enhancer that calls the prop handler `onResize` when the div has been resized.


### PR DESCRIPTION
## Description
This PR removes the [resize-observer-polyfill](https://www.npmjs.com/package/resize-observer-polyfill) npm package from the dependencies.¨

The package is a polyfill for [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) which has been available for all modern browsers since July 2020.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
We are currently downloading a npm package to polyfill the ResizeObserver package.
#11501

**What is the new behavior?**
We will no longe need the npm package.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
