### PR TITLE
Fix the legend rendering issue and add the test case for it

### DIFF
--- a/web/client/utils/LegendUtils.js
+++ b/web/client/utils/LegendUtils.js
@@ -89,27 +89,25 @@ export const updateLayerWithLegendFilters = (layers, dependencies) => {
     const layerInCommon = layers?.find(l => l.name === targetLayerName) || {};
     let filterObjCollection = {};
     let layersUpdatedWithCql = {};
-    let cqlFilter = undefined;
 
     if (dependencies?.mapSync && !isEmpty(layerInCommon)
-        && (filterObj.featureTypeName ? filterObj.featureTypeName === targetLayerName : true)) {
-        if (dependencies?.quickFilters) {
-            filterObjCollection = {
-                ...filterObjCollection,
-                ...composeFilterObject(filterObj, dependencies?.quickFilters, dependencies?.options)
-            };
-        }
-        cqlFilter = toCQLFilter(filterObjCollection);
-        if (!isEmpty(filterObjCollection) && cqlFilter) {
-            layersUpdatedWithCql = arrayUpdate(false,
-                {
-                    ...layerInCommon,
-                    params: optionsToVendorParams({ params: {CQL_FILTER: cqlFilter}})
-                },
-                {name: targetLayerName},
-                layers
-            );
-        }
+        && (filterObj.featureTypeName ? filterObj.featureTypeName === targetLayerName : true)
+        && dependencies?.quickFilters) {
+        filterObjCollection = {
+            ...filterObjCollection,
+            ...composeFilterObject(filterObj, dependencies?.quickFilters, dependencies?.options)
+        };
+    }
+    const cqlFilter = toCQLFilter(filterObjCollection);
+    if (!isEmpty(filterObjCollection) && cqlFilter) {
+        layersUpdatedWithCql = arrayUpdate(false,
+            {
+                ...layerInCommon,
+                params: optionsToVendorParams({ params: {CQL_FILTER: cqlFilter}})
+            },
+            {name: targetLayerName},
+            layers
+        );
     } else {
         layersUpdatedWithCql = layers.map(l => ({...l, params: {...l.params, CQL_FILTER: undefined}}));
     }

--- a/web/client/utils/__tests__/LegendUtils-test.js
+++ b/web/client/utils/__tests__/LegendUtils-test.js
@@ -407,5 +407,66 @@ describe('LegendUtils', () => {
             expect(result[0].name).toBe("layer1");
             expect(result[0].params.CQL_FILTER).toBe(CQL_FILTER);
         });
+
+        it('should clear CQL_FILTER when quickFilters are missing', () => {
+            const layers = [
+                { name: 'layer1', params: { CQL_FILTER: 'some_filter' } },
+                { name: 'layer2', params: { CQL_FILTER: 'some_filter' } }
+            ];
+            const dependencies = {
+                layer: { name: 'layer1' },
+                filter,
+                mapSync: true,
+                options: {}
+            };
+
+            const result = updateLayerWithLegendFilters(layers, dependencies);
+            expect(result).toBeTruthy();
+            expect(result).toEqual([
+                { name: 'layer1', params: {CQL_FILTER: undefined} },
+                { name: 'layer2', params: {CQL_FILTER: undefined} }
+            ]);
+        });
+
+        it('should skip applying filters when featureTypeName does not match target layer', () => {
+            const layers = [
+                { name: 'layer1', params: { CQL_FILTER: 'some_filter' } },
+                { name: 'layer2', params: { CQL_FILTER: 'some_filter' } }
+            ];
+            const dependencies = {
+                layer: { name: 'layer1' },
+                filter: { ...filter, featureTypeName: 'anotherLayer' },
+                mapSync: true,
+                quickFilters: {},
+                options: {}
+            };
+
+            const result = updateLayerWithLegendFilters(layers, dependencies);
+            expect(result).toBeTruthy();
+            expect(result).toEqual([
+                { name: 'layer1', params: {CQL_FILTER: undefined} },
+                { name: 'layer2', params: {CQL_FILTER: undefined} }
+            ]);
+        });
+
+        it('should clear filters when layer dependency is missing', () => {
+            const layers = [
+                { name: 'layer1', params: { CQL_FILTER: 'some_filter' } },
+                { name: 'layer2', params: { CQL_FILTER: 'some_filter' } }
+            ];
+            const dependencies = {
+                filter,
+                mapSync: true,
+                quickFilters: {},
+                options: {}
+            };
+
+            const result = updateLayerWithLegendFilters(layers, dependencies);
+            expect(result).toBeTruthy();
+            expect(result).toEqual([
+                { name: 'layer1', params: {CQL_FILTER: undefined} },
+                { name: 'layer2', params: {CQL_FILTER: undefined} }
+            ]);
+        });
     });
 });


### PR DESCRIPTION
## Description
This PR fixes the legend rendering issue when the map is connected to the table.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue
**What is the current behavior?**
The legend does not render the layers that are present in the map. The container for the legend is empty.
#11710

**What is the new behavior?**
The legend properly renders all the layers that are present in the map.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
