### PR TITLE
#11779: FIX Setting the map projection freezes MapStore causing OOM if resolutions configured in new.json file with a different projection

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -353,14 +353,34 @@ class OpenlayersMap extends React.Component {
      * - custom grid set with custom extent. You need to customize the projection definition extent to make it work.
      * - custom grid set is partially supported by mapOptions.view.resolutions but this is not managed by projection change yet
      * - custom tile sizes
-     *
+     * ** NOTES**: If mapOptions.view.resolutions + mapOptions.view.projection are provided and match → will use them.
+     * - Else → will compute resolutions for provided/mapView projection.
      */
     getResolutions = (srs) => {
-        if (this.props.mapOptions && this.props.mapOptions.view && this.props.mapOptions.view.resolutions) {
-            return this.props.mapOptions.view.resolutions;
+    // Resolve requested projection
+        const requestedProj = srs
+            ? getProjection(srs)
+            : (this.map?.getView()?.getProjection());
+        const requestedSRS = normalizeSRS(srs || requestedProj.getCode());
+
+        // Check for explicitly configured resolutions + matching projection
+        const viewOptions = this.props?.mapOptions?.view || {};
+        const configuredResolutions = viewOptions.resolutions;
+        const configuredResProjection = viewOptions.projection && normalizeSRS(viewOptions.projection);
+
+        // If resolutions are explicitly configured *and* tied to a projection that matches our target,
+        // return them directly — avoids recomputation and ensures consistency with custom tile sources.
+        if (
+            configuredResolutions &&
+        Array.isArray(configuredResolutions) &&
+        configuredResProjection &&
+        requestedSRS === configuredResProjection
+        ) {
+            return configuredResolutions;
         }
-        const projection = srs ? getProjection(srs) : this.map.getView().getProjection();
-        const extent = projection.getExtent();
+
+        // Otherwise compute dynamically
+        const extent = requestedProj.getExtent();
         return getResolutionsForProjection(
             srs ?? this.map.getView().getProjection().getCode(),
             {
@@ -516,22 +536,39 @@ class OpenlayersMap extends React.Component {
         // limit has a crs defined
         const extent = limits.restrictedExtent && limits.crs && reprojectBbox(limits.restrictedExtent, limits.crs, normalizeSRS(projection));
         const newOptions = !options || (options && !options.view) ? Object.assign({}, options, { extent }) : Object.assign({}, options);
+
+        // Determine whether to use configured resolutions
+        const configuredResolutions = options?.resolutions;
+        const configuredProj = normalizeSRS(options?.projection);
+
+        let resolutionsToUse;
+        if (configuredResolutions && configuredProj === normalizeSRS(projection)) {
+            // use provided resolutions (keep backward compatibility)
+            resolutionsToUse = configuredResolutions;
+        } else {
+            // compute resolutions dynamically (e.g., EPSG:4326)
+            resolutionsToUse = this.getResolutions(normalizeSRS(projection));
+        }
         /*
         * setting the zoom level in the localConfig file is co-related to the projection extent(size)
         * it is recommended to use projections with the same coverage area (extent). If you want to have the same restricted zoom level (minZoom)
         */
-        const viewOptions = Object.assign({}, {
-            projection: normalizeSRS(projection),
-            center: [center.x, center.y],
-            zoom: zoom,
-            minZoom: limits.minZoom,
-            // allow to zoom to level 0 and see world wrapping
-            multiWorld: true,
-            // does not allow intermediary zoom levels
-            // we need this at true to set correctly the scale box
-            constrainResolution: true,
-            resolutions: this.getResolutions(normalizeSRS(projection))
-        }, newOptions || {});
+        const viewOptions = Object.assign(
+            {},
+            newOptions || {},
+            {
+                projection: normalizeSRS(projection),
+                center: [center.x, center.y],
+                zoom: zoom,
+                resolutions: resolutionsToUse,
+                minZoom: limits.minZoom,
+                // allow to zoom to level 0 and see world wrapping
+                multiWorld: true,
+                // does not allow intermediary zoom levels
+                // we need this at true to set correctly the scale box
+                constrainResolution: true
+            }
+        );
         return new View(viewOptions);
     };
 

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -1523,4 +1523,41 @@ describe('OpenlayersMap', () => {
         // center is modified
         expect(map.map.getView().getCenter()).toEqual([10.3346773790, 43.9323234388]);
     });
+    it('should correctly apply view projection without propagating to zoom changes', () => {
+        const resolutions = [0.0005, 0.0004, 0.0003, 0.0002];
+        const map = ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 45, x: 10}}
+                zoom={2}
+                projection="EPSG:4326"
+                mapOptions={{ view: { projection: 'EPSG:4326', resolutions } }}
+            />,
+            document.getElementById("map")
+        );
+
+        const view = map.map.getView();
+        expect(view.getProjection().getCode()).toBe('EPSG:4326');
+        expect(view.getResolutions()).toEqual(resolutions); // Custom resolutions applied
+
+        // Simulate a zoom change
+        view.setZoom(3);
+        expect(view.getProjection().getCode()).toBe('EPSG:4326');
+
+        // Simulate receiving new props with a different projection
+        ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 45, x: 10}}
+                zoom={3}
+                projection="EPSG:3857"
+                mapOptions={{ view: { projection: 'EPSG:4326', resolutions } }}
+            />,
+            document.getElementById("map")
+        );
+
+        const updatedView = map.map.getView();
+        updatedView.setZoom(5);
+        expect(updatedView.getProjection().getCode()).toBe('EPSG:3857');
+        expect(updatedView.getResolutions()).toNotEqual(resolutions);
+    });
+
 });

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -1404,7 +1404,7 @@ describe('OpenlayersMap', () => {
             <OpenlayersMap
                 center={{y: 43.9, x: 10.3}}
                 zoom={11}
-                mapOptions={{view: { resolutions }}}
+                mapOptions={{view: { resolutions, projection: "EPSG:3857" }}}
             >
                 <OpenlayersLayer type="wms" srs="EPSG:3857" options={options} />
             </OpenlayersMap>, document.getElementById("map")
@@ -1460,7 +1460,7 @@ describe('OpenlayersMap', () => {
             <OpenlayersMap
                 center={{y: 43.9, x: 10.3}}
                 zoom={11}
-                mapOptions={{view: { resolutions }}}
+                mapOptions={{view: { resolutions, projection: "EPSG:3857" }}}
             >
                 <OpenlayersLayer type="wms" srs="EPSG:3857" options={options} />
             </OpenlayersMap>, document.getElementById("map")

--- a/web/client/components/print/MapPreview.jsx
+++ b/web/client/components/print/MapPreview.jsx
@@ -149,7 +149,8 @@ class MapPreview extends React.Component {
         let mapOptions = !isEmpty(resolutions) || !isNil(this.props.rotation) ? {
             view: {
                 ...(!isEmpty(resolutions) && {resolutions}),
-                rotation: !isNil(this.props.rotation) ? Number(this.props.rotation) : 0
+                rotation: !isNil(this.props.rotation) ? Number(this.props.rotation) : 0,
+                projection
             }
         } : {};
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes:
- prevent OOM by enforcing projection-aware resolutions in new.json file in mapOptions.view
- Add strict check: only use configured resolutions if `view.projection` in **new.json file** matches target SRS in createView
- Eliminates infinite tile loading and out-of-memory crashes when switching to different CRS
- fix print file by passing the projection prop with resolutions to gurantee the above check

** the new edits includes -> a projection should be added to resolutions/scales in **mapOptions.view** in **new.json file** to be read properly. **

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11779 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The OOM behavior not happen now if a resolutions and projection provided in new.json file and user switch to different projection rather than the resolutions one.


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
This new.json for test
```
{
  "version": 2,
  "map": {
    "projection": "EPSG:900913",
    "units": "m",
    "center": { "x": 1250000.0, "y": 5370000.0, "crs": "EPSG:900913" },
    "zoom": 5,
    "mapOptions": {
      "view": {
        "resolutions": [
          84666.66666666688,
          42333.33333333344,
          21166.66666666672,
          10583.33333333336,
          5291.66666666668,
          2645.83333333334,
          1322.91666666667,
          661.458333333335000,
          529.166666666668000,
          396.875000000001000,
          264.583333333334000,
          132.291666666667000,
          66.145833333333500,
          39.687500000000100,
          26.458333333333400,
          13.229166666666700,
          6.614583333333350,
          3.968750000000010,
          2.645833333333340,
          1.322916666666670,
          0.661458333333335
        ],
        "projection": "EPSG:3857"
      }
    },
    "maxExtent": [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
    "layers": [
      {
        "format": "image/jpeg",
        "group": "background",
        "name": "osm:osm_simple_light",
        "opacity": 1,
        "title": "OSM Simple Light",
        "thumbURL": "product/assets/img/osm-simple-light.jpg",
        "type": "wms",
        "url": [
          "https://maps1.geosolutionsgroup.com/geoserver/wms",
          "https://maps2.geosolutionsgroup.com/geoserver/wms",
          "https://maps3.geosolutionsgroup.com/geoserver/wms",
          "https://maps4.geosolutionsgroup.com/geoserver/wms",
          "https://maps5.geosolutionsgroup.com/geoserver/wms",
          "https://maps6.geosolutionsgroup.com/geoserver/wms"
        ],
        "tileSize": 512,
        "visibility": false,
        "singleTile": false,
        "credits": {
          "title": "OSM Simple Light | Rendering <a href=\"https://www.geo-solutions.it/\">GeoSolutions</a> | Data © <a href=\"http://www.openstreetmap.org/\">OpenStreetMap</a> contributors, <a href=\"http://www.openstreetmap.org/copyright\">ODbL</a>"
        }
      },
      {
        "format": "image/jpeg",
        "group": "background",
        "name": "osm:osm_simple_dark",
        "opacity": 1,
        "title": "OSM Simple Dark",
        "thumbURL": "product/assets/img/osm-simple-dark.jpg",
        "type": "wms",
        "url": [
          "https://maps6.geosolutionsgroup.com/geoserver/wms",
          "https://maps3.geosolutionsgroup.com/geoserver/wms",
          "https://maps1.geosolutionsgroup.com/geoserver/wms",
          "https://maps4.geosolutionsgroup.com/geoserver/wms",
          "https://maps2.geosolutionsgroup.com/geoserver/wms",
          "https://maps5.geosolutionsgroup.com/geoserver/wms"
        ],
        "tileSize": 512,
        "visibility": false,
        "singleTile": false,
        "credits": {
          "title": "OSM Simple Dark | Rendering <a href=\"https://www.geo-solutions.it/\">GeoSolutions</a> | Data © <a href=\"http://www.openstreetmap.org/\">OpenStreetMap</a> contributors, <a href=\"http://www.openstreetmap.org/copyright\">ODbL</a>"
        }
      },
      {
        "format": "image/jpeg",
        "group": "background",
        "name": "osm:osm",
        "opacity": 1,
        "title": "OSM Bright",
        "thumbURL": "product/assets/img/osm-bright.jpg",
        "type": "wms",
        "url": [
          "https://maps1.geosolutionsgroup.com/geoserver/wms",
          "https://maps2.geosolutionsgroup.com/geoserver/wms",
          "https://maps3.geosolutionsgroup.com/geoserver/wms",
          "https://maps4.geosolutionsgroup.com/geoserver/wms",
          "https://maps5.geosolutionsgroup.com/geoserver/wms",
          "https://maps6.geosolutionsgroup.com/geoserver/wms"
        ],
        "tileSize": 512,
        "visibility": true,
        "singleTile": false,
        "credits": {
          "title": "OSM Bright | Rendering <a href=\"https://www.geo-solutions.it/\">GeoSolutions</a> | Data © <a href=\"http://www.openstreetmap.org/\">OpenStreetMap</a> contributors, <a href=\"http://www.openstreetmap.org/copyright\">ODbL</a>"
        }
      },
      {
        "format": "image/jpeg",
        "group": "background",
        "name": "ne:ne-political",
        "opacity": 1,
        "title": "NE Political",
        "thumbURL": "product/assets/img/ne-political.jpg",
        "type": "wms",
        "url": [
          "https://maps1.geosolutionsgroup.com/geoserver/wms",
          "https://maps2.geosolutionsgroup.com/geoserver/wms",
          "https://maps3.geosolutionsgroup.com/geoserver/wms",
          "https://maps4.geosolutionsgroup.com/geoserver/wms",
          "https://maps5.geosolutionsgroup.com/geoserver/wms",
          "https://maps6.geosolutionsgroup.com/geoserver/wms"
        ],
        "tileSize": 512,
        "visibility": false,
        "singleTile": false,
        "credits": {
          "title": "<p></p>\n"
        }
      },
      {
        "format": "image/jpeg",
        "group": "background",
        "name": "s2cloudless:s2cloudless",
        "opacity": 1,
        "title": "Sentinel 2 Cloudless",
        "type": "wms",
        "url": [
          "https://maps1.geosolutionsgroup.com/geoserver/wms",
          "https://maps2.geosolutionsgroup.com/geoserver/wms",
          "https://maps3.geosolutionsgroup.com/geoserver/wms",
          "https://maps4.geosolutionsgroup.com/geoserver/wms",
          "https://maps5.geosolutionsgroup.com/geoserver/wms",
          "https://maps6.geosolutionsgroup.com/geoserver/wms"
        ],
        "tileSize": 512,
        "source": "s2cloudless",
        "singleTile": false,
        "visibility": false
      },
      {
        "type": "osm",
        "title": "Open Street Map",
        "name": "mapnik",
        "source": "osm",
        "group": "background",
        "visibility": false
      },
      {
        "source": "ol",
        "group": "background",
        "title": "Empty Background",
        "fixed": true,
        "type": "empty",
        "visibility": false
      }
    ]
  }
}

```

I think guides should be added for this edit 