### PR TITLE
[Backport 2026.01.xx] Bump webpack from 5.94.0 to 5.104.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "style-loader": "2.0.0",
     "terser": "5.18.1",
     "url-loader": "0.5.7",
-    "webpack": "5.94.0",
+    "webpack": "5.104.1",
     "webpack-bundle-size-analyzer": "2.0.2",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "3.11.0"


### PR DESCRIPTION
# Description
Backport of #11962 to `2026.01.xx`.

Fixes #