### PR TITLE
[Backport 2026.01.xx] #11589: correct urls in config.yaml to fix issue of print profiles not compatible with windows

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -112,6 +112,19 @@ With Java 17 you need to add the following lines to your `web/pom.xml` Cargo con
                 </configuration>
 ```
 
+### Updating Local File Paths in `config.yaml` for Windows Compatibility
+
+If you are using local file paths for resources (such as print headers, logos, or styles) in your `config.yaml`, you must ensure they use the `file://` protocol prefix. Relative paths or absolute paths without the protocol may fail on Windows environments.
+
+Check your config.yaml for any url properties pointing to local files within `${configDir}` or other local directories. Update them to include the `file://` prefix.
+
+For Example:
+
+```diff
+- url: '/${configDir}/print_header.png'
++ url: 'file://${configDir}/print_header.png'
+```
+
 ### Replace authenticationRules with requestsConfigurationRules
 
 As part of improving the authentication rules to make dynamic request configurations, we have deprecated the use of `authenticationRules` in favor of the new request rule configuration `requestsConfigurationRules`. The new system provides a more flexible way to configure request authentication and parameters.

--- a/java/printing/resources/geoserver/print/config.yaml
+++ b/java/printing/resources/geoserver/print/config.yaml
@@ -1272,7 +1272,7 @@ layouts:
           items:
             - !image
               maxWidth: 1105
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 837
           height: 1340
@@ -1390,7 +1390,7 @@ layouts:
           items:
             - !image
               maxWidth: 1563
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 1184
           height: 840
@@ -1490,7 +1490,7 @@ layouts:
           items:
             - !image
               maxWidth: 1105
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 1111
           height: 1340
@@ -1581,7 +1581,7 @@ layouts:
           items:
             - !image
               maxWidth: 1563
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 1600
           height: 840
@@ -1654,7 +1654,7 @@ layouts:
           items:
             - !image
               maxWidth: 1105
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 1111
           height: 1340
@@ -1782,7 +1782,7 @@ layouts:
           items:
             - !image
               maxWidth: 1563
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 1600
           height: 840


### PR DESCRIPTION
# Description
Backport of #12269 to `2026.01.xx`.

Fixes #11589