### PR TITLE
Fix #11855 the scroll issue when there is no rows/features in the dataset

### DIFF
--- a/web/client/themes/default/less/react-data-grid.less
+++ b/web/client/themes/default/less/react-data-grid.less
@@ -335,19 +335,42 @@
     }
 }
 
+
 .feature-grid-container{
-     .ms2-border-layout-body{
-         .react-grid-HeaderRow{
-             .react-grid-HeaderCell{
-                 .rw-datetimepicker.rw-widget input {
-                      .input-size(@input-height-small; @padding-small-vertical; @padding-small-horizontal; @font-size-small; @line-height-small; @input-border-radius-small);
-                 }
-                 .rw-datetimepicker.rw-widget input:disabled{
-                    height:100%;
-                 }
-             }
-         }
-     }
+    .ms2-border-layout-body{
+        &:has(.react-grid-Empty) {
+            .ms2-border-layout-content {
+                overflow-x: auto !important;
+            }
+            .react-grid-HeaderRow {
+                min-width: max-content;
+            }
+            .react-grid-Viewport {
+                min-width: max-content;
+            }
+            // Make the grid scrollable horizontally when there are many columns
+            .react-grid-Grid {
+                min-width: max-content;
+                overflow-x: auto !important;
+            }
+        }
+        .react-grid-HeaderRow{
+            .react-grid-HeaderCell{
+                .rw-datetimepicker.rw-widget input {
+                     .input-size(@input-height-small; @padding-small-vertical; @padding-small-horizontal; @font-size-small; @line-height-small; @input-border-radius-small);
+                }
+                .rw-datetimepicker.rw-widget input:disabled{
+                   height:100%;
+                }
+            }
+        }
+        
+        // Ensure the empty state respects the grid width for scrolling
+        .react-grid-Empty {
+            min-width: inherit;
+            width: 100%;
+        }
+    }
 }
 #page-rulesmanager{
     .ms2-border-layout-body{


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes the issue of the scroll to view available column of the dataset in the feature grid when it do not have any rows or feature.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue
**What is the current behavior?**
The feature grid will say "No features available" and only the columns that are visible in viewport can be viewed.
#11855 

**What is the new behavior?**
When opening the feature grid and there are multiple fields, then it allows to scroll.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information