### PR TITLE
Longitudinal Profile: handle unnecessary warnings on different conditions while drawing second line #11641

### DIFF
--- a/web/client/epics/longitudinalProfile.js
+++ b/web/client/epics/longitudinalProfile.js
@@ -416,7 +416,13 @@ export const LPdeactivateIdentifyEnabledEpic = (action$, store) =>
 export const LPclickToProfileEpic = (action$, {getState}) =>
     action$
         .ofType(CLICK_ON_MAP)
-        .filter(() => isListeningClickSelector(getState()))
+        .filter(() => {
+            const state = getState();
+            const isListeningClick = isListeningClickSelector(state);
+            const mode = dataSourceModeSelector(state);
+            // Only process clicks when in select mode to avoid triggering during drawing
+            return isListeningClick && mode === 'select';
+        })
         .switchMap(({point}) => {
             const state = getState();
             const map = mapSelector(state);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes a fix for a bug: Repeatedly showing warning messages while drawing second line.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

#11641

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11641
Unnecessary warnings on different conditions while drawing second line

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The user should be able to draw next line without seeing the any type of warnings.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
