### PR TITLE
backport c027-2025.01.xx - Fix #11468 tag saving filter

### DIFF
--- a/web/client/observables/__tests__/geostore-test.js
+++ b/web/client/observables/__tests__/geostore-test.js
@@ -462,7 +462,7 @@ describe('geostore observables for resources management', () => {
         const testResource = {
             id: ID,
             tags: [
-                {tag: { id: '1' }},
+                { tag: { id: '1' }},
                 { tag: { id: '2' }, action: 'link'}
             ]
         };

--- a/web/client/observables/geostore.js
+++ b/web/client/observables/geostore.js
@@ -346,7 +346,7 @@ export const updateResource = ({ id, data, permission, metadata, linkedResources
         // update tags
         parsedTags.length > 0 ? Observable
             .defer(() => Promise.all(
-                (tags || [])
+                (parsedTags || [])
                     .map(({ tag, action }) => action === 'link'
                         ? API.linkTagToResource(tag.id, id)
                         : API.unlinkTagFromResource(tag.id, id)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport c027-2025.01.xx - Fix #11468 tag saving filter

the issues was that entry has a structure like 
```
entry: 
{
  tag: {},
  action: "link"
}
```
current code process this correctly
