### PR TITLE
#12166: Allow configurable defaults for Printing

### DIFF
--- a/web/client/actions/__tests__/print-test.js
+++ b/web/client/actions/__tests__/print-test.js
@@ -20,6 +20,7 @@ import {
     PRINT_CREATED,
     PRINT_ERROR,
     PRINT_CANCEL,
+    INIT_PRINT_SPEC_FROM_CONFIG,
     loadPrintCapabilities,
     setPrintParameter,
     addPrintTransformer,
@@ -28,7 +29,8 @@ import {
     changeMapPrintPreview,
     printSubmit,
     printSubmitting,
-    printCancel
+    printCancel,
+    initPrintSpecFromConfig
 } from '../print';
 
 describe('Test correctness of the print actions', () => {
@@ -182,5 +184,15 @@ describe('Test correctness of the print actions', () => {
         const retVal = printCancel();
         expect(retVal).toExist();
         expect(retVal.type).toBe(PRINT_CANCEL);
+    });
+    it('initPrintSpecFromConfig', () => {
+        const configPayload = {
+            sheet: 'A3',
+            resolution: 600
+        };
+        const retVal = initPrintSpecFromConfig(configPayload);
+        expect(retVal).toExist();
+        expect(retVal.type).toBe(INIT_PRINT_SPEC_FROM_CONFIG);
+        expect(retVal.initPrintCfgSpec).toBe(configPayload);
     });
 });

--- a/web/client/actions/__tests__/print-test.js
+++ b/web/client/actions/__tests__/print-test.js
@@ -30,7 +30,9 @@ import {
     printSubmit,
     printSubmitting,
     printCancel,
-    initPrintSpecFromConfig
+    initPrintSpecFromConfig,
+    resetPrintSpec,
+    RESET_PRINT_SPEC
 } from '../print';
 
 describe('Test correctness of the print actions', () => {
@@ -194,5 +196,10 @@ describe('Test correctness of the print actions', () => {
         expect(retVal).toExist();
         expect(retVal.type).toBe(INIT_PRINT_SPEC_FROM_CONFIG);
         expect(retVal.initPrintCfgSpec).toBe(configPayload);
+    });
+    it('resetPrintSpec', () => {
+        const retVal = resetPrintSpec();
+        expect(retVal).toExist();
+        expect(retVal.type).toBe(RESET_PRINT_SPEC);
     });
 });

--- a/web/client/actions/print.js
+++ b/web/client/actions/print.js
@@ -19,6 +19,7 @@ export const PRINT_SUBMITTING = 'PRINT_SUBMITTING';
 export const PRINT_ERROR = 'PRINT_ERROR';
 export const PRINT_CREATED = 'PRINT_CREATED';
 export const PRINT_CANCEL = 'PRINT_CANCEL';
+export const INIT_PRINT_SPEC_FROM_CONFIG = "INIT_PRINT_SPEC_FROM_CONFIG";
 
 import axios from '../libs/ajax';
 
@@ -170,3 +171,13 @@ export function changeMapPrintPreview(center, zoom, bbox, size, mapStateSource, 
         resolution
     };
 }
+/**
+ * Action initializes the print specification from plugin cfg.
+ *
+ * @param {Object} configSpec - The default print specification object defined in plugin config.
+ * @returns {{type: string, initPrintCfgSpec: Object}} The action object containing the config spec.
+ */
+export const initPrintSpecFromConfig = (configSpec)=> ({
+    type: INIT_PRINT_SPEC_FROM_CONFIG,
+    initPrintCfgSpec: configSpec
+});

--- a/web/client/actions/print.js
+++ b/web/client/actions/print.js
@@ -20,6 +20,7 @@ export const PRINT_ERROR = 'PRINT_ERROR';
 export const PRINT_CREATED = 'PRINT_CREATED';
 export const PRINT_CANCEL = 'PRINT_CANCEL';
 export const INIT_PRINT_SPEC_FROM_CONFIG = "INIT_PRINT_SPEC_FROM_CONFIG";
+export const RESET_PRINT_SPEC = "RESET_PRINT_SPEC";
 
 import axios from '../libs/ajax';
 
