### PR TITLE
Bump axios-mock-adapter to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@geosolutions/mocha": "6.2.1-3",
     "@mapstore/eslint-config-mapstore": "1.0.6",
     "@testing-library/react": "12.1.5",
-    "axios-mock-adapter": "1.16.0",
+    "axios-mock-adapter": "2.1.0",
     "babel-loader": "8.0.5",
     "babel-plugin-add-module-exports": "0.1.4",
     "babel-plugin-istanbul": "6.0.0",


### PR DESCRIPTION
## Description
This PR updates axios-mock-adapter to version 2.1.0

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11555

**What is the new behavior?**
The npm package axios-mock-adapter will be bumped to 2.1.0

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
