### PR TITLE
Fix: #11607 Remove html2canvas from webpack config

### DIFF
--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -200,7 +200,6 @@ module.exports = (...args) => mapArgumentsToObject(args, ({
         ...(resolveModules && { modules: resolveModules })
     },
     module: {
-        noParse: [/html2canvas/],
         rules: [
             {
                 test: /\.css$/,

--- a/build/createExtensionWebpackConfig.js
+++ b/build/createExtensionWebpackConfig.js
@@ -57,7 +57,6 @@ module.exports = ({ prod = true, name, exposes, sharedLibrariesEager = true, ali
         filename: "assets/css/[name].css"
     }), ...plugins],
     module: {
-        noParse: [/html2canvas/],
         rules: [
             {
                 test: /\.css$/,


### PR DESCRIPTION
## Description
This PR removes html2canvas from our webpack config, the config was no longer used.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11607

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
html2canvas is removed from the webpack config

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
