### PR TITLE
fix #10924: fix the regression issue of disable ip filter

### DIFF
--- a/web/client/components/manager/rulesmanager/rulesgrid/enhancers/rulesgrid.js
+++ b/web/client/components/manager/rulesmanager/rulesgrid/enhancers/rulesgrid.js
@@ -97,7 +97,7 @@ export default compose(
         const isStandAloneGeofence = Api.getRuleServiceType() === 'geofence';
         let columns = [{ key: 'rolename', name: <Message msgId={"rulesmanager.role"} />, filterable: true, filterRenderer: FilterRenderers.RolesFilter},
             { key: 'username', name: <Message msgId={"rulesmanager.user"} />, filterable: true, filterRenderer: FilterRenderers.UsersFilter},
-            { key: 'ipaddress', name: <Message msgId={"rulesmanager.ip"} />, filterable: false},
+            { key: 'ipaddress', name: <Message msgId={"rulesmanager.ip"} />, filterable: true, filterRenderer: FilterRenderers.IPAddressFilter},
             { key: 'service', name: <Message msgId={"rulesmanager.service"} />, filterable: true, filterRenderer: FilterRenderers.ServicesFilter},
             { key: 'request', name: <Message msgId={"rulesmanager.request"} />, filterable: true, filterRenderer: FilterRenderers.RequestsFilter },
             { key: 'workspace', name: <Message msgId={"rulesmanager.workspace"} />, filterable: true, filterRenderer: FilterRenderers.WorkspacesFilter},

--- a/web/client/plugins/__tests__/RulesDataGrid-test.jsx
+++ b/web/client/plugins/__tests__/RulesDataGrid-test.jsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+import { act } from 'react-dom/test-utils';
+
+import { getPluginForTest } from './pluginsTestUtils';
+import RulesDataGrid from '../RulesDataGrid';
+
+import ConfigUtils from '../../utils/ConfigUtils';
+
+describe('RulesDataGridPlugin', () => {
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="container"></div>';
+    });
+
+    afterEach(() => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        ConfigUtils.removeConfigProp('geoFenceServiceType');
+
+    });
+
+    it('renders RulesDataGridPlugin with (non-standalone) geofence', () => {
+        ConfigUtils.setConfigProp('geoFenceServiceType', "geoserver");
+
+        const { Plugin } = getPluginForTest(RulesDataGrid, {
+            rulesmanager: {
+                activeGrid: 'rules'
+            }
+        });
+        act(() => {
+            ReactDOM.render(<Plugin />, document.getElementById('container'));
+        });
+
+        // In non-standalone mode, only RulesGrid is shown
+        const container = document.querySelector('.rules-data-gird');
+        expect(container).toExist();
+
+        // Should not render tabs when geofence is not standalone
+        const tabs = document.getElementById('rules-manager-tabs');
+        expect(tabs).toNotExist();
+    });
+
+    it('renders with standalone GeoFence and shows Tabs', async() => {
+        ConfigUtils.setConfigProp('geoFenceServiceType', "geofence");
+
+        const { Plugin } = getPluginForTest(RulesDataGrid, {
+            rulesmanager: {
+                activeGrid: 'rules'
+            }
+        });
+        const comp = ReactDOM.render(<Plugin />, document.getElementById('container'));
+        await act(async() => comp);
+        // Tabs should exist now
+        const tabs = document.getElementById('rules-manager-tabs');
+        expect(tabs).toExist();
+
+        // The div container should exist
+        const container = document.querySelector('.rules-data-gird');
+        expect(container).toExist();
+        // the columns names
+        const columnsElems = container.querySelectorAll('.react-grid-HeaderRow .react-grid-HeaderCell .widget-HeaderCell__value span');
+        expect(columnsElems.length).toBe(10);
+        expect(columnsElems[0].innerHTML).toEqual('rulesmanager.gsInstance');
+    });
+    it('renders with standalone GeoFence and existing ipRange filter', async() => {
+        ConfigUtils.setConfigProp('geoFenceServiceType', "geofence");
+        const { Plugin } = getPluginForTest(RulesDataGrid, {
+            rulesmanager: {
+                activeGrid: 'rules'
+            }
+        });
+        const comp = ReactDOM.render(<Plugin />, document.getElementById('container'));
+        await act(async() => comp);
+
+        // The div container should exist
+        const container = document.querySelector('.rules-data-gird');
+        expect(container).toExist();
+        // the columns names
+        const ipFilterElem = container.querySelectorAll('.react-grid-HeaderCell .autocompleteField .input-clearable input')[0];
+        expect(ipFilterElem).toBeTruthy();
+        expect(ipFilterElem.placeholder).toEqual('rulesmanager.placeholders.ipRange');
+    });
+});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes fixing a regression issue of disable ip filter due to this: https://github.com/geosolutions-it/MapStore2/pull/11063/files#diff-a9732eedb8fc0863a1129b75595b92f3ef557629490f87e935466999b030d6c1R100
I have added a new unit test for the RulesGrid plugin and added a specific unit test for the ip filter.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#10924 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The filter ip is shown and not disabled. User can filter by ip in rules grid.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
