### PR TITLE
Remove babel-plugin-add-module-exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@testing-library/react": "12.1.5",
     "axios-mock-adapter": "2.1.0",
     "babel-loader": "8.0.5",
-    "babel-plugin-add-module-exports": "0.1.4",
     "babel-plugin-istanbul": "6.0.0",
     "babel-plugin-transform-imports": "2.0.0",
     "copy-webpack-plugin": "5.0.2",


### PR DESCRIPTION
## Description
This PR removes the [babel-plugin-add-module-exports](https://www.npmjs.com/package/babel-plugin-add-module-exports) package from our package.json. The babel plugin is not being used anywhere.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11595

**What is the new behavior?**
The [babel-plugin-add-module-exports](https://www.npmjs.com/package/babel-plugin-add-module-exports) package will be removed from package.json and will no longer be installed

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
