### PR TITLE
Fix: #12130 Longitudinal profile layout issues

### DIFF
--- a/web/client/plugins/longitudinalProfile/Import.jsx
+++ b/web/client/plugins/longitudinalProfile/Import.jsx
@@ -14,6 +14,7 @@ import processFile from './enhancers/processFile';
 import useFile from './enhancers/useFile';
 import ImportContent from './ImportContent';
 import ImportSelectCRS from './ImportSelectCRS';
+import Portal from '../../components/misc/Portal';
 
 export default compose(
     processFile,
@@ -30,19 +31,20 @@ export default compose(
         additionalCRS,
         crsSelectedDXF,
         ...props
-    }) => (<DragZone
-        onClose={onClose}
-        onDrop={onDrop}
-        onRef={onRef}
-    >
-        {[<ImportContent {...props}/>, showProjectionCombobox ?
-            <ImportSelectCRS
-                additionalCRS={additionalCRS}
-                crsSelectedDXF={crsSelectedDXF}
-                feature={props.flattenFeatures[0]}
-                filterAllowedCRS={filterAllowedCRS}
-                onChangeCRS={onChangeCRS}
-                onChangeGeometry={props.onChangeGeometry}
-                onClose={onClose}
-            /> : null]}
-    </DragZone>));
+    }) => (
+        <Portal><DragZone
+            onClose={onClose}
+            onDrop={onDrop}
+            onRef={onRef}
+        >
+            {[<ImportContent {...props}/>, showProjectionCombobox ?
+                <ImportSelectCRS
+                    additionalCRS={additionalCRS}
+                    crsSelectedDXF={crsSelectedDXF}
+                    feature={props.flattenFeatures[0]}
+                    filterAllowedCRS={filterAllowedCRS}
+                    onChangeCRS={onChangeCRS}
+                    onChangeGeometry={props.onChangeGeometry}
+                    onClose={onClose}
+                /> : null]}
+        </DragZone></Portal>));

--- a/web/client/plugins/longitudinalProfile/SettingsPanel.jsx
+++ b/web/client/plugins/longitudinalProfile/SettingsPanel.jsx
@@ -18,6 +18,7 @@ import SettingsPanelComp from "../../plugins/settings/SettingsPanel";
 import {
     isParametersOpenSelector
 } from '../../selectors/longitudinalProfile';
+import Portal from '../../components/misc/Portal';
 
 const Panel = ({
     isParametersOpen,
@@ -25,7 +26,7 @@ const Panel = ({
     onToggleParameters
 }) => {
 
-    return (<Dialog
+    return (<Portal><Dialog
         id={"LongitudinalSettingsPanel"}
         style={{...panelStyle, display: isParametersOpen ? 'block' : 'none'}}
         draggable={false}
@@ -45,7 +46,7 @@ const Panel = ({
         <SettingsPanelComp key="LongitudinalSettingsPanel" role="body">
             <Properties />
         </SettingsPanelComp>
-    </Dialog>);
+    </Dialog></Portal>);
 };
 
 const PanelConnected = connect(

--- a/web/client/utils/DOMUtil.js
+++ b/web/client/utils/DOMUtil.js
@@ -43,5 +43,5 @@ export function getOffsetTop( elem ) {
  */
 export const getOffsetBottom = ( element, containerClass = "container") =>{
     const container = document.getElementById(containerClass);
-    return container.clientHeight - getOffsetTop(element);
+    return container?.clientHeight - getOffsetTop(element);
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes the layout issues of the Longitudinal profile tool :  Import Dialog and Settings panel

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12130 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
<img width="1510" height="771" alt="Screenshot 2026-03-23 at 18 14 14" src="https://github.com/user-attachments/assets/f553287a-d29e-490e-919f-f92434af973a" />
<img width="996" height="655" alt="Screenshot 2026-03-23 at 18 52 04" src="https://github.com/user-attachments/assets/4830db08-e05b-473a-9af9-360f8b5031a3" />

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
