### PR TITLE
Fix #11646 baselayer selector doesn't adjust to the map after Save

### DIFF
--- a/web/client/plugins/Annotations/epics/__tests__/annotations-test.js
+++ b/web/client/plugins/Annotations/epics/__tests__/annotations-test.js
@@ -44,7 +44,7 @@ import {
     mergeAnnotationsFeaturesEpic,
     closeAnnotationsOnMapInfoLoadedEpic
 } from '../annotations';
-import { mapInfoLoaded } from '../../../../actions/config';
+import { mapSaved } from '../../../../actions/config';
 import { testEpic } from '../../../../epics/__tests__/epicTestUtils';
 
 describe('annotations epics', () => {
@@ -223,7 +223,7 @@ describe('annotations epics', () => {
                     editing: true
                 }
             };
-            testEpic(closeAnnotationsOnMapInfoLoadedEpic, 1, mapInfoLoaded({}, 1), (actions) => {
+            testEpic(closeAnnotationsOnMapInfoLoadedEpic, 1, mapSaved({}, 1), (actions) => {
                 try {
                     expect(actions.map(({ type }) => type)).toEqual([ CONFIRM_CLOSE_ANNOTATIONS ]);
                     done();

--- a/web/client/plugins/Annotations/epics/annotations.js
+++ b/web/client/plugins/Annotations/epics/annotations.js
@@ -18,7 +18,7 @@ import {
     closeIdentify,
     purgeMapInfoResults
 } from '../../../actions/mapInfo';
-import { MAP_INFO_LOADED } from '../../../actions/config';
+import { MAP_SAVED } from '../../../actions/config';
 import {
     EDIT_ANNOTATION,
     DOWNLOAD,
@@ -198,7 +198,7 @@ export const mergeAnnotationsFeaturesEpic = (action$, { getState }) =>
  * This ensures annotations.editing is reset to fix layout calculation issues
  */
 export const closeAnnotationsOnMapInfoLoadedEpic = (action$, { getState }) =>
-    action$.ofType(MAP_INFO_LOADED)
+    action$.ofType(MAP_SAVED)
         .switchMap(() => {
             const selectedAnnotationLayer = getAnnotationsSession(getState());
             if (selectedAnnotationLayer) {


### PR DESCRIPTION
## Description
This PR fixes the issue of position of the baselayer selector on the map after editing the annotation and saving.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
The baselayer selector remains in the same position without adapting to the map's resizing.
https://github.com/geosolutions-it/MapStore2/issues/11646

**What is the new behavior?**
The baselayer selector reposition itself in bottom-left with a small margin.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