@@ -180,4 +181,12 @@ export function changeMapPrintPreview(center, zoom, bbox, size, mapStateSource, 
 export const initPrintSpecFromConfig = (configSpec)=> ({
     type: INIT_PRINT_SPEC_FROM_CONFIG,
     initPrintCfgSpec: configSpec
+});
+/**
+ * Action to reset the print specification to its initial configured defaults.
+ * This is typically dispatched when opening map/context
+ * to ensure a clean state for the next opening.
+ */
+export const resetPrintSpec = () => ({
+    type: RESET_PRINT_SPEC
 });

--- a/web/client/epics/__tests__/print-test.js
+++ b/web/client/epics/__tests__/print-test.js
@@ -8,7 +8,7 @@
 
 import expect from 'expect';
 import {
-    addPrintTransformer, PRINT_TRANSFORMER_ADDED
+    addPrintTransformer, PRINT_TRANSFORMER_ADDED, RESET_PRINT_SPEC
 } from '../../actions/print';
 
 import {
@@ -16,10 +16,12 @@ import {
 } from '../../utils/PrintUtils';
 
 import {
-    addPrintTransformerEpic
+    addPrintTransformerEpic,
+    resetMountPrintEpic
 } from '../print';
 
 import { testEpic } from './epicTestUtils';
+import { MAP_PLUGIN_LOAD } from '../../actions/map';
 
 
 describe('Test the print epics', () => {
@@ -65,6 +67,61 @@ describe('Test the print epics', () => {
                     done(e);
                 }
             }, {}
+        );
+    });
+    it('should dispatch RESET_PRINT_SPEC if print is mounted when MAP_PLUGIN_LOAD occurs', (done) => {
+        const mockState = {
+            print: {
+                isMounted: true,
+                spec: { sheet: 'A4' }
+            }
+        };
+
+        const triggerAction = {
+            type: MAP_PLUGIN_LOAD
+        };
+
+        testEpic(
+            resetMountPrintEpic,
+            1,
+            triggerAction,
+            (actions) => {
+                try {
+                    expect(actions.length).toEqual(1);
+                    expect(actions[0].type).toEqual(RESET_PRINT_SPEC);
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            },
+            mockState
+        );
+    });
+
+    it('should NOT dispatch any action if print is NOT mounted when MAP_PLUGIN_LOAD occurs', (done) => {
+        const mockState = {
+            print: {
+                isMounted: false
+            }
+        };
+
+        const triggerAction = {
+            type: MAP_PLUGIN_LOAD
+        };
+
+        testEpic(
+            resetMountPrintEpic,
+            0,
+            triggerAction,
+            (actions) => {
+                try {
+                    expect(actions.length).toEqual(0);
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            },
+            mockState
         );
     });
 });

--- a/web/client/epics/print.js
+++ b/web/client/epics/print.js
@@ -8,8 +8,9 @@
 
 
 import Rx from 'rxjs';
-import { ADD_PRINT_TRANSFORMER, printTransformerAdded } from '../actions/print';
+import { ADD_PRINT_TRANSFORMER, printTransformerAdded, resetPrintSpec } from '../actions/print';
 import { addTransformer } from '../utils/PrintUtils';
+import { MAP_PLUGIN_LOAD } from '../actions/map';
 
 
 export const addPrintTransformerEpic = (action$) =>
@@ -18,7 +19,16 @@ export const addPrintTransformerEpic = (action$) =>
             addTransformer(action.name, action.transformer, action.position);
             return Rx.Observable.of(printTransformerAdded(action.name));
         });
+export const resetMountPrintEpic = (action$, store) =>
+    action$.ofType(MAP_PLUGIN_LOAD)
+        .switchMap(() => {
+            const state = store.getState();
+            const isPrintMounted = state.print.isMounted;
+            if (!isPrintMounted) return Rx.Observable.empty();
+            return Rx.Observable.of(resetPrintSpec());
+        });
 
 export default {
-    addPrintTransformerEpic
+    addPrintTransformerEpic,
+    resetMountPrintEpic
 };

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -32,7 +32,7 @@ import { normalizeSRS, convertDegreesToRadian } from '../utils/CoordinatesUtils'
 import { getMessageById } from '../utils/LocaleUtils';
 import { defaultGetZoomForExtent, getResolutions, mapUpdated, dpi2dpu, DEFAULT_SCREEN_DPI, getScales, reprojectZoom } from '../utils/MapUtils';
 import { getDerivedLayersVisibility, isInsideResolutionsLimits } from '../utils/LayersUtils';
