### PR TITLE
fix #12114 DynamicLegend broken layout

### DIFF
--- a/web/client/plugins/DynamicLegend/components/DynamicLegend.jsx
+++ b/web/client/plugins/DynamicLegend/components/DynamicLegend.jsx
@@ -64,7 +64,6 @@ const DynamicLegend = ({
         });
     }, [isFloating, flatLegend, setConfiguration]);
 
-
     return (
         <ContainerComponent
             {...(isFloating ? {
@@ -76,7 +75,6 @@ const DynamicLegend = ({
                 draggable: true,
                 style: { zIndex: 1993 }
             } : {
-                containerStyle: dockStyle,
                 containerId: "dynamic-legend-container",
                 containerClassName: "dock-container",
                 className: "dynamic-legend-dock-panel",

--- a/web/client/plugins/DynamicLegend/epics/__tests__/dynamiclegend-test.js
+++ b/web/client/plugins/DynamicLegend/epics/__tests__/dynamiclegend-test.js
@@ -11,6 +11,7 @@ import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from '../../../../epics/__test
 import { dynamicLegendMapLayoutEpic } from '../dynamiclegend';
 import { UPDATE_MAP_LAYOUT, updateMapLayout } from '../../../../actions/maplayout';
 import { CONTROL_NAME } from '../../constants';
+import { DEFAULT_PANEL_WIDTH } from '../../../../utils/LayoutUtils';
 
 describe('dynamiclegend epics', () => {
 
@@ -28,9 +29,9 @@ describe('dynamiclegend epics', () => {
             actions => {
                 expect(actions[0].type).toBe(UPDATE_MAP_LAYOUT);
                 expect(actions[0].source).toBe(CONTROL_NAME);
-                expect(actions[0].layout.right).toBe(620);
+                expect(actions[0].layout.right).toBe(DEFAULT_PANEL_WIDTH + (layout?.boundingSidebarRect?.right ?? 0));
                 expect(actions[0].layout.rightPanel).toBe(true);
-                expect(actions[0].layout.boundingMapRect.right).toBe(620);
+                expect(actions[0].layout.boundingMapRect.right).toBe(DEFAULT_PANEL_WIDTH);
                 expect(actions[0].layout.boundingSidebarRect.right).toBe(200);
                 done();
             },

--- a/web/client/plugins/DynamicLegend/epics/dynamiclegend.js
+++ b/web/client/plugins/DynamicLegend/epics/dynamiclegend.js
@@ -21,17 +21,20 @@ const OFFSET = DEFAULT_PANEL_WIDTH;
  */
 export const dynamicLegendMapLayoutEpic = (action$, store) =>
     action$.ofType(UPDATE_MAP_LAYOUT)
-        .filter(({source}) => !isFloatingSelector(store.getState()) && enabledSelector(store.getState()) && isNil(source))
+        .filter(({source}) => {
+            return !isFloatingSelector(store.getState()) && enabledSelector(store.getState()) && isNil(source);
+        })
         .map(({layout}) => {
-            const action = updateMapLayout({
+            const newLayout = {
                 ...layout,
                 right: OFFSET + (layout?.boundingSidebarRect?.right ?? 0),
                 boundingMapRect: {
                     ...(layout.boundingMapRect || {}),
-                    right: OFFSET + (layout?.boundingSidebarRect?.right ?? 0)
+                    right: OFFSET
                 },
                 rightPanel: true
-            });
+            };
+            const action = updateMapLayout(newLayout);
             return { ...action, source: CONTROL_NAME };
         });
 


### PR DESCRIPTION
## Description
Fix issue #12114 

- fix DynamicPanel layout size on map update layout
- improve exists tests

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
dynamicLenged panel layout is broken when window is resized

**What is the new behavior?**
Test enagle DynamicLegend and resize window, look video below:

https://github.com/user-attachments/assets/4be5618c-52e2-4d91-9889-0128e9ff2a7d

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
To replicate enable DynamicLegend adding con `desktop` in `localConfig.json`:
```json
   {
      "name": "DynamicLegend",
      "glyph": "align-left",
      "title": "plugins.DynamicLegend.title",
      "description": "plugins.DynamicLegend.description",
      "dependencies": ["SidebarMenu"]
    }
```