### PR TITLE
Remove glob

### DIFF
--- a/build/themes.js
+++ b/build/themes.js
@@ -1,21 +1,19 @@
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-var path = require("path");
-const glob = require('glob');
 const extractThemesPlugin = new MiniCssExtractPlugin({
     filename: '[name].css'
 });
 
+const { readdirSync } = require("fs");
+const path = require("path");
 
 const themeEntries = (() => {
-    const globPath = path.join(__dirname, "..", "web", "client", "themes", "*");
-    var files = glob.sync(globPath, {mark: true});
-    return files.filter((f) => f.lastIndexOf('/') === f.length - 1).reduce((res, curr) => {
-        var finalRes = res || {};
-        var themeName = path.basename(curr, path.extname(curr));
-        finalRes["themes/" + themeName] = path.join(__dirname, "..", "web", "client", "themes", `${themeName}`, "theme.less");
-        return finalRes;
-    }, {});
+    const entries = {};
 
+    const dirPath = path.join(__dirname, "..", "web", "client", "themes");
+    readdirSync(dirPath, { withFileTypes: true }).filter(entry => entry.isDirectory()).forEach(entry => {
+        entries[`themes/${entry.name}`] = path.join(dirPath, entry.name, "theme.less");
+    });
+    return entries;
 })();
 module.exports = {
     themeEntries,

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "eslint-plugin-react": "3.16.1",
     "expect": "1.20.1",
     "file-loader": "2.0.0",
-    "glob": "7.1.1",
     "html-loader": "2.0.0",
     "html-webpack-plugin": "5.2.0",
     "karma": "6.4.0",


### PR DESCRIPTION
## Description
This PR replaces glob with readdirSync from node:fs because the current version of glob is deprecated and we don't need to pull in an entire npm package for this functionality.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Build related changes

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11667

**What is the new behavior?**
Glob will be removed from package.json and will no longer be installed when running npm install

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
