### PR TITLE
Fix #5981 improve backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,7 @@
 name: Backport merged pull request
 on:
   pull_request_target:
-    types: [closed]
+    types: [closed, labeled]
 permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests
@@ -10,7 +10,15 @@ jobs:
     name: Backport pull request
     runs-on: ubuntu-latest
     # Don't run on closed unmerged pull requests
-    if: github.event.pull_request.merged
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
     steps:
       - uses: actions/checkout@v4
       - name: Create backport pull requests
@@ -19,5 +27,5 @@ jobs:
           copy_assignees: true
           copy_milestone: true
           copy_requested_reviewers: true
-          conflict_resolution: draft_commit_conflicts
+          experimental: '{ "conflict_resolution": "draft_commit_conflicts" }'
           add_labels: Backport


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR improve the backport action by allowing to label the backport PR after being closed. In addition there is a fix on the configuration

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] CI related changes

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#5981

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Improvement of the backport action

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
