### PR TITLE
[Backport 2026.01.xx] Bump ajv from 8.17.1 to 8.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@turf/point-on-surface": "4.1.0",
     "@turf/polygon-to-linestring": "4.1.0",
     "@znemz/cesium-navigation": "4.0.0",
-    "ajv": "8.17.1",
+    "ajv": "8.18.0",
     "assert": "2.0.0",
     "axios": "0.30.3",
     "bootstrap": "3.4.1",


### PR DESCRIPTION
# Description
Backport of #12011 to `2026.01.xx`.

Fixes #