### PR TITLE
[Backport 2025.02.xx] Fix #12071. Made rowWidthGap parametric

### DIFF
--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -101,6 +101,7 @@ compose(
         withProps(({
             width,
             rowHeight,
+            rowHeightGap = 20,
             cols,
             height,
             maximized,
@@ -116,7 +117,7 @@ compose(
                 : height - backgroundSelectorOffset - 120;
             const nRows = isSingleWidgetLayout ? 1 : 4;
             const rowHeightRecalculated = !isSingleWidgetLayout
-                ? Math.floor(divHeight / nRows - 20)
+                ? Math.floor(divHeight / nRows - rowHeightGap)
                 : divHeight > singleWidgetLayoutMaxHeight
                     ? singleWidgetLayoutMaxHeight
                     : divHeight < singleWidgetLayoutMinHeight
@@ -305,6 +306,7 @@ class Widgets extends React.Component {
  * @prop {boolean|string|array} [toolsOptions.showHide] show the "hide tool" for the widget (the tool allows to hide the widget to users that have `seeHidden=false` ). By default is false, in the most common case it should be the same of `seeHidden`.
  * @prop {boolean|string|array} [toolsOptions.seeHidden] hides the widgets under particular conditions
  * @prop {number} cfg.rowHeight Rows have a static height
+ * @prop {number} cfg.rowHeightGap 20 by default. Describe the margin from bottom used to calculate the rowHeight. Useful if the layout has some CSS customization
  * @prop {object} cfg.cols Number of columns in this layout. default is { md: 6, xxs: 1 }
  * @prop {object} cfg.defaults options that are used to initialize the plugin when mounted
  * @prop {object} cfg.defaults.initialSize new widget's default sizes in grid units. It contains 2 integers, `w` and `h`, representing the initial size of the new widget. This is useful when customizing `rowHeight` and/or `cols`, to generate a widget with a proportionated size.


### PR DESCRIPTION
# Description
Backport of #12072 to `2025.02.xx`.

Fixes #12071