### PR TITLE
#12237: fix the background selector show an error in console

### DIFF
--- a/web/client/components/background/BackgroundSelector.jsx
+++ b/web/client/components/background/BackgroundSelector.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, lazy } from 'react';
+import React, { useState, lazy, useEffect } from 'react';
 
 import ConfirmDialog from '../../components/layout/ConfirmDialog';
 import withSuspense from '../misc/withSuspense';
@@ -93,7 +93,7 @@ function BackgroundSelector({
     const currentBackground = getCurrentBackground();
     const currentTerrain = getCurrentTerrainLayer();
     // Include the ellipsoidal terrain if missing
-    React.useEffect(() => {
+    useEffect(() => {
         const hasEllipsoidTerrain = backgroundsProp.some(bg => bg.type === 'terrain' && bg.provider === 'ellipsoid');
         if (!hasEllipsoidTerrain) {
             const newEllipsoidLayer = {

--- a/web/client/components/background/BackgroundSelector.jsx
+++ b/web/client/components/background/BackgroundSelector.jsx
@@ -64,19 +64,12 @@ function BackgroundSelector({
         open: false,
         layer: undefined
     });
-    // handlers
-    const onToggleLayer =  (layer) => {
-        onPropertiesChange(layer.id ?? "ellipsoid", {visibility: true});
+    const getCurrentTerrainLayer = () => {
+        const terrainLayer = backgroundsProp.find(bg => bg.type === 'terrain');
+        const visibleTerrain = backgroundsProp.find(bg => bg.type === 'terrain' && bg.visibility === true);
+        if (visibleTerrain) return visibleTerrain;
+        return terrainLayer;
     };
-    const handleAddEditTerrainLayer = (layerToAdd) => {
-        if (showTerrainModal.layer) {
-            updateNode(layerToAdd.id, 'layers', layerToAdd);
-        } else {
-            addLayer(layerToAdd);
-            onPropertiesChange(layerToAdd.id, {visibility: true});
-        }
-    };
-
     // Get current selected background (that is not a terrain and with visibility: true)
     const getCurrentBackground = () => {
         const visibleBackground = backgroundsProp.find(bg => bg.type !== 'terrain' && bg.visibility === true);
@@ -89,14 +82,35 @@ function BackgroundSelector({
         }
         return backgroundsProp[0];
     };
-    const getCurrentTerrainLayer = () => {
-        const terrainLayers = backgroundsProp.find(bg => bg.type === 'terrain');
-        const visibleTerrain = backgroundsProp.find(bg => bg.type === 'terrain' && bg.visibility === true);
-        if (visibleTerrain) return visibleTerrain;
-        return terrainLayers?.[0];
+    const handleAddEditTerrainLayer = (layerToAdd) => {
+        if (showTerrainModal.layer) {
+            updateNode(layerToAdd.id, 'layers', layerToAdd);
+        } else {
+            addLayer(layerToAdd);
+            onPropertiesChange(layerToAdd.id, {visibility: true});
+        }
     };
     const currentBackground = getCurrentBackground();
     const currentTerrain = getCurrentTerrainLayer();
+    // Include the ellipsoidal terrain if missing
+    React.useEffect(() => {
+        const hasEllipsoidTerrain = backgroundsProp.some(bg => bg.type === 'terrain' && bg.provider === 'ellipsoid');
+        if (!hasEllipsoidTerrain) {
+            const newEllipsoidLayer = {
+                type: 'terrain',
+                visibility: !currentTerrain, // only visible if no other terrain is active
+                title: 'Ellipsoid',
+                provider: 'ellipsoid',
+                group: 'background',
+                id: "ellipsoid"
+            };
+            handleAddEditTerrainLayer(newEllipsoidLayer);
+        }
+    }, [backgroundsProp, currentTerrain]);
+    // handlers
+    const onToggleLayer =  (layer) => {
+        onPropertiesChange(layer.id ?? "ellipsoid", {visibility: true});
+    };
 
     const filteredBackgrounds = backgroundsProp.filter(({ type }) => type !== 'terrain');
     const backgrounds = filteredBackgrounds.map((background) => {
@@ -115,18 +129,6 @@ function BackgroundSelector({
             deletable: canEdit && allowDeletion && terrain.provider !== 'ellipsoid'
         };
     });
-
-    // include the ellipsoidal terrain if missing
-    const hasEllipsoidTerrain = terrains.some(terrain => terrain.provider === 'ellipsoid');
-    if (!hasEllipsoidTerrain) {
-        handleAddEditTerrainLayer({
-            type: 'terrain',
-            visibility: !currentTerrain,
-            title: 'Ellipsoid',
-            provider: 'ellipsoid',
-            group: "background"
-        });
-    }
 
     const {show: showConfirm, layerId: confirmLayerId, layerTitle: confirmLayerTitle} = confirmDeleteBackgroundModal || {show: false};
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes resolving "Cannot update during an existing state transition" console error in BackgroundSelector. It includes:
- Refactored **BackgroundSelector.jsx**
- Moved the logic for detecting and adding the missing **Ellipsoid terrain** from the main function body into a **React.useEffect** hook

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12237 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The console error of background selector has been gone, resolved by the fix.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
