### PR TITLE
Fix #11754 - Moved assemply to bin-war module

### DIFF
--- a/binary/bin-war/pom.xml
+++ b/binary/bin-war/pom.xml
@@ -65,6 +65,29 @@
                     </webResources>
                 </configuration>
             </plugin>
+            <!-- artifact assembly moved here so it runs after WAR packaging -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.1</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>../bin.xml</descriptor>
+                    </descriptors>
+                    <finalName>mapstore2-${binary.number}</finalName>
+                    <!-- place ZIP in the binary module target directory (bin-war -> ../../target) -->
+                    <outputDirectory>${project.build.directory}/../../target</outputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/binary/bin.xml
+++ b/binary/bin.xml
@@ -4,10 +4,12 @@
     <format>zip</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
+  <!-- main webapp (war built by bin-war module) -->
   <fileSets>
+    <!-- NOTE: we keep fileSets for other files (jre, libs, scripts, tomcat conf, logs, work) -->
     <fileSet>
-      <!-- the main webapp -->
-      <directory>./bin-war/target/</directory>
+      <!-- the main webapp (relative to bin-war module where assembly will run) -->
+      <directory>target/</directory>
       <outputDirectory>mapstore2/webapps/</outputDirectory>
       <includes>
         <include>mapstore.war</include>
@@ -22,7 +24,7 @@
       </includes>
     </fileSet>
     <fileSet>
-      <!-- the libs needed to run tomcat -->
+      <!-- the libs needed to run tomcat (copied by dependency plugin into target/dependency) -->
       <directory>target/dependency</directory>
       <outputDirectory>mapstore2/lib</outputDirectory>
       <includes>
@@ -31,8 +33,8 @@
       </includes>
     </fileSet>
     <fileSet>
-      <!-- windows batch files -->
-      <directory>bin</directory>
+      <!-- windows batch files (stored in binary/bin) -->
+      <directory>../bin</directory>
       <lineEnding>keep</lineEnding>
       <outputDirectory>mapstore2/</outputDirectory>
       <includes>
@@ -40,8 +42,8 @@
       </includes>
     </fileSet>
     <fileSet>
-      <!-- unix shell scripts -->
-      <directory>bin</directory>
+      <!-- unix shell scripts (stored in binary/bin) -->
+      <directory>../bin</directory>
       <lineEnding>unix</lineEnding>
       <outputDirectory>mapstore2/</outputDirectory>
       <fileMode>0755</fileMode>
@@ -51,21 +53,21 @@
       </includes>
     </fileSet>
     <fileSet>
-      <!-- tomcat configuration -->
-      <directory>tomcat</directory>
+      <!-- tomcat configuration (stored in binary/tomcat) -->
+      <directory>../tomcat</directory>
       <outputDirectory>mapstore2</outputDirectory>
       <includes>
         <include>**/*</include>
       </includes>
     </fileSet>
     <fileSet>
-      <!-- empty log directory -->
-      <directory>logs</directory>
+      <!-- empty log directory (in binary/logs) -->
+      <directory>../logs</directory>
       <outputDirectory>mapstore2</outputDirectory>
     </fileSet>
     <fileSet>
-      <!-- empty work directory -->
-      <directory>work</directory>
+      <!-- empty work directory (in binary/work) -->
+      <directory>../work</directory>
       <outputDirectory>mapstore2</outputDirectory>
     </fileSet>
   </fileSets>

--- a/binary/pom.xml
+++ b/binary/pom.xml
@@ -142,28 +142,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- artifact assembly -->
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.1</version>
-                <configuration>
-                    <descriptors>
-                        <descriptor>bin.xml</descriptor>
-                    </descriptors>
-                    <finalName>mapstore2-${binary.number}</finalName>
-                    <outputDirectory>${project.build.directory}</outputDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <inherited>false</inherited>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <modules>


### PR DESCRIPTION
## Description
Because of parent-child relationship introduced recently on bin package, during a full reactor build the `mapstore-binary` aggregator module executed the assembly plugin *before* the `bin-war` child produced `mapstore.war` on the CI server. 
That means the ZIP created by the assembly could miss the WAR or copy an older artifact. Locally this was less visible because of incremental artifacts in the developer workspace.

- What I changed

- The assembly execution was moved from `binary/pom.xml` into `binary/bin-war/pom.xml`.
- The assembly descriptor `binary/bin.xml` was updated to use paths relative to `bin-war` (so it can include `target/mapstore.war`, `target/jre` and `target/dependency`).
- The assembly output directory was adjusted so the final ZIP lands in `binary/target/` just like before.

- Why this fixes it: Putting assembly in `bin-war` makes the assembly run as part of the `bin-war` module lifecycle which is executed after packaging the WAR. This removes reactor ordering issues (parent pom executed before child modules) that previously allowed the assembly to run before the WAR existed on CI.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #11754

**What is the new behavior?**

Bin build should be always done after war creation.


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No


