### PR TITLE
Fix #11899 - Add flags to force sofware WebGL emulation

### DIFF
--- a/build/testConfig.js
+++ b/build/testConfig.js
@@ -6,9 +6,19 @@ const {
     VERSION_INFO_DEFINE_PLUGIN
 } = require('./BuildUtils');
 
-module.exports = ({browsers = [ 'ChromeHeadless' ], files, path, testFile, singleRun, basePath = ".", alias = {}}) => ({
+module.exports = ({browsers = [ 'ChromeHeadlessWebGL' ], files, path, testFile, singleRun, basePath = ".", alias = {}}) => ({
     browsers,
-
+    customLaunchers: {
+        ChromeHeadlessWebGL: {
+            base: 'ChromeHeadless',
+            flags: [
+                '--headless=new', // new headless mode, more similar to non-headless
+                '--no-sandbox', // < -- required to run Chrome inside docker
+                '--use-angle=swiftshader', // < -- enables software WebGL rendering
+                '--disable-dev-shm-usage' // < -- overcome limited resource problems
+            ]
+        }
+    },
     browserNoActivityTimeout: 30000,
 
     reportSlowerThan: 100,


### PR DESCRIPTION
## Description

This PR makes the ChromeHeadless run WebGL in software emulated, so it should work regardless the runner. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
 #11899

**What is the new behavior?**

Fix #11899

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
