### PR TITLE
#12120 - Fix: cookies panel is not correctly visible

### DIFF
--- a/web/client/components/cookie/Cookie.jsx
+++ b/web/client/components/cookie/Cookie.jsx
@@ -8,6 +8,7 @@
 import PropTypes from 'prop-types';
 
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { Glyphicon, Col } from 'react-bootstrap';
 import Button from '../misc/Button';
 import Message from '../../components/I18N/Message';
@@ -94,7 +95,10 @@ class Cookie extends React.Component {
         </a>);
     }
     render() {
-        return this.props.show ? (
+        if (!this.props.show) {
+            return null;
+        }
+        const content = (
             <div className={this.props.seeMore ? "mapstore-cookie-panel see-more" : "mapstore-cookie-panel not-see-more"}>
                 <div role="header" className="cookie-header" style={{height: this.props.seeMore ? "44px" : "0px"}}>
                     {this.props.seeMore ? <Glyphicon className="cookie-close-btn" glyph="1-close" onClick={() => this.props.onMoreDetails(false)}/> : null }
@@ -124,7 +128,8 @@ class Cookie extends React.Component {
                         </div>) : null }
                 </div>
             </div>
-        ) : null;
+        );
+        return createPortal(content, document.body);
     }
     moreDetails = () => {
         this.props.onMoreDetails(!this.props.seeMore);

--- a/web/client/components/cookie/__tests__/Cookie-test.jsx
+++ b/web/client/components/cookie/__tests__/Cookie-test.jsx
@@ -10,7 +10,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Cookie from '../Cookie';
 import expect from 'expect';
-import TestUtils from 'react-dom/test-utils';
 
 describe('Test for Cookie component', () => {
     beforeEach((done) => {
@@ -27,12 +26,22 @@ describe('Test for Cookie component', () => {
     it('render with defaults', () => {
         const cmp = ReactDOM.render(<Cookie/>, document.getElementById("container"));
         expect(cmp).toExist();
+        expect(document.body.querySelector('.mapstore-cookie-panel')).toNotExist();
     });
 
     it('render with show = true', () => {
         const cmp = ReactDOM.render(<Cookie show externalCookieUrl=""/>, document.getElementById("container"));
         expect(cmp).toExist();
-        expect(TestUtils.scryRenderedDOMComponentsWithClass(cmp, "mapstore-cookie-panel")).toExist();
+        const panel = document.body.querySelector('.mapstore-cookie-panel');
+        expect(panel).toExist();
+        expect(panel.classList.contains('not-see-more')).toBe(true);
+    });
+
+    it('renders cookie panel into document.body via portal', () => {
+        ReactDOM.render(<Cookie show/>, document.getElementById("container"));
+        const panel = document.body.querySelector('.mapstore-cookie-panel');
+        expect(panel).toExist();
+        expect(panel.parentNode).toBe(document.body);
     });
 
 });


### PR DESCRIPTION
## Description
This PR fixes the cookie panel being hidden in the viewer page by rendering it at the document level as a DOM portal

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #12120 

**What is the new behavior?**
- Renders the cookie panel correctly

<img width="577" height="241" alt="image" src="https://github.com/user-attachments/assets/c97bba0a-1a41-4978-b4fc-0b0320b132f5" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
