### PR TITLE
Query layer attributes sometimes do not load list #11544

### DIFF
--- a/web/client/epics/autocomplete.js
+++ b/web/client/epics/autocomplete.js
@@ -27,7 +27,7 @@ import { getWpsPayload } from '../utils/ogc/WPS/autocomplete';
 import { getParsedUrl } from '../utils/ConfigUtils';
 
 import { typeNameSelector } from '../selectors/query';
-import { maxFeaturesWPSSelector, appliedFilterSelector, storedFilterSelector } from '../selectors/queryform';
+import { maxFeaturesWPSSelector } from '../selectors/queryform';
 import { authkeyParamNameSelector } from '../selectors/catalog';
 
 /**
@@ -82,7 +82,6 @@ export const fetchAutocompleteOptionsEpic = (action$, store) =>
             const data = getWpsPayload({
                 attribute: filterField.attribute,
                 layerName: action.type === UPDATE_CROSS_LAYER_FILTER_FIELD ? state.queryform.crossLayerFilter?.collectGeometries?.queryCollection.typeName : typeNameSelector(state),
-                layerFilter: appliedFilterSelector(state) || storedFilterSelector(state),
                 maxFeatures: maxFeaturesWPS,
                 startIndex: action.fieldOptions.currentPage ? (action.fieldOptions.currentPage - 1) : 1 * maxFeaturesWPS,
                 value: action.fieldValue


### PR DESCRIPTION
## Description
This PR removes the use of layerFilters while calling the autoComplete API(Options API). 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

fixes #11544

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11544

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
- The autocomplete API doesn't use any layer filters, which also prevents the options API from failing due to previously applied problematic filters(like memory limit issue)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
- No test changes needed. getWpsPayload still supports the optional layerFilter parameter
- There are NO tests that verify the epic must pass layerFilter. The existing tests only confirm that getWpsPayload supports the parameter when provided, not that it's required.
