### PR TITLE
Remove @babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@babel/plugin-transform-regenerator": "7.23.3",
     "@babel/preset-env": "7.23.9",
     "@babel/preset-react": "7.23.3",
-    "@babel/runtime": "7.23.9",
     "@geosolutions/acorn-jsx": "4.0.2",
     "@geosolutions/jsdoc": "3.4.4",
     "@geosolutions/mocha": "6.2.1-3",


### PR DESCRIPTION
## Description
This PR removes the @babel/runtime package, because it is not being used anywhere.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11593

**What is the new behavior?**
The @babel/runtime package will be removed from package.json and will no longer be installed

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
