### PR TITLE
[Backport 2026.01.xx] Filter Widget "None" filter breaks Feature Grid WFS (CQL -> OGC null parsing) #12041

### DIFF
--- a/web/client/utils/filter/converters/__tests__/cql-test.js
+++ b/web/client/utils/filter/converters/__tests__/cql-test.js
@@ -37,6 +37,25 @@ describe('CQL converter', () => {
             cql: 'prop1 <= 1',
             opts: {filterNS: 'ogc'},
             ogc: '<ogc:PropertyIsLessThanOrEqualTo><ogc:PropertyName>prop1</ogc:PropertyName><ogc:Literal>1</ogc:Literal></ogc:PropertyIsLessThanOrEqualTo>'
+        }, {
+            cql: '(NOT ("STATE_NAME" IS NULL))',
+            opts: {filterNS: 'ogc'},
+            ogc: '<ogc:Not><ogc:PropertyIsNull><ogc:PropertyName>STATE_NAME</ogc:PropertyName></ogc:PropertyIsNull></ogc:Not>'
+        },
+        {
+            cql: '"STATE_NAME" IS NULL AND prop1 = 1',
+            opts: {filterNS: 'ogc'},
+            ogc: '<ogc:And><ogc:PropertyIsNull><ogc:PropertyName>STATE_NAME</ogc:PropertyName></ogc:PropertyIsNull><ogc:PropertyIsEqualTo><ogc:PropertyName>prop1</ogc:PropertyName><ogc:Literal>1</ogc:Literal></ogc:PropertyIsEqualTo></ogc:And>'
+        },
+        {
+            cql: 'isNull("STATE_NAME")=true',
+            opts: {filterNS: 'ogc'},
+            ogc: '<ogc:PropertyIsEqualTo><ogc:Function name="isNull"><ogc:PropertyName>STATE_NAME</ogc:PropertyName></ogc:Function><ogc:Literal>true</ogc:Literal></ogc:PropertyIsEqualTo>'
+        },
+        {
+            cql: '(NOT (isNull("STATE_NAME")=true))',
+            opts: {filterNS: 'ogc'},
+            ogc: '<ogc:Not><ogc:PropertyIsEqualTo><ogc:Function name="isNull"><ogc:PropertyName>STATE_NAME</ogc:PropertyName></ogc:Function><ogc:Literal>true</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Not>'
         }
 
     ];

--- a/web/client/utils/ogc/Filter/CQL/parser.js
+++ b/web/client/utils/ogc/Filter/CQL/parser.js
@@ -21,7 +21,7 @@ export const patterns = {
     EXCLUDE: /^EXCLUDE$/,
     PROPERTY: /^"?[_a-zA-Z"]\w*"?/,
     COMPARISON: /^(=|<>|<=|<|>=|>|LIKE|ILIKE)/i,
-    IS_NULL: /^IS NULL/i,
+    IS_NULL: /^IS\s+NULL/i,
     COMMA: /^,/,
     AND: /^(AND)/i,
     OR: /^(OR)/i,
@@ -69,11 +69,11 @@ export const patterns = {
 const follows = {
     INCLUDE: ['END'],
     EXCLUDE: ['END'],
-    LPAREN: ['GEOMETRY', 'SPATIAL', 'FUNCTION', 'PROPERTY', 'VALUE', 'LPAREN', 'RPAREN', 'NOT'],
+    LPAREN: ['GEOMETRY', 'SPATIAL', 'FUNCTION', 'NOT', 'PROPERTY', 'VALUE', 'LPAREN', 'RPAREN'],
     RPAREN: ['NOT', 'AND', 'OR', 'END', 'RPAREN', 'COMMA', 'COMPARISON', 'BETWEEN', 'IS_NULL'],
     PROPERTY: ['COMPARISON', 'BETWEEN', 'COMMA', 'IS_NULL', 'RPAREN'],
     BETWEEN: ['VALUE'],
-    IS_NULL: ['END'],
+    IS_NULL: ['AND', 'OR', 'COMMA', 'RPAREN', 'END'],
     COMPARISON: ['VALUE', 'FUNCTION'],
     COMMA: ['GEOMETRY', 'FUNCTION', 'VALUE', 'PROPERTY'],
     VALUE: ['AND', 'OR', 'COMMA', 'RPAREN', 'END'],
@@ -113,7 +113,8 @@ const precedence = {
     'RPAREN': 4,
     'OR': 3,
     'AND': 2,
-    'COMPARISON': 1
+    'COMPARISON': 1,
+    'IS_NULL': 1
 };
 
 const tryToken = (text, pattern) => {

--- a/web/client/utils/ogc/Filter/fromObject.js
+++ b/web/client/utils/ogc/Filter/fromObject.js
@@ -10,8 +10,8 @@ const operators = {
     '>': "greater",
     '>=': "greaterOrEqual",
     'like': "like",
-    'ilike': "ilike"
-    // TODO: support unary operators like isNull
+    'ilike': "ilike",
+    'isNull': "isNull"
     // TODO: support geometry operations
 };
 const spatial = ["intersects", "within", "bbox", "dwithin", "contains"];


### PR DESCRIPTION
# Description
Backport of #12042 to `2026.01.xx`.

Fixes #12041