### PR TITLE
Replace babel-standalone with @babel/standalone

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@znemz/cesium-navigation": "4.0.0",
     "assert": "2.0.0",
     "axios": "0.30.2",
-    "babel-standalone": "6.7.7",
+    "@babel/standalone": "7.23.9",
     "bootstrap": "3.4.1",
     "buffer": "6.0.3",
     "canvas-to-blob": "0.0.0",

--- a/web/client/components/TOC/fragments/__tests__/LayerMetadataModal-test.jsx
+++ b/web/client/components/TOC/fragments/__tests__/LayerMetadataModal-test.jsx
@@ -118,14 +118,10 @@ describe('TOC LayerMetadataModal', () => {
             maskLoading: false
         };
 
-        let comp = ReactDOM.render(<LayerMetadataModal renderContent={RenderTemplate} metadataTemplate={metadataTemplate} layerMetadata={layerMetadata} />, document.getElementById("container"));
+        ReactDOM.render(<LayerMetadataModal renderContent={RenderTemplate} metadataTemplate={metadataTemplate} layerMetadata={layerMetadata} />, document.getElementById("container"));
         const panelClass = document.getElementsByClassName('layer-settings-metadata-panel-title');
         expect(panelClass).toExist();
-        new Promise((resolve) => {
-            require.ensure(['babel-standalone'], () => {
-                resolve(comp);
-            });
-        }).then(() => {
+        import("@babel/standalone").then(() => {
             try {
                 const cmpDom = document.getElementById("msg_rss_micro");
                 expect(cmpDom).toExist();
@@ -157,14 +153,10 @@ describe('TOC LayerMetadataModal', () => {
             maskLoading: false
         };
 
-        let comp = ReactDOM.render(<LayerMetadataModal renderContent={RenderTemplate} metadataTemplate={CompTemplate} layerMetadata={layerMetadata} />, document.getElementById("container"));
+        ReactDOM.render(<LayerMetadataModal renderContent={RenderTemplate} metadataTemplate={CompTemplate} layerMetadata={layerMetadata} />, document.getElementById("container"));
         const panelClass = document.getElementsByClassName('layer-settings-metadata-panel-title');
         expect(panelClass).toExist();
-        new Promise((resolve) => {
-            require.ensure(['babel-standalone'], () => {
-                resolve(comp);
-            });
-        }).then(() => {
+        import("@babel/standalone").then(() => {
             try {
                 const cmpDom = document.getElementById("msg_rss_micro");
                 expect(cmpDom).toExist();

--- a/web/client/components/TOC/fragments/template/__tests__/MetadataTemplate-test.jsx
+++ b/web/client/components/TOC/fragments/template/__tests__/MetadataTemplate-test.jsx
@@ -38,15 +38,11 @@ describe("Test Layer Metadata JSX Template", () => {
             },
             expanded: true
         };
-        let comp = ReactDOM.render(
+        ReactDOM.render(
             <MetadataTemplate
                 model={layerMetadata.metadataRecord}
             />, document.getElementById("container"));
-        new Promise((resolve) => {
-            require.ensure(['babel-standalone'], () => {
-                resolve(comp);
-            });
-        }).then(() => {
+        import("@babel/standalone").then(() => {
             try {
                 const cmpDom = document.getElementById("msg_rss_micro");
                 expect(cmpDom).toExist();
@@ -79,16 +75,12 @@ describe("Test Layer Metadata JSX Template", () => {
                 }
             }
         };
-        let comp = ReactDOM.render(
+        ReactDOM.render(
             <Localized locale="en" messages={messages}>
                 <MetadataTemplate
                     model={layerMetadata.metadataRecord}
                 /></Localized>, document.getElementById("container"));
-        new Promise((resolve) => {
-            require.ensure(['babel-standalone'], () => {
-                resolve(comp);
-            });
-        }).then(() => {
+        import("@babel/standalone").then(() => {
             try {
                 const cmpDom = document.getElementById("msg_rss_micro");
                 expect(cmpDom).toExist();

--- a/web/client/components/data/template/jsx/__tests__/Template-test.jsx
+++ b/web/client/components/data/template/jsx/__tests__/Template-test.jsx
@@ -25,13 +25,9 @@ describe("Test JSX Template", () => {
     });
 
     it('Test Template render jsx string', (done) => {
-        let comp = ReactDOM.render(
+        ReactDOM.render(
             <Template template="<div id='template'/>"/>, document.getElementById("container"));
-        new Promise((resolve) => {
-            require.ensure(['babel-standalone'], () => {
-                resolve(comp);
-            });
-        }).then(() => {
+        import("@babel/standalone").then(() => {
             try {
                 const cmpDom = document.getElementById("template");
                 expect(cmpDom).toExist();
@@ -47,11 +43,7 @@ describe("Test JSX Template", () => {
         let comp = ReactDOM.render(
             <Template
                 template={ () => { return "<div id='template'/>"; } } />, document.getElementById("container"));
-        new Promise((resolve) => {
-            require.ensure(['babel-standalone'], () => {
-                resolve(comp);
-            });
-        }).then(() => {
+        import("@babel/standalone").then(() => {
             try {
                 expect(comp).toExist();
                 const cmpDom = document.getElementById("template");
@@ -68,11 +60,7 @@ describe("Test JSX Template", () => {
         let comp = ReactDOM.render(
             <Template template="<div id={model.id}/>" model={{id: "template"}} />
             , document.getElementById("container"));
-        new Promise((resolve) => {
-            require.ensure(['babel-standalone'], () => {
-                resolve(comp);
-            });
-        }).then(() => {
+        import("@babel/standalone").then(() => {
             try {
                 expect(comp).toExist();
                 const cmpDom = document.getElementById("template");
@@ -89,11 +77,7 @@ describe("Test JSX Template", () => {
         let comp = ReactDOM.render(
             <Template template="<div id={model.id}/>" model={{id: "template"}} />
             , document.getElementById("container"));
-        new Promise((resolve) => {
-            require.ensure(['babel-standalone'], () => {
-                resolve(comp);
-            });
-        }).then(() => {
+        import("@babel/standalone").then(() => {
             try {
                 expect(comp).toExist();
                 const cmpDom = document.getElementById("template");
@@ -118,11 +102,7 @@ describe("Test JSX Template", () => {
         let comp = ReactDOM.render(
             <Template template="<div id={model.id}/>" model={{id: "temp"}} />
             , document.getElementById("container"));
-        new Promise((resolve) => {
-            require.ensure(['babel-standalone'], () => {
-                resolve(comp);
-            });
-        }).then(() => {
+        import("@babel/standalone").then(() => {
             try {
                 expect(comp).toExist();
                 const cmpDom = document.getElementById("temp");

--- a/web/client/utils/TemplateUtils.js
+++ b/web/client/utils/TemplateUtils.js
@@ -85,12 +85,11 @@ export const generateTemplateString = (function() {
 })();
 
 export const parseTemplate = function(temp, callback) {
-    require.ensure(['babel-standalone'], function() {
-        const Babel = require('babel-standalone');
-        let chosenTemplate = typeof temp === 'function' ? temp() : temp;
+    import("@babel/standalone").then(({transform}) => {
+        let chosenTemplate = typeof temp === "function" ? temp() : temp;
         try {
-            const comp = Babel.transform(chosenTemplate, { presets: ['es2015', 'react', 'stage-0'] }).code;
-            callback(comp);
+            const { code } = transform(chosenTemplate, { presets: ["env", "react"] });
+            callback(code);
         } catch (e) {
             callback(null, e);
         }


### PR DESCRIPTION
## Description
This PR replaces  [babel-standalone](https://www.npmjs.com/package/babel-standalone) with [@babel/standalone](https://www.npmjs.com/package/@babel/standalone). The package is now maintaiend in the main babel repository.

I also took the opportunity to update the presets that were used in the parseTemplate function located in TemplateUtils.js.

Another change I did, was to replace [require.ensure](https://webpack.js.org/api/module-methods/#requireensure) with promise, as this seemed safe to do, according to the webpack documentation.

All tests are passing, and I also did a manual test by using the html provided in the example from the documentation https://mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins#plugins.MetadataInfo

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Refactoring (no functional changes, no api changes)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11591

**What is the new behavior?**
[babel-standalone](https://www.npmjs.com/package/babel-standalone) will be replacedwith [@babel/standalone](https://www.npmjs.com/package/@babel/standalone)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
