### PR TITLE
[Backport 2025.02.xx] Fix #11806 Tests compliant with standard italian thousand separator (#11807)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,14 +17,6 @@ on:
     - '[cC][0-9][0-9][0-9]-+**' # c123 or c123-something for custom branch
     - '[0-9][0-9][0-9][0-9].[0-9][0-9].xx' # stable branches. E.g. 2021.01.xx
     - '[geonode]-[0-9].[0-9].x' # stable branches for GeoNode. E.g. geonode-4.4.x
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    branches:
-    - master
-    # using filter pattern: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-    - '[cC][0-9][0-9][0-9]-+**' # c123 or c123-something for custom branch
-    - '[0-9][0-9][0-9][0-9].[0-9][0-9].xx' # stable branches. E.g. 2021.01.xx
-    - '[geonode]-[0-9].[0-9].x' # stable branches for GeoNode. E.g. geonode-4.4.x
 jobs:
   test-front-end:
     runs-on: ubuntu-latest

--- a/web/client/components/I18N/__tests__/IntlNumberFormatControl-test.jsx
+++ b/web/client/components/I18N/__tests__/IntlNumberFormatControl-test.jsx
@@ -63,18 +63,18 @@ describe('IntlNumberFormControl', () => {
         expect(elements[0].value).toBe("1.899,01");
     });
 
-    it('checks if the component renders value in IT locale', () => {
+    it('checks if the component renders value in IT locale for ten thousands', () => { // see https://unicode-org.atlassian.net/browse/CLDR-18213
         const intl = {locale: "it-IT"};
         let formProps = {
             name: "name",
-            value: 1899.01
+            value: 12899.01
         };
         const InputIntl = intlNumberFormControlWithContext(intl);
         const cmp = ReactDOM.render(
             <InputIntl {...formProps}/>, document.getElementById("container"));
         expect(cmp).toExist();
         const elements = document.querySelectorAll('input');
-        expect(elements[0].value).toBe("1.899,01");
+        expect(elements[0].value).toBe("12.899,01");
     });
 
     it('checks if the component renders value in FR locale', () => {

--- a/web/client/components/data/query/__tests__/NumberField-test.jsx
+++ b/web/client/components/data/query/__tests__/NumberField-test.jsx
@@ -114,7 +114,7 @@ describe('NumberField', () => {
     it("check if the number is rendered in correct language format", () => {
         // Test with different locales to ensure numbers are formatted correctly
         const testCases = [
-            { locale: "it-IT", value: 1234.56, expected: "1.234,56" }, // Italiano
+            { locale: "it-IT", value: 10234.56, expected: "10.234,56" }, // Italiano
             { locale: "en-US", value: 1234.56, expected: "1,234.56" }, // English
             { locale: "fr-FR", value: 1234.56, expected: /1\s234,56/ }, // Français (regex for space)
             { locale: "de-DE", value: 1234.56, expected: "1.234,56" }, // Deutsch


### PR DESCRIPTION
[Backport 2025.02.xx] Fix #11806 Tests compliant with standard italian thousand separator (#11807)

* Fix #11806. Tests complient with standard italian thousand separator
* removed wrong CI target

