### PR TITLE
Fix: #12029 Long CRS name overflows in dropdown selector in CRS Selector

### DIFF
--- a/web/client/themes/default/less/map-footer.less
+++ b/web/client/themes/default/less/map-footer.less
@@ -228,7 +228,8 @@
                 display: block;
                 cursor: pointer;
                 line-height: 1.25rem;
-                width: max-content;
+                width: fit-content;
+                min-width: 4rem;
                 padding-right: 4px;
             }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fix long CRS name overflows in the CRS Selector.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12029 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

CRS name should be ellipsis.

<img width="512" height="76" alt="Screenshot 2026-03-02 at 12 38 12" src="https://github.com/user-attachments/assets/ee0d97e4-fa17-4af8-8dbf-d72eb4875c2a" />
<img width="1506" height="777" alt="Screenshot 2026-03-02 at 12 38 34" src="https://github.com/user-attachments/assets/e9ac105d-39d6-49a1-9c92-c7f9f131eb43" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
