### PR TITLE
[Backport 2025.02.xx] Remove @babel/runtime ( again ) (#11629)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@babel/core": "7.28.4",
     "@babel/preset-env": "7.28.3",
     "@babel/preset-react": "7.27.1",
-    "@babel/runtime": "7.23.9",
     "@geosolutions/acorn-jsx": "4.0.2",
     "@geosolutions/jsdoc": "3.4.4",
     "@geosolutions/mocha": "6.2.1-3",


### PR DESCRIPTION
[Backport 2025.02.xx] Remove @babel/runtime ( again ) (#11629)