### PR TITLE
[Backport 2026.01.xx] Fix doc of MapImport plugin

### DIFF
--- a/web/client/plugins/MapImport.jsx
+++ b/web/client/plugins/MapImport.jsx
@@ -46,7 +46,7 @@ import { DEFAULT_VECTOR_FILE_MAX_SIZE_IN_MB } from '../utils/FileUtils';
  * @memberof plugins
  * @name MapImport
  * @class
- * @prop {number} cfg.importedVectorFileMaxSizeInMB it is the max allowable file size for import vectir layers in mega bytes
+ * @prop {number} cfg.importedVectorFileMaxSizeInMB it is the max allowable file size for import vector layers in mega bytes, default is 3MB
  */
 export default {
     MapImportPlugin: Object.assign({loadPlugin: (resolve) => {


### PR DESCRIPTION
# Description
Backport of #12197 to `2026.01.xx`.

Fixes #