### PR TITLE
[Backport 2026.01.xx] fix #12094: fix link popup widget in map layer TOC widget

### DIFF
--- a/web/client/plugins/WidgetsBuilder.jsx
+++ b/web/client/plugins/WidgetsBuilder.jsx
@@ -89,6 +89,7 @@ class SideBarComponent extends React.Component {
                      enabled={this.props.enabled}
                      onClose={this.props.onClose}
                      typeFilter={({ type } = {}) => type !== 'map' && type !== 'legend'}
+                     linkModalDirection={"left"}
                  />
              </DockPanel>);
 


### PR DESCRIPTION
# Description
Backport of #12294 to `2026.01.xx`.

Fixes #12094