### PR TITLE
Remove leaflet-plugins dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     "leaflet-draw": "1.0.2",
     "leaflet-extra-markers": "1.0.6",
     "leaflet-minimap": "3.6.0",
-    "leaflet-plugins": "3.0.2",
     "leaflet-rotatedmarker": "0.2.0",
     "leaflet-simple-graticule": "1.0.2",
     "leaflet.gridlayer.googlemutant": "0.6.4",


### PR DESCRIPTION
## Description
We can remove the leaflet-plugins dependency as it no longer used. The packaged was used to provide support for Bing layers in the leaflet implementation, but Bing layers were recently removed from MapStore.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
The leaflet-plugins is currently in package.json
#11518

**What is the new behavior?**
The leaflet-plugins will be removed from package.json

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
