### PR TITLE
[Backport 2026.01.xx] #12151 - Fix date picker is overlapped in 3D map settings panel

### DIFF
--- a/web/client/plugins/Settings.jsx
+++ b/web/client/plugins/Settings.jsx
@@ -143,7 +143,7 @@ class SettingsButton extends React.Component {
                         {settings}
                     </Panel>);
                 }
-                return (<Portal><Dialog id={this.props.id} style={{...this.props.panelStyle, display: this.props.visible ? 'block' : 'none'}} className={this.props.panelClassName} draggable={false} modal>
+                return (<Portal><Dialog id={this.props.id} style={{...this.props.panelStyle, display: this.props.visible ? 'block' : 'none'}} className={this.props.panelClassName} containerClassName="settings-panel-container" draggable={false} modal>
                     <span role="header">
                         <span className="modal-title settings-panel-title"><Message msgId="settings"/></span>
                         <button onClick={this.props.toggleControl} className="settings-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>

--- a/web/client/themes/default/less/settings.less
+++ b/web/client/themes/default/less/settings.less
@@ -35,3 +35,9 @@
         }
     }
 }
+
+.fade.in.modal{
+    &.settings-panel-container {
+        z-index: 3500;
+    }
+}


### PR DESCRIPTION
# Description
Backport of #12164 to `2026.01.xx`.

Fixes #12151