### PR TITLE
Print Plugin: Configurable Default Projection #11955

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -118,6 +118,7 @@ import { getResolutionMultiplier } from '../utils/PrintUtils';
  * @prop {string[]} cfg.excludeLayersFromLegend list of layer names e.g. ["workspace:layerName"] to exclude from printed document
  * @prop {object} cfg.mergeableParams object to pass to mapfish-print v2 to merge params, example here https://github.com/mapfish/mapfish-print-v2/blob/main/docs/protocol.rst#printpdf
  * @prop {object[]} cfg.projectionOptions.projections array of available projections, e.g. [{"name": "EPSG:3857", "value": "EPSG:3857"}]
+ * @prop {string} cfg.projectionOptions.defaultProjection default projection when the print dialog opens; should be one of the values from projections list
  * @prop {object} cfg.overlayLayersOptions options for overlay layers
  * @prop {boolean} cfg.overlayLayersOptions.enabled if true a checkbox will be shown to exclude or include overlay layers to the print
  *
@@ -190,7 +191,7 @@ import { getResolutionMultiplier } from '../utils/PrintUtils';
  * }
  *
  * @example
- * // enable custom projections for printing
+ * // enable custom projections for printing; defaultProjection must be one of the values from projections list
  * "projectionDefs": [{
  *    "code": "EPSG:23032",
  *    "def": "+proj=utm +zone=32 +ellps=intl +towgs84=-87,-98,-121,0,0,0,0 +units=m +no_defs",
@@ -202,7 +203,8 @@ import { getResolutionMultiplier } from '../utils/PrintUtils';
  *   "name": "Print",
  *   "cfg": {
  *       "projectionOptions": {
- *          "projections": [{"name": "UTM32N", "value": "EPSG:23032"}, {"name": "EPSG:3857", "value": "EPSG:3857"}, {"name": "EPSG:4326", "value": "EPSG:4326"}]
+ *          "projections": [{"name": "UTM32N", "value": "EPSG:23032"}, {"name": "EPSG:3857", "value": "EPSG:3857"}, {"name": "EPSG:4326", "value": "EPSG:4326"}],
+ *          "defaultProjection": "EPSG:23032"
  *       }
  *    }
  * }

--- a/web/client/plugins/print/index.js
+++ b/web/client/plugins/print/index.js
@@ -70,10 +70,10 @@ export const OutputFormat = connect((state) => ({
     onChangeParameter: setPrintParameter
 })(OutputFormatComp);
 
-export const Projection = connect((state) => ({
+export const Projection = connect((state, ownProps) => ({
     spec: state?.print?.spec || {},
     map: state?.print?.map,
-    projection: projectionSelector(state),
+    projection: projectionSelector(state, ownProps?.defaultProjection),
     items: Object.keys(getAvailableCRS()).map(p => ({
         name: p,
         value: p


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The default selected projection can be configured from config. On local Config
```
{
  "name": "Print",
  "cfg": {
    "projectionOptions": {
      "projections": [
        {"name": "EPSG:32122 (Ohio North)", "value": "EPSG:32122"},
        {"name": "EPSG:3857", "value": "EPSG:3857"},
        {"name": "EPSG:4326", "value": "EPSG:4326"}
      ],
      "defaultProjection": "EPSG:32122" // DefaultProjection to be selected
    }
  }
}
```
DefaultProjection will be selected when the print panel is opened.
NOTE: If defaultProjection is custom projection then that must be in projectionDefs
For test this can be used.
```
"projectionDefs": [
    {
      "code": "EPSG:32122",
      "def": "+proj=lcc +lat_1=41.7 +lat_2=40.43333333333333 +lat_0=39.66666666666666 +lon_0=-82.5 +x_0=600000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
      "extent": [
        403035.4105968763,
        48133.91598795739,
        769684.5675940284,
        298304.0075010298
      ],
      "worldExtent": [
        -84.809194047635,
        40.076629775274405,
        -80.4412897899362,
        42.33467076175862
      ]
    }
  ]
```

Demo for the above configuration:

https://github.com/user-attachments/assets/ee18e1a5-95d4-450c-8603-27c894676214



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11955

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The default projection to be selected when the print panel is opened can be configured in the print plugin.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information