### PR TITLE
[Backport geonode-5.0.x] #12126 - Allow configuring defaultQuery in ResourcesFiltersForm plugin

### DIFF
--- a/web/client/plugins/ResourcesCatalog/ResourcesFiltersForm.jsx
+++ b/web/client/plugins/ResourcesCatalog/ResourcesFiltersForm.jsx
@@ -37,6 +37,7 @@ import { isMenuItemSupportedSupported } from '../../utils/ResourcesUtils';
  * @prop {string} cfg.navbarNodeSelector optional valid query selector for the navbar under the header, used to set the position of the panel
  * @prop {string} cfg.footerNodeSelector optional valid query selector for the footer in the page, used to set the position of the panel
  * @prop {string} cfg.targetSelector optional valid query selector for a node used to mount the plugin root component
+ * @prop {object} cfg.defaultQuery optional default query to be applied to the filter form
  * @prop {object[]} cfg.fields array of filter object configurations
  * @example
  * {
@@ -105,6 +106,7 @@ function ResourcesFiltersForm({
     resourcesGridId,
     onClose,
     onSearch,
+    defaultQuery,
     extent = {
         layers: [
             {
@@ -206,6 +208,7 @@ function ResourcesFiltersForm({
 }, context) {
 
     const { query } = url.parse(location.search, true);
+    const updatedQuery = defaultQuery ? { ...query, ...defaultQuery } : query;
 
     const parsedConfig = useParsePluginConfigExpressions(monitoredState, {
         extent,
@@ -230,7 +233,7 @@ function ResourcesFiltersForm({
     const {
         fields
     } = useFilterFacets({
-        query,
+        query: updatedQuery,
         fields: parsedConfig.fields,
         request: (...args) => getCatalogFacets(...args).toPromise(),
         monitoredState,
@@ -250,7 +253,8 @@ function ResourcesFiltersForm({
                     id={id}
                     extentProps={parsedConfig.extent}
                     fields={fields}
-                    query={query}
+                    query={updatedQuery}
+                    defaultQuery={defaultQuery}
                     onChange={(params) => onSearch({ params }, resourcesGridId)}
                     onClear={() => onSearch({ clear: true }, resourcesGridId)}
                     onClose={() => onClose(resourcesGridId)}

--- a/web/client/plugins/ResourcesCatalog/components/FiltersForm.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/FiltersForm.jsx
@@ -30,6 +30,7 @@ function FiltersForm({
     style,
     styleContainerForm,
     query,
+    defaultQuery,
     fields,
     onChange,
     onClose,
@@ -59,7 +60,7 @@ function FiltersForm({
                     size="sm"
                     variant="default"
                     onClick={onClear}
-                    disabled={isEmpty(omit(query, ['d', 'page', 'sort']))}
+                    disabled={isEmpty(omit(query, ['d', 'page', 'sort', ...Object.keys(defaultQuery)]))}
                 >
                     <Message msgId="resourcesCatalog.clearFilters"/>
                 </Button>
@@ -99,6 +100,7 @@ FiltersForm.defaultProps = {
     style: PropTypes.object,
     styleContainerForm: PropTypes.object,
     query: PropTypes.object,
+    defaultQuery: PropTypes.object,
     fields: PropTypes.array,
     onChange: PropTypes.func,
     onClose: PropTypes.func,
@@ -112,6 +114,7 @@ FiltersForm.defaultProps = {
 
 FiltersForm.defaultProps = {
     query: {},
+    defaultQuery: {},
     fields: [],
     onChange: () => {},
     onClose: () => {},
@@ -123,6 +126,7 @@ FiltersForm.defaultProps = {
 
 const arePropsEqual = (prevProps, nextProps) => {
     return isEqual(prevProps.query, nextProps.query)
+        && isEqual(prevProps.defaultQuery, nextProps.defaultQuery)
         && isEqual(prevProps.fields, nextProps.fields)
         && isEqual(prevProps.filters, nextProps.filters);
 };

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/FiltersForm-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/FiltersForm-test.jsx
@@ -27,4 +27,52 @@ describe('FilterForm component', () => {
         const filtersForm = document.querySelector('.ms-filters-form');
         expect(filtersForm).toBeTruthy();
     });
+    it('should disable clear button when query only contains defaultQuery keys', () => {
+        ReactDOM.render(
+            <FiltersForm
+                query={{ f: 'featured' }}
+                defaultQuery={{ f: 'featured' }}
+            />,
+            document.getElementById('container')
+        );
+        const clearButton = document.querySelector('.ms-filters-form button');
+        expect(clearButton).toBeTruthy();
+        expect(clearButton.disabled).toBe(true);
+    });
+    it('should enable clear button when query has keys beyond defaultQuery', () => {
+        ReactDOM.render(
+            <FiltersForm
+                query={{ f: 'featured', filter: 'someTerm' }}
+                defaultQuery={{ f: 'featured' }}
+            />,
+            document.getElementById('container')
+        );
+        const clearButton = document.querySelector('.ms-filters-form button');
+        expect(clearButton).toBeTruthy();
+        expect(clearButton.disabled).toBe(false);
+    });
+    it('should disable clear button when query only contains built-in excluded keys and defaultQuery keys', () => {
+        ReactDOM.render(
+            <FiltersForm
+                query={{ d: '1', page: '2', sort: 'name', f: 'featured' }}
+                defaultQuery={{ f: 'featured' }}
+            />,
+            document.getElementById('container')
+        );
+        const clearButton = document.querySelector('.ms-filters-form button');
+        expect(clearButton).toBeTruthy();
+        expect(clearButton.disabled).toBe(true);
+    });
+    it('should disable clear button with empty query and empty defaultQuery', () => {
+        ReactDOM.render(
+            <FiltersForm
+                query={{}}
+                defaultQuery={{}}
+            />,
+            document.getElementById('container')
+        );
+        const clearButton = document.querySelector('.ms-filters-form button');
+        expect(clearButton).toBeTruthy();
+        expect(clearButton.disabled).toBe(true);
+    });
 });


### PR DESCRIPTION
# Description
Backport of #12127 to `geonode-5.0.x`.

Fixes #12126