### PR TITLE
[Backport 2026.01.xx] #12207: Fix - ScaleBox plugin - Custom scales not reported on map load

### DIFF
--- a/web/client/components/mapcontrols/scale/__tests__/ScaleBox-test.jsx
+++ b/web/client/components/mapcontrols/scale/__tests__/ScaleBox-test.jsx
@@ -225,4 +225,24 @@ describe('ScaleBox', () => {
         // the custom scale must appear in component state
         expect(sb.state.scales.some(s => s.value === 75000)).toBe(true);
     });
+
+    it('custom scales survive a re-render', () => {
+        const customScales = [5000, 10000, 50000, 100000, 500000];
+        TestUtils.act(() => {
+            ReactDOM.render(
+                <ScaleBox scales={customScales} currentZoomLvl={0} />,
+                document.getElementById("container")
+            );
+        });
+        expect(document.querySelectorAll('option').length).toBe(5);
+        TestUtils.act(() => {
+            ReactDOM.render(
+                <ScaleBox scales={customScales} currentZoomLvl={1} />,
+                document.getElementById("container")
+            );
+        });
+        expect(document.querySelectorAll('option').length).toBe(5);
+        const select = document.querySelector('select');
+        expect(select.value).toBe('1');
+    });
 });

--- a/web/client/plugins/ScaleBox.jsx
+++ b/web/client/plugins/ScaleBox.jsx
@@ -17,14 +17,12 @@ import Message from './locale/Message';
 import ScaleBox from '../components/mapcontrols/scale/ScaleBox';
 import { getScales } from '../utils/MapUtils';
 
-const selector = createSelector([mapSelector, minZoomSelector], (map, minZoom) => ({
-    minZoom,
-    currentZoomLvl: map && map.zoom,
-    scales: getScales(
-        map && map.projection || 'EPSG:3857',
-        map && map.mapOptions && map.mapOptions.view && map.mapOptions.view.DPI || null
-    )
-}));
+// exported for unit testing
+export const scaleBoxSelector = createSelector([mapSelector, minZoomSelector], (map, minZoom) => {
+    const { projection, mapOptions } = map || {};
+    const scales = mapOptions?.view?.scales || getScales(projection || 'EPSG:3857', mapOptions?.view?.DPI || null);
+    return { minZoom, currentZoomLvl: map && map.zoom, scales };
+});
 
 import './scalebox/scalebox.css';
 
@@ -51,7 +49,7 @@ class ScaleBoxTool extends React.Component {
   * @prop {Boolean} cfg.useRawInput set true if you want to use an normal html input object
   *
   */
-const ScaleBoxPlugin = connect(selector, {
+const ScaleBoxPlugin = connect(scaleBoxSelector, {
     onChange: changeZoomLevel
 })(ScaleBoxTool);
 

--- a/web/client/plugins/__tests__/ScaleBox-test.jsx
+++ b/web/client/plugins/__tests__/ScaleBox-test.jsx
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2026, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import ScaleBoxPlugin, { scaleBoxSelector } from '../ScaleBox';
+import { getPluginForTest } from './pluginsTestUtils';
+import { getScales } from '../../utils/MapUtils';
+
+describe('ScaleBox Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    describe('renders ScaleBox plugin', () => {
+        it('default render of ScaleBox plugin', () => {
+            const { Plugin } = getPluginForTest(ScaleBoxPlugin, {
+                map: {
+                    present: {
+                        projection: 'EPSG:900913',
+                        zoom: 5
+                    }
+                }
+            });
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            expect(document.getElementById('mapstore-scalebox')).toExist();
+        });
+        it('dropdown shows custom scales from mapOptions.view.scales', () => {
+            const customScales = [500000, 100000, 50000, 10000, 5000];
+            const { Plugin } = getPluginForTest(ScaleBoxPlugin, {
+                map: {
+                    present: {
+                        projection: 'EPSG:3857',
+                        zoom: 2,
+                        mapOptions: {
+                            view: {
+                                scales: customScales
+                            }
+                        }
+                    }
+                }
+            });
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            const options = document.querySelectorAll('#mapstore-scalebox option');
+            expect(options.length).toBe(customScales.length);
+        });
+
+        it('dropdown shows default scales when no custom scales configured', () => {
+            const { Plugin } = getPluginForTest(ScaleBoxPlugin, {
+                map: {
+                    present: {
+                        projection: 'EPSG:3857',
+                        zoom: 5
+                    }
+                }
+            });
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            const options = document.querySelectorAll('#mapstore-scalebox option');
+            const defaultScales = getScales('EPSG:3857', null);
+            expect(options.length).toBe(defaultScales.length);
+        });
+    });
+
+    describe('scaleBoxSelector', () => {
+        it('returns default scales when no custom scales are configured', () => {
+            const state = {
+                map: {
+                    present: {
+                        projection: 'EPSG:3857',
+                        zoom: 5
+                    }
+                }
+            };
+            const result = scaleBoxSelector(state);
+            const defaultScales = getScales('EPSG:3857', null);
+            expect(result.scales).toEqual(defaultScales);
+            expect(result.currentZoomLvl).toBe(5);
+        });
+
+        it('returns custom scales from mapOptions.view.scales', () => {
+            const customScales = [20000000, 10000000, 4000000, 2000000, 1000000, 500000];
+            const state = {
+                map: {
+                    present: {
+                        projection: 'EPSG:3857',
+                        zoom: 3,
+                        mapOptions: {
+                            view: {
+                                scales: customScales
+                            }
+                        }
+                    }
+                }
+            };
+            const result = scaleBoxSelector(state);
+            expect(result.scales).toEqual(customScales);
+            expect(result.scales.length).toBe(6);
+            expect(result.currentZoomLvl).toBe(3);
+        });
+
+        it('custom scales take priority over getScales default', () => {
+            const customScales = [50000, 10000, 5000];
+            const state = {
+                map: {
+                    present: {
+                        projection: 'EPSG:3857',
+                        zoom: 0,
+                        mapOptions: {
+                            view: {
+                                scales: customScales,
+                                resolutions: [13.229166666666666, 2.645833333333333, 1.3229166666666665]
+                            }
+                        }
+                    }
+                }
+            };
+            const result = scaleBoxSelector(state);
+            expect(result.scales.length).toBe(3);
+            expect(result.scales).toNotEqual(getScales('EPSG:3857', null));
+        });
+
+        it('falls back to getScales when mapOptions exists but view.scales is absent', () => {
+            const state = {
+                map: {
+                    present: {
+                        projection: 'EPSG:3857',
+                        zoom: 2,
+                        mapOptions: {
+                            view: {}
+                        }
+                    }
+                }
+            };
+            const result = scaleBoxSelector(state);
+            expect(result.scales).toEqual(getScales('EPSG:3857', null));
+        });
+
+        it('handles map state being null', () => {
+            const state = { map: null };
+            const result = scaleBoxSelector(state);
+            expect(result.scales).toEqual(getScales('EPSG:3857', null));
+            expect(result.currentZoomLvl).toBe(null);
+            expect(result.minZoom).toExist;
+        });
+    });
+});


### PR DESCRIPTION
# Description
Backport of #12212 to `2026.01.xx`.

Fixes #12207