### PR TITLE
Fix #12291 Switching map projection will adjust zoom level.

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -316,7 +316,27 @@ class OpenlayersMap extends React.Component {
                     newProps.center.x,
                     newProps.center.y
                 ], 'EPSG:4326', mapProjection);
-                this.map.setView(this.createView(center, newProps.zoom, newProps.projection, newProps.mapOptions && newProps.mapOptions.view, newProps.limits));
+                let closestMatchedZoom = newProps.zoom;
+                const projectionChanged = this.props.projection !== newProps.projection;
+                if (projectionChanged) {
+                    const currentProjection = getProjection(this.props.projection);
+                    const nextProjection = getProjection(mapProjection);
+                    const currentResolution = Number.isFinite(this.props.resolution)
+                        ? this.props.resolution
+                        : this.map.getView().getResolution(); // Fall back to map resolution if not provided by props.
+                    const currentMetersPerUnit = currentProjection?.getMetersPerUnit?.() ?? 1;
+                    const nextMetersPerUnit = nextProjection?.getMetersPerUnit?.() ?? 1;
+                    const resolutionInMeters = currentResolution * currentMetersPerUnit;
+                    const newResolutions = getResolutionsForProjection(mapProjection)
+                        .map((resol) => resol * nextMetersPerUnit)
+                        .filter(Number.isFinite);
+                    if (Number.isFinite(resolutionInMeters) && newResolutions.length > 0) {
+                        closestMatchedZoom = newResolutions.reduce((zoom, resol, reIndex) => {
+                            return Math.abs(resol - resolutionInMeters) < Math.abs(newResolutions[zoom] - resolutionInMeters) ? reIndex : zoom;
+                        }, 0);
+                    }
+                }
+                this.map.setView(this.createView(center, closestMatchedZoom, newProps.projection, newProps.mapOptions && newProps.mapOptions.view, newProps.limits));
                 this.props.onResolutionsChange(this.getResolutions());
             }
             // We have to force ol to drop tile and reload

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -14,7 +14,7 @@ import OpenlayersMap from '../Map';
 import { DEFAULT_INTERACTION_OPTIONS } from '../../../../utils/openlayers/DrawUtils';
 
 import proj from 'proj4';
-import MapUtils from '../../../../utils/MapUtils';
+import MapUtils, {getResolutionsForProjection} from '../../../../utils/MapUtils';
 
 import '../../../../utils/openlayers/Layers';
 import '../plugins/OSMLayer';
@@ -650,6 +650,41 @@ describe('OpenlayersMap', () => {
         expect(secondView.length).toBe(4);
         expect(firstView[0].toFixed(0)).toNotEqual(secondView[0].toFixed(0));
 
+    });
+
+    it('matches closest zoom on projection change', () => {
+        const targetProjection = 'EPSG:4326';
+        let map = ReactDOM.render(
+            <OpenlayersMap
+                projection="EPSG:3857"
+                center={{y: 43.9, x: 10.3}}
+                zoom={20} // Note: used high zoom so that the expected zoom should be calculated to return the same
+            />,
+            document.getElementById("map")
+        );
+
+        const currentResolution = map.map.getView().getResolution();
+        const currentMetersPerUnit = get('EPSG:3857')?.getMetersPerUnit?.() ?? 1;
+        const targetMetersPerUnit = get(targetProjection)?.getMetersPerUnit?.() ?? 1;
+        const resolutionInMeters = currentResolution * currentMetersPerUnit;
+        const targetResolutions = getResolutionsForProjection(targetProjection)
+            .map((resol) => resol * targetMetersPerUnit)
+            .filter(Number.isFinite);
+        const expectedZoom = targetResolutions.reduce((zoom, resol, reIndex) => {
+            return Math.abs(resol - resolutionInMeters) < Math.abs(targetResolutions[zoom] - resolutionInMeters) ? reIndex : zoom;
+        }, 0);
+
+        map = ReactDOM.render(
+            <OpenlayersMap
+                projection={targetProjection}
+                center={{y: 43.9, x: 10.3}}
+                zoom={20}
+            />,
+            document.getElementById("map")
+        );
+
+        expect(map.map.getView().getProjection().getCode()).toBe(targetProjection);
+        expect(map.map.getView().getZoom()).toBe(expectedZoom);
     });
 
     it('check result of "haveResolutionsChanged()" when receiving new props', () => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds following:

It calculate a best fit zoom level by :

1. Getting resolutions pyramid for old projection along with resolution.
2. Getting resolutions pyramid for new projection, and find the index (zoom) of the resolution/scale most similar to the old one.
3. Finally using the new zoom for the view to ensure alignment between resolution and scale.


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12291 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

- When user now change the map projection a best fit zoom level is calculated to prevent significant jumps. 

https://github.com/user-attachments/assets/4b5fa8d2-19e6-4b22-9713-04e2878d181c


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
