### PR TITLE
Remove jsdoc-jsx devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "glob": "7.1.1",
     "html-loader": "2.0.0",
     "html-webpack-plugin": "5.2.0",
-    "jsdoc-jsx": "0.1.0",
     "karma": "6.4.0",
     "karma-chrome-launcher": "3.1.1",
     "karma-cli": "2.0.0",


### PR DESCRIPTION
## Description
This PR removes [jsdoc-jsx](https://www.npmjs.com/package/jsdoc-jsx) from devDependencies, because it is not being used anywhere.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11550

**What is the new behavior?**
We will no longer pm install jsdoc-jsx

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
