### PR TITLE
[Backport 2026.01.xx] Fix #12051 Cesium map will now make use of maxZoom and prevent zooming too close for small extent.

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -587,25 +587,63 @@ class CesiumMap extends React.Component {
         this.props.hookRegister.registerHook(GET_COORDINATES_FROM_PIXEL_HOOK);
 
         // Register hook
-        this.props.hookRegister.registerHook(ZOOM_TO_EXTENT_HOOK, (extent, { crs, duration } = {}) => {
-            // TODO: manage padding and maxZoom
+        this.props.hookRegister.registerHook(ZOOM_TO_EXTENT_HOOK, (extent, { crs, duration, maxZoom, padding, ...options  } = {}) => {
             const bounds = reprojectBbox(extent, crs, 'EPSG:4326');
-            if (this.map.camera.flyTo) {
-                const rectangle = Cesium.Rectangle.fromDegrees(
-                    bounds[0], // west,
-                    bounds[1], // south,
-                    bounds[2], // east,
-                    bounds[3] // north
+            if (!bounds || bounds.length !== 4) {
+                return;
+            }
+            const ellipsoid = this.map.scene.globe.ellipsoid;
+            const [west, south, east, north] = bounds;
+            const height = options?.height ?? options?.altitude ?? 0;
+
+            const centerLon = (west + east) / 2;
+            const centerLat = (south + north) / 2;
+            const center = Cesium.Cartesian3.fromDegrees(centerLon, centerLat, height);
+
+            const minRadius = this.props.mapOptions?.zoomToExtentSettings?.minRadius || 10;
+            const isPoint = west === east && south === north;
+            const radius = isPoint
+                ? minRadius
+                : Math.max(
+                    minRadius,
+                    Cesium.Cartesian3.distance(
+                        ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(west, south, height)),
+                        ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(east, north, height))
+                    ) / 2
                 );
+            const boundingSphere = new Cesium.BoundingSphere(center, radius);
+
+            if (this.map.camera.flyToBoundingSphere) {
+                const fitFactor = this.props.mapOptions?.zoomToExtentSettings?.fitFactor || 2.0;
+                const maxZoomValue = Number.isFinite(maxZoom) ? maxZoom : this.props.mapOptions?.zoomToExtentSettings?.maxZoom;
+                const idealRange = fitFactor * radius;
+                const minRangeFromMaxZoom = Number.isFinite(maxZoomValue) ? this.getHeightFromZoom(maxZoomValue) : 0;
+                const range = Number.isFinite(maxZoomValue) && idealRange < minRangeFromMaxZoom
+                    ? minRangeFromMaxZoom
+                    : idealRange;
+                const offset = new Cesium.HeadingPitchRange(0, -Math.PI / 2, range);
+                this.map.camera.flyToBoundingSphere(boundingSphere, {
+                    duration,
+                    offset,
+                    /*
+                    * updateMapInfoState is triggered by camera.moveEnd
+                    * too late (seconds later).
+                    * This handler on complete cause duplicated call of updateMapInfoState but
+                    * guarantees the testability of the callback
+                    */
+                    complete: this.updateMapInfoState
+                });
+            } else if (this.map.camera.flyTo) {
+                const rectangle = Cesium.Rectangle.fromDegrees(west, south, east, north);
                 this.map.camera.flyTo({
                     destination: rectangle,
                     duration,
                     /*
-                     * updateMapInfoState is triggered by camera.moveEnd
-                     * too late (seconds later).
-                     * This handler on complete cause duplicated call of updateMapInfoState but
-                     * guarantees the testability of the callback
-                     */
+                    * updateMapInfoState is triggered by camera.moveEnd
+                    * too late (seconds later).
+                    * This handler on complete cause duplicated call of updateMapInfoState but
+                    * guarantees the testability of the callback
+                    */
                     complete: this.updateMapInfoState
                 });
             }

--- a/web/client/components/map/cesium/__tests__/Map-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test.jsx
@@ -520,7 +520,7 @@ describe('CesiumMap', () => {
         expect(Math.round(cesiumMap.camera.positionCartographic.longitude * 180.0 / Math.PI)).toBe(10);
     });
     it('test ZOOM_TO_EXTENT_HOOK', (done) => {
-        // instanciating the map that will be used to compute the bounfing box
+        // instanciating the map that will be used to compute the bounding box
         const testHandlers = {
             onMapViewChanges: (args) => {
                 expect(args).toBeTruthy();
@@ -535,13 +535,19 @@ describe('CesiumMap', () => {
             center={{ y: 43.9, x: 10.3 }}
             zoom={11}
             onMapViewChanges={testHandlers.onMapViewChanges}
+            mapOptions={{
+                zoomToExtentSettings: {
+                    minRadius: 10,
+                    fitFactor: 2.0,
+                    maxZoom: 20
+                }
+            }}
         />, document.getElementById("container"));
         // computing the bounding box for the new center and the new zoom
         const hook = getHook(ZOOM_TO_EXTENT_HOOK);
         // update the map with the new center and the new zoom so we can check our computed bouding box
         expect(hook).toBeTruthy();
-
-        hook([10, 10, 20, 20], {crs: "EPSG:4326", duration: 0});
+        hook([10, 10, 20, 20], {crs: "EPSG:4326", duration: 0, maxZoom: 15});
         // unregister hook
         registerHook(ZOOM_TO_EXTENT_HOOK);
     });

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -40,6 +40,11 @@
       "depthTestAgainstTerrain": false,
       "terrainProvider": {
         "type": "ellipsoid"
+      },
+      "zoomToExtentSettings": {
+        "minRadius": 10,
+        "fitFactor": 2.0,
+        "maxZoom": 20
       }
     },
     "floatingIdentifyDelay": 1000


### PR DESCRIPTION
# Description
Backport of #12052 to `2026.01.xx`.

Fixes #12051