### PR TITLE
Remove babel-plugin-react-transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "babel-loader": "8.0.5",
     "babel-plugin-add-module-exports": "0.1.4",
     "babel-plugin-istanbul": "6.0.0",
-    "babel-plugin-react-transform": "2.0.2",
     "babel-plugin-transform-imports": "2.0.0",
     "copy-webpack-plugin": "5.0.2",
     "css-loader": "5.1.2",


### PR DESCRIPTION
## Description
This PR removes the babel-plugin-react-transform devDependency from package.json because it is not being used anywhere.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11586

**What is the new behavior?**
The npm package babel-plugin-react-transform will be removed from package.json

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
