### PR TITLE
Allow usage of same area of interest in Query layer #11461

### DIFF
--- a/web/client/components/data/query/CrossLayerFilter.jsx
+++ b/web/client/components/data/query/CrossLayerFilter.jsx
@@ -16,10 +16,39 @@ import GeometricOperationSelector from './GeometricOperationSelector';
 import GroupField from './GroupField';
 import { isSameUrl } from '../../../utils/URLUtils';
 import InfoPopover from '../../widgets/widget/InfoPopover';
+import SwitchButton from '../../misc/switch/SwitchButton';
 
 const isSameOGCServiceRoot = (origSearchUrl, {search, url} = {}) => isSameUrl(origSearchUrl, url) || isSameUrl(origSearchUrl, (search && search.url));
 // bbox make not sense with cross layer filter
 const getAllowedSpatialOperations = (spatialOperations) => (spatialOperations || []).filter( ({id} = {}) => id !== "BBOX");
+
+/**
+ * Renders the area of interest toggle control
+ * @param {boolean} enabled - Current state of area of interest
+ * @param {function} onToggle - Callback function to handle toggle changes
+ * @returns {JSX.Element} Area of interest row
+ */
+const renderAreaOfInterestToggle = (enabled, onToggle) => (
+    <Row className="inline-form filter-field-fixed-row">
+        <Col xs={6}>
+            <div className="pull-left">
+                <Message msgId="queryform.crossLayerFilter.areaOfInterest"/>
+                &nbsp;
+                <InfoPopover bsStyle="link"
+                    text={<Message msgId="queryform.crossLayerFilter.areaOfInterestTooltip" />}
+                />
+            </div>
+        </Col>
+        <Col xs={6}>
+            <SwitchButton
+                checked={enabled}
+                onChange={onToggle}
+                className="pull-right cross-layer-aoi"
+            />
+        </Col>
+    </Row>
+);
+
 
 export default ({
     crossLayerExpanded = true,
@@ -33,9 +62,11 @@ export default ({
     queryCollection = {},
     attributes = [],
     operation,
+    enabledAreaOfInterest = true,
     updateLogicCombo = () => {},
     resetCrossLayerFilter = () => {},
     setOperation = () => {},
+    setEnabledAreaOfInterest = () => {},
     setQueryCollectionParameter = () => {},
     addCrossLayerFilterField = () => {},
     updateCrossLayerFilterField = () => {},
@@ -53,7 +84,7 @@ export default ({
 
     const renderUnMatchingLayersInfo = () => {
         if (layers.length && unMatchingLayerOptions.length) {
-            return (<InfoPopover bsStyle="link" text={<Message msgId="queryform.crossLayerFilter.errors.layersExcluded" />}/>);
+            return (<InfoPopover id="unmatchingLayersInfo" bsStyle="link" text={<Message msgId="queryform.crossLayerFilter.errors.layersExcluded" />}/>);
         }
         return null;
     };
@@ -111,6 +142,9 @@ export default ({
                     />
                 </Col>
             </Row>)
+            : null}
+        {(typeName && geometryName && operation)
+            ? renderAreaOfInterestToggle(enabledAreaOfInterest, setEnabledAreaOfInterest)
             : null}
         {(typeName && geometryName && operation)
             ? (<Row className="filter-field-fixed-row">

--- a/web/client/components/data/query/__tests__/CrossLayerFilter-test.jsx
+++ b/web/client/components/data/query/__tests__/CrossLayerFilter-test.jsx
@@ -150,8 +150,47 @@ describe('CrossLayerFilter component', () => {
                 name: "Within"
             }]}
         />, document.getElementById("container"));
-        const infoIcon = container.querySelector('.mapstore-info-popover');
+        const infoIcon = container.querySelector('#unmatchingLayersInfo');
         expect(infoIcon).toNotExist();
+    });
+
+    it('area of interest toggle is checked by default', () => {
+        const container = document.getElementById('container');
+        ReactDOM.render(<CrossLayerFilter
+            crossLayerExpanded
+            layers={[{name: "test"}]}
+            queryCollection={{
+                typeName: "test",
+                geometryName: "geometry"
+            }}
+            operation="INTERSECTS"
+            spatialOperations={[{id: "INTERSECTS", name: "Intersects"}]}
+        />, container);
+        const input = container.querySelector('.mapstore-switch-btn input');
+        expect(input).toExist();
+        expect(input.checked).toBe(true);
+    });
+
+    it('calls setEnabledAreaOfInterest when toggle is changed', () => {
+        const actions = {
+            setEnabledAreaOfInterest: () => {}
+        };
+        const spy = expect.spyOn(actions, 'setEnabledAreaOfInterest');
+        const container = document.getElementById('container');
+        ReactDOM.render(<CrossLayerFilter
+            crossLayerExpanded
+            layers={[{name: "test"}]}
+            queryCollection={{
+                typeName: "test",
+                geometryName: "geometry"
+            }}
+            operation="INTERSECTS"
+            spatialOperations={[{id: "INTERSECTS", name: "Intersects"}]}
+            setEnabledAreaOfInterest={actions.setEnabledAreaOfInterest}
+        />, container);
+        const input = container.querySelector('.cross-layer-aoi input');
+        ReactTestUtils.Simulate.change(input);
+        expect(spy).toHaveBeenCalled();
     });
 
 });

--- a/web/client/components/data/query/enhancers/crossLayerFilter.js
+++ b/web/client/components/data/query/enhancers/crossLayerFilter.js
@@ -86,7 +86,8 @@ export default compose(
         ({crossLayerFilter = {}} = {}) => ({
             queryCollection: get(crossLayerFilter, 'collectGeometries.queryCollection'),
             operation: get(crossLayerFilter, 'operation'),
-            distance: get(crossLayerFilter, 'distance')
+            distance: get(crossLayerFilter, 'distance'),
+            enabledAreaOfInterest: get(crossLayerFilter, 'enabledAreaOfInterest')
         })),
     withProps(({layers = [], queryCollection = {}} = {}) => ({
         layer: find(layers, ({name} = {}) => name === queryCollection.typeName)
@@ -104,7 +105,8 @@ export default compose(
                 logic,
                 index: 0
             }]),
-        setOperation: ({setCrossLayerFilterParameter = () => {}}) => (v) => setCrossLayerFilterParameter(`operation`, v)
+        setOperation: ({setCrossLayerFilterParameter = () => {}}) => (v) => setCrossLayerFilterParameter(`operation`, v),
+        setEnabledAreaOfInterest: ({setCrossLayerFilterParameter = () => {}}) => (v) => setCrossLayerFilterParameter(`enabledAreaOfInterest`, v)
     }),
     defaultProps({
         dataStreamFactory: ($props, {setQueryCollectionParameter = () => {}} = {}) =>

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1292,6 +1292,8 @@
         "targetLayer": "Zielebene",
         "clear": "Filter löschen",
         "operation": "Geometrische Operation",
+        "areaOfInterest": "Interessengebiet",
+        "areaOfInterestTooltip": "Verwenden Sie dasselbe Interessengebiet der Ebene",
         "placeholder": "Wählen Sie eine Ebene aus",
         "errors": {
           "noCrossLayerAvailable": "Ebenenfilter ist für die ausgewählte Ebene nicht verfügbar",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1253,6 +1253,8 @@
         "targetLayer": "Target layer",
         "clear": "Clear filter",
         "operation": "Operation",
+        "areaOfInterest": "Area of Interest",
+        "areaOfInterestTooltip": "Use the same area of interest of the layer",
         "placeholder": "Select layer",
         "errors": {
           "noCrossLayerAvailable": "Cross layer filtering is not available for the selected layer",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1253,6 +1253,8 @@
         "targetLayer": "Capa objetivo",
         "clear": "Eliminar filtro",
         "operation": "Operación",
+        "areaOfInterest": "Área de Interés",
+        "areaOfInterestTooltip": "Usar la misma área de interés de la capa",
         "placeholder": "Selecciona una capa",
         "errors": {
           "noCrossLayerAvailable": "El filtro de capa no está disponible para la capa seleccionada",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1253,6 +1253,8 @@
         "targetLayer": "Couche cible",
         "clear": "Effacer le filtre",
         "operation": "Opération",
+        "areaOfInterest": "Zone d'Intérêt",
+        "areaOfInterestTooltip": "Utiliser la même zone d'intérêt de la couche",
         "placeholder": "Sélectionner une couche",
         "errors": {
           "noCrossLayerAvailable": "Le filtrage croisé n'est pas disponible pour la couche sélectionné",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1253,6 +1253,8 @@
         "targetLayer": "Livello Filtro",
         "clear": "Pulisci Filtro",
         "operation": "Operazione",
+        "areaOfInterest": "Area di Interesse",
+        "areaOfInterestTooltip": "Usa la stessa area di interesse del layer",
         "placeholder": "Seleziona il livello",
         "errors": {
           "noCrossLayerAvailable": "L'operazione di filtraggio usando un livello non è supportata per il layer selezionato",

--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -72,6 +72,7 @@ export const setupCrossLayerFilterDefaults = (crossLayerFilter) => {
             }];
         return {
             ...crossLayerFilter,
+            enabledAreaOfInterest: crossLayerFilter.enabledAreaOfInterest ?? true,
             collectGeometries: {
                 ...crossLayerFilter.collectGeometries,
                 queryCollection: {
@@ -735,15 +736,39 @@ export const toCQLFilter = function(json) {
     }
     if (objFilter.crossLayerFilter) {
         const {crossLayerFilter} = objFilter;
-        const {operation} = crossLayerFilter;
+        const {operation, enabledAreaOfInterest} = crossLayerFilter;
         const attribute = crossLayerFilter.attribute; // || (objFilter.spatialField && objFilter.spatialField.attribute)
         const queryCollection = crossLayerFilter.collectGeometries && crossLayerFilter.collectGeometries.queryCollection;
         // Something like CONTAINS(the_geom, collectGeometries(queryCollection('sf:roads','the_geom','INCLUDE')))
         if (operation && attribute && queryCollection) {
             const {typeName, geometryName} = queryCollection;
-            const cqlFilter =
+            let cqlFilter =
                 FilterUtils.getCrossLayerCqlFilter(crossLayerFilter)
                     ; // escape single quotes to make the CQL a valid string.
+
+            // Add spatial filter to cross-layer queryCollection when area of interest is enabled
+            if (enabledAreaOfInterest && objFilter.spatialField) {
+                // Clone spatial field(s) and replace geometry attribute with cross-layer's geometryName
+                const modifiedSpatialField = isArray(objFilter.spatialField)
+                    ? objFilter.spatialField.map(sf => ({...sf, attribute: geometryName}))
+                    : {...objFilter.spatialField, attribute: geometryName};
+
+                // Create temp object to reuse processCQLSpatialFilter without modifying original
+                const tempObjFilter = {...objFilter, spatialField: modifiedSpatialField};
+
+                // Generate spatial CQL with cross-layer's geometry name
+                const spatialCQL = FilterUtils.processCQLSpatialFilter(tempObjFilter);
+
+                // Combine spatial filter with existing attribute filters
+                if (spatialCQL) {
+                    if (cqlFilter && cqlFilter !== 'INCLUDE') {
+                        cqlFilter = `${cqlFilter} AND ${spatialCQL}`;
+                    } else {
+                        cqlFilter = spatialCQL;
+                    }
+                }
+            }
+
             // TODO DWITHIN needs also distance and unit
             const cg = cqlCollectGeometries(cqlQueryCollection({typeName, geometryName, cqlFilter}));
             filters.push(`${operation}(${attribute},${cg})`);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

fixes #11461

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11461
Add area of interest for cross-layer filter too.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
- user can enable and disable area of interest filter to be applied to the cross-layer filter too.
<img width="1194" height="604" alt="image" src="https://github.com/user-attachments/assets/dad37799-1933-4385-9c4f-c37aace55344" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
- Area of interest filter is enabled by default.
- Only applied when the Standard area of interest is selected for the layer.
- User can also disable it

Some generated sample cql:
- When the Standard Area of interest is selected 
  ```
    ("isActive" = 'true')
    AND
    INTERSECTS(
      "the_geom",
      SRID=3857;
      POLYGON((
        -9156367.175772902 5112844.0245766295,
        -9156367.175772902 5003486.523671881,
        -9071082.561463717 5003486.523671881,
        -9071082.561463717 5112844.0245766295,
        -9156367.175772902 5112844.0245766295
      ))
    )
    AND
    INTERSECTS(
      the_geom,
      collectGeometries(
        queryCollection(
          'gs:us_states',
          'the_geom',
          "STATE_NAME" = 'Ohio'
          AND
          INTERSECTS(
            "the_geom",
            SRID=3857;
            POLYGON((
              -9156367.175772902 5112844.0245766295,
              -9156367.175772902 5003486.523671881,
              -9071082.561463717 5003486.523671881,
              -9071082.561463717 5112844.0245766295,
              -9156367.175772902 5112844.0245766295
            ))
          )
        )
      )
    )
  ```

- When the Standard area of interest is not selected: 
  ```
    ("isActive" = 'true')
    AND
    INTERSECTS(
      the_geom,
      collectGeometries(
        queryCollection(
          'gs:us_states',
          'the_geom',
          "STATE_NAME" = 'Ohio'
        )
      )
    )
  ```
