### PR TITLE
[Backport 2026.01.xx] Bump org.apache.tomcat:tomcat-catalina from 9.0.110 to 9.0.113 in /binary

### DIFF
--- a/binary/pom.xml
+++ b/binary/pom.xml
@@ -13,7 +13,7 @@
     <url>http://www.geo-solutions.it</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>9.0.110</tomcat.version>
+        <tomcat.version>9.0.113</tomcat.version>
         <binary.number>${mapstore2.version}</binary.number>
     </properties>
     <dependencies>


### PR DESCRIPTION
# Description
Backport of #12068 to `2026.01.xx`.

no issue related.