### PR TITLE
Fix #11883 the thumbnail issue for a new background in background selector plugin

### DIFF
--- a/web/client/components/background/BackgroundSelector.jsx
+++ b/web/client/components/background/BackgroundSelector.jsx
@@ -77,9 +77,9 @@ function BackgroundSelector({
         }
     };
 
-    // Get current selected background (the one with visibility: true)
+    // Get current selected background (that is not a terrain and with visibility: true)
     const getCurrentBackground = () => {
-        const visibleBackground = backgroundsProp.find(bg => bg.visibility === true);
+        const visibleBackground = backgroundsProp.find(bg => bg.type !== 'terrain' && bg.visibility === true);
         if (visibleBackground) {
             const thumbURL = visibleBackground.thumbURL || thumbs?.[visibleBackground.source]?.[visibleBackground.name] || thumbs.unknown;
             return {

--- a/web/client/components/background/__tests__/BackgroundSelector-test.jsx
+++ b/web/client/components/background/__tests__/BackgroundSelector-test.jsx
@@ -215,4 +215,81 @@ describe("test the BackgroundSelector", () => {
         expect(editButtons.length).toBe(0);
         expect(deleteButtons.length).toBe(0);
     });
+
+    it('test BackgroundSelector displays regular background thumbnail when terrain layer is visible first', () => {
+        const layers = [
+            {
+                id: 'terrain_layer',
+                title: 'Terrain Layer',
+                type: 'terrain',
+                visibility: true,
+                group: 'background',
+                provider: 'ellipsoid'
+            },
+            {
+                id: 'regular_background',
+                title: 'Regular Background',
+                type: 'wms',
+                visibility: true,
+                group: 'background',
+                source: 'osm',
+                name: 'osm',
+                thumbURL: 'http://example.com/thumbnail.jpg'
+            }
+        ];
+
+        ReactDOM.render(<BackgroundSelector alwaysVisible enabled backgrounds={layers} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const previewButton = container.querySelector('.ms-background-selector-preview');
+        expect(previewButton).toExist();
+
+        // Verify that the thumbnail displayed is from the regular background, not the terrain
+        const thumbnailImg = previewButton.querySelector('img');
+        expect(thumbnailImg).toExist();
+        // The thumbnail should be from the regular background (which has thumbURL)
+        // or from the default thumbs, not from terrain (which doesn't have thumbnails)
+        expect(thumbnailImg.src).toContain('thumbnail.jpg');
+    });
+
+    it('test BackgroundSelector excludes terrain layers from current background selection', () => {
+        const layers = [
+            {
+                id: 'terrain_layer',
+                title: 'Terrain Layer',
+                type: 'terrain',
+                visibility: true,
+                group: 'background',
+                provider: 'ellipsoid'
+            },
+            {
+                id: 'regular_background',
+                title: 'Regular Background',
+                type: 'wms',
+                visibility: false,
+                group: 'background',
+                source: 'osm',
+                name: 'osm'
+            },
+            {
+                id: 'another_background',
+                title: 'Another Background',
+                type: 'wms',
+                visibility: true,
+                group: 'background',
+                source: 'mapbox',
+                name: 'streets'
+            }
+        ];
+
+        ReactDOM.render(<BackgroundSelector alwaysVisible enabled backgrounds={layers} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const previewButton = container.querySelector('.ms-background-selector-preview');
+        expect(previewButton).toExist();
+
+        const thumbnailImg = previewButton.querySelector('img');
+        expect(thumbnailImg).toExist();
+        // Should display the visible regular background (another_background), not the terrain
+        // Even though terrain appears first in the list and is visible
+        expect(thumbnailImg.alt).toBe('Another Background');
+    });
 });


### PR DESCRIPTION
## Description
This PR fixes the thumbnail issue for the new background added in the background selector plugin.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
The thumbnail of the new background is not visible in the background selector.
https://github.com/geosolutions-it/MapStore2/issues/11883

**What is the new behavior?**
The thumbnail of the new background is visible in the background selector.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information