### PR TITLE
[Backport 2026.01.xx] Bump axios from 0.30.2 to 0.30.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@znemz/cesium-navigation": "4.0.0",
     "ajv": "8.17.1",
     "assert": "2.0.0",
-    "axios": "0.30.2",
+    "axios": "0.30.3",
     "bootstrap": "3.4.1",
     "buffer": "6.0.3",
     "canvas-to-blob": "0.0.0",


### PR DESCRIPTION
# Description
Backport of #12045 to `2026.01.xx`.

Fixes #