### PR TITLE
Added venv to ignore mklint

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -3,3 +3,4 @@ node_modules
 product
 web/client/dist
 **/target
+venv


### PR DESCRIPTION
## Description
Given that when building mkdocs locally you may have a `venv` configured, as for doc, adding these changes makes the build ignore the `venv` directory created when parsing markdown. 

This is a very small work for dev help. 