### PR TITLE
Access Restrictions for Maps Created from Unadvertised Contexts #11748

### DIFF
--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -4557,7 +4557,7 @@
         "errorDefault": "Netzwerkfehler"
       },
       "resourceIssues": {
-        "dependencyMissing": "Diese Ressource kann nicht geöffnet werden. Fehlende Berechtigungen für eine zugehörige Ressource."
+        "dependencyMissing": "Fehlende Berechtigungen für eine zugehörige Ressource."
       },
       "deleteError": {
         "error403": "Sie dürfen die Ressource nicht löschen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -4528,7 +4528,7 @@
         "errorDefault": "Network error"
       },
       "resourceIssues": {
-        "dependencyMissing": "This resource can't be open. Missing permissions on an associated resource."
+        "dependencyMissing": "Missing permissions on an associated resource."
       },
       "deleteError": {
         "error403": "You are not allowed to delete the resource",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -4518,7 +4518,7 @@
         "errorDefault": "Error de red"
       },
       "resourceIssues": {
-        "dependencyMissing": "Este recurso no se puede abrir. Faltan permisos en un recurso asociado."
+        "dependencyMissing": "Faltan permisos en un recurso asociado."
       },
       "deleteError": {
         "error403": "No tiene permiso para eliminar el recurso",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -4519,7 +4519,7 @@
         "errorDefault": "Erreur réseau"
       },
       "resourceIssues": {
-        "dependencyMissing": "Cette ressource ne peut pas être ouverte. Autorisations manquantes sur une ressource associée."
+        "dependencyMissing": "Autorisations manquantes sur une ressource associée."
       },
       "deleteError": {
         "error403": "Vous n'êtes pas autorisé à supprimer la ressource",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -4520,7 +4520,7 @@
         "errorDefault": "Errore di rete"
       },
       "resourceIssues": {
-        "dependencyMissing": "Questa risorsa non può essere aperta. Autorizzazioni mancanti su una risorsa associata."
+        "dependencyMissing": "Autorizzazioni mancanti su una risorsa associata."
       },
       "deleteError": {
         "error403": "Non sei autorizzato a eliminare la risorsa",

--- a/web/client/utils/GeostoreUtils.js
+++ b/web/client/utils/GeostoreUtils.js
@@ -48,9 +48,6 @@ const resourceTypes = {
     MAP: {
         icon: { glyph: '1-map' },
         formatViewerPath: (resource, context) => {
-            if (hasInaccessibleContext(resource, context)) {
-                return null;
-            }
             if (context?.name) {
                 return `/context/${context.name}/${resource.id}`;
             }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
From the discussion and conclusion [here](https://github.com/geosolutions-it/MapStore2/issues/11748#issuecomment-3596863569), it was decided to make the non-advertised context's map clickable to open in the default viewer, along with showing a warning.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

#11748

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11748
For a normal user, the user can not open a non-advertised context's map even if they have edit/view permission.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The user can click and open a non-advertised context's map in the default viewer. Warning about permission will be as it is.
<img width="398" height="350" alt="image" src="https://github.com/user-attachments/assets/d5435ab3-bbf4-44b5-8821-8840578035f0" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
The warning message has also been updated to not include: "This resource can't be open"
