### PR TITLE
#11543: fix editing a url gs instance not working

### DIFF
--- a/web/client/api/geofence/GSInstanceService.js
+++ b/web/client/api/geofence/GSInstanceService.js
@@ -14,17 +14,11 @@ import { toJSONPromise } from './common';
  * @param {object} object the gsInstance
  */
 export const cleanConstraintsForUpdate = (gsInstance) => {
-    const gsInstanceToUpdate = {...gsInstance};
-    // clean non-allowed prop 'name', 'id'
-    delete gsInstanceToUpdate.name;
-    delete gsInstanceToUpdate.username;
-    delete gsInstanceToUpdate.password;
-    delete gsInstanceToUpdate.id;
-    // replace 'url' that fetched with 'baseURL' that required for edit/create
-    gsInstanceToUpdate.baseURL = gsInstanceToUpdate.url;
-    // clean non correct prop
-    delete gsInstanceToUpdate.url;
-    return gsInstanceToUpdate;
+    // cleaned non-allowed prop 'name', 'id', 'url'
+    const { name, id, url, ...cleaned } = gsInstance;
+    return {
+        ...cleaned
+    };
 };
 
 

--- a/web/client/api/geofence/__tests__/GSInstanceService-test.js
+++ b/web/client/api/geofence/__tests__/GSInstanceService-test.js
@@ -14,7 +14,7 @@ import GS_INSTANCES from 'raw-loader!../../../test-resources/geofence/rest/rules
 
 import axios from '../../../libs/ajax';
 import GF_INSTANCE from '../../../test-resources/geofence/rest/rules/full_gsInstance1.json';
-import gsInstanceServiceFactory from '../GSInstanceService';
+import gsInstanceServiceFactory, {cleanConstraintsForUpdate} from '../GSInstanceService';
 
 const GSInstanceService = gsInstanceServiceFactory({
     addBaseUrl: (opts) => ({...opts, baseURL: BASE_URL}),
@@ -98,6 +98,25 @@ describe('GSInstanceService API for GeoFence StandAlone', () => {
             "description": "description"
         }).then(() => {
             done();
+        });
+    });
+    it('cleanConstraintsForUpdate for update gs instance', () => {
+        let editedGSInstance = {
+            id: "1",
+            name: "geoserver",
+            url: "http://localhost:8080/geoserver",
+            description: "geoserver description"
+        };
+        // edit includes description only
+        let cleanedGSInstanceForEdit1 = cleanConstraintsForUpdate(editedGSInstance);
+        expect(cleanedGSInstanceForEdit1).toEqual({
+            description: "geoserver description"
+        });
+        // edit includes url
+        let cleanedGSInstanceForEdit2 = cleanConstraintsForUpdate({...editedGSInstance, baseURL: "http://localhost:8080/geoserver1"});
+        expect(cleanedGSInstanceForEdit2).toEqual({
+            description: "geoserver description",
+            baseURL: "http://localhost:8080/geoserver1"
         });
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fix the issue of editing gs instance url. It includes editing the **cleanConstraintsForUpdate** util function to take the updated url of gs instance to be edited correctly.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11543

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
https://github.com/user-attachments/assets/fb9f106b-3c56-40fd-9b62-097300155dfa


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
