### PR TITLE
fix #12094: fix link popup widget in map layer TOC widget

### DIFF
--- a/web/client/plugins/WidgetsBuilder.jsx
+++ b/web/client/plugins/WidgetsBuilder.jsx
@@ -135,7 +135,7 @@ const WidgetsBuilderButton = connect((state) => ({ available: widgetBuilderAvail
                 {...props}
                 glyph="widgets"
                 tooltipId={'toc.createWidget'}
-                onClick={() => layer?.error ? onClick({ mapSync: false, owner: 'toc' }) : onClick({owner: 'toc'})} // allows anyway to create a widget, not connected to map
+                onClick={() => layer?.error ? onClick({ mapSync: false }) : onClick()} // allows anyway to create a widget, not connected to map
             />
         );
     }

--- a/web/client/plugins/WidgetsBuilder.jsx
+++ b/web/client/plugins/WidgetsBuilder.jsx
@@ -89,6 +89,7 @@ class SideBarComponent extends React.Component {
                      enabled={this.props.enabled}
                      onClose={this.props.onClose}
                      typeFilter={({ type } = {}) => type !== 'map' && type !== 'legend'}
+                     linkModalDirection={"left"}
                  />
              </DockPanel>);
 
@@ -134,7 +135,7 @@ const WidgetsBuilderButton = connect((state) => ({ available: widgetBuilderAvail
                 {...props}
                 glyph="widgets"
                 tooltipId={'toc.createWidget'}
-                onClick={() => layer?.error ? onClick({ mapSync: false }) : onClick()} // allows anyway to create a widget, not connected to map
+                onClick={() => layer?.error ? onClick({ mapSync: false, owner: 'toc' }) : onClick({owner: 'toc'})} // allows anyway to create a widget, not connected to map
             />
         );
     }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes link popup wrong position in TOC layer text widget.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
(https://github.com/geosolutions-it/MapStore2/issues/12094#issuecomment-4295090014)

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
<img width="692" height="870" alt="image" src="https://github.com/user-attachments/assets/c81fd737-d88f-41d8-bdf7-c3f9fc1a0a66" />



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
