### PR TITLE
Fix #11864 : In the Permission tab when username is very long text then it is no properly clipped.

### DIFF
--- a/web/client/plugins/ResourcesCatalog/components/Permissions.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/Permissions.jsx
@@ -18,7 +18,6 @@ import localizedProps from '../../../components/misc/enhancers/localizedProps';
 import FlexBox from '../../../components/layout/FlexBox';
 import Text from '../../../components/layout/Text';
 import Spinner from '../../../components/layout/Spinner';
-import ALink from './ALink';
 
 const FormControl = localizedProps('placeholder')(FormControlRB);
 
@@ -156,10 +155,12 @@ function Permissions({
                                                         ? <img src={item.avatar}/>
                                                         : <Glyphicon glyph={item.type} />}
                                                 </Text>
-                                                <ALink
-                                                    href={item.link}>
+                                                <Text
+                                                    title={item.name}
+                                                    ellipsis
+                                                    className="ms-permission-entryname">
                                                     {item.name}
-                                                </ALink>
+                                                </Text>
                                             </FlexBox>
                                         </div>
                                     </FlexBox>

--- a/web/client/themes/default/less/resources-catalog/_permissions.less
+++ b/web/client/themes/default/less/resources-catalog/_permissions.less
@@ -26,3 +26,7 @@
         word-break: break-word;
     }
 }
+
+.ms-permission-entryname {
+    max-width: 145px;
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

In the Permissions tab, usernames with long text are now clipped (ellipsis).

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11864 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Username is properly clipped.

<img width="664" height="723" alt="fixlongusername" src="https://github.com/user-attachments/assets/9f6d7bb1-91b6-484d-85c5-adfd68ab2847" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
