### PR TITLE
Remove @babel/plugin-syntax-dynamic-import

### DIFF
--- a/build/babel.config.js
+++ b/build/babel.config.js
@@ -6,7 +6,6 @@ module.exports = function(api) {
             "@babel/preset-react"
         ],
         "plugins": [
-            "@babel/plugin-syntax-dynamic-import",
             ["transform-imports", {
                 "lodash": {
                     "transform": "lodash/${member}",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.9",
-    "@babel/plugin-syntax-dynamic-import": "7.8.3",
+    "@babel/plugin-transform-regenerator": "7.23.3",
     "@babel/preset-env": "7.23.9",
     "@babel/preset-react": "7.23.3",
     "@babel/runtime": "7.23.9",

--- a/utility/eslint/package.json
+++ b/utility/eslint/package.json
@@ -24,7 +24,6 @@
     "@babel/eslint-plugin": "7.11.5"
   },
   "peerDependencies": {
-    "@babel/plugin-syntax-dynamic-import": ">= 7.8.3",
     "eslint": ">= 7.5.0",
     "eslint-plugin-import": ">= 2.20.2",
     "eslint-plugin-no-only-tests": ">= 2.3.1",


### PR DESCRIPTION
## Description
This PR removes the [@babel/plugin-syntax-dynamic-import](https://www.npmjs.com/package/@babel/plugin-syntax-dynamic-import) package because it is no longer necessary. 

This PR also removes the peerDependency from the package.json located in utility/eslint folder. Which means a new version will probably be needed to be built and published at some point.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Build related changes


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11603

**What is the new behavior?**
The @babel/plugin-syntax-dynamic-import package will be removed from package.json and will no longer be installed

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
