### PR TITLE
[Backport 2026.01.xx] Fix #12136. Update tomcat. Fixed cargo startup issues with Java 17

### DIFF
--- a/binary/bin-war/pom.xml
+++ b/binary/bin-war/pom.xml
@@ -14,7 +14,7 @@
     <url>http://www.geo-solutions.it</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>9.0.108</tomcat.version>
+        <tomcat.version>9.0.116</tomcat.version>
         <binary.number>${mapstore2.version}</binary.number>
     </properties>
 

--- a/binary/pom.xml
+++ b/binary/pom.xml
@@ -13,7 +13,7 @@
     <url>http://www.geo-solutions.it</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>9.0.113</tomcat.version>
+        <tomcat.version>9.0.116</tomcat.version>
         <binary.number>${mapstore2.version}</binary.number>
     </properties>
     <dependencies>

--- a/docs/developer-guide/advanced-project-customization.md
+++ b/docs/developer-guide/advanced-project-customization.md
@@ -46,6 +46,10 @@ Find the entry for `cargo-maven3-plugin` and add the `systemProperties` tag with
                         ${project.build.directory}/apache-tomcat-${tomcat.version}
                     </home>
                     <properties>
+                        <cargo.jvmargs>
+                            --add-opens=java.base/java.lang=ALL-UNNAMED
+                            --add-opens=java.base/java.io=ALL-UNNAMED
+                        </cargo.jvmargs>
                         <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
                         <cargo.logging>low</cargo.logging>
                     </properties>
@@ -96,12 +100,12 @@ For the purpose of this guideline we will adhere to the following folder structu
             │   │   └── custom-style.css
             │   ├── img
             │   │   └── custom-logo.jpg
-            │   │              
+            │   │  
             │   └── js
                     └── customPlugin.js
             ├── index.js
             ├── index.js.LICENSE.txt
-   
+
             ├── index.json
             └── translations
                 ├── data.en-US.json

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -22,7 +22,9 @@ This is a list of things to check if you want to update from a previous version 
 
 ## Migration from 2025.02.02 to 2026.01.00
 
-### Update of Java and print module
+### Update to Java 17
+
+#### Update of Java and print module
 
 You need to update `pom.xml` to align to most recent versions of the libraries. In particular you will have to update in your `pom.xml`:
 
@@ -31,6 +33,26 @@ You need to update `pom.xml` to align to most recent versions of the libraries. 
 ```
 
 notice that this new version of print lib **requires Java 17** so make sure that your application will run with this version of Java, respecting the requirements.
+
+#### Running dev backend locally
+
+With Java 17 you need to add the following lines to your `web/pom.xml` Cargo configuration in order to make the backend dev instance start.
+
+```diff
+                <configuration>
+                    <type>standalone</type>
+                    <home>
+                        ${project.build.directory}/apache-tomcat-${tomcat.version}
+                    </home>
+                    <properties>
++                        <cargo.jvmargs>
++                            --add-opens=java.base/java.lang=ALL-UNNAMED
++                            --add-opens=java.base/java.io=ALL-UNNAMED
++                        </cargo.jvmargs>
+                        <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
+                        <cargo.logging>low</cargo.logging>
+                    </properties>
+                </configuration>
 
 ### Replace authenticationRules with requestsConfigurationRules
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
         <!-- platform BOM versions -->
         <tomcat.port>8080</tomcat.port>
-        <tomcat.version>9.0.108</tomcat.version>
+        <tomcat.version>9.0.116</tomcat.version>
         <jackson.version>2.16.1</jackson.version>
         <gt.version>31.3</gt.version>
         <metrics.version>4.2.12</metrics.version>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -293,6 +293,10 @@
                             ${project.build.directory}/apache-tomcat-${tomcat.version}
                         </home>
                         <properties>
+                            <cargo.jvmargs>
+                                --add-opens=java.base/java.lang=ALL-UNNAMED
+                                --add-opens=java.base/java.io=ALL-UNNAMED
+                            </cargo.jvmargs>
                             <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
                             <cargo.logging>low</cargo.logging>
                             <!-- setting javax.xml.parsers.SAXParserFactory is a workaround for issue https://github.com/geosolutions-it/geostore/issues/311 and can be removed when solved -->

--- a/project/standard/templates/pom.xml
+++ b/project/standard/templates/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- platform BOM versions -->
         <tomcat.port>8080</tomcat.port>
-        <tomcat.version>9.0.108</tomcat.version>
+        <tomcat.version>9.0.116</tomcat.version>
         <jackson.version>2.16.1</jackson.version>
         <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -406,6 +406,10 @@
                         ${project.build.directory}/apache-tomcat-${tomcat.version}
                     </home>
                     <properties>
+                        <cargo.jvmargs>
+                            --add-opens=java.base/java.lang=ALL-UNNAMED
+                            --add-opens=java.base/java.io=ALL-UNNAMED
+                        </cargo.jvmargs>
                         <cargo.servlet.port>${tomcat.port}</cargo.servlet.port>
                         <cargo.logging>low</cargo.logging>
                     </properties>


### PR DESCRIPTION
# Description
Backport of #12139 to `2026.01.xx`.

Fixes #12136, #12138