### PR TITLE
#12151 - Fix date picker is overlapped in 3D map settings panel

### DIFF
--- a/web/client/plugins/Settings.jsx
+++ b/web/client/plugins/Settings.jsx
@@ -143,7 +143,7 @@ class SettingsButton extends React.Component {
                         {settings}
                     </Panel>);
                 }
-                return (<Portal><Dialog id={this.props.id} style={{...this.props.panelStyle, display: this.props.visible ? 'block' : 'none'}} className={this.props.panelClassName} draggable={false} modal>
+                return (<Portal><Dialog id={this.props.id} style={{...this.props.panelStyle, display: this.props.visible ? 'block' : 'none'}} className={this.props.panelClassName} containerClassName="settings-panel-container" draggable={false} modal>
                     <span role="header">
                         <span className="modal-title settings-panel-title"><Message msgId="settings"/></span>
                         <button onClick={this.props.toggleControl} className="settings-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>

--- a/web/client/themes/default/less/settings.less
+++ b/web/client/themes/default/less/settings.less
@@ -35,3 +35,9 @@
         }
     }
 }
+
+.fade.in.modal{
+    &.settings-panel-container {
+        z-index: 3500;
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes date picker is overlapped in 3D map settings panel

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
- #12151 

**What is the new behavior?**
<img width="479" height="640" alt="image" src="https://github.com/user-attachments/assets/ec6b1c85-a239-482e-b3e1-81ed61188abd" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
