### PR TITLE
Fix #12140 : Permissions now support disabled property  to disable selecting permissions , deleting permission and geolimits modifications

### DIFF
--- a/web/client/plugins/ResourcesCatalog/components/Permissions.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/Permissions.jsx
@@ -31,7 +31,6 @@ function Permissions({
     entriesTabs = [],
     loading,
     permissionOptions,
-    user,
     showGroupsPermissions = true,
     tools = []
 }) {
@@ -262,23 +261,22 @@ function Permissions({
                 {filteredEntries
                     .filter((item) => item.permissions !== 'owner' && !item.is_superuser)
                     .map((entry, idx) => {
-                        const isCurrentUserEntry = entry?.type === 'user' && entry?.id === user?.pk;
-                        const entryDisabled = isCurrentUserEntry && entry?.permissions === 'manage';
+                        const disabled =   entry?.disabled ? entry.disabled : false;
                         return (
                             <li
                                 key={getEntryIdKey(entry) + '-' + idx}>
                                 <PermissionsRow
                                     {...entry}
-                                    disabled={entryDisabled}
+                                    disabled ={disabled}
                                     onChange={editing ? handleUpdateEntry.bind(null, getEntryIdKey(entry)) : null}
                                     options={permissionOptions?.[`entry.name.${entry.name}`] || permissionOptions?.default}
                                 >
                                     {entry.permissions !== 'owner' &&  editing ?
                                         <>
                                             {tools.map(({ Component, name }) => (
-                                                <Component key={name} entry={entry} onUpdate={handleUpdateEntry} disabled={entryDisabled} />
+                                                <Component key={name} entry={entry} onUpdate={handleUpdateEntry} disabled={disabled} />
                                             ))}
-                                            <Button disabled={entryDisabled} onClick={handleRemoveEntry.bind(null, entry)}>
+                                            <Button disabled={disabled} onClick={handleRemoveEntry.bind(null, entry)}>
                                                 <Glyphicon glyph="trash" />
                                             </Button>
                                         </>

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/Permissions-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/Permissions-test.jsx
@@ -125,8 +125,8 @@ describe('Permissions component', () => {
             user={{ pk: 1 }}
             compactPermissions={{
                 entries: [
-                    { type: 'user', id: 1, name: 'current-user', permissions: 'manage' },
-                    { type: 'group', id: 2, name: 'custom-group', permissions: 'edit' }
+                    { type: 'user', id: 1, name: 'current-user', permissions: 'manage', disabled: true },
+                    { type: 'group', id: 2, name: 'custom-group', permissions: 'edit', disabled: false}
                 ]
             }}
             permissionOptions={defaultPermissionOptions}

--- a/web/client/plugins/ResourcesCatalog/containers/ResourcePermissions.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/ResourcePermissions.jsx
@@ -30,7 +30,6 @@ function hasPermission(entry, group) {
 function ResourcePermissions({
     editing,
     resource,
-    user,
     onChange
 }) {
 
@@ -117,7 +116,6 @@ function ResourcePermissions({
     return (
         <Permissions
             editing={editing}
-            user={user}
             compactPermissions={{
                 entries: permissionEntries
             }}


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Minor changes to existing features
 

<!-- add here the ReadTheDocs link (if needed) -->

## 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12140 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Permissions now support disable property . It is an enhancement in Permissions Panel so that certain permission entry can be made disabled as required. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
