### PR TITLE
Fix #11508 Add spinner to resource details update

### DIFF
--- a/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourceDetails.jsx
@@ -128,7 +128,7 @@ function ResourceDetails({
                                 disabled={isEmpty(pendingChanges)}
                                 onClick={() => handleUpdateResource(computeSaveResource(resourceInfo.initialResource, resourceInfo.resource, resourceInfo.data))}
                             >
-                                <Glyphicon glyph="floppy-disk" />
+                                {updating ? <Spinner /> : <Glyphicon glyph="floppy-disk" />}
                             </Button> : null}
                             {canEditResource ? <Button
                                 tooltipId="resourcesCatalog.editResourceProperties"

--- a/web/client/plugins/ResourcesCatalog/hooks/__tests__/useRequestResource-test.js
+++ b/web/client/plugins/ResourcesCatalog/hooks/__tests__/useRequestResource-test.js
@@ -14,9 +14,10 @@ import { act, Simulate } from 'react-dom/test-utils';
 
 const Component = ({ newResource, ...props }) => {
     const {
-        update
+        update,
+        updating
     } = useRequestResource(props);
-    return <button onClick={() => update(newResource)}></button>;
+    return <button className={updating ? 'updating' : ''} onClick={() => update(newResource)}></button>;
 };
 
 describe('useRequestResource', () => {
@@ -45,7 +46,12 @@ describe('useRequestResource', () => {
             ReactDOM.render(<Component
                 resourceId="01"
                 setRequest={() => Promise.resolve({ id: '01' })}
-                updateRequest={() => Promise.resolve({ id: '01' })}
+                updateRequest={() => new Promise((resolve) => setTimeout(() => resolve({ id: '01' }), 5))}
+                onUpdateStart={() => {
+                    setTimeout(() => {
+                        expect(document.querySelector('.updating')).toBeTruthy();
+                    });
+                }}
                 onUpdateSuccess={() => {
                     done();
                 }}

--- a/web/client/plugins/ResourcesCatalog/hooks/useRequestResource.js
+++ b/web/client/plugins/ResourcesCatalog/hooks/useRequestResource.js
@@ -96,6 +96,7 @@ const useRequestResource = ({
     return {
         resource,
         loading,
+        updating,
         update: (newResource) => {
             if (!updating) {
                 setUpdating(true);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds the missing feedback to update button in the resource details panel

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#11508

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
