### PR TITLE
[Backport 2026.01.xx] #12218: fix pagination in rules manager layers autocomplete does not work

### DIFF
--- a/web/client/components/manager/rulesmanager/enhancers/autoComplete.js
+++ b/web/client/components/manager/rulesmanager/enhancers/autoComplete.js
@@ -52,7 +52,7 @@ const loadPageStream = page$ => page$
     .switchMap(({pageStep, page, parentsFilter, count, val, size,
         pagination, setData, loadData, onError, loadingErrorMsg}) => {
         const newPage = page + pageStep;
-        return loadData(val, newPage, size, parentsFilter)
+        return loadData(val, newPage, size, parentsFilter, true)
             .do(({data}) => {
                 setData({
                     pagination: {...pagination, firstPage: newPage === 0, lastPage: Math.ceil(count / size) <= newPage + 1},


### PR DESCRIPTION
# Description
Backport of #12219 to `2026.01.xx`.

Fixes #null,12218