### PR TITLE
Fix #11848 - linking issues on backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -30,11 +30,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.BACKPORT_ACTION_PAT }}
       - name: Create backport pull requests
-        uses: korthout/backport-action@v3
+        id: create_backport_pr
+        uses: korthout/backport-action@v4
         with:
           # Token for git actions, see https://github.com/korthout/backport-action/issues/379
           github_token: ${{ secrets.BACKPORT_ACTION_PAT }}
           auto_merge_method: squash
+          auto_merge_enabled: true
           copy_assignees: true
           copy_milestone: true
           copy_requested_reviewers: true
@@ -49,3 +51,12 @@ jobs:
             {
               "conflict_resolution": "draft_commit_conflicts"
             }
+      - name: Link all backport PRs to original issue
+        if: ${{ steps.get-issues.outputs.issues != '' && steps.create_backport_pr.outputs.created_pull_numbers != '' }}
+        run: |
+          for pr in $(echo "${{ steps.create_backport_pr.outputs.created_pull_numbers }}"); do
+            for issue in $(echo "${{ steps.get-issues.outputs.issues }}" | tr ',' ' '); do
+              echo "Linking PR #$pr to issue #$issue"
+              gh issue develop geosolutions-it/MapStore2#$issue --add-linked-pull-requests geosolutions-it/MapStore2#$pr
+            done
+          done


### PR DESCRIPTION
Not tested yet.
[backport 2026.01.xx](https://github.com/geosolutions-it/MapStore2/issues?q=state%3Aopen%20label%3A%22backport%202026.01.xx%22)  is for test only we will not merge

## Description

This connect issues when doing backport.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
