### PR TITLE
Change of path for favourites endpoint #11992

### DIFF
--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -652,23 +652,21 @@ const Api = {
         return axios.delete(url, Api.addBaseUrl(parseOptions(options))).then((response) => response.data);
     },
     /**
-     * add a resource to user favorites
-     * @param  {string} userId user identifier
+     * add a resource to user favorites (current logged user)
      * @param  {string} resourceId resource identifier
      * @param  {object} options additional axios options
      */
-    addFavoriteResource: (userId, resourceId, options) => {
-        const url = `/users/user/${userId}/favorite/${resourceId}`;
+    addFavoriteResource: (resourceId, options) => {
+        const url = `/users/user/favorite/${resourceId}`;
         return axios.post(url, undefined, Api.addBaseUrl(parseOptions(options))).then((response) => response.data);
     },
     /**
-     * remove a resource from user favorites
-     * @param  {string} userId user identifier
+     * remove a resource from user favorites (current logged user)
      * @param  {string} resourceId resource identifier
      * @param  {object} options additional axios options
      */
-    removeFavoriteResource: (userId, resourceId, options) => {
-        const url = `/users/user/${userId}/favorite/${resourceId}`;
+    removeFavoriteResource: (resourceId, options) => {
+        const url = `/users/user/favorite/${resourceId}`;
         return axios.delete(url, Api.addBaseUrl(parseOptions(options))).then((response) => response.data);
     },
     getIPRanges: function(options = {}) {

--- a/web/client/api/__tests__/GeoStoreDAO-test.jsx
+++ b/web/client/api/__tests__/GeoStoreDAO-test.jsx
@@ -508,25 +508,25 @@ describe('Test correctness of the GeoStore APIs', () => {
     it('addFavoriteResource', (done) => {
         mockAxios.onPost().reply((data) => {
             try {
-                expect(data.url).toEqual('/users/user/10/favorite/15');
+                expect(data.url).toEqual('/users/user/favorite/15');
                 done();
             } catch (e) {
                 done(e);
             }
             return [200];
         });
-        API.addFavoriteResource("10", "15");
+        API.addFavoriteResource("15");
     });
     it('removeFavoriteResource', (done) => {
         mockAxios.onDelete().reply((data) => {
             try {
-                expect(data.url).toEqual('/users/user/10/favorite/15');
+                expect(data.url).toEqual('/users/user/favorite/15');
                 done();
             } catch (e) {
                 done(e);
             }
             return [200];
         });
-        API.removeFavoriteResource("10", "15");
+        API.removeFavoriteResource("15");
     });
 });

--- a/web/client/plugins/ResourcesCatalog/containers/Favorites.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/Favorites.jsx
@@ -50,7 +50,7 @@ function Favorites({
             const promise = isFavorite
                 ? GeoStoreDAO.removeFavoriteResource
                 : GeoStoreDAO.addFavoriteResource;
-            promise(user?.id, resource?.id)
+            promise(resource?.id)
                 .then(() => isMounted(() => {
                     setIsFavorite(!isFavorite);
                     updateResource({ isFavorite: !isFavorite, id: resource?.id });

--- a/web/client/plugins/ResourcesCatalog/containers/__tests__/Favorites-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/__tests__/Favorites-test.jsx
@@ -37,7 +37,7 @@ describe('Favorites container', () => {
     it('should trigger addFavoriteResource', (done) => {
         mockAxios.onPost().reply((data) => {
             try {
-                expect(data.url).toEqual('/users/user/10/favorite/15');
+                expect(data.url).toEqual('/users/user/favorite/15');
             } catch (e) {
                 done(e);
             }
@@ -67,7 +67,7 @@ describe('Favorites container', () => {
     it('should trigger removeFavoriteResource', (done) => {
         mockAxios.onDelete().reply((data) => {
             try {
-                expect(data.url).toEqual('/users/user/10/favorite/15');
+                expect(data.url).toEqual('/users/user/favorite/15');
             } catch (e) {
                 done(e);
             }
@@ -97,7 +97,7 @@ describe('Favorites container', () => {
     it('should trigger onSearch if the query has the favorite f filter', (done) => {
         mockAxios.onPost().reply((data) => {
             try {
-                expect(data.url).toEqual('/users/user/10/favorite/15');
+                expect(data.url).toEqual('/users/user/favorite/15');
             } catch (e) {
                 done(e);
             }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Update favorite management endpoints to use current-user paths (`/users/user/favorite/${resourceId}`) instead of user-specific paths (`/users/user/${userId}/favorite/${resourceId}`), aligning with GeoStore's new endpoints that derive the user from authentication.

https://github.com/user-attachments/assets/82794281-690c-4485-8514-65f7b71f7dad


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Change endpoint

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#11992 
`addFavoriteResource` and `removeFavoriteResource` require a `userId` parameter and call:
- `POST /users/user/${userId}/favorite/${resourceId}`
- `DELETE /users/user/${userId}/favorite/${resourceId}`

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

`addFavoriteResource` and `removeFavoriteResource` only require `resourceId` and call:
- `POST /users/user/favorite/${resourceId}`
- `DELETE /users/user/favorite/${resourceId}`

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Requires corresponding GeoStore changes exposing the new endpoints. Tested locally by downloading the latest snapshot of Geostore. New endpoints are exposed on this PR: https://github.com/geosolutions-it/geostore/pull/469