### PR TITLE
[Backport 2026.01.xx] Fix: #12029 Long CRS name overflows in dropdown selector in CRS Selector

### DIFF
--- a/web/client/themes/default/less/map-footer.less
+++ b/web/client/themes/default/less/map-footer.less
@@ -212,7 +212,6 @@
         button.dropdown-toggle {
             padding: 0;
             text-align: left;
-            max-width: 4.5rem;
             display: block;
             height: auto;
             line-height: 1.25rem;
@@ -226,7 +225,8 @@
                 display: block;
                 cursor: pointer;
                 line-height: 1.25rem;
-                width: max-content;
+                width: fit-content;
+                min-width: 4rem;
                 padding-right: 4px;
             }
 


### PR DESCRIPTION
# Description
Backport of #12030 to `2026.01.xx`.

Fixes #12029