### PR TITLE
#11803: Time dimension: Reload not working, when the last feature is not anymore valid

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -3357,6 +3357,125 @@ describe('Openlayers layer', () => {
         expect(cmp.layer).toBeTruthy();
         expect(cmp.layer.get('getElevation')).toBeTruthy();
     });
+    it('wms layer should refresh source when loadingError changes to Error', () => {
+        var refreshCalled = false;
+        const options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms"
+        };
+
+        // create layer
+        const layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+
+        expect(layer).toBeTruthy();
+        expect(map.getLayers().getLength()).toBe(1);
+
+        const wmsSource = map.getLayers().item(0).getSource();
+        const originalRefresh = wmsSource.refresh;
+
+        // mock refresh method to set boolean to refreshCalled to trigger change
+        wmsSource.refresh = function() {
+            refreshCalled = true;
+            originalRefresh.call(this);
+        };
+
+        // update layer with loadingError set to "Error"
+        ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={{...options, loadingError: "Error"}} map={map} />, document.getElementById("container"));
+
+        // check that refresh was called
+        expect(refreshCalled).toBe(true);
+
+        // restore original method
+        wmsSource.refresh = originalRefresh;
+    });
+
+    it('wms layer should not refresh source when loadingError remains Error', () => {
+        var refreshCalled = false;
+        const options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms",
+            "loadingError": "Error"
+        };
+
+        // create layer with loadingError already set to "Error"
+        const layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+
+        expect(layer).toBeTruthy();
+
+        const wmsSource = map.getLayers().item(0).getSource();
+        const originalRefresh = wmsSource.refresh;
+
+        // mock refresh method to set boolean to refreshCalled to trigger change
+        wmsSource.refresh = function() {
+            refreshCalled = true;
+            originalRefresh.call(this);
+        };
+
+        // update layer with loadingError still "Error"
+        ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={{...options, loadingError: "Error"}} map={map} />, document.getElementById("container"));
+
+        // refresh should NOT be called because loadingError didn't change from non-Error to Error
+        expect(refreshCalled).toBe(false);
+
+        // restore original method
+        wmsSource.refresh = originalRefresh;
+    });
+
+    it('wms layer should not refresh source when loadingError changes from Error to undefined', () => {
+        var refreshCalled = false;
+        const options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms",
+            "loadingError": "Error"
+        };
+
+        // create layer with loadingError set to "Error"
+        const layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+
+        expect(layer).toBeTruthy();
+
+        const wmsSource = map.getLayers().item(0).getSource();
+        const originalRefresh = wmsSource.refresh;
+
+        // mock refresh method to set boolean to refreshCalled to trigger change
+        wmsSource.refresh = function() {
+            refreshCalled = true;
+            originalRefresh.call(this);
+        };
+
+        // update layer with loadingError changing from "Error" to undefined
+        ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={{...options, loadingError: false}} map={map} />, document.getElementById("container"));
+
+        // refresh should NOT be called
+        expect(refreshCalled).toBe(false);
+
+        // restore original method
+        wmsSource.refresh = originalRefresh;
+    });
     it('creates a arcgis layer (MapServer)', () => {
         const options = {
             type: 'arcgis',

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -256,7 +256,12 @@ Layers.registerType('wms', {
 
             needsRefresh = needsRefresh || changed;
         }
-
+        // refresh/update wms layer if there is error in loading tiles like: incorrect time dimension date filter, ..etc
+        if (oldOptions.loadingError !== "Error" && newOptions.loadingError === "Error") {
+            // Clear tile cache before refresh to avoid showing old broken tiles
+            wmsSource?.tileCache?.pruneExceptNewestZ?.();
+            wmsSource?.refresh();
+        }
         if (oldOptions.minResolution !== newOptions.minResolution) {
             layer.setMinResolution(newOptions.minResolution === undefined ? 0 : newOptions.minResolution);
         }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes handling refreshing wms layer if there a loading error detecting. This fixes the issue of keeping cache tiles on map if user filters with date not included in the layer data from the time dimension filter.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#11803 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
If the layer filtered by a date not included in the layer data, a layer refresh happens to update map.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
