### PR TITLE
Fix #5981 add backport github action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,3 +15,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create backport pull requests
         uses: korthout/backport-action@v3
+        with:
+          copy_assignees: true
+          copy_milestone: true
+          copy_requested_reviewers: true
+          conflict_resolution: draft_commit_conflicts
+          add_labels: Backport


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces this [backport-action](https://github.com/korthout/backport-action/tree/main) that triggers a backport PR using labels with this structure `backport <branch-name>`, e.g.: `backport 2025.02.xx`, `backport geonode-5.0.x`, ...

This will allow to automate the backport process when there are not conflicts

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] CI related changes


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5981

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Add new github action to trigger backport using labels

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