-import { has, includes } from 'lodash';
+import { has, includes, isEmpty } from 'lodash';
 import {additionalLayersSelector} from "../selectors/additionallayers";
 import { MapLibraries } from '../utils/MapTypeUtils';
 import FlexBox from '../components/layout/FlexBox';
@@ -431,7 +431,7 @@ export default {
                     componentDidMount() {
                         const { initialSpecSettings, initPrintSpec } = this.props;
                         // Only dispatch if we have config and haven't initialized yet
-                        if (initialSpecSettings) {
+                        if (!isEmpty(initialSpecSettings)) {
                             initPrintSpec(initialSpecSettings);
                         }
                     }

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -18,7 +18,7 @@ import { connect } from '../utils/PluginsUtils';
 import { createSelector } from 'reselect';
 
 import { setControlProperty, toggleControl } from '../actions/controls';
-import { configurePrintMap, printError, printSubmit, printSubmitting, addPrintParameter } from '../actions/print';
+import { configurePrintMap, printError, printSubmit, printSubmitting, addPrintParameter, initPrintSpecFromConfig } from '../actions/print';
 import Message from '../components/I18N/Message';
 import Dialog from '../components/misc/Dialog';
 import printReducers from '../reducers/print';
@@ -122,6 +122,23 @@ import Portal from '../components/misc/Portal';
  * @prop {string} cfg.projectionOptions.defaultProjection default projection when the print dialog opens; should be one of the values from projections list
  * @prop {object} cfg.overlayLayersOptions options for overlay layers
  * @prop {boolean} cfg.overlayLayersOptions.enabled if true a checkbox will be shown to exclude or include overlay layers to the print
+ * @prop {Object} cfg.initialSpecSettings default settings for the print specification.
+ * These values are used to initialize the print state when the plugin loads.
+ * If not provided, safe defaults in print reducer (e.g., A4 sheet) are used.
+ * @prop {string} [cfg.initialSpecSettings.sheet='A4'] The default paper size (e.g., 'A4', 'A3', 'Letter').
+ * @prop {number} [cfg.initialSpecSettings.resolution=96] The default resolution in DPI.
+ * @prop {string} [cfg.initialSpecSettings.outputFormat='pdf'] The default output format (e.g., 'pdf', 'png').
+ * @prop {string} [cfg.initialSpecSettings.name=''] The default name for the print job.
+ * @prop {string} [cfg.initialSpecSettings.description=''] The default description for the print job.
+ * @prop {number} [cfg.initialSpecSettings.rotation=0] The default rotation angle in degrees.
+ * @prop {boolean} [cfg.initialSpecSettings.antiAliasing=true] Whether to enable anti-aliasing for the print output.
+ * @prop {number} [cfg.initialSpecSettings.iconsWidth=24] The default width for legend icons in pixels.
+ * @prop {number} [cfg.initialSpecSettings.iconsHeight=24] The default height for legend icons in pixels.
+ * @prop {number} [cfg.initialSpecSettings.legendDpi=96] The DPI setting specifically for legend rendering.
+ * @prop {string} [cfg.initialSpecSettings.fontFamily='Verdana'] The default font family for text elements.
+ * @prop {number} [cfg.initialSpecSettings.fontSize=8] The default font size in points.
+ * @prop {boolean} [cfg.initialSpecSettings.bold=false] Whether text should be bold by default.
+ * @prop {boolean} [cfg.initialSpecSettings.italic=false] Whether text should be italic by default.
  *
  * @example
  * // printing in geodetic mode
@@ -344,7 +361,9 @@ export default {
                         mergeableParams: PropTypes.object,
                         addPrintParameter: PropTypes.func,
                         printingService: PropTypes.object,
-                        printMap: PropTypes.object
+                        printMap: PropTypes.object,
+                        initialSpecSettings: PropTypes.object,
+                        initPrintSpec: PropTypes.func
                     };
 
                     static contextTypes = {
@@ -398,7 +417,8 @@ export default {
                         items: [],
                         printingService: getDefaultPrintingService(),
                         printMap: {},
-                        editScale: false
+                        editScale: false,
+                        initPrintSpec: () => {}
                     };
                     constructor(props) {
                         super(props);
@@ -408,7 +428,13 @@ export default {
                             activeAccordionPanel: 0
                         };
                     }
-
+                    componentDidMount() {
+                        const { initialSpecSettings, initPrintSpec } = this.props;
+                        // Only dispatch if we have config and haven't initialized yet
+                        if (initialSpecSettings) {
+                            initPrintSpec(initialSpecSettings);
+                        }
+                    }
                     UNSAFE_componentWillReceiveProps(nextProps) {
                         const hasBeenOpened = nextProps.open && !this.props.open;
                         const mapHasChanged = this.props.open && this.props.syncMapPreview && mapUpdated(this.props.map, nextProps.map);
@@ -740,7 +766,8 @@ export default {
                     onBeforePrint: printSubmitting,
                     setPage: setControlProperty.bind(null, 'print', 'currentPage'),
                     configurePrintMap,
-                    addPrintParameter
+                    addPrintParameter,
+                    initPrintSpec: initPrintSpecFromConfig
                 })(Print);
                 resolve(PrintPlugin);
             });

--- a/web/client/reducers/__tests__/print-test.js
+++ b/web/client/reducers/__tests__/print-test.js
@@ -19,7 +19,8 @@ import {
     PRINT_SUBMITTING,
     PRINT_CREATED,
     PRINT_ERROR,
-    PRINT_CANCEL
+    PRINT_CANCEL,
+    INIT_PRINT_SPEC_FROM_CONFIG
 } from '../../actions/print';
 
 describe('Test the print reducer', () => {
@@ -383,5 +384,37 @@ describe('Test the print reducer', () => {
         expect(state.spec.iconsWidth).toBe(24);
         expect(state.spec.iconsWidth).toBe(24);
         expect(state.spec.forceIconsSize).toBeFalsy();
+    });
+    it('should initialize spec with config values and fallback defaults', () => {
+        const configPayload = {
+            sheet: 'A3',
+            resolution: 600
+        };
+
+        const initialState = undefined;
+        const action = {
+            type: INIT_PRINT_SPEC_FROM_CONFIG,
+            initPrintCfgSpec: configPayload
+        };
+
+        const newState = print(initialState, action);
+
+        expect(newState.spec.sheet).toBe('A3');
+        expect(newState.spec.resolution).toBe(600);
+        // outputFormat -> takes init reducer value
+        expect(newState.spec.outputFormat).toBe('pdf');
+    });
+
+    it('should fall back to safe defaults if config is empty', () => {
+        const action = {
+            type: INIT_PRINT_SPEC_FROM_CONFIG,
+            initPrintCfgSpec: {}
+        };
+
+        const newState = print(undefined, action);
+
+        // Should rely entirely on SAFE_FALLBACKS defined in reducer
+        expect(newState.spec.sheet).toBe('A4');
+        expect(newState.spec.outputFormat).toBe('pdf');
     });
 });

--- a/web/client/reducers/__tests__/print-test.js
+++ b/web/client/reducers/__tests__/print-test.js
@@ -20,7 +20,8 @@ import {
     PRINT_CREATED,
     PRINT_ERROR,
     PRINT_CANCEL,
-    INIT_PRINT_SPEC_FROM_CONFIG
+    INIT_PRINT_SPEC_FROM_CONFIG,
+    RESET_PRINT_SPEC
 } from '../../actions/print';
 
 describe('Test the print reducer', () => {
@@ -416,5 +417,27 @@ describe('Test the print reducer', () => {
         // Should rely entirely on SAFE_FALLBACKS defined in reducer
         expect(newState.spec.sheet).toBe('A4');
         expect(newState.spec.outputFormat).toBe('pdf');
+    });
+    it('should reset spec to initial defaults and set isMounted to false', () => {
+        const modifiedState = {
+            isMounted: true,
+            spec: {
+                sheet: 'Letter',
+                resolution: 600,
+                name: 'My Custom Map',
+                antiAliasing: false
+            }
+        };
+        const action = {
+            type: RESET_PRINT_SPEC
+        };
+        const newState = print(modifiedState, action);
+
+        expect(newState.isMounted).toBe(false);
+
+        expect(newState.spec.sheet).toBe('A4');
+        expect(newState.spec.resolution).toBe(96);
+        expect(newState.spec.name).toBe('');
+        expect(newState.spec.antiAliasing).toBe(true);
     });
 });

--- a/web/client/reducers/__tests__/print-test.js
+++ b/web/client/reducers/__tests__/print-test.js
@@ -426,6 +426,9 @@ describe('Test the print reducer', () => {
                 resolution: 600,
                 name: 'My Custom Map',
                 antiAliasing: false
+            }, capabilities: {
+                layouts: [{ name: 'A4' }],
+                dpis: [{ value: 96 }]
             }
         };
         const action = {

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -160,8 +160,15 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
         return state;
     }
     case RESET_PRINT_SPEC: {
+        const layouts = get(state, 'capabilities.layouts', [{name: 'A4'}]);
+        const sheetName = layouts.filter(l => getSheetName(l.name) === initialSpec.sheet).length ?
+            initialSpec.sheet : getSheetName(layouts[0].name);
+        const capResolution = state.capabilities && state.capabilities.dpis
+                        && state.capabilities.dpis.length
+                        && state.capabilities.dpis[0].value;
         return Object.assign({}, state, {
-            isMounted: false, spec: Object.assign({}, state.spec || {}, {...initialSpec})
+            isMounted: false, spec: Object.assign({}, state.spec || {}, {...initialSpec, sheet: sheetName,
+                resolution: capResolution ?? initialSpec.resolution})
         });
     }
     default:

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -17,7 +17,8 @@ import {
     PRINT_SUBMITTING,
     PRINT_CREATED,
     PRINT_ERROR,
-    PRINT_CANCEL
+    PRINT_CANCEL,
+    INIT_PRINT_SPEC_FROM_CONFIG
 } from '../actions/print';
 
 import { TOGGLE_CONTROL } from '../actions/controls';
@@ -38,14 +39,15 @@ const initialSpec = {
     name: '',
     description: '',
     outputFormat: "pdf",
-    rotation: 0
+    rotation: 0,
+    sheet: 'A4'
 };
 
 const getSheetName = (name = '') => {
     return name.split('_')[0];
 };
 
-function print(state = {spec: initialSpec, capabilities: null, map: null, isLoading: false, pdfUrl: null}, action) {
+function print(state = {spec: initialSpec, capabilities: null, map: null, isLoading: false, pdfUrl: null, isMounted: false}, action) {
     switch (action.type) {
     case TOGGLE_CONTROL: {
         if (action.control === 'print') {
@@ -147,6 +149,14 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
     }
     case PRINT_CANCEL: {
         return Object.assign({}, state, {isLoading: false, pdfUrl: null, error: null});
+    }
+    case INIT_PRINT_SPEC_FROM_CONFIG: {
+        if (!state.isMounted) {
+            return Object.assign({}, state, {
+                isMounted: true, spec: Object.assign({}, state.spec || {}, {...action.initPrintCfgSpec})
+            });
+        }
+        return state;
     }
     default:
         return state;

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -18,7 +18,8 @@ import {
     PRINT_CREATED,
     PRINT_ERROR,
     PRINT_CANCEL,
-    INIT_PRINT_SPEC_FROM_CONFIG
+    INIT_PRINT_SPEC_FROM_CONFIG,
+    RESET_PRINT_SPEC
 } from '../actions/print';
 
 import { TOGGLE_CONTROL } from '../actions/controls';
@@ -157,6 +158,11 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
             });
         }
         return state;
+    }
+    case RESET_PRINT_SPEC: {
+        return Object.assign({}, state, {
+            isMounted: false, spec: Object.assign({}, state.spec || {}, {...initialSpec})
+        });
     }
     default:
         return state;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Previously, all print plugin **spec** defaults were hardcoded in the reducer's **initialSpec** object so there was no customizations to be allowable using cfg.

This PR improves the **Print plugin** by making its default specifications configurable via the plugin configuration `cfg`.
It introduces a new cfg for **Print plugin** called **'initialSpecSettings'** to allow customizations in print spec like sheet, resolution, rotation ...etc. This cfg can be used in context plugin configration.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12166 

**What is the new behavior?**

https://github.com/user-attachments/assets/0e3a07fb-5901-4694-a2c1-ccd262a192de



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
This is a sample of cfg of spec print:
```
{
  "name": "Print",
  "cfg": {
    "initialSpecSettings": {
      "sheet": "A3",
      "resolution": 300,
      "outputFormat": "pdf",
      "name": "Custom Export",
      "description": "High-resolution export"
    }
  }
}
```

Note: a state reset on reload added logic to automatically reset the print state to these defaults when the map/plugin reloads, ensuring no stale user settings persist across sessions.