### PR TITLE
[Backport 2026.01.xx] Update print-module and set min version of java

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -22,6 +22,16 @@ This is a list of things to check if you want to update from a previous version 
 
 ## Migration from 2025.02.02 to 2026.01.00
 
+### Update of Java and print module
+
+You need to update `pom.xml` to align to most recent versions of the libraries. In particular you will have to update in your `pom.xml`:
+
+```xml
+<print-lib.version>2.4.0</print-lib.version>
+```
+
+notice that this new version of print lib **requires Java 17** so make sure that your application will run with this version of Java, respecting the requirements.
+
 ### Replace authenticationRules with requestsConfigurationRules
 
 As part of improving the authentication rules to make dynamic request configurations, we have deprecated the use of `authenticationRules` in favor of the new request rule configuration `requestsConfigurationRules`. The new system provides a more flexible way to configure request authentication and parameters.

--- a/docs/developer-guide/requirements.md
+++ b/docs/developer-guide/requirements.md
@@ -8,7 +8,7 @@ You can download a java web container like *Apache Tomcat* from and *Java JRE*
 
 | Tool   | Link                                               | Minimum         | Recommended | Maximum       |
 |--------|----------------------------------------------------|-----------------|-------------|---------------|
-| Java   | [link](https://jdk.java.net/archive/)          | 11<sup>1</sup>  | 17          | 21            |
+| Java   | [link](https://jdk.java.net/archive/)          | 17<sup>1</sup>  | 17          | 21            |
 | Tomcat | [link](https://tomcat.apache.org/download-90.cgi)  | 8.5             | 9           | 9<sup>2</sup> |
 
 ## Debug / Build
@@ -19,14 +19,14 @@ These tools needs to be installed (other than **Java** in versions above above):
 |-----------------------|------------------------------------------------------------|---------|-------------|-----------------|
 | npm                   | [link](https://www.npmjs.com/get-npm)                      | 8       | 10          |                 |
 | NodeJS                | [link](https://nodejs.org/en/)                             | 20      | 20          | 24<sup>3</sup>  |
-| Java (JDK)            | [link](https://jdk.java.net/archive/) | 11      | 17          | 21              |
+| Java (JDK)            | [link](https://jdk.java.net/archive/) | 17      | 17          | 21              |
 | Maven                 | [link](https://maven.apache.org/download.cgi)              | 3.1.0   | 3.6         |                 |
 | python<sup>4</sup>    | [link](https://www.python.org/downloads/)                  | 2.7.9   | 3.7         |                 |
 
 !!! notes
     Here some notes about some requirements and reasons for max version indicated, for future improvements and maintenance :
 
-    - <sup>1</sup> Java 8 is the minimum version required for running MapStore, but it is not compatible in case you want to use the print module. In this case, you need to use Java 11.
+    - <sup>1</sup> Java 11 is the minimum version required for running MapStore, but it is not compatible in case you want to use the print module. In this case, you need to use Java 17.
     - <sup>2</sup> Running with Tomcat 10 causes this issue [#7524](https://github.com/geosolutions-it/MapStore2/issues/7524).
     - <sup>3</sup> Latest version tested.
     - <sup>4</sup> Python is only needed for building documentation.

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
         <!-- MapStore‑specific -->
         <geostore-webapp.version>2.5-SNAPSHOT</geostore-webapp.version>
-        <print-lib.version>2.3.4</print-lib.version>
+        <print-lib.version>2.4.0</print-lib.version>
         <http_proxy.version>1.6-SNAPSHOT</http_proxy.version>
 
         <!-- Commons extras -->


### PR DESCRIPTION
# Description
Backport of #12106 to `2026.01.xx`.

Fixes #12067