### PR TITLE
Enhance Itinerary panel

### DIFF
--- a/web/client/plugins/Isochrone/epics/__tests__/isochrone-test.js
+++ b/web/client/plugins/Isochrone/epics/__tests__/isochrone-test.js
@@ -18,6 +18,7 @@ import {
     isochroneUpdateLocationMapEpic,
     onIsochroneRunEpic,
     onCloseIsochroneEpic,
+    onToggleControlIsochroneEpic,
     isochroneAddAsLayerEpic
 } from '../isochrone';
 import {
@@ -582,6 +583,59 @@ describe('Isochrone Epics', () => {
                     done();
                 },
                 mockStore.getState()
+            );
+        });
+    });
+
+    describe('onToggleControlIsochroneEpic', () => {
+        it('should disable isochrone when a different control is toggled and isochrone is enabled', (done) => {
+            const NUMBER_OF_ACTIONS = 1;
+
+            testEpic(
+                addTimeoutEpic(onToggleControlIsochroneEpic, 10),
+                NUMBER_OF_ACTIONS,
+                toggleControl('otherControl'),
+                actions => {
+                    expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                    expect(actions[0].type).toBe('SET_CONTROL_PROPERTY');
+                    expect(actions[0].control).toBe(CONTROL_NAME);
+                    expect(actions[0].property).toBe('enabled');
+                    expect(actions[0].value).toBe(false);
+                    done();
+                },
+                mockStore.getState()
+            );
+        });
+
+        it('should not trigger when the isochrone control itself is toggled', (done) => {
+            const NUMBER_OF_ACTIONS = 1;
+
+            testEpic(
+                addTimeoutEpic(onToggleControlIsochroneEpic, 10),
+                NUMBER_OF_ACTIONS,
+                toggleControl(CONTROL_NAME),
+                actions => {
+                    expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                    expect(actions[0].type).toBe(TEST_TIMEOUT);
+                    done();
+                },
+                mockStore.getState()
+            );
+        });
+
+        it('should not trigger when isochrone is disabled', (done) => {
+            const NUMBER_OF_ACTIONS = 1;
+
+            testEpic(
+                addTimeoutEpic(onToggleControlIsochroneEpic, 10),
+                NUMBER_OF_ACTIONS,
+                toggleControl('otherControl'),
+                actions => {
+                    expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                    expect(actions[0].type).toBe(TEST_TIMEOUT);
+                    done();
+                },
+                mockStoreDisabled.getState()
             );
         });
     });

--- a/web/client/plugins/Isochrone/epics/isochrone.js
+++ b/web/client/plugins/Isochrone/epics/isochrone.js
@@ -236,6 +236,19 @@ export const onIsochroneRunEpic = (action$) =>
         });
 
 /**
+ * Handles toggling of isochrone control
+ * @memberof epics.isochrone
+ * @param {external:Observable} action$ manages `TOGGLE_CONTROL`
+ * @return {external:Observable}
+ */
+export const onToggleControlIsochroneEpic = (action$, {getState}) =>
+    action$.ofType(TOGGLE_CONTROL)
+        .filter(({control}) => control !== CONTROL_NAME && enabledSelector(getState()))
+        .switchMap(() => {
+            return Observable.of(setControlProperty(CONTROL_NAME, 'enabled', false));
+        });
+
+/**
  * Handles closing of isochrone
  * @memberof epics.isochrone
  * @param {external:Observable} action$ manages `SET_CONTROL_PROPERTY`, `RESET_ISOCHRONE`

--- a/web/client/plugins/Itinerary/components/GraphHopperProvider.jsx
+++ b/web/client/plugins/Itinerary/components/GraphHopperProvider.jsx
@@ -55,6 +55,13 @@ const GraphHopperProvider = ({
     }, []);
     const [avoidRoads, setAvoidRoads] = useState([]);
 
+    // Reset avoidRoads
+    useEffect(() => {
+        if (providerConfig.custom_model === undefined) {
+            setAvoidRoads(prev => prev.length > 0 ? [] : prev);
+        }
+    }, [providerConfig.custom_model]);
+
     const handleProviderBodyChange = (key, value) => {
         let _value = value;
         setProviderConfig(prev => {
@@ -173,8 +180,9 @@ const GraphHopperProvider = ({
                             key={option.value}
                             checked={avoidRoads.includes(option.value)}
                             onChange={(e) => {
+                                const isChecked = e.target?.checked;
                                 setAvoidRoads(prev => {
-                                    const newAvoidRoads = e.target.checked
+                                    const newAvoidRoads = isChecked
                                         ? [...prev, option.value]
                                         : prev.filter(item => item !== option.value);
                                     handleProviderBodyChange('custom_model', newAvoidRoads);


### PR DESCRIPTION
## Description
This PR enhances the itinerary panel functionality, improving its open and close behavior along with other plugins for a smoother user experience

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- https://github.com/geosolutions-it/MapStore2/pull/11388#issuecomment-3491649934

**What is the new behavior?**
- Opening the Catalog panel while the Itinerary/Isochrone panel is open will now close the Itinerary/Isochrone panel
- Fix: Resolved an issue where an occasional synthetic event caused the app to crash from the provider component
- Fix: Reset action now correctly clears the “Avoid Roads” settings
- Fix: Restored the GFI functionality when the panel is closed

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
