### PR TITLE
#11437: Fix: Incorrect direction parameter handling in isochrone call

### DIFF
--- a/web/client/plugins/Isochrone/components/GraphHopperProvider.jsx
+++ b/web/client/plugins/Isochrone/components/GraphHopperProvider.jsx
@@ -203,9 +203,9 @@ const Graphhopper = ({ registerApi, config, currentRunParameters }, context) => 
                             key={option}
                             centerChildren
                             className={"_relative ms-isochrone-direction-btn"}
-                            variant={(option === 'departure' && !providerBody.reverse_flow) ||
-                                (option === "arrival" && providerBody.reverse_flow) ? 'primary' : 'default'}
-                            onClick={() => handleProviderBodyChange("reverse_flow", option !== 'departure')}
+                            variant={(option === 'departure' && !providerBody.reverseFlow) ||
+                                (option === "arrival" && providerBody.reverseFlow) ? 'primary' : 'default'}
+                            onClick={() => handleProviderBodyChange("reverseFlow", option !== 'departure')}
                         >
                             <Message msgId={`isochrone.${option}`} />
                         </FlexBox.Fill>

--- a/web/client/plugins/Isochrone/components/__tests__/GraphHopperProvider-test.jsx
+++ b/web/client/plugins/Isochrone/components/__tests__/GraphHopperProvider-test.jsx
@@ -217,4 +217,48 @@ describe('GraphHopperProvider component', () => {
         // The component should handle errors in getDirections
         expect(container.querySelector('.ms-isochrone-provider')).toBeTruthy();
     });
+
+    describe('direction selection', () => {
+        it('should render direction selection container', () => {
+            renderComponent();
+            const directionContainer = container.querySelector('.ms-isochrone-direction-container');
+            expect(directionContainer).toBeTruthy();
+        });
+
+        it('should render direction button group', () => {
+            renderComponent();
+            const buttonGroup = container.querySelector('.ms-isochrone-direction');
+            expect(buttonGroup).toBeTruthy();
+            const buttons = container.querySelectorAll('.ms-isochrone-direction-btn');
+            expect(buttons[0].textContent).toBe('isochrone.departure');
+            expect(buttons[1].textContent).toBe('isochrone.arrival');
+        });
+
+        it('should call handleProviderBodyChange when departure button is clicked', () => {
+            const props = {
+                currentRunParameters: { reverseFlow: true }
+            };
+
+            renderComponent(props);
+            const buttons = container.querySelectorAll('.ms-isochrone-direction-btn');
+            const departureButton = buttons[0];
+
+            TestUtils.Simulate.click(departureButton);
+
+            expect(departureButton.classList.contains('btn-primary')).toBe(true);
+        });
+
+        it('should call handleProviderBodyChange when arrival button is clicked', () => {
+            const props = {
+                currentRunParameters: { reverseFlow: false }
+            };
+            renderComponent(props);
+            const buttons = container.querySelectorAll('.ms-isochrone-direction-btn');
+            const arrivalButton = buttons[1];
+
+            TestUtils.Simulate.click(arrivalButton);
+
+            expect(arrivalButton.classList.contains('btn-primary')).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
## Description
This PR fixes the incorrect direction parameter name sent in isochrone call

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- https://github.com/geosolutions-it/MapStore2/pull/11478#issuecomment-3327232958

**What is the new behavior?**
The directions are correctly sent in isochrone (Graphhopper) api call

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
