### PR TITLE
#11678: Fix Manage Rule - WMS service is not reachable

### DIFF
--- a/web/client/plugins/manager/EditorEnhancer.js
+++ b/web/client/plugins/manager/EditorEnhancer.js
@@ -33,7 +33,8 @@ const dataStreamFactory = prop$ => {
             const geoFenceType = ConfigUtils.getDefaults().geoFenceServiceType;
             // in case non stand-alone geofence
             if (geoFenceType !== "geofence") {
-                return getStylesAndAttributes(layer, workspace).do(opts => optionsLoaded(opts))
+                const {url} = ConfigUtils.getDefaults().geoFenceGeoServerInstance || {};
+                return getStylesAndAttributes(layer, workspace, url).do(opts => optionsLoaded(opts))
                     .catch(() => {
                         setLoading(false);
                         onError({


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes a regression issue of missing passing the geofence url to function **'getStylesAndAttributes'** here:
https://github.com/geosolutions-it/MapStore2/blob/54e906246890002e3cc5735ea979e0514ad6b3b9/web/client/plugins/manager/EditorEnhancer.js#L35-L36

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#11678 

**What is the current behavior?**
#11678

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
For non geofence stand-alone
Now when user can want to add new rule selecting **User, Workspace and Layer** .

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
