### PR TITLE
Fix map toolbar issue when opening attribute table and catalog

### DIFF
--- a/web/client/plugins/Toolbar.jsx
+++ b/web/client/plugins/Toolbar.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isFeatureGridOpen } from '../selectors/featuregrid';
-import { mapLayoutValuesSelector } from '../selectors/maplayout';
+import { boundingMapRectLayoutValuesSelector } from '../selectors/maplayout';
 import { createSelector } from 'reselect';
 import ToolsContainer from './containers/ToolsContainer';
 
@@ -122,7 +122,7 @@ const toolbarSelector = stateSelector => createSelector([
     state => state.controls && state.controls[stateSelector] && state.controls[stateSelector].active,
     state => state.controls && state.controls[stateSelector] && state.controls[stateSelector].expanded,
     isFeatureGridOpen,
-    state => mapLayoutValuesSelector(state, {right: true, bottom: true})
+    state => boundingMapRectLayoutValuesSelector(state, { right: true })
 ], (active, allVisible, featuregridOpen, style) => ({
     active,
     allVisible,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes the issue of the map toolbar not being visible when opening the attribute table and then the catalog as per the comment https://github.com/geosolutions-it/MapStore2/issues/11794#issuecomment-4038683855. It updates the calculation for the map toolbar.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
When opening attribute table and then the catalog, the map toolbar is not visible.
<!-- You can also link to an existing issue here -->
https://github.com/geosolutions-it/MapStore2/issues/11794

**What is the new behavior?**
The map toolbar is aligned with the catalog.
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->
## Other useful information
