### PR TITLE
#11494: Fix - Table widget's zoom to feature not working in anonymous mode

### DIFF
--- a/web/client/components/widgets/enhancers/__tests__/tableWidget-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/tableWidget-test.jsx
@@ -57,7 +57,7 @@ describe('widgets tableWidget enhancer', () => {
             );
             done();
         }));
-        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget ={"true"} id="123456" mapSync={"true"} widgetType={"table"} isDashboardOpened={"true"} updateProperty={(id, path, value) => {
+        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget ={"true"} id="123456" mapSync={"true"} widgetType={"table"} isDashboardWidget updateProperty={(id, path, value) => {
             expect(path).toBe("dependencies.extentObj");
             expect(id).toBe("123456");
             expect(value).toEqual({
@@ -74,7 +74,7 @@ describe('widgets tableWidget enhancer', () => {
             expect(props.gridTools.length).toEqual(0);
             done();
         }));
-        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} id="123456" mapSync={false} widgetType={"table"} isDashboardOpened={"true"} updateProperty={() => {}} /></Provider>, document.getElementById("container"));
+        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} id="123456" mapSync={false} widgetType={"table"} isDashboardWidget updateProperty={() => {}} /></Provider>, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toExist();
 
@@ -85,7 +85,7 @@ describe('widgets tableWidget enhancer', () => {
             expect(props.gridTools.length).toEqual(0);
             done();
         }));
-        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={false} id="123456" mapSync={"true"} widgetType={"table"} isDashboardOpened={"true"} updateProperty={() => {}}/></Provider>, document.getElementById("container"));
+        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={false} id="123456" mapSync={"true"} widgetType={"table"} isDashboardWidget updateProperty={() => {}}/></Provider>, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toExist();
 
@@ -121,7 +121,7 @@ describe('widgets tableWidget enhancer', () => {
             expect(mapWidgetsConnectedWithTbl.length).toEqual(2);
             done();
         }));
-        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} widgets={widgets} id="123456" mapSync={"true"} widgetType={"table"} isDashboardOpened={"true"} updateProperty={(id, path, value) => {
+        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} widgets={widgets} id="123456" mapSync={"true"} widgetType={"table"} isDashboardWidget updateProperty={(id, path, value) => {
             expect(path).toBe("dependencies.extentObj");
             expect(id).toBe("123456");
             expect(value).toEqual({
@@ -148,7 +148,7 @@ describe('widgets tableWidget enhancer', () => {
             expect(mapWidgetsConnectedWithTbl.length).toEqual(0);
             done();
         }));
-        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} widgets={widgets} id="123456" mapSync={false} widgetType={"table"} isDashboardOpened={"true"} updateProperty={() => {}}/></Provider>, document.getElementById("container"));
+        ReactDOM.render( <Provider store={store}><Sink enableZoomInTblWidget={"true"} widgets={widgets} id="123456" mapSync={false} widgetType={"table"} isDashboardWidget updateProperty={() => {}}/></Provider>, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toExist();
 

--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -30,7 +30,6 @@ import {
     isBrowserMobile,
     isDashboardLoading,
     showConnectionsSelector,
-    isDashboardAvailable,
     dashboardTitleSelector
 } from '../selectors/dashboard';
 import { currentLocaleLanguageSelector, currentLocaleSelector } from '../selectors/locale';
@@ -70,9 +69,8 @@ const WidgetsView = compose(
             localizedLayerStylesEnvSelector,
             getMaximizedState,
             currentLocaleSelector,
-            isDashboardAvailable,
             (resource, widgets, layouts, dependencies, selectionActive, editingWidget, groups, showGroupColor, loading, isMobile, currentLocaleLanguage, isLocalizedLayerStylesEnabled,
-                env, maximized, currentLocale, isDashboardOpened) => ({
+                env, maximized, currentLocale) => ({
                 resource,
                 loading,
                 canEdit: isMobile ? !isMobile : resource && !!resource.canEdit,
@@ -86,8 +84,7 @@ const WidgetsView = compose(
                 language: isLocalizedLayerStylesEnabled ? currentLocaleLanguage : null,
                 env,
                 maximized,
-                currentLocale,
-                isDashboardOpened
+                currentLocale
             })
         ), {
             editWidget,
@@ -196,6 +193,7 @@ class DashboardPlugin extends React.Component {
                 minLayoutWidth={this.props.minLayoutWidth}
                 enableZoomInTblWidget={this.props.enableZoomInTblWidget}
                 widgetOpts={this.props.widgetOpts}
+                isDashboardWidget
             />
             : null;
 


### PR DESCRIPTION
## Description
This PR fixes an issue where the table widget’s _zoom to feature_ functionality did not work when the user was in anonymous mode or not logged in. Previously, the dashboard triggered a _zoom to extent_ action instead, causing the dependent map to respond incorrectly in the dashboard view.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #11494 

**What is the new behavior?**
- The table widget enhancer correctly determines the state in which the widget is loaded and performs appropriate action, resulting in zoom to feature working correctly in dashboard 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
