### PR TITLE
Fix: #11712 Support for template format on vector layer.

### DIFF
--- a/web/client/utils/mapinfo/__tests__/vector-test.js
+++ b/web/client/utils/mapinfo/__tests__/vector-test.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from "expect";
+import vector from "../vector";
+
+describe("mapinfo vector utils", () => {
+    it("should create a request for a generic vector layer", () => {
+        const layer = {
+            id: "layer1",
+            title: "My Layer",
+            features: [{ properties: { prop1: "val", embedUrl: "test" } }],
+            featureInfo: {
+                format: "TEMPLATE",
+                template: "<p>Test</p>"
+            }
+        };
+        const props = {
+            point: {
+                latlng: { lat: 40, lng: 10 },
+                intersectedFeatures: [
+                    {
+                        id: "layer1",
+                        features: [
+                            { type: "Feature", properties: { prop1: "val", embedUrl: "test" } }
+                        ]
+                    }
+                ]
+            },
+            map: {
+                resolution: 10,
+                units: "m"
+            }
+        };
+        const result = vector.buildRequest(layer, props);
+
+        expect(result).toEqual({
+            request: {
+                features: [{ type: "Feature", properties: { prop1: "val", embedUrl: "test" } }],
+                outputFormat: "application/json",
+                lat: 40,
+                lng: 10
+            },
+            metadata: {
+                fields: ["prop1", "embedUrl"],
+                title: "My Layer",
+                resolution: 10,
+                buffer: 2,
+                units: "m",
+                rowViewer: undefined,
+                viewer: undefined,
+                featureInfo: {
+                    format: "TEMPLATE",
+                    template: "<p>Test</p>"
+                },
+                layerId: "layer1"
+            },
+            url: "client"
+        });
+    });
+});
+

--- a/web/client/utils/mapinfo/vector.js
+++ b/web/client/utils/mapinfo/vector.js
@@ -44,7 +44,8 @@ export default {
                 units: props.map && props.map.units,
                 rowViewer: layer.rowViewer,
                 viewer: layer.viewer,
-                layerId: layer.id
+                layerId: layer.id,
+                featureInfo: layer?.featureInfo
             },
             url: 'client'
         };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR add support for template layer on vector layer. This is added to show the embed content in Identify panel.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11712 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
<img width="1055" height="508" alt="Screenshot 2025-11-24 at 16 51 16" src="https://github.com/user-attachments/assets/323dbb9e-2ad3-4d6e-bede-d86082f2fcd2" />

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
