### PR TITLE
fix flatgeobuf params by getRequestConfigurationByUrl

### DIFF
--- a/web/client/components/map/openlayers/plugins/FlatGeobufLayer.js
+++ b/web/client/components/map/openlayers/plugins/FlatGeobufLayer.js
@@ -49,8 +49,8 @@ const getFlatGeobufStyle = (layer, options, map) => {
 
 const createLoader = (source, options, strategy) => (extent, resolution, projection) => {
     getFlatGeobufOl().then(flatgeobuf => {
-        const { headers } = getRequestConfigurationByUrl(options.url, options?.security?.sourceId);
-        const secureUrl = updateUrlParams(options.url, options.params);
+        const { headers, params } = getRequestConfigurationByUrl(options.url, options?.security?.sourceId);
+        const secureUrl = updateUrlParams(options.url, params);
         const loader = flatgeobuf.createLoader(source, secureUrl, 'EPSG:4326', strategy, true, headers);
         source.setLoader(loader);
         loader(extent, resolution, projection); // force load at creation(needed for flatgeobuf only)


### PR DESCRIPTION
Fix #12162 

- fix cog catalog sugin security params
- new function setSecurityParams
- added unit test for setSecurityParams
- secure params in 3D layers
- fix tests SecurityUtils
- This PR includes missing security params in the FlatGeoBufLayer requests

## Description
In short, in cases of datasets using custom rules in the requestsConfigurationRules section of localConfig.json, the URL parameters for resource addresses corresponding to COG and FlatGeobuf files were not being passed. See the issue for an example of rules to use for testing.


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue
**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#12162 

**What is the new behavior?**
Ensure the security params are included inside FlatGeoBufLayer in openlayers

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
See the linked issue for bug reproducing details.
Geonode-client porting is required