### PR TITLE
Issue with owner permission with LDAP integration #12013

### DIFF
--- a/web/client/plugins/ResourcesCatalog/components/Permissions.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/Permissions.jsx
@@ -40,6 +40,11 @@ function Permissions({
     const [order, setOrder] = useState([]);
     const [filter, setFilter] = useState('');
 
+    function getEntryIdKey(entry) {
+        if (!entry) return '';
+        if (entry.id !== -1) return entry.id;
+        return `${entry.type ?? 'entry'}-${entry.name ?? ''}`;
+    }
     function handleChange(newValues) {
         onChange({
             entries: permissionsEntires,
@@ -75,20 +80,18 @@ function Permissions({
     }
 
     function handleRemoveEntry(newEntry) {
-        const newEntries = permissionsEntires.filter(entry => entry.id !== newEntry.id);
+        const key = getEntryIdKey(newEntry);
+        const newEntries = permissionsEntires.filter(entry => getEntryIdKey(entry) !== key);
         setPermissionsEntires(newEntries);
         handleChange({ entries: newEntries });
     }
 
-    function handleUpdateEntry(entryId, properties, noCallback) {
-        const newEntries = permissionsEntires.map(entry => {
-            if (entry.id === entryId) {
-                return {
-                    ...entry,
-                    ...properties
-                };
+    function handleUpdateEntry(entryKey, properties, noCallback) {
+        const newEntries = permissionsEntires.map(e => {
+            if (getEntryIdKey(e) === entryKey) {
+                return { ...e, ...properties };
             }
-            return entry;
+            return e;
         });
         setPermissionsEntires(newEntries);
         if (!noCallback) {
@@ -262,10 +265,10 @@ function Permissions({
                     .map((entry, idx) => {
                         return (
                             <li
-                                key={entry.id + '-' + idx}>
+                                key={getEntryIdKey(entry) + '-' + idx}>
                                 <PermissionsRow
                                     {...entry}
-                                    onChange={editing ? handleUpdateEntry.bind(null, entry.id) : null}
+                                    onChange={editing ? handleUpdateEntry.bind(null, getEntryIdKey(entry)) : null}
                                     options={permissionOptions?.[`entry.name.${entry.name}`] || permissionOptions?.default}
                                 >
                                     {entry.permissions !== 'owner' && editing ?

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/Permissions-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/Permissions-test.jsx
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2025, GeoSolutions Sas.
  * All rights reserved.
@@ -10,7 +9,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import expect from 'expect';
+import { Simulate } from 'react-dom/test-utils';
 import Permissions from '../Permissions';
+
+const defaultPermissionOptions = {
+    'entry.name.everyone': [
+        { value: 'view', labelId: 'resourcesCatalog.viewPermission' }
+    ],
+    'default': [
+        { value: 'view', labelId: 'resourcesCatalog.viewPermission' },
+        { value: 'edit', labelId: 'resourcesCatalog.editPermission' }
+    ]
+};
 
 describe('Permissions component', () => {
     beforeEach((done) => {
@@ -47,24 +57,7 @@ describe('Permissions component', () => {
                     }
                 ]
             }}
-            permissionOptions={{
-                'entry.name.everyone': [
-                    {
-                        value: 'view',
-                        labelId: 'resourcesCatalog.viewPermission'
-                    }
-                ],
-                'default': [
-                    {
-                        value: 'view',
-                        labelId: 'resourcesCatalog.viewPermission'
-                    },
-                    {
-                        value: 'edit',
-                        labelId: 'resourcesCatalog.editPermission'
-                    }
-                ]
-            }}
+            permissionOptions={defaultPermissionOptions}
         />, document.getElementById('container'));
         const permissions = document.querySelector('.ms-permissions');
         expect(permissions).toBeTruthy();
@@ -73,5 +66,55 @@ describe('Permissions component', () => {
         expect([...permissionsRows].map(row => row.innerText)).toEqual(['everyone\nresourcesCatalog.viewPermission', 'custom-group\nresourcesCatalog.viewPermission']);
         const disabled = permissionsRows[0].querySelector('.is-disabled');
         expect(disabled).toBeTruthy();
+    });
+
+    it('should remove only the clicked entry when entries have normal ids', () => {
+        const onChangeSpy = expect.createSpy();
+        ReactDOM.render(<Permissions
+            editing
+            compactPermissions={{
+                entries: [
+                    { type: 'group', id: 1, name: 'everyone', permissions: 'view' },
+                    { type: 'group', id: 2, name: 'custom-group', permissions: 'edit' }
+                ]
+            }}
+            permissionOptions={defaultPermissionOptions}
+            onChange={onChangeSpy}
+        />, document.getElementById('container'));
+        const rows = document.querySelectorAll('.ms-permissions .ms-permissions-row');
+        expect(rows.length).toBe(2);
+        const secondRowDeleteButton = rows[1].querySelector('button');
+        expect(secondRowDeleteButton).toBeTruthy();
+        Simulate.click(secondRowDeleteButton);
+        expect(onChangeSpy).toHaveBeenCalled();
+        const entries = onChangeSpy.calls[0].arguments[0].entries;
+        expect(entries.length).toBe(1);
+        expect(entries[0].name).toBe('everyone');
+        expect(entries[0].id).toBe(1);
+    });
+
+    it('should remove only the clicked entry when all entries have id = -1', () => {
+        const onChangeSpy = expect.createSpy();
+        ReactDOM.render(<Permissions
+            editing
+            compactPermissions={{
+                entries: [
+                    { type: 'group', id: -1, name: 'everyone', permissions: 'view' },
+                    { type: 'group', id: -1, name: 'custom-group', permissions: 'edit' }
+                ]
+            }}
+            permissionOptions={defaultPermissionOptions}
+            onChange={onChangeSpy}
+        />, document.getElementById('container'));
+        const rows = document.querySelectorAll('.ms-permissions .ms-permissions-row');
+        expect(rows.length).toBe(2);
+        const secondRowDeleteButton = rows[1].querySelector('button');
+        expect(secondRowDeleteButton).toBeTruthy();
+        Simulate.click(secondRowDeleteButton);
+        expect(onChangeSpy).toHaveBeenCalled();
+        const entries = onChangeSpy.calls[0].arguments[0].entries;
+        expect(entries.length).toBe(1);
+        expect(entries[0].name).toBe('everyone');
+        expect(entries[0].id).toBe(-1);
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
On LDAP integrated system, permission entries can be -1 for all entries. So it -1 is the ID then checks for changing entry behaviour (delete, edit) has been changed using entry type and entry name.
So if handles gracefully, even id of multiple entries is -1.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12013

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Even if all permission entry id's is -1, permission can be removed and updated individually.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
- LDAP setup locally was not performed, and tested on the unit test.

