### PR TITLE
Add loading state in select when linking existing dashboard

### DIFF
--- a/web/client/components/dashboard/ConfigureView.jsx
+++ b/web/client/components/dashboard/ConfigureView.jsx
@@ -18,18 +18,24 @@ const GlyphiconIndicator = withTooltip(Glyphicon);
 const ConfigureView = ({ active, onToggle, data, onSave, user, configureViewOptions }) => {
     const [setting, setSetting] = useState(data);
     const [dashboardOptions, setDashboardOptions] = useState([]);
+    const [loadingDashboards, setLoadingDashboards] = useState(false);
 
     useEffect(() => {
         if (!active || !user) return;
         const args = createCatalogResourcesArgs({configureViewOptions, user});
         const catalogResources = getCatalogResources(...args).toPromise();
-        catalogResources.then(res => {
-            const options = res.resources.map(d => ({
-                value: d.id || d.pk,
-                label: d.name
-            }));
-            setDashboardOptions(options);
-        });
+        setLoadingDashboards(true);
+        catalogResources
+            .then(res => {
+                const options = res.resources.map(d => ({
+                    value: d.id || d.pk,
+                    label: d.name
+                }));
+                setDashboardOptions(options);
+            })
+            .finally(() => {
+                setLoadingDashboards(false);
+            });
     }, [active, user]);
 
     const canAddLayout = !data.dashboard
@@ -99,6 +105,7 @@ const ConfigureView = ({ active, onToggle, data, onSave, user, configureViewOpti
                                 value={setting.dashboard || ''}
                                 options={dashboardOptions}
                                 name="dashboard"
+                                isLoading={loadingDashboards}
                                 onChange={selected => setSetting(prev => ({...prev, dashboard: selected?.value }))}
                             />
                         </FormGroup>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR adds the loading state in the select when linking the existing dashboard. It adds the loader in the select component when fetching the dashboard letting user know the data is loading.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
There is no loading state in the select when trying to connect another existing dashboard.
https://github.com/geosolutions-it/MapStore2/issues/12032

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The loading state have been added to the select while fetching the dashboard.
<img width="684" height="397" alt="image" src="https://github.com/user-attachments/assets/a9dda471-153c-4852-8483-dbe51bdedbc3" />

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
