### PR TITLE
Remove @babel/plugin-transform-regenerator

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@babel/core": "7.23.9",
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
-    "@babel/plugin-transform-regenerator": "7.23.3",
     "@babel/preset-env": "7.23.9",
     "@babel/preset-react": "7.23.3",
     "@babel/runtime": "7.23.9",


### PR DESCRIPTION
## Description
This PR removes the @babel/plugin-transform-regenerator package because it is no longer being used.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11599

**What is the new behavior?**
The package will be removed from package.json and will no longer be installed

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
