### PR TITLE
#12094: Fix dropdown menu overflow when adding links to text widget in TextEditor

### DIFF
--- a/web/client/components/mapviews/settings/CompactRichTextEditor.jsx
+++ b/web/client/components/mapviews/settings/CompactRichTextEditor.jsx
@@ -44,6 +44,7 @@ export const resizeBase64Image = (src, options) => {
 function CompactRichTextEditor({
     wrapperClassName = 'ms-compact-text-editor',
     toolbarOptions,
+    linkModalDirection = "auto",
     ...props
 }) {
 
@@ -92,7 +93,9 @@ function CompactRichTextEditor({
                     inDropdown: false,
                     showOpenOptionOnHover: true,
                     defaultTargetOption: '_self',
-                    options: ['link', 'unlink']
+                    options: ['link', 'unlink'],
+                    // popupClassName added to fix dropdown menu overflow when open link text widget. ref: https://github.com/jpuri/react-draft-wysiwyg/issues/664#issuecomment-511354161
+                    popupClassName: linkModalDirection === 'left' ? 'popup-left-link-in-text-editor' : ''
                 },
                 blockType: {
                     inDropdown: true,

--- a/web/client/components/mapviews/settings/__tests__/CompactRichTextEditor-test.jsx
+++ b/web/client/components/mapviews/settings/__tests__/CompactRichTextEditor-test.jsx
@@ -47,4 +47,20 @@ describe('CompactRichTextEditor component', () => {
         const uploadImgInput = document.querySelector(".rdw-image-modal-upload-option");
         expect(uploadImgInput).toBeTruthy();
     });
+    it('test rendering TextEditor with linkModalDirection set to left', () => {
+        ReactDOM.render(
+            <CompactRichTextEditor linkModalDirection="left" />,
+            document.getElementById("container")
+        );
+        const textEditorContainer = document.querySelector(".ms-compact-text-editor.rdw-editor-wrapper");
+        expect(textEditorContainer).toBeTruthy();
+        const linkWidget = document.querySelector(".rdw-link-wrapper .rdw-option-wrapper");
+        TestUtils.act(() => {
+            TestUtils.Simulate.click(linkWidget);
+        });
+        const linkModal = document.querySelector(".rdw-link-modal");
+        expect(linkModal).toBeTruthy();
+        // Check that modal is positioned to the left
+        expect(linkModal.classList.contains('popup-left-link-in-text-editor')).toBeTruthy();
+    });
 });

--- a/web/client/components/widgets/builder/wizard/TextWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/TextWizard.jsx
@@ -18,7 +18,8 @@ const Wizard = wizardHandlers(WizardContainer);
 export default ({
     onChange = () => {}, onFinish = () => {}, setPage = () => {},
     step = 0,
-    editorData = {}
+    editorData = {},
+    linkModalDirection = "auto"
 } = {}) => (
     <Wizard
         step={step}
@@ -29,6 +30,7 @@ export default ({
             key="widget-options"
             data={editorData}
             onChange={onChange}
+            linkModalDirection={linkModalDirection}
         />
     </Wizard>
 );

--- a/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
@@ -23,7 +23,7 @@ const DescriptorEditor = withDebounceOnCallback(
     "editorState"
 )(CompactRichTextEditor);
 
-function TextOptions({ data = {}, onChange = () => {} }) {
+function TextOptions({ data = {}, onChange = () => {}, linkModalDirection = "auto" }) {
     const [editorState, setEditorState] = useState(
         htmlToDraftJSEditorState(data.text || "")
     );
@@ -48,6 +48,7 @@ function TextOptions({ data = {}, onChange = () => {} }) {
                 </Form>
             </Col>
             <DescriptorEditor
+                linkModalDirection={linkModalDirection}
                 uploadEnabled
                 editorState={editorState}
                 onEditorStateChange={(newEditorState) => {

--- a/web/client/plugins/Annotations/components/AnnotationsFields.jsx
+++ b/web/client/plugins/Annotations/components/AnnotationsFields.jsx
@@ -97,6 +97,7 @@ function AnnotationsFields({
                             </ControlLabel>}
                             {isEditable
                                 ? <DescriptionEditor
+                                    linkModalDirection={'left'}
                                     editorState={editorState[field.name]}
                                     onEditorStateChange={(newEditorState) => {
                                         const previousHTML = draftJSEditorStateToHtml(editorState[field.name]);

--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -107,6 +107,7 @@ class DashboardEditorComponent extends React.Component {
                     enabled={this.props.editing}
                     onClose={() => this.props.setEditing(false)}
                     catalog={this.props.catalog}
+                    linkModalDirection={"left"}
                 />
             </div>
             : false;

--- a/web/client/plugins/widgetbuilder/TextBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/TextBuilder.jsx
@@ -43,9 +43,9 @@ const Builder = connect(
     wizardStateToProps
 )(TextWizardComp);
 
-export default ({ enabled, onClose = () => {}} = {}) =>
+export default ({ enabled, onClose = () => {}, linkModalDirection = "auto"} = {}) =>
     (<BorderLayout
         header={<BuilderHeader onClose={onClose}><Toolbar /></BuilderHeader>}
     >
-        {enabled ? <Builder /> : null}
+        {enabled ? <Builder linkModalDirection={linkModalDirection} /> : null}
     </BorderLayout>);

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -363,6 +363,12 @@ div#sync-popover.popover {
         font-style: italic;
     }
 }
+.rdw-editor-wrapper{
+    .popup-left-link-in-text-editor{
+        left: initial !important;
+        right: 5px;
+    }
+}
 
 
 .DraftEditor-editorContainer, // selector editor


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR includes:

- Add linkModalDirection prop to CompactRichTextEditor to control dropdown positioning and prevent off-screen overflow when adding links in the dashboard editor and edit annotation screen

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12094 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
For dashboard:

<img width="608" height="580" alt="image" src="https://github.com/user-attachments/assets/0788a5f3-cecd-434e-a6f7-76a21d749533" />


For Annotations:

<img width="1492" height="722" alt="image" src="https://github.com/user-attachments/assets/97de2427-a101-41c4-9cc0-58b81dc9ac23" />

For feature info edit:

<img width="1912" height="873" alt="feature info editor" src="https://github.com/user-attachments/assets/55ed9eb0-949d-4cd6-8656-20f9afc8db08" />

For map views:

<img width="1912" height="871" alt="MapViews desc" src="https://github.com/user-attachments/assets/d59602fe-bc45-4250-9259-bd02d020dcf4" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
The fix has inspired from https://github.com/jpuri/react-draft-wysiwyg/issues/664#issuecomment-511354161
