### PR TITLE
Remove @turf/boolean-clockwise dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "@turf/area": "6.5.0",
     "@turf/bbox": "4.1.0",
     "@turf/bbox-polygon": "5.1.5",
-    "@turf/boolean-clockwise": "6.5.0",
     "@turf/boolean-contains": "5.1.5",
     "@turf/boolean-intersects": "6.5.0",
     "@turf/boolean-overlap": "5.1.5",


### PR DESCRIPTION
## Description
This PR removes the [@turf/boolean-clockwise](https://www.npmjs.com/package/@turf/boolean-clockwise/v/6.5.0) npm dependency, since it is not being used anywhere

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11535

**What is the new behavior?**
We will no longer npm install @turf/boolean-clockwise npm package

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
