### PR TITLE
Fix: #11553 Add missing geotiff package

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,7 +271,8 @@
     "webfontloader": "1.6.28",
     "wellknown": "0.5.0",
     "xml2js": "0.6.2",
-    "xpath": "0.0.27"
+    "xpath": "0.0.27",
+    "geotiff": "2.1.3"
   },
   "scripts": {
     "start": "npm run app:start",


### PR DESCRIPTION
## Description
This PR adds the missing [geotiff](https://www.npmjs.com/package/geotiff/v/2.1.3) package to the list of dependencies in package.json

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11553

**What is the new behavior?**
The [geotiff](https://www.npmjs.com/package/geotiff/v/2.1.3) will now be installed as a direct dependency

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
