### PR TITLE
Concatenated filtering does not work in map

### DIFF
--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -796,6 +796,9 @@ export const processCQLFilterGroup = function(root, objFilter) {
             })
             .filter(Boolean)
             .join(" " + fixedRoot.logic + " ");
+        if (!subGroupCql) {
+            return cql;
+        }
         return cql ? [cql, subGroupCql].join(" " + fixedRoot.logic + " ") : subGroupCql;
     }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR resolves the issue of the concatenated filtering using the quick filters from the table. This PR removes the extra paramters from the CQL filter.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
<!-- add here the ReadTheDocs link (if needed) -->

## Issue
**What is the current behavior?**
<!-- You can also link to an existing issue here -->
After the filter is applied, the map filters the data for single filter, but when the second search parameter is added after comma, the map does not get updated and will display only the result of the single filter.
#11709 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The map filters the layer based on the input search parameters in quick filter in the table.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No