### PR TITLE
backport C040-2025.02.xx - #12218: fix pagination in rules manager layers autocomplete does not work (#12219)

### DIFF
--- a/web/client/components/manager/rulesmanager/enhancers/autoComplete.js
+++ b/web/client/components/manager/rulesmanager/enhancers/autoComplete.js
@@ -52,7 +52,7 @@ const loadPageStream = page$ => page$
     .switchMap(({pageStep, page, parentsFilter, count, val, size,
         pagination, setData, loadData, onError, loadingErrorMsg}) => {
         const newPage = page + pageStep;
-        return loadData(val, newPage, size, parentsFilter)
+        return loadData(val, newPage, size, parentsFilter, true)
             .do(({data}) => {
                 setData({
                     pagination: {...pagination, firstPage: newPage === 0, lastPage: Math.ceil(count / size) <= newPage + 1},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport C040-2025.02.xx - #12218: fix pagination in rules manager layers autocomplete does not work (#12219)