### PR TITLE
[Backport 2026.01.xx] Bump markdown from 3.4.4 to 3.8.1 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 mkdocs==1.5.2
 mkdocs-material==9.2.6
 jinja2==3.1.6
-Markdown==3.4.4
+Markdown==3.8.1
 WeasyPrint==68.0
 mkdocs-with-pdf==0.9.3
 mkdocs-kroki-plugin==0.9.0


### PR DESCRIPTION
# Description
Backport of #12061 to `2026.01.xx`.

Fixes #