### PR TITLE
#12218: fix pagination in rules manager layers autocomplete does not work

### DIFF
--- a/web/client/components/manager/rulesmanager/enhancers/autoComplete.js
+++ b/web/client/components/manager/rulesmanager/enhancers/autoComplete.js
@@ -52,7 +52,7 @@ const loadPageStream = page$ => page$
     .switchMap(({pageStep, page, parentsFilter, count, val, size,
         pagination, setData, loadData, onError, loadingErrorMsg}) => {
         const newPage = page + pageStep;
-        return loadData(val, newPage, size, parentsFilter)
+        return loadData(val, newPage, size, parentsFilter, true)
             .do(({data}) => {
                 setData({
                     pagination: {...pagination, firstPage: newPage === 0, lastPage: Math.ceil(count / size) <= newPage + 1},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes the paginated layers in rules manager screen by passing the missing param to **loadData** in **loadPageStream** in **rulesmanager/enhancers/autocomplete file** to enable reading the gsInstance URL and use it in get paginated layers


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12218

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

https://github.com/user-attachments/assets/f7567235-761c-45db-9b6f-72d6794242e4



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
