### PR TITLE
#11777: fix issue of coordinate in the GFI and Share-tool depend on each other instead of the config in localConfig.json

### DIFF
--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import {connect, createPlugin} from '../utils/PluginsUtils';
 import { Glyphicon } from 'react-bootstrap';
 import Message from '../components/I18N/Message';
@@ -22,7 +22,6 @@ import { mapIdSelector, mapSelector } from '../selectors/map';
 import { currentContextSelector } from '../selectors/context';
 import { get } from 'lodash';
 import controls from '../reducers/controls';
-import { changeFormat } from '../actions/mapInfo';
 import { addMarker, hideMarker } from '../actions/search';
 import { updateMapView } from '../actions/map';
 import { resourceSelector as geostoryResourceSelector, updateUrlOnScrollSelector } from '../selectors/geostory';
@@ -69,7 +68,6 @@ const Share = connect(createSelector([
     mapTypeSelector,
     currentContextSelector,
     state => get(state, 'controls.share.settings', {}),
-    (state) => state.mapInfo && state.mapInfo.formatCoord || ConfigUtils.getConfigProp("defaultCoordinateFormat"),
     state => state.search && state.search.markerPosition || {},
     updateUrlOnScrollSelector,
     state => get(state, 'map.present.viewerOptions'),
@@ -84,7 +82,7 @@ const Share = connect(createSelector([
     },
     state => get(state, 'controls.share.resource.shareUrl') || location.href,
     state => get(state, 'controls.share.resource.categoryName')
-], (isVisible, version, map, mapType, context, settings, formatCoords, point, isScrollPosition, viewerOptions, center, shareUrl, categoryName) => ({
+], (isVisible, version, map, mapType, context, settings, point, isScrollPosition, viewerOptions, center, shareUrl, categoryName) => ({
     isVisible,
     shareUrl,
     shareApiUrl: getApiUrl(shareUrl),
@@ -104,7 +102,6 @@ const Share = connect(createSelector([
         bbox: true,
         centerAndZoom: true
     },
-    formatCoords: formatCoords,
     point,
     isScrollPosition,
     categoryName})), {
@@ -112,12 +109,12 @@ const Share = connect(createSelector([
     hideMarker,
     updateMapView,
     onUpdateSettings: setControlProperty.bind(null, 'share', 'settings'),
-    onChangeFormat: changeFormat,
     addMarker: addMarker,
     onClearShareResource: setControlProperty.bind(null, 'share', 'resource', undefined)
 })(({ categoryName, ...props }) => {
+    const [formatCoord, setFormatCoords] = useState(ConfigUtils.getConfigProp("defaultCoordinateFormat") || 'decimal');
     const categoryCfg = props[categoryName];
-    return <SharePanel {...props} {...categoryCfg} />;
+    return <SharePanel {...props} {...categoryCfg} onChangeFormat={setFormatCoords} formatCoords={formatCoord} />;
 });
 
 const ActionCardShareButton = connect(

--- a/web/client/plugins/__tests__/Share-test.jsx
+++ b/web/client/plugins/__tests__/Share-test.jsx
@@ -17,6 +17,7 @@ import { TOGGLE_CONTROL } from '../../actions/controls';
 import { PURGE_MAPINFO_RESULTS, HIDE_MAPINFO_MARKER } from '../../actions/mapInfo';
 import mapInfo from '../../reducers/mapInfo';
 import search from '../../reducers/search';
+import ConfigUtils from '../../utils/ConfigUtils';
 
 describe('Share Plugin', () => {
     beforeEach(() => {
@@ -484,5 +485,90 @@ describe('Share Plugin', () => {
         expect(toNumber(lat.value)).toBe(40);
         expect(toNumber(lon.value)).toBe(-80);
         expect(toNumber(zoom.value)).toBe(5);
+    });
+    it('test Share plugin with coordinate editor with default decimal formatCoord', () => {
+        let storeState = {
+            map: {
+                center: {
+                    crs: "EPSG:4326",
+                    x: -86.25,
+                    y: 38.07
+                },
+                zoom: 5
+            },
+            controls: {
+                share: {
+                    enabled: true,
+                    settings: {
+                        centerAndZoomEnabled: true
+                    }
+                }
+            },
+            search: {
+                markerPosition: {latlng: {lat: 40, lng: -80}}
+            }
+        };
+        const props = {
+            advancedSettings: {
+                centerAndZoom: true,
+                defaultEnabled: "markerAndZoom"
+            }
+        };
+        const {Plugin} = getPluginForTest({...SharePlugin, reducers: {
+            mapInfo,
+            search
+        }}, storeState);
+        ReactDOM.render(<Plugin {...props}/>, document.getElementById("container"));
+        const sharePanelElem = document.getElementsByClassName('share-panel-modal-body')[0];
+        expect(sharePanelElem).toExist();
+        let coordinateLngLatElems = sharePanelElem.querySelectorAll(".coordinate .input-group-container .input-group .form-group");
+
+        expect(coordinateLngLatElems.length).toEqual(2);
+    });
+    it('test Share plugin with coordinate editor with auronautical formatCoord', () => {
+        let storeState = {
+            map: {
+                center: {
+                    crs: "EPSG:4326",
+                    x: -86.25,
+                    y: 38.07
+                },
+                zoom: 5
+            },
+            controls: {
+                share: {
+                    enabled: true,
+                    settings: {
+                        centerAndZoomEnabled: true
+                    }
+                }
+            },
+            search: {
+                markerPosition: {latlng: {lat: 40, lng: -80}}
+            }
+        };
+        const props = {
+            advancedSettings: {
+                centerAndZoom: true,
+                defaultEnabled: "markerAndZoom"
+            }
+        };
+        ConfigUtils.setConfigProp('defaultCoordinateFormat', "aeronautical");
+        const {Plugin} = getPluginForTest({...SharePlugin, reducers: {
+            mapInfo,
+            search
+        }}, storeState);
+        ReactDOM.render(<Plugin {...props} />, document.getElementById("container"));
+        const sharePanelElem = document.getElementsByClassName('share-panel-modal-body')[0];
+        expect(sharePanelElem).toExist();
+        let coordinateLngLatElems = sharePanelElem.querySelectorAll(".coordinate .input-group-container .input-group .form-group");
+
+        expect(coordinateLngLatElems.length).toEqual(2);
+        expect(coordinateLngLatElems[0].childNodes.length).toEqual(4);
+        expect(coordinateLngLatElems[0].querySelector('.degrees')).toExist();
+        expect(coordinateLngLatElems[0].querySelector('.minutes')).toExist();
+        expect(coordinateLngLatElems[0].querySelector('.seconds')).toExist();
+        expect(coordinateLngLatElems[0].querySelector('.direction-select')).toExist();
+        ConfigUtils.removeConfigProp('defaultCoordinateFormat');
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes fix issue of using coordinate format from mapInfo state within Share Panel plugin by creating a separate local state for Share panel only without any dependent with Identify.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11777 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
In share panel, the coordinate editor reads the init value of coordinate format from localConfig or decimal by default and not related with the Identify formatCoord at all.


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
