### PR TITLE
Range validation error misses minimumValue if the minimum is 0

### DIFF
--- a/web/client/components/data/featuregrid/renderers/__tests__/CellValidationErrorMessage-test.jsx
+++ b/web/client/components/data/featuregrid/renderers/__tests__/CellValidationErrorMessage-test.jsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-dom/test-utils';
 import expect from 'expect';
 
 import CellValidationErrorMessage from '../CellValidationErrorMessage';
@@ -221,6 +222,38 @@ describe('Tests CellValidationErrorMessage component', () => {
         const container = document.getElementById("container");
         const indicator = container.querySelector('.ms-cell-validation-indicator');
         expect(indicator).toBeTruthy();
+    });
+
+    it('should handle column with range schema (0 to 100)', () => {
+        const props = {
+            value: 'test',
+            valid: false,
+            column: {
+                key: 'testColumn',
+                schema: {
+                    type: 'number',
+                    minimum: 0,
+                    maximum: 100
+                },
+                schemaRequired: true
+            },
+            changed: false
+        };
+        ReactDOM.render(<CellValidationErrorMessage {...props} />, document.getElementById("container"));
+        const container = document.getElementById("container");
+        const indicator = container.querySelector('.ms-cell-validation-indicator');
+        expect(indicator).toBeTruthy();
+        expect(indicator.getAttribute('class')).toInclude('ms-warning-text');
+        // Trigger tooltip to check validation message
+        ReactTestUtils.Simulate.mouseOver(indicator);
+        const tooltip = document.querySelector('.tooltip-inner');
+        expect(tooltip).toBeTruthy();
+        // Check that the range validation message is displayed
+        const tooltipText = tooltip.textContent || tooltip.innerText;
+        // Check for range message ID (always present) and range values if IntlProvider is available
+        expect(tooltipText).toInclude('featuregrid.restrictions.range');
+        // Check for required message as well since schemaRequired is true
+        expect(tooltipText).toInclude('featuregrid.restrictions.required');
     });
 });
 

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -456,8 +456,8 @@ export const getRestrictionsMessageInfo = (schema, required) => {
             ],
             msgParams: {
                 options: (enumerator || []).filter(value => value !== null).join(', '),
-                minimum,
-                maximum
+                minimum: minimum?.toString(),
+                maximum: maximum?.toString()
             }
         };
     }


### PR DESCRIPTION
## Description
This PR renders the range properly for the range validation error message in the feature grid.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue
**What is the current behavior?**
The range validation error message misses the value 0 in the feature grid.
https://github.com/geosolutions-it/MapStore2/issues/11812

**What is the new behavior?**
The range validation error message renders 0 properly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information