### PR TITLE
Remove object-fit-images dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,6 @@
     "md5": "2.3.0",
     "moment": "2.29.4",
     "node-geo-distance": "1.2.0",
-    "object-fit-images": "3.2.4",
     "ol": "7.4.0",
     "pdfmake": "0.2.7",
     "plotly.js-cartesian-dist": "2.35.2",

--- a/web/client/components/geostory/media/Image.jsx
+++ b/web/client/components/geostory/media/Image.jsx
@@ -8,7 +8,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Lightbox from 'react-image-lightbox';
-import objectFitImages from 'object-fit-images';
 import { compose, withState } from 'recompose';
 
 /**
@@ -44,16 +43,6 @@ class Image extends Component {
         caption: PropTypes.string,
         loaderStyle: PropTypes.object
     };
-
-    componentDidMount() {
-        objectFitImages(this._node);
-    }
-
-    UNSAFE_componentWillReceiveProps(newProps) {
-        if (newProps.src !== this.props.src) {
-            objectFitImages(this._node);
-        }
-    }
 
     render() {
         const {


### PR DESCRIPTION
## Description
This PR removes the object-fit-images npm dependency, the polyfill the dependency provides is no longer necessary.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11537

**What is the new behavior?**
We will no longer npm install object-fit-images package

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
