### PR TITLE
Support filter combinations from Dynamic filters and (toc) layer filter on map #11892

### DIFF
--- a/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
@@ -29,7 +29,8 @@ import {
     resultQuickFiltersAndDependenciesFilter,
     resultSpatialAndQuickFilters,
     resultLayerFilter,
-    resultFilterForEmptyGeom
+    resultFilterForEmptyGeom,
+    resultInteractionFiltersOnly
 } from '../../../../test-resources/widgets/dependenciesToFiltersData';
 
 describe('widgets dependenciesToFilter enhancer', () => {
@@ -61,6 +62,16 @@ describe('widgets dependenciesToFilter enhancer', () => {
             options={{
                 propertyName: ["state_abbr"]
             }}/>, document.getElementById("container"));
+    });
+    it('dependenciesToFilter with interactionFilters only', (done) => {
+        const Sink = dependenciesToFilter(createSink(props => {
+            expect(props).toExist();
+            expect(props.filter).toBe(resultInteractionFiltersOnly);
+            done();
+        }));
+        ReactDOM.render(<Sink
+            interactionFilters={[{ format: 'cql', body: 'prop = 1' }]}
+        />, document.getElementById("container"));
     });
     it('dependenciesToFilter with quickFilters and dependencies.quickFilters', (done) => {
         const Sink = dependenciesToFilter(createSink( props => {

--- a/web/client/components/widgets/enhancers/dependenciesToFilter.js
+++ b/web/client/components/widgets/enhancers/dependenciesToFilter.js
@@ -10,7 +10,7 @@ import { find, isEmpty, pick } from 'lodash';
 import { compose, withPropsOnChange } from 'recompose';
 
 import { getViewportGeometry } from '../../../utils/CoordinatesUtils';
-import { composeAttributeFilters, toOGCFilterParts } from '../../../utils/FilterUtils';
+import { composeAttributeFilters, toOGCFilterParts, convertFiltersToOGC } from '../../../utils/FilterUtils';
 import { read } from '../../../utils/ogc/Filter/CQL/parser';
 import filterBuilder from '../../../utils/ogc/Filter/FilterBuilder';
 import fromObject from '../../../utils/ogc/Filter/fromObject';
@@ -24,7 +24,7 @@ const getCqlFilter = (layer, dependencies) => {
 
 const getLayerFilter = ({layerFilter} = {}) => layerFilter;
 
-const shouldMapOrKeys = ({ mapSync, geomProp, dependencies = {}, layer, quickFilters, options, filter } = {}, nextProps = {}) => {
+const shouldMapOrKeys = ({ mapSync, geomProp, dependencies = {}, layer, quickFilters, options, filter, interactionFilters } = {}, nextProps = {}) => {
     return mapSync !== nextProps.mapSync
         || dependencies.viewport !== (nextProps.dependencies && nextProps.dependencies.viewport)
         || dependencies.quickFilters !== (nextProps.dependencies && nextProps.dependencies.quickFilters)
@@ -34,10 +34,11 @@ const shouldMapOrKeys = ({ mapSync, geomProp, dependencies = {}, layer, quickFil
         || options !== nextProps.options
         || quickFilters !== nextProps.quickFilters
         || getCqlFilter(layer, dependencies) !== getCqlFilter(nextProps.layer, nextProps.dependencies)
-        || getLayerFilter(layer) !== getLayerFilter(nextProps.layer);
+        || getLayerFilter(layer) !== getLayerFilter(nextProps.layer)
+        || interactionFilters !== nextProps.interactionFilters;
 };
 
-const createFilterProps = ({ mapSync, geomProp, dependencies = {}, filter: filterObj, layer, quickFilters, options } = {}) => {
+const createFilterProps = ({ mapSync, geomProp, dependencies = {}, filter: filterObj, layer, quickFilters, options, interactionFilters } = {}) => {
     const viewport = dependencies.viewport;
     const fb = filterBuilder({ gmlVersion: "3.1.1" });
     const toFilter = fromObject(fb);
@@ -48,11 +49,17 @@ const createFilterProps = ({ mapSync, geomProp, dependencies = {}, filter: filte
     // merging attribute filter and quickFilters of the current widget into a single filterObj
     let newFilterObj = composeFilterObject(filterObj, quickFilters, options);
 
+    // Process interactionFilters once - convert to OGC filter parts
+    const interactionFilterParts = (interactionFilters && Array.isArray(interactionFilters) && interactionFilters.length > 0)
+        ? convertFiltersToOGC(interactionFilters, {nsplaceholder: "ogc", versionOGC: "1.1.0"}) || []
+        : [];
+
     if (!mapSync) {
         return {
-            filter: !isEmpty(newFilterObj) || layerFilter ? filter(and(
+            filter: !isEmpty(newFilterObj) || layerFilter || interactionFilterParts.length > 0 ? filter(and(
                 ...(layerFilter && !layerFilter.disabled ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : []),
-                ...(newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : [])
+                ...(newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : []),
+                ...interactionFilterParts
             )) : undefined
         };
     }
@@ -80,18 +87,20 @@ const createFilterProps = ({ mapSync, geomProp, dependencies = {}, filter: filte
                 ...cqlFilterRules,
                 ...(layerFilter  && !layerFilter.disabled ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : []),
                 ...(newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : []),
-                ...(geomProp ? [property(geomProp).intersects(geom)] : [])))
+                ...(geomProp ? [property(geomProp).intersects(geom)] : []),
+                ...interactionFilterParts
+            ))
         };
     }
     // this will contain only an ogc filter based on current and other filters (cql excluded)
     const ogcLayerFilterParts = layerFilter ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : [];
     const ogcNewFilterObjParts = newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : [];
-    const ogcFilter = isEmpty(ogcLayerFilterParts) && isEmpty(ogcNewFilterObjParts) ? undefined
-        : filter(and(...ogcLayerFilterParts, ...ogcNewFilterObjParts));
+    const ogcFilter = isEmpty(ogcLayerFilterParts) && isEmpty(ogcNewFilterObjParts) && interactionFilterParts.length === 0 ? undefined
+        : filter(and(...ogcLayerFilterParts, ...ogcNewFilterObjParts, ...interactionFilterParts));
     return { filter: ogcFilter };
 };
 
-const TRACE_PROPS = ['mapSync', 'dependencies', 'dependenciesMap', 'widgets'];
+const TRACE_PROPS = ['mapSync', 'dependencies', 'dependenciesMap', 'widgets', 'interactionFilters'];
 /**
  * Merges filter object and dependencies map into an ogc filter
  */

--- a/web/client/epics/__tests__/interactions-test.js
+++ b/web/client/epics/__tests__/interactions-test.js
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+
+import { testEpic } from './epicTestUtils';
+import { applyFilterWidgetInteractionsEpic, cleanupAndReapplyFilterWidgetInteractionsEpic } from '../interactions';
+import { applyFilterWidgetInteractions } from '../../actions/interactions';
+import { UPDATE_PROPERTY, DELETE } from '../../actions/widgets';
+
+const FILTER_ID = 'filter-1';
+const FILTER_WIDGET_ID = 'filter-widget-1';
+const CHART_WIDGET_ID = 'chart-widget-1';
+const TABLE_WIDGET_ID = 'table-widget-1';
+const TRACE_ID = 'trace-1';
+const CHART_ID = 'chart-1';
+
+const makeFilterWidget = (overrides = {}) => ({
+    id: FILTER_WIDGET_ID,
+    widgetType: 'filter',
+    title: 'Filter Widget',
+    filters: [{
+        id: FILTER_ID,
+        data: {
+            dataSource: 'features',
+            valuesFrom: 'grouped',
+            valueAttribute: 'STATE_NAME'
+        }
+    }],
+    selections: { [FILTER_ID]: ['Arizona'] },
+    interactions: [
+        {
+            id: 'int-1',
+            plugged: true,
+            targetType: 'applyFilter',
+            source: { nodePath: `root.widgets[${FILTER_WIDGET_ID}].filters[${FILTER_ID}]` },
+            target: { nodePath: `root.widgets[${CHART_WIDGET_ID}].charts[${CHART_ID}].traces[${TRACE_ID}]` }
+        }
+    ],
+    ...overrides
+});
+
+const makeChartWidget = (overrides = {}) => ({
+    id: CHART_WIDGET_ID,
+    widgetType: 'chart',
+    title: 'Chart Widget',
+    charts: [{
+        chartId: CHART_ID,
+        traces: [{
+            id: TRACE_ID,
+            type: 'pie',
+            layer: { name: 'test:layer', id: 'layer-1' }
+        }]
+    }],
+    ...overrides
+});
+
+const makeTableWidget = (overrides = {}) => ({
+    id: TABLE_WIDGET_ID,
+    widgetType: 'table',
+    title: 'Table Widget',
+    layer: { name: 'test:layer', id: 'layer-1' },
+    ...overrides
+});
+
+const makeState = (widgets) => ({
+    widgets: {
+        containers: {
+            floating: {
+                widgets
+            }
+        }
+    }
+});
+
+describe('interactions epics', () => {
+    describe('applyFilterWidgetInteractionsEpic', () => {
+        it('dispatches updateWidgetProperty with charts and trace.interactionFilters for chart target', (done) => {
+            const filterWidget = makeFilterWidget();
+            const chartWidget = makeChartWidget();
+            const state = makeState([filterWidget, chartWidget]);
+
+            testEpic(
+                applyFilterWidgetInteractionsEpic,
+                1,
+                [applyFilterWidgetInteractions(FILTER_WIDGET_ID, 'floating', FILTER_ID)],
+                (actions) => {
+                    expect(actions.length).toBe(1);
+                    expect(actions[0].type).toBe(UPDATE_PROPERTY);
+                    expect(actions[0].id).toBe(CHART_WIDGET_ID);
+                    expect(actions[0].key).toBe('charts');
+                    expect(Array.isArray(actions[0].value)).toBe(true);
+                    const charts = actions[0].value;
+                    expect(charts.length).toBe(1);
+                    const traces = charts[0].traces || [];
+                    expect(traces.length).toBe(1);
+                    expect(Array.isArray(traces[0].interactionFilters)).toBe(true);
+                    expect(traces[0].interactionFilters.length).toBeGreaterThan(0);
+                    expect(traces[0].interactionFilters[0].appliedFromWidget).toBe(FILTER_WIDGET_ID);
+                    expect(traces[0].layer).toBeTruthy();
+                    expect(traces[0].layer.layerFilter).toBeFalsy();
+                },
+                state,
+                done
+            );
+        });
+
+        it('dispatches updateWidgetProperty with interactionFilters for table target', (done) => {
+            const filterWidget = makeFilterWidget({
+                interactions: [{
+                    id: 'int-2',
+                    plugged: true,
+                    targetType: 'applyFilter',
+                    source: { nodePath: `root.widgets[${FILTER_WIDGET_ID}].filters[${FILTER_ID}]` },
+                    target: { nodePath: `root.widgets[${TABLE_WIDGET_ID}]` }
+                }]
+            });
+            const tableWidget = makeTableWidget();
+            const state = makeState([filterWidget, tableWidget]);
+
+            testEpic(
+                applyFilterWidgetInteractionsEpic,
+                1,
+                [applyFilterWidgetInteractions(FILTER_WIDGET_ID, 'floating', FILTER_ID)],
+                (actions) => {
+                    expect(actions.length).toBe(1);
+                    expect(actions[0].type).toBe(UPDATE_PROPERTY);
+                    expect(actions[0].id).toBe(TABLE_WIDGET_ID);
+                    expect(actions[0].key).toBe('interactionFilters');
+                    expect(Array.isArray(actions[0].value)).toBe(true);
+                    expect(actions[0].value.length).toBeGreaterThan(0);
+                    expect(actions[0].value[0].appliedFromWidget).toBe(FILTER_WIDGET_ID);
+                },
+                state,
+                done
+            );
+        });
+    });
+
+    describe('cleanupAndReapplyFilterWidgetInteractionsEpic', () => {
+        it('on DELETE filter widget, cleans up trace.interactionFilters from chart and dispatches updateWidgetProperty(charts)', (done) => {
+            const filterWidget = makeFilterWidget();
+            const chartWidget = makeChartWidget({
+                charts: [{
+                    chartId: CHART_ID,
+                    traces: [{
+                        id: TRACE_ID,
+                        type: 'pie',
+                        layer: { name: 'test:layer', id: 'layer-1' },
+                        interactionFilters: [{
+                            id: 'f1',
+                            appliedFromWidget: FILTER_WIDGET_ID,
+                            format: 'logic',
+                            filters: []
+                        }]
+                    }]
+                }]
+            });
+            const state = makeState([filterWidget, chartWidget]);
+
+            testEpic(
+                cleanupAndReapplyFilterWidgetInteractionsEpic,
+                1,
+                [{ type: DELETE, widget: filterWidget, target: 'floating' }],
+                (actions) => {
+                    const updateActions = actions.filter(a => a.type === UPDATE_PROPERTY);
+                    expect(updateActions.length >= 1).toBe(true);
+                    const chartUpdate = updateActions.find(a => a.key === 'charts' && a.id === CHART_WIDGET_ID);
+                    expect(chartUpdate).toBeTruthy();
+                    const traces = chartUpdate.value[0].traces || [];
+                    expect(traces.length).toBe(1);
+                    expect(traces[0].interactionFilters).toEqual([]);
+                },
+                state,
+                done
+            );
+        });
+
+        it('on DELETE filter widget, cleans up widget.interactionFilters from table and dispatches updateWidgetProperty(interactionFilters)', (done) => {
+            const filterWidget = makeFilterWidget();
+            const tableWidget = makeTableWidget({
+                interactionFilters: [{
+                    id: 'f1',
+                    appliedFromWidget: FILTER_WIDGET_ID,
+                    format: 'logic',
+                    filters: []
+                }]
+            });
+            const state = makeState([filterWidget, tableWidget]);
+
+            testEpic(
+                cleanupAndReapplyFilterWidgetInteractionsEpic,
+                1,
+                [{ type: DELETE, widget: filterWidget, target: 'floating' }],
+                (actions) => {
+                    const updateActions = actions.filter(a => a.type === UPDATE_PROPERTY);
+                    expect(updateActions.length >= 1).toBe(true);
+                    const tableUpdate = updateActions.find(a => a.key === 'interactionFilters' && a.id === TABLE_WIDGET_ID);
+                    expect(tableUpdate).toBeTruthy();
+                    expect(tableUpdate.value).toEqual([]);
+                },
+                state,
+                done
+            );
+        });
+    });
+});

--- a/web/client/epics/interactions.js
+++ b/web/client/epics/interactions.js
@@ -88,6 +88,18 @@ function ensureLayerFilterStructure(layer) {
 }
 
 /**
+ * Ensures interactionFilters array exists on a container (trace or widget)
+ * @param {object} container - The trace or widget object to ensure structure on
+ * @returns {object} The container with ensured interactionFilters array
+ */
+function ensureInteractionFiltersStructure(container) {
+    if (!Array.isArray(container.interactionFilters)) {
+        container.interactionFilters = [];
+    }
+    return container;
+}
+
+/**
  * Updates filters array by finding existing filter by ID and replacing or appending
  * @param {array} existingFilters - The current filters array
  * @param {object} updatedFilter - The filter to add or update
@@ -137,7 +149,7 @@ function createUpdatedFilter(interaction, widgetId) {
 }
 
 /**
- * Updates a chart widget with filter by updating the trace's layer filter
+ * Updates a chart widget with filter by updating the trace's interactionFilters
  * @param {object} widget - The chart widget object
  * @param {object} interaction - The interaction object
  * @param {object} traceObject - The trace object to update
@@ -149,23 +161,16 @@ function updateChartWidgetWithFilter(widget, interaction, traceObject, widgetId)
     const filterWidgetId = extractWidgetIdFromNodePath(interaction?.source?.nodePath);
     const updatedFilter = createUpdatedFilter(interaction, filterWidgetId);
 
-    // Update filters in trace layer
     widgetCharts.forEach(chart => {
-        chart.traces = chart.traces.map(trace => {
+        chart.traces = (chart.traces || []).map(trace => {
             if (trace.id === traceObject.id) {
-                ensureLayerFilterStructure(trace.layer);
-                const existingFilters = trace.layer.layerFilter.filters || [];
+                ensureInteractionFiltersStructure(trace);
+                const existingFilters = trace.interactionFilters || [];
                 const updatedFilters = updateFiltersArray(existingFilters, updatedFilter);
                 const cleanedFilters = removeEmptyFilters(updatedFilters, interaction, updatedFilter.id);
                 return {
                     ...trace,
-                    layer: {
-                        ...trace.layer,
-                        layerFilter: {
-                            ...trace.layer.layerFilter,
-                            filters: cleanedFilters
-                        }
-                    }
+                    interactionFilters: cleanedFilters
                 };
             }
             return trace;
@@ -176,29 +181,25 @@ function updateChartWidgetWithFilter(widget, interaction, traceObject, widgetId)
 }
 
 /**
- * Updates a layer-based widget (table or counter) with filter by updating the widget's layer filter
+ * Updates a layer-based widget (table or counter) with filter by updating the widget's interactionFilters
  * @param {object} widget - The widget object (table or counter)
  * @param {object} interaction - The interaction object
  * @param {string} widgetId - The widget ID
- * @returns {object} Action to update the widget's layer property
+ * @returns {object} Action to update the widget's interactionFilters property
  */
 function updateLayerBasedWidgetWithFilter(widget, interaction, widgetId) {
     const updatedWidget = JSON.parse(JSON.stringify(widget));
     const filterWidgetId = extractWidgetIdFromNodePath(interaction?.source?.nodePath);
     const updatedFilter = createUpdatedFilter(interaction, filterWidgetId);
 
-    // Ensure layer and layerFilter exist
-    if (!updatedWidget.layer) {
-        updatedWidget.layer = {};
-    }
-    ensureLayerFilterStructure(updatedWidget.layer);
+    ensureInteractionFiltersStructure(updatedWidget);
 
-    const existingFilters = updatedWidget.layer.layerFilter.filters || [];
+    const existingFilters = updatedWidget.interactionFilters || [];
     const updatedFilters = updateFiltersArray(existingFilters, updatedFilter);
     const cleanedFilters = removeEmptyFilters(updatedFilters, interaction, updatedFilter.id);
-    updatedWidget.layer.layerFilter.filters = cleanedFilters;
+    updatedWidget.interactionFilters = cleanedFilters;
 
-    return updateWidgetProperty(widgetId, 'layer', updatedWidget.layer);
+    return updateWidgetProperty(widgetId, 'interactionFilters', updatedWidget.interactionFilters);
 }
 
 
@@ -424,6 +425,46 @@ function removeFiltersByWidgetId(filters, widgetId) {
 }
 
 /**
+ * Cleans up interactionFilters from a container (trace or widget).
+ * Returns an object with cleaned filters and update flags.
+ * @param {object} container - The container object (trace or widget) to clean filters from
+ * @param {string} widgetId - The filter widget ID
+ * @returns {object} Object with { updatedContainer, needsUpdate } where updatedContainer has cleaned filters
+ */
+function cleanupInteractionFilters(container, widgetId) {
+    let needsUpdate = false;
+    const updatedContainer = { ...container };
+
+    // Cleanup from interactionFilters
+    if (container.interactionFilters && Array.isArray(container.interactionFilters)) {
+        const filteredFilters = removeFiltersByWidgetId(container.interactionFilters, widgetId);
+        if (filteredFilters.length !== container.interactionFilters.length) {
+            needsUpdate = true;
+            updatedContainer.interactionFilters = filteredFilters;
+        }
+    }
+    // Cleanup from old location: layer.layerFilter.filters (backward compatibility)
+    if (container.layer && container.layer.layerFilter && container.layer.layerFilter.filters && Array.isArray(container.layer.layerFilter.filters)) {
+        const filteredLayerFilters = removeFiltersByWidgetId(
+            container.layer.layerFilter.filters,
+            widgetId
+        );
+        if (filteredLayerFilters.length !== container.layer.layerFilter.filters.length) {
+            needsUpdate = true;
+            updatedContainer.layer = {
+                ...container.layer,
+                layerFilter: {
+                    ...container.layer.layerFilter,
+                    filters: filteredLayerFilters
+                }
+            };
+        }
+    }
+
+    return { updatedContainer, needsUpdate };
+}
+
+/**
  * Cleanup filters from map layers
  * @param {string} widgetId - The filter widget ID
  * @param {object} state - Redux state
@@ -472,24 +513,10 @@ function cleanupFiltersFromChartWidget(widget, widgetId) {
         }
 
         const updatedTraces = chart.traces.map(trace => {
-            if (trace.layer && trace.layer.layerFilter && trace.layer.layerFilter.filters) {
-                const filteredFilters = removeFiltersByWidgetId(
-                    trace.layer.layerFilter.filters,
-                    widgetId
-                );
-                if (filteredFilters.length !== trace.layer.layerFilter.filters.length) {
-                    needsUpdate = true;
-                    return {
-                        ...trace,
-                        layer: {
-                            ...trace.layer,
-                            layerFilter: {
-                                ...trace.layer.layerFilter,
-                                filters: filteredFilters
-                            }
-                        }
-                    };
-                }
+            const { updatedContainer, needsUpdate: traceUpdated } = cleanupInteractionFilters(trace, widgetId);
+            if (traceUpdated) {
+                needsUpdate = true;
+                return updatedContainer;
             }
             return trace;
         });
@@ -510,25 +537,8 @@ function cleanupFiltersFromChartWidget(widget, widgetId) {
  * @returns {object|null} Updated widget or null if no changes
  */
 function cleanupFiltersFromLayerBasedWidget(widget, widgetId) {
-    if (!widget.layer || !widget.layer.layerFilter || !widget.layer.layerFilter.filters) {
-        return null;
-    }
-
-    const filteredFilters = removeFiltersByWidgetId(widget.layer.layerFilter.filters, widgetId);
-    if (filteredFilters.length === widget.layer.layerFilter.filters.length) {
-        return null;
-    }
-
-    return {
-        ...widget,
-        layer: {
-            ...widget.layer,
-            layerFilter: {
-                ...widget.layer.layerFilter,
-                filters: filteredFilters
-            }
-        }
-    };
+    const { updatedContainer, needsUpdate } = cleanupInteractionFilters(widget, widgetId);
+    return needsUpdate ? updatedContainer : null;
 }
 
 /**
@@ -599,7 +609,7 @@ function cleanupFiltersFromWidgets(widgetId, state, targetContainer = 'floating'
         case 'counter':
             updatedWidget = cleanupFiltersFromLayerBasedWidget(widget, widgetId);
             if (updatedWidget) {
-                actions.push(updateWidgetProperty(widget.id, 'layer', updatedWidget.layer));
+                actions.push(updateWidgetProperty(widget.id, 'interactionFilters', updatedWidget.interactionFilters));
             }
             break;
         case 'map':

--- a/web/client/test-resources/widgets/dependenciesToFiltersData.js
+++ b/web/client/test-resources/widgets/dependenciesToFiltersData.js
@@ -201,3 +201,5 @@ export const resultSpatialFilterMultiple =
 
 export const resultLayerFilter = `<ogc:Filter><ogc:And><ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>STATE_NAME</ogc:PropertyName><ogc:Literal>Arizona</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Or></ogc:And></ogc:Filter>`;
 export const resultFilterForEmptyGeom = `<ogc:Filter><ogc:And><ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo><ogc:Intersects><ogc:PropertyName>geometry</ogc:PropertyName><gml:Polygon srsName="EPSG:4326"><gml:exterior><gml:LinearRing><gml:posList>1 1 1 2 2 2 2 1 1 1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogc:Intersects></ogc:And></ogc:Filter>`
+
+export const resultInteractionFiltersOnly = `<ogc:Filter><ogc:And><ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>1</ogc:Literal></ogc:PropertyIsEqualTo></ogc:And></ogc:Filter>`;

--- a/web/client/utils/InteractionUtils.js
+++ b/web/client/utils/InteractionUtils.js
@@ -61,23 +61,18 @@ export const WIDGET_TARGETS_BY_TYPE = {
         {
             targetType: TARGET_TYPES.APPLY_FILTER,
             expectedDataType: DATATYPES.LAYER_FILTER,
-            targetProperty: "layerFilter.filters",
-            constraints: {},
-            mode: "upsert"
+            constraints: {}
         }
     ],
     layer: [
         {
             targetType: TARGET_TYPES.APPLY_FILTER,
             expectedDataType: DATATYPES.LAYER_FILTER,
-            attributeName: "layerFilter.filters",
-            constraints: {},
-            mode: "upsert"
+            constraints: {}
         },
         {
             targetType: TARGET_TYPES.APPLY_STYLE,
             expectedDataType: DATATYPES.LAYER_STYLE,
-            attributeName: "layer.style",
             constraints: {}
         }
     ],
@@ -85,18 +80,14 @@ export const WIDGET_TARGETS_BY_TYPE = {
         {
             targetType: TARGET_TYPES.APPLY_FILTER,
             expectedDataType: DATATYPES.LAYER_FILTER,
-            attributeName: "layerFilter.filters",
-            constraints: {},
-            mode: "upsert"
+            constraints: {}
         }
     ],
     counter: [
         {
             targetType: TARGET_TYPES.APPLY_FILTER,
             expectedDataType: DATATYPES.LAYER_FILTER,
-            attributeName: "layerFilter.filters",
-            constraints: {},
-            mode: "upsert"
+            constraints: {}
         }
     ]
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Filter for connectable widgets(charts, counter, table), filter from filter widgets is combined seperetly independent of the layer filter.

https://github.com/user-attachments/assets/57f619df-eeb0-4afd-8a75-1a1866d1d735



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11892

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Even the layer filter is disabled from the TOC layer. Filters from filter widgets are independently applied to the connectable widgets.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
- For layers, directly updating the layer filters. 
- As filters to be applied field is changed, to clean up already applied filters on the past variable layerFilter.filters type,source filter needs to be again saved or deleted.
