### PR TITLE
[Backport 2026.01.xx] Bump weasyprint from 52.5 to 68.0 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ mkdocs==1.5.2
 mkdocs-material==9.2.6
 jinja2==3.1.6
 Markdown==3.4.4
-WeasyPrint==52.5
+WeasyPrint==68.0
 mkdocs-with-pdf==0.9.3
 mkdocs-kroki-plugin==0.9.0


### PR DESCRIPTION
# Description
Backport of #11893 to `2026.01.xx`.

Fixes #