### PR TITLE
Fix COG and FlatGeobuf layers support params for protected storage

### DIFF
--- a/web/client/api/FlatGeobuf.js
+++ b/web/client/api/FlatGeobuf.js
@@ -7,7 +7,7 @@
  */
 import axios from '../libs/ajax';
 import isEmpty from 'lodash/isEmpty';
-import { setSecurityParams } from '../utils/SecurityUtils';
+import { updateUrlParams } from '../utils/URLUtils';
 
 export const FGB = 'fgb';
 export const FGB_LAYER_TYPE = 'flatgeobuf';
@@ -46,8 +46,8 @@ export const getCapabilities = (url) => {
     return getFlatGeobufGeneric().then(flatgeobuf => {
         return axios.get(url, {
             adapter: config => {
-                const axiosUrl = setSecurityParams(config.url);
-                return flatgeobuf.readMetadata(axiosUrl);
+                const secureUrl = updateUrlParams(config.url, config.params);
+                return flatgeobuf.readMetadata(secureUrl, true, config.headers);
             }
         }).then((metadata) => {
 

--- a/web/client/components/map/cesium/plugins/COGLayer.js
+++ b/web/client/components/map/cesium/plugins/COGLayer.js
@@ -7,7 +7,8 @@
  */
 
 import Layers from '../../../../utils/cesium/Layers';
-import { setSecurityParams } from '../../../../utils/SecurityUtils';
+import { getRequestConfigurationByUrl } from '../../../../utils/SecurityUtils';
+import { updateUrlParams } from '../../../../utils/URLUtils';
 
 import isEqual from 'lodash/isEqual';
 import proj4 from 'proj4';
@@ -90,11 +91,17 @@ const createLayer = (options) => {
     if (!options.visibility) {
         return null;
     }
-    const url = setSecurityParams(options.url || options?.sources[0]?.url);
 
+    const url = options.url || options?.sources[0]?.url;
+    const {headers, params} = getRequestConfigurationByUrl(url, options?.security?.sourceId);
+    const secureUrl = updateUrlParams(url, params);
     const renderOptions = buildRenderOptions(options);
 
-    return TIFFImageryProvider.fromUrl(url, {
+    // https://github.com/hongfaqiu/TIFFImageryProvider?tab=readme-ov-file#api
+    return TIFFImageryProvider.fromUrl(secureUrl, {
+        requestOptions: {
+            headers
+        },
         projFunc: (code) => {
             const epsgCode = `EPSG:${code}`;
             if (isProjectionAvailable(epsgCode)) {

--- a/web/client/components/map/cesium/plugins/FlatGeobufLayer.js
+++ b/web/client/components/map/cesium/plugins/FlatGeobufLayer.js
@@ -16,7 +16,8 @@ import {
 import { applyDefaultStyleToVectorLayer } from '../../../../utils/StyleUtils';
 import GeoJSONStyledFeatures from  '../../../../utils/cesium/GeoJSONStyledFeatures';
 import { createVectorFeatureFilter } from '../../../../utils/FilterUtils';
-import { setSecurityParams } from '../../../../utils/SecurityUtils';
+import { updateUrlParams } from '../../../../utils/URLUtils';
+import { getRequestConfigurationByUrl } from '../../../../utils/SecurityUtils';
 
 import {
     FGB_LAYER_TYPE,
@@ -70,9 +71,9 @@ const createLayer = (options, map) => {
         };
 
         let rect = mapBbox();
-
-        const secureUrl = setSecurityParams(options.url);
-        for await (const feature of flatgeobuf.deserialize(secureUrl, rect)) {
+        const {headers} = getRequestConfigurationByUrl(options.url, options?.security?.sourceId);
+        const secureUrl = updateUrlParams(options.url, options.params);
+        for await (const feature of flatgeobuf.deserialize(secureUrl, rect, headers)) {
             geojson.features.push(feature);
         }
 

--- a/web/client/components/map/openlayers/plugins/COGLayer.js
+++ b/web/client/components/map/openlayers/plugins/COGLayer.js
@@ -13,21 +13,22 @@ import get from 'lodash/get';
 import GeoTIFF from 'ol/source/GeoTIFF.js';
 import TileLayer from 'ol/layer/WebGLTile.js';
 import { isProjectionAvailable } from '../../../../utils/ProjectionUtils';
-import { getRequestConfigurationByUrl, setSecurityParams } from '../../../../utils/SecurityUtils';
+import { getRequestConfigurationByUrl } from '../../../../utils/SecurityUtils';
+import { updateUrlParams } from '../../../../utils/URLUtils';
 
 function create(options) {
     let sources = [];
     let sourceOptions = {};
     if (options.sources && options.sources.length > 0) {
         const firstSource = options.sources[0];
-        const {headers} = getRequestConfigurationByUrl(firstSource.url, null, options.security?.sourceId);
+        const {headers, params} = getRequestConfigurationByUrl(firstSource.url, null, options.security?.sourceId);
         if (headers) {
             sourceOptions.headers = headers;
         }
         sources = options.sources.map((source) => {
             return {
                 ...source,
-                url: setSecurityParams(source.url, options.security?.sourceId)
+                url: updateUrlParams(source.url, params)
             };
         });
     }

--- a/web/client/components/map/openlayers/plugins/FlatGeobufLayer.js
+++ b/web/client/components/map/openlayers/plugins/FlatGeobufLayer.js
@@ -17,8 +17,8 @@ import {
     FGB_LAYER_TYPE,
     getFlatGeobufOl
 } from '../../../../api/FlatGeobuf';
-import { setSecurityParams } from '../../../../utils/SecurityUtils';
-
+import { getRequestConfigurationByUrl } from '../../../../utils/SecurityUtils';
+import { updateUrlParams } from '../../../../utils/URLUtils';
 
 const getFlatGeobufStyle = (layer, options, map) => {
 
@@ -49,8 +49,9 @@ const getFlatGeobufStyle = (layer, options, map) => {
 
 const createLoader = (source, options, strategy) => (extent, resolution, projection) => {
     getFlatGeobufOl().then(flatgeobuf => {
-        const secureUrl = setSecurityParams(options.url);
-        const loader = flatgeobuf.createLoader(source, secureUrl, 'EPSG:4326', strategy, true);
+        const { headers } = getRequestConfigurationByUrl(options.url, options?.security?.sourceId);
+        const secureUrl = updateUrlParams(options.url, options.params);
+        const loader = flatgeobuf.createLoader(source, secureUrl, 'EPSG:4326', strategy, true, headers);
         source.setLoader(loader);
         loader(extent, resolution, projection); // force load at creation(needed for flatgeobuf only)
         options.onLoadEnd && options.onLoadEnd();

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -356,30 +356,6 @@ export const getRequestConfigurationByUrl = (url, securityToken, sourceId) => {
     };
 };
 
-/**
- * Append to an url the security params if there are some configured for it
- * @param {*} sourceUrl original url without security params, but support another url with params
- * @param {*} sourceId optional key used by getRequestConfigurationByUrl
- * @returns {String} url with security params if there are some, otherwise the original url
- */
-export function setSecurityParams(sourceUrl, sourceId) {
-    const {params} = getRequestConfigurationByUrl(sourceUrl, null, sourceId);
-    if (params) {
-        try {
-            const url = URL.parse(sourceUrl, true);
-            Object.entries(params).forEach(([key, value]) => {
-                url.query[key] = value;
-            });
-            // we need to remove this to force the use of query
-            delete url.search;
-            return URL.format(url);
-        } catch (e) {
-            return sourceUrl;
-        }
-    }
-    return sourceUrl;
-}
-
 export const hasRequestConfigurationByUrl = (url, securityToken, sourceId) => {
     const { headers, params } = getRequestConfigurationByUrl(url, securityToken, sourceId);
     return !!(headers || params);
@@ -487,7 +463,6 @@ const SecurityUtils = {
     getRequestConfigurationRules,
     getRequestConfigurationRule,
     getAuthenticationMethod,
-    setSecurityParams,
     isRequestConfigurationActivated,
     convertAuthenticationRulesToRequestConfiguration,
     USER_GROUP_ALL

--- a/web/client/utils/URLUtils.js
+++ b/web/client/utils/URLUtils.js
@@ -165,5 +165,6 @@ export function updateUrlParams(url, params) {
     const parsedUrl = queryString.parseUrl(url);
     const updatedQuery = { ...parsedUrl?.query, ...params };
     // TODO: use stringifyUrl instead after updating `query-string`, not supported in current version
-    return parsedUrl?.url + '?' + queryString.stringify(updatedQuery);
+    const query = queryString.stringify(updatedQuery);
+    return query ? `${parsedUrl?.url}?${query}` : parsedUrl?.url;
 }

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -376,24 +376,6 @@ describe('Test security utils methods', () => {
         });
     });
 
-    describe('setSecurityParams', () => {
-        it('should set multiple params at once', () => {
-            const sourceUrl = 'https://storage.net/cog/test.tif';
-            const rules = [
-                {
-                    "urlPattern": "https://storage.net/cog/.*",
-                    "params": {
-                        "token": "1531416215",
-                        "sig": "VZLpxS5I574XQctJduY3yHBaMHFIIuCbYQZ1sXpr7iA"
-                    }
-                }
-            ];
-            ConfigUtils.setConfigProp('requestsConfigurationRules', rules);
-            const secureUrl = SecurityUtils.setSecurityParams(sourceUrl);
-            expect(secureUrl).toBe('https://storage.net/cog/test.tif?token=1531416215&sig=VZLpxS5I574XQctJduY3yHBaMHFIIuCbYQZ1sXpr7iA');
-        });
-    });
-
     describe('isRequestConfigurationActivated', () => {
         it('should return true when user has token and rules exist in state', () => {
             const stateWithRules = {

--- a/web/client/utils/__tests__/URLUtils-test.js
+++ b/web/client/utils/__tests__/URLUtils-test.js
@@ -196,6 +196,11 @@ describe('URLUtils', () => {
         const updatedUrl = updateUrlParams(url, { newParam: 'newValue' });
         expect(updatedUrl).toBe('https://my-site.com/some/path/to/resouce?newParam=newValue');
     });
+    it("add new Url param empty", () => {
+        const url = 'https://my-site.com/some/path/to/resouce';
+        const updatedUrl = updateUrlParams(url, {});
+        expect(updatedUrl).toBe('https://my-site.com/some/path/to/resouce');
+    });
 });
 
 

--- a/web/client/utils/cog/LayerUtils.js
+++ b/web/client/utils/cog/LayerUtils.js
@@ -3,7 +3,8 @@ import isEmpty from 'lodash/isEmpty';
 import get from 'lodash/get';
 
 import { isProjectionAvailable } from "../ProjectionUtils";
-import { setSecurityParams } from '../SecurityUtils';
+import { getRequestConfigurationByUrl } from '../SecurityUtils';
+import { updateUrlParams } from '../URLUtils';
 
 export const getTiffImageryProvider = () => import('tiff-imagery-provider').then(mod => mod);
 
@@ -48,10 +49,14 @@ export const fromUrl = (url, signal) => {
     if (signal?.aborted) {
         return abortError(Promise.reject);
     }
-    const secureUrl = setSecurityParams(url);
+    const {headers, params} = getRequestConfigurationByUrl(url);
+    const secureUrl = updateUrlParams(url, params);
     return new Promise((resolve, reject) => {
         signal?.addEventListener("abort", () => abortError(reject));
-        return fromGeotiffUrl(secureUrl)
+        return fromGeotiffUrl(secureUrl, {
+            // https://geotiffjs.github.io/geotiff.js/interfaces/geotiff.RemoteSourceOptions.html
+            headers
+        })
             .then((image)=> image.getImage())
             .then((image) => resolve(image))
             .catch(()=> abortError(reject));


### PR DESCRIPTION
Fix #12162 

- fix cog catalog sugin security params
- new function setSecurityParams
- added unit test for setSecurityParams
- secure params in 3D layers
- fix tests SecurityUtils

## Description
In short, in cases of datasets using custom rules in the requestsConfigurationRules section of localConfig.json, the URL parameters for resource addresses corresponding to COG and FlatGeobuf files were not being passed. See the issue for an example of rules to use for testing.

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue
Fix #12162 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
A new method `setSecurityParams` has been added to avoid code replication that automatically appends parameters to the URL when necessary. In cases where no rules exist, the original URL is used

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
See the linked issue for bug reproducing details.
Geonode-client porting is required