### PR TITLE
Fix #11497 Swipe state is not reset triggering pending changes in map viewer

### DIFF
--- a/web/client/epics/swipe.js
+++ b/web/client/epics/swipe.js
@@ -11,15 +11,10 @@ import Rx from 'rxjs';
 import { SELECT_NODE } from '../actions/layers';
 import {
     setActive
-    // setMode,
-    // setSwipeSliderOps,
-    // setSwipeLayer
 } from '../actions/swipe';
 
 import { LOCATION_CHANGE } from 'connected-react-router';
 import { layerSwipeSettingsSelector } from '../selectors/swipe';
-
-// import { LOAD_NEW_MAP } from '../actions/config';
 
 /**
  * Ensures that swipeSettings active is changed back to false when a layer is deselected in TOC or group is selected
@@ -47,17 +42,6 @@ export const deactivateSwipeToolOnSwitchMaps = (action$, store) =>
                 : Rx.Observable.empty();
         });
 
-// TODO new epic for resetting swipe on new map(may be unnecessary)
-// export const resetSwipeToolOnNewMap = (action$, store) =>
-//     action$.ofType(LOAD_NEW_MAP)
-//         .switchMap(() => {
-//             const swipeSettings = layerSwipeSettingsSelector(store.getState());
-//             return swipeSettings.active
-//                 ? Rx.Observable.of(setActive(false), setSwipeSliderOps({}), setMode(null), setSwipeLayer(null))
-//                 : Rx.Observable.empty();
-//         });
-
-
 /**
  * Deactivates the swipe tool when maps are switched
  * @memberof epics.swipe
@@ -67,5 +51,4 @@ export const deactivateSwipeToolOnSwitchMaps = (action$, store) =>
 export default {
     resetLayerSwipeSettingsEpic,
     deactivateSwipeToolOnSwitchMaps
-    // resetSwipeToolOnNewMap
 };

--- a/web/client/epics/swipe.js
+++ b/web/client/epics/swipe.js
@@ -9,9 +9,17 @@
 import Rx from 'rxjs';
 
 import { SELECT_NODE } from '../actions/layers';
-import { setActive } from '../actions/swipe';
+import {
+    setActive
+    // setMode,
+    // setSwipeSliderOps,
+    // setSwipeLayer
+} from '../actions/swipe';
+
 import { LOCATION_CHANGE } from 'connected-react-router';
 import { layerSwipeSettingsSelector } from '../selectors/swipe';
+
+// import { LOAD_NEW_MAP } from '../actions/config';
 
 /**
  * Ensures that swipeSettings active is changed back to false when a layer is deselected in TOC or group is selected
@@ -39,6 +47,17 @@ export const deactivateSwipeToolOnSwitchMaps = (action$, store) =>
                 : Rx.Observable.empty();
         });
 
+// TODO new epic for resetting swipe on new map(may be unnecessary)
+// export const resetSwipeToolOnNewMap = (action$, store) =>
+//     action$.ofType(LOAD_NEW_MAP)
+//         .switchMap(() => {
+//             const swipeSettings = layerSwipeSettingsSelector(store.getState());
+//             return swipeSettings.active
+//                 ? Rx.Observable.of(setActive(false), setSwipeSliderOps({}), setMode(null), setSwipeLayer(null))
+//                 : Rx.Observable.empty();
+//         });
+
+
 /**
  * Deactivates the swipe tool when maps are switched
  * @memberof epics.swipe
@@ -48,4 +67,5 @@ export const deactivateSwipeToolOnSwitchMaps = (action$, store) =>
 export default {
     resetLayerSwipeSettingsEpic,
     deactivateSwipeToolOnSwitchMaps
+    // resetSwipeToolOnNewMap
 };

--- a/web/client/reducers/__tests__/swipe-test.js
+++ b/web/client/reducers/__tests__/swipe-test.js
@@ -70,7 +70,7 @@ describe('Swipe tool REDUCERS', () => {
         const state = swipe({}, action);
         expect(state.spy.radius).toBe(80);
     });
-    it('test setting swipe data if map config loaded', () => {
+    it('test setting swipe data if map config loaded and', () => {
         const action = {
             type: MAP_CONFIG_LOADED,
             config: {
@@ -82,7 +82,11 @@ describe('Swipe tool REDUCERS', () => {
             }
         };
         const state = swipe({}, action);
+
         expect(state).toEqual(action.config.swipe);
+        // check loading a new empty map from previous map with swipe tool activated
+        const state2 = swipe(state, {type: 'MAP_CONFIG_LOADED'});
+        expect(state2).toEqual({});
     });
     it('test seting swipe slider options', () => {
         const action = {

--- a/web/client/reducers/swipe.js
+++ b/web/client/reducers/swipe.js
@@ -16,8 +16,7 @@ export default (state = {}, action) => {
         return { ...state, [action.prop]: action.active, ...(action.active === false && { sliderOptions: {} }) };
     }
     case MAP_CONFIG_LOADED: {
-        const swipeConfig = action.config.swipe || {};
-        return {...state, ...swipeConfig};
+        return action.config?.swipe || {};
     }
     case SET_SWIPE_LAYER: {
         return { ...state, layerId: action.layerId };


### PR DESCRIPTION
Fix issue #11497 

- fix yellow circle button in `SaveAs`
- the state of swipe tool il resetted for new map, The specific change for this part of the state is used to build the map configuration. We need to reset it on load to avoid false positives in the pendingChanges.
- added unit test to cover the case of new map opened after a previous map with swipe tool active

## Description


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11497 yellow circle compare on new map if previous map have swipe enabled

**What is the new behavior?**
for new map yellow badge is hidden

https://github.com/user-attachments/assets/40ba913e-af9e-43bd-85c2-f5def696b0fc



