### PR TITLE
fix utils/generateTemplateString() in case of props is null or undefined

### DIFF
--- a/web/client/utils/TemplateUtils.js
+++ b/web/client/utils/TemplateUtils.js
@@ -67,7 +67,7 @@ export const generateTemplateString = (function() {
                     .replace(/\$\{([\s]*[^;\s\{]+[\s]*)\}/g, (_, match) => {
                         const escapeFunction = escapeFn || (a => a);
                         return escapeFunction(match.trim().split(".").reduce((a, b) => {
-                            return a && a[b];
+                            return a && a[b] || '';
                         }, map));
                     });
 

--- a/web/client/utils/__tests__/TemplateUtils-test.js
+++ b/web/client/utils/__tests__/TemplateUtils-test.js
@@ -50,6 +50,12 @@ describe('TemplateUtils', () => {
         let templateResult = templateFunction({test: "TEST"});
         expect(templateResult).toBe("this is a TEST2");
     });
+    it('generateTemplateString with some null or undefined attributes', () => {
+        let templateFunction = generateTemplateString("#${desc}, ${desc1}, ${desc2}#");
+        expect(templateFunction).toExist();
+        let templateResult = templateFunction({desc: "desc value", desc1: null, desc2: undefined});
+        expect(templateResult).toEqual("#desc value, , #");
+    });
 
     it('validateStringAttribute', () => {
         const testObj = {


### PR DESCRIPTION
- fix `generateTemplateString()` in case of props is `null` or `undefined`
- added a new test for this case


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
the bug show in case of search services use null or undefined sub props:
<img width="551" height="275" alt="image" src="https://github.com/user-attachments/assets/f2610e41-c2c6-4394-94e9-96b73c98b930" />

**What is the new behavior?**
strip all null o undefined subprop with empty char

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

