### PR TITLE
Remove babel-polyfill devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "@znemz/cesium-navigation": "4.0.0",
     "assert": "2.0.0",
     "axios": "0.30.2",
-    "babel-polyfill": "6.8.0",
     "babel-standalone": "6.7.7",
     "bootstrap": "3.4.1",
     "buffer": "6.0.3",

--- a/web/client/components/development/Debug.jsx
+++ b/web/client/components/development/Debug.jsx
@@ -9,9 +9,6 @@
 import React from 'react';
 
 import url from 'url';
-if (!global.Symbol) {
-    require("babel-polyfill");
-}
 
 const urlQuery = url.parse(window.location.href, true).query;
 

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -7,7 +7,6 @@
  */
 
 import expect from 'expect';
-import 'babel-polyfill';
 
 import mapInfo from '../mapInfo';
 import {


### PR DESCRIPTION
## Description
This PR removes the babel-polyfill devDependency, because it is no longer needed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11548

**What is the new behavior?**
We will no longer npm install babel-polyfill

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
