### PR TITLE
Remove @turf/convex dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "@turf/center": "5.1.5",
     "@turf/centroid": "6.5.0",
     "@turf/circle": "6.0.1",
-    "@turf/convex": "6.5.0",
     "@turf/difference": "6.5.0",
     "@turf/flatten": "6.5.0",
     "@turf/great-circle": "5.1.5",


### PR DESCRIPTION
## Description
This PR removes the [@turf/convex](https://www.npmjs.com/package/@turf/convex/v/6.5.0) npm dependency, since it is not being used anywhere

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11533

**What is the new behavior?**
We will no longer npm install @turf/convex npm package

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
