### PR TITLE
 Fix #12302: Disable cropping WMS layers to map projection extent.

### DIFF
--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -259,11 +259,13 @@ export default class extends React.Component {
                             {(this.props.element?.serverType !== ServerTypes.NO_VENDOR && (
                                 <>
                                     <hr/>
-                                    <Checkbox key="cropToProjectionExtent" value="cropToProjectionExtent"
+                                    {!this.props.isCesiumActive && <Checkbox
+                                        disabled={!!this.props.element.singleTile}
+                                        key="cropToProjectionExtent" value="cropToProjectionExtent"
                                         checked={this.props.element && (this.props.element.cropToProjectionExtent !== undefined ? this.props.element.cropToProjectionExtent : true )}
                                         onChange={(e) => this.props.onChange("cropToProjectionExtent", e.target.checked)}>
-                                        <Message msgId="layerProperties.cropToProjectionExtent"/>
-                                    </Checkbox>
+                                        <Message msgId="layerProperties.cropToProjectionExtent.label" />&nbsp;<InfoPopover text={<Message msgId="layerProperties.cropToProjectionExtent.tooltip" />} />
+                                    </Checkbox>}
                                     <WMSCacheOptions
                                         layer={this.props.element}
                                         projection={this.props.projection}

--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -259,6 +259,11 @@ export default class extends React.Component {
                             {(this.props.element?.serverType !== ServerTypes.NO_VENDOR && (
                                 <>
                                     <hr/>
+                                    <Checkbox key="cropToProjectionExtent" value="cropToProjectionExtent"
+                                        checked={this.props.element && (this.props.element.cropToProjectionExtent !== undefined ? this.props.element.cropToProjectionExtent : true )}
+                                        onChange={(e) => this.props.onChange("cropToProjectionExtent", e.target.checked)}>
+                                        <Message msgId="layerProperties.cropToProjectionExtent"/>
+                                    </Checkbox>
                                     <WMSCacheOptions
                                         layer={this.props.element}
                                         projection={this.props.projection}

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -14,6 +14,7 @@ import GET_CAP_RESPONSE from 'raw-loader!../../../../../test-resources/wms/GetCa
 import Display from '../Display';
 import MockAdapter from "axios-mock-adapter";
 import axios from "../../../../../libs/ajax";
+import { ServerTypes } from '../../../../../utils/LayersUtils';
 let mockAxios;
 describe('test Layer Properties Display module component', () => {
     beforeEach((done) => {
@@ -194,6 +195,111 @@ describe('test Layer Properties Display module component', () => {
         ReactDOM.render(<Display isLocalizedLayerStylesEnabled element={l} settings={settings}/>, document.getElementById("container"));
         const isLocalizedLayerStylesOption = document.querySelector('[data-qa="display-lacalized-layer-styles-option"]');
         expect(isLocalizedLayerStylesOption).toBeTruthy();
+    });
+
+    it('tests Display component renders crop to projection extent enabled by default', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const settings = {
+            options: { opacity: 0.7 }
+        };
+
+        ReactDOM.render(<Display element={l} settings={settings}/>, document.getElementById("container"));
+        const cropToProjectionExtentInput = document.querySelector("input[value='cropToProjectionExtent']");
+        expect(cropToProjectionExtentInput).toBeTruthy();
+        expect(cropToProjectionExtentInput.checked).toBeTruthy();
+        expect(cropToProjectionExtentInput.disabled).toBeFalsy();
+    });
+
+    it('tests Display component triggers crop to projection extent change', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const settings = {
+            options: { opacity: 0.7 }
+        };
+        const handlers = {
+            onChange() {}
+        };
+        const spy = expect.spyOn(handlers, 'onChange');
+
+        ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        const cropToProjectionExtentInput = document.querySelector("input[value='cropToProjectionExtent']");
+        expect(cropToProjectionExtentInput).toBeTruthy();
+
+        cropToProjectionExtentInput.checked = false;
+        ReactTestUtils.Simulate.change(cropToProjectionExtentInput);
+        expect(spy).toHaveBeenCalled();
+        expect(spy.calls[0].arguments[0]).toBe('cropToProjectionExtent');
+        expect(spy.calls[0].arguments[1]).toBe(false);
+    });
+
+    it('tests Display component disables crop to projection extent when singleTile is true', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            singleTile: true,
+            url: 'fakeurl'
+        };
+        const settings = {
+            options: { opacity: 0.7 }
+        };
+
+        ReactDOM.render(<Display element={l} settings={settings}/>, document.getElementById("container"));
+        const cropToProjectionExtentInput = document.querySelector("input[value='cropToProjectionExtent']");
+        expect(cropToProjectionExtentInput).toBeTruthy();
+        expect(cropToProjectionExtentInput.disabled).toBeTruthy();
+    });
+
+    it('tests Display component hides crop to projection extent in cesium mode', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const settings = {
+            options: { opacity: 0.7 }
+        };
+
+        ReactDOM.render(<Display element={l} settings={settings} isCesiumActive/>, document.getElementById("container"));
+        const cropToProjectionExtentInput = document.querySelector("input[value='cropToProjectionExtent']");
+        expect(cropToProjectionExtentInput).toBeFalsy();
+    });
+
+    it('tests Display component hides crop to projection extent for no vendor server type', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            serverType: ServerTypes.NO_VENDOR,
+            url: 'fakeurl'
+        };
+        const settings = {
+            options: { opacity: 0.7 }
+        };
+
+        ReactDOM.render(<Display element={l} settings={settings}/>, document.getElementById("container"));
+        const cropToProjectionExtentInput = document.querySelector("input[value='cropToProjectionExtent']");
+        expect(cropToProjectionExtentInput).toBeFalsy();
     });
 
 

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -75,7 +75,7 @@ describe('test Layer Properties Display module component', () => {
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toBeTruthy();
-        expect(inputs.length).toBe(14);
+        expect(inputs.length).toBe(15);
         ReactTestUtils.Simulate.focus(inputs[2]);
         expect(inputs[2].value).toBe('70');
         inputs[8].click();
@@ -103,7 +103,7 @@ describe('test Layer Properties Display module component', () => {
         expect(comp).toBeTruthy();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toBeTruthy();
-        expect(inputs.length).toBe(13);
+        expect(inputs.length).toBe(14);
         ReactTestUtils.Simulate.focus(inputs[2]);
         expect(inputs[2].value).toBe('70');
         inputs[8].click();
@@ -321,12 +321,11 @@ describe('test Layer Properties Display module component', () => {
         const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "control-label" );
-        const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
-        const legendWidth = inputs[12];
-        const legendHeight = inputs[13];
+        const legendWidth = document.querySelector(".legend-options input[name='legendWidth']");
+        const legendHeight = document.querySelector(".legend-options input[name='legendHeight']");
         // Default legend values
-        expect(legendWidth.value).toBe('12');
-        expect(legendHeight.value).toBe('12');
+        expect(legendWidth).toBeTruthy();
+        expect(legendHeight).toBeTruthy();
         expect(labels.length).toBe(8);
         expect(labels[4].innerText).toBe("layerProperties.legendOptions.title");
         expect(labels[5].innerText).toBe("layerProperties.legendOptions.legendWidth");
@@ -351,12 +350,11 @@ describe('test Layer Properties Display module component', () => {
         const comp = ReactDOM.render(<Display element={l} hideInteractiveLegendOption settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
         const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "control-label" );
-        const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
-        const legendWidth = inputs[11];
-        const legendHeight = inputs[12];
+        const legendWidth = document.querySelector(".legend-options input[name='legendWidth']");
+        const legendHeight = document.querySelector(".legend-options input[name='legendHeight']");
         // Default legend values
-        expect(legendWidth.value).toBe('12');
-        expect(legendHeight.value).toBe('12');
+        expect(legendWidth).toBeTruthy();
+        expect(legendHeight).toBeTruthy();
         expect(labels.length).toBe(8);
         expect(labels[4].innerText).toBe("layerProperties.legendOptions.title");
         expect(labels[5].innerText).toBe("layerProperties.legendOptions.legendWidth");
@@ -388,14 +386,14 @@ describe('test Layer Properties Display module component', () => {
         let spy = expect.spyOn(handlers, "onChange");
         const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
-        const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         const legendPreview = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "legend-preview" );
         expect(legendPreview).toBeTruthy();
-        expect(inputs).toBeTruthy();
-        expect(inputs.length).toBe(14);
-        let interactiveLegendConfig = inputs[10];
-        let legendWidth = inputs[12];
-        let legendHeight = inputs[13];
+        let interactiveLegendConfig = document.querySelector(".legend-options input[data-qa='display-interactive-legend-option']");
+        let legendWidth = document.querySelector(".legend-options input[name='legendWidth']");
+        let legendHeight = document.querySelector(".legend-options input[name='legendHeight']");
+        expect(interactiveLegendConfig).toBeTruthy();
+        expect(legendWidth).toBeTruthy();
+        expect(legendHeight).toBeTruthy();
         const img = ReactTestUtils.scryRenderedDOMComponentsWithTag(comp, 'img');
 
         // Check value in img src
@@ -464,11 +462,12 @@ describe('test Layer Properties Display module component', () => {
         };
         const comp = ReactDOM.render(<Display element={l} settings={settings}/>, document.getElementById("container"));
         expect(comp).toBeTruthy();
-        const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
-        expect(inputs).toBeTruthy();
-        expect(inputs.length).toBe(14);
-        expect(inputs[12].value).toBe("20");
-        expect(inputs[13].value).toBe("40");
+        const legendWidth = document.querySelector(".legend-options input[name='legendWidth']");
+        const legendHeight = document.querySelector(".legend-options input[name='legendHeight']");
+        expect(legendWidth).toBeTruthy();
+        expect(legendHeight).toBeTruthy();
+        expect(legendWidth.value).toBe("20");
+        expect(legendHeight.value).toBe("40");
     });
     it('tests wfs Layer Properties Legend component events', () => {
         const l = {

--- a/web/client/components/background/BackgroundDialog.jsx
+++ b/web/client/components/background/BackgroundDialog.jsx
@@ -20,13 +20,14 @@ import uuidv1 from 'uuid/v1';
 import {pick, omit, get, keys, isNumber, isBoolean} from 'lodash';
 import Message from '../I18N/Message';
 import ResizableModal from '../misc/ResizableModal';
-import {Form, FormGroup, ControlLabel, FormControl, Glyphicon} from 'react-bootstrap';
+import {Form, FormGroup, ControlLabel, FormControl, Glyphicon, Checkbox} from 'react-bootstrap';
 import ButtonRB from '../misc/Button';
 import Thumbnail from '../maps/forms/Thumbnail';
 import WMSCacheOptions from '../TOC/fragments/settings/WMSCacheOptions';
 import { ServerTypes } from '../../utils/LayersUtils';
 import {getMessageById} from '../../utils/LocaleUtils';
 import tooltip from '../misc/enhancers/tooltip';
+import InfoPopover from '../widgets/widget/InfoPopover';
 const Button = tooltip(ButtonRB);
 const Editor = localizedProps("placeholder")(WYSIWYGEditor);
 
@@ -56,7 +57,8 @@ export default class BackgroundDialog extends React.Component {
         parameterTypeOptions: PropTypes.array,
         booleanOptions: PropTypes.array,
         projection: PropTypes.string,
-        disableTileGrids: PropTypes.bool
+        disableTileGrids: PropTypes.bool,
+        disableCropToProjectionExtent: PropTypes.bool
     };
 
     static contextTypes = {
@@ -177,6 +179,13 @@ export default class BackgroundDialog extends React.Component {
                     />
                 </FormGroup>
                 {this.renderStyleSelector()}
+                {!this.props.disableCropToProjectionExtent && <Checkbox
+                    disabled={!!this.props.layer.singleTile}
+                    key="cropToProjectionExtent" value="cropToProjectionExtent"
+                    checked={({ ...this.props.layer, ...this.state }.cropToProjectionExtent ?? true)}
+                    onChange={(e) => this.setState({ cropToProjectionExtent: e.target.checked })}>
+                    <Message msgId="layerProperties.cropToProjectionExtent.label" />&nbsp;<InfoPopover text={<Message msgId="layerProperties.cropToProjectionExtent.tooltip" />} />
+                </Checkbox>}
                 {this.props.layer?.serverType !== ServerTypes.NO_VENDOR && <FormGroup>
                     <WMSCacheOptions
                         layer={{ ...this.props.layer, ...this.state }}

--- a/web/client/components/background/BackgroundSelector.jsx
+++ b/web/client/components/background/BackgroundSelector.jsx
@@ -51,6 +51,7 @@ function BackgroundSelector({
     backgroundAdded,
     onUpdateThumbnail,
     disableTileGrids,
+    disableCropToProjectionExtent,
     backgroundList,
     enableTerrainList,
     alwaysVisible,
@@ -184,6 +185,7 @@ function BackgroundSelector({
                 updateThumbnail={onUpdateThumbnail}
                 projection={projection}
                 disableTileGrids={disableTileGrids}
+                disableCropToProjectionExtent={disableCropToProjectionExtent}
                 {...backgroundDialogParams}
                 {...modalParams}
             />}

--- a/web/client/components/background/__tests__/BackgroundDialog-test.jsx
+++ b/web/client/components/background/__tests__/BackgroundDialog-test.jsx
@@ -84,7 +84,7 @@ describe('test BackgroundDialog', () => {
         expect(wmsCacheOptionsToolbar).toBeTruthy();
     });
 
-    it.only('should render crop to projection checkbox enabled and checked by default', () => {
+    it('should render crop to projection checkbox enabled and checked by default', () => {
         ReactDOM.render(<BackgroundDialog
             layer={{
                 type: 'wms',
@@ -100,7 +100,7 @@ describe('test BackgroundDialog', () => {
         expect(cropToProjectionExtent.checked).toBe(true);
     });
 
-    it.only('should not render crop to projection checkbox when disabled via props', () => {
+    it('should not render crop to projection checkbox when disabled via props', () => {
         ReactDOM.render(<BackgroundDialog
             disableCropToProjectionExtent
             layer={{
@@ -115,7 +115,7 @@ describe('test BackgroundDialog', () => {
         expect(cropToProjectionExtent).toBeFalsy();
     });
 
-    it.only('should save cropToProjectionExtent as false when unchecked', () => {
+    it('should save cropToProjectionExtent as false when unchecked', () => {
         const actions = {
             updateThumbnail: () => {},
             onSave: () => {}

--- a/web/client/components/background/__tests__/BackgroundDialog-test.jsx
+++ b/web/client/components/background/__tests__/BackgroundDialog-test.jsx
@@ -83,4 +83,64 @@ describe('test BackgroundDialog', () => {
         const wmsCacheOptionsToolbar = document.querySelector('.ms-wms-cache-options-toolbar');
         expect(wmsCacheOptionsToolbar).toBeTruthy();
     });
+
+    it.only('should render crop to projection checkbox enabled and checked by default', () => {
+        ReactDOM.render(<BackgroundDialog
+            layer={{
+                type: 'wms',
+                url: '/geoserver/wms',
+                name: 'workspace:name'
+            }}
+        />,
+        document.getElementById("container"));
+
+        const cropToProjectionExtent = document.querySelector('input[value="cropToProjectionExtent"]');
+        expect(cropToProjectionExtent).toBeTruthy();
+        expect(cropToProjectionExtent.disabled).toBe(false);
+        expect(cropToProjectionExtent.checked).toBe(true);
+    });
+
+    it.only('should not render crop to projection checkbox when disabled via props', () => {
+        ReactDOM.render(<BackgroundDialog
+            disableCropToProjectionExtent
+            layer={{
+                type: 'wms',
+                url: '/geoserver/wms',
+                name: 'workspace:name'
+            }}
+        />,
+        document.getElementById("container"));
+
+        const cropToProjectionExtent = document.querySelector('input[value="cropToProjectionExtent"]');
+        expect(cropToProjectionExtent).toBeFalsy();
+    });
+
+    it.only('should save cropToProjectionExtent as false when unchecked', () => {
+        const actions = {
+            updateThumbnail: () => {},
+            onSave: () => {}
+        };
+        const onSaveSpy = expect.spyOn(actions, 'onSave');
+
+        ReactDOM.render(<BackgroundDialog
+            layer={{
+                type: 'wms',
+                url: '/geoserver/wms',
+                name: 'workspace:name'
+            }}
+            updateThumbnail={actions.updateThumbnail}
+            onSave={actions.onSave}
+        />,
+        document.getElementById("container"));
+
+        const cropToProjectionExtent = document.querySelector('input[value="cropToProjectionExtent"]');
+        expect(cropToProjectionExtent).toBeTruthy();
+        TestUtils.Simulate.change(cropToProjectionExtent, { target: { checked: false } });
+
+        const saveButton = document.querySelector('.modal-footer .btn');
+        TestUtils.Simulate.click(saveButton);
+
+        expect(onSaveSpy).toHaveBeenCalled();
+        expect(onSaveSpy.calls[0].arguments[0].cropToProjectionExtent).toBe(false);
+    });
 });

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -108,6 +108,14 @@ export default ({
                 <Message msgId="layerProperties.singleTile" />&nbsp;<InfoPopover text={<Message msgId="catalog.singleTile.tooltip" />} />
             </Checkbox>
         </FormGroup>}
+        {!isNil(service.type) && service.type === "wms" && <FormGroup controlId="cropToProjectionExtent" key="cropToProjectionExtent">
+            <Checkbox
+                disabled={!!service?.layerOptions?.singleTile}
+                onChange={(e) => onChangeServiceProperty("layerOptions", { ...service.layerOptions, cropToProjectionExtent: e.target.checked })}
+                checked={!isNil(service?.layerOptions?.cropToProjectionExtent) ? service.layerOptions.cropToProjectionExtent : true}>
+                <Message msgId="layerProperties.cropToProjectionExtent.label" />&nbsp;<InfoPopover text={<Message msgId="layerProperties.cropToProjectionExtent.tooltip" />} />
+            </Checkbox>
+        </FormGroup>}
         {(!isNil(service.type) ? (service.type === "csw" && !service.excludeShowTemplate) : false) && (<FormGroup controlId="metadata-template" key="metadata-template" className="metadata-template-editor">
             <Checkbox
                 onChange={() => onToggleTemplate()}

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -33,7 +33,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
-        expect(fields.length).toBe(14);
+        expect(fields.length).toBe(15);
         // check disabled refresh button
 
     });
@@ -42,7 +42,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
-        expect(fields.length).toBe(12);
+        expect(fields.length).toBe(13);
         const refreshButton = document.querySelectorAll('button')[0];
         expect(refreshButton).toBeTruthy();
         expect(refreshButton.disabled).toBe(false);
@@ -222,7 +222,7 @@ describe('Test Raster advanced settings', () => {
         />, document.getElementById("container"));
         const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingsPanel).toBeTruthy();
-        const formGroup = document.querySelectorAll('.form-group')[6];
+        const formGroup = document.querySelectorAll('.form-group')[7];
         expect(formGroup.textContent.trim()).toBe('layerProperties.useCacheOptionInfo.label');
         const useCacheOption = formGroup.querySelector('input[type="checkbox"]');
         expect(useCacheOption).toBeTruthy();

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -1825,6 +1825,63 @@ describe('Openlayers layer', () => {
         // this prevents old cache to be rendered while loading
         expect(spy).toHaveBeenCalled();
     });
+    it('wms layer is recreated when cropToProjectionExtent changes', () => {
+        const options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms",
+            "cropToProjectionExtent": true
+        };
+        // create initial layer
+        let layer = ReactDOM.render(
+            <OpenlayersLayer type="wms" options={options} map={map} />,
+            document.getElementById("container")
+        );
+        expect(layer).toBeTruthy();
+        expect(map.getLayers().getLength()).toBe(1);
+        const originalSource = map.getLayers().item(0).getSource();
+
+        // update with cropToProjectionExtent: false — must trigger layer recreation
+        layer = ReactDOM.render(
+            <OpenlayersLayer type="wms" options={{ ...options, cropToProjectionExtent: false }} map={map} />,
+            document.getElementById("container")
+        );
+        expect(map.getLayers().getLength()).toBe(1);
+        // a new source is created when the layer is recreated
+        expect(map.getLayers().item(0).getSource()).toNotBe(originalSource);
+    });
+
+    it('wms layer is recreated when cropToProjectionExtent is re-enabled', () => {
+        const options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms",
+            "cropToProjectionExtent": false
+        };
+        // create layer with cropToProjectionExtent disabled
+        let layer = ReactDOM.render(
+            <OpenlayersLayer type="wms" options={options} map={map} />,
+            document.getElementById("container")
+        );
+        expect(layer).toBeTruthy();
+        expect(map.getLayers().getLength()).toBe(1);
+        const originalSource = map.getLayers().item(0).getSource();
+
+        // re-enable cropToProjectionExtent — must trigger layer recreation
+        layer = ReactDOM.render(
+            <OpenlayersLayer type="wms" options={{ ...options, cropToProjectionExtent: true }} map={map} />,
+            document.getElementById("container")
+        );
+        expect(map.getLayers().getLength()).toBe(1);
+        expect(map.getLayers().item(0).getSource()).toNotBe(originalSource);
+    });
+
     it('dimensions triggers params change', () => {
         // this tests if dimension parameter changes, this triggers updateParams
         var options = {

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -94,7 +94,6 @@ const loadFunction = (options, headers) => function(image, src) {
 };
 
 const createLayer = (options, map, mapId) => {
-    console.log(options, 'options');
     // the useForElevation in wms types will be deprecated
     // as support for existing configuration
     // we can use this fallback
@@ -176,6 +175,7 @@ const createLayer = (options, map, mapId) => {
 
 const mustCreateNewLayer = (oldOptions, newOptions) => {
     return (oldOptions.singleTile !== newOptions.singleTile
+        || oldOptions.cropToProjectionExtent !== newOptions.cropToProjectionExtent
         || oldOptions.securityToken !== newOptions.securityToken
         || oldOptions.ratio !== newOptions.ratio
         // no way to remove attribution when credits are removed, so have re-create the layer is needed. Seems to be solved in OL v5.3.0, due to the ol commit 9b8232f65b391d5d381d7a99a7cd070fc36696e9 (https://github.com/openlayers/openlayers/pull/7329)
@@ -195,8 +195,6 @@ const mustCreateNewLayer = (oldOptions, newOptions) => {
 Layers.registerType('wms', {
     create: createLayer,
     update: (layer, newOptions, oldOptions, map) => {
-        console.log(newOptions, "newOptions");
-        console.log(oldOptions, "oldOptions");
         const newIsVector = isVectorFormat(newOptions.format);
 
         if (mustCreateNewLayer(oldOptions, newOptions)) {
@@ -283,7 +281,6 @@ Layers.registerType('wms', {
             }
 
             if (changed) {
-                console.log("Params has to be changed");
                 const params = Object.assign(newParams, addAuthenticationToSLD(optionsToVendorParams(newOptions) || {}, newOptions));
 
                 wmsSource.updateParams(Object.assign(params, Object.keys(oldParams || {}).reduce((previous, key) => {

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -94,6 +94,7 @@ const loadFunction = (options, headers) => function(image, src) {
 };
 
 const createLayer = (options, map, mapId) => {
+    console.log(options, 'options');
     // the useForElevation in wms types will be deprecated
     // as support for existing configuration
     // we can use this fallback
@@ -108,7 +109,6 @@ const createLayer = (options, map, mapId) => {
     queryParameters = addAuthenticationParameter(urls[0] || '', queryParameters, options.securityToken, options.security?.sourceId);
     const headers = getAuthenticationHeaders(urls[0], options.securityToken, options.security);
     const vectorFormat = isVectorFormat(options.format);
-
     if (options.singleTile && !vectorFormat) {
         return new ImageLayer({
             msId: options.id,
@@ -195,6 +195,8 @@ const mustCreateNewLayer = (oldOptions, newOptions) => {
 Layers.registerType('wms', {
     create: createLayer,
     update: (layer, newOptions, oldOptions, map) => {
+        console.log(newOptions, "newOptions");
+        console.log(oldOptions, "oldOptions");
         const newIsVector = isVectorFormat(newOptions.format);
 
         if (mustCreateNewLayer(oldOptions, newOptions)) {
@@ -249,7 +251,7 @@ Layers.registerType('wms', {
             }
             oldParams = wmsToOpenlayersOptions(oldOptions);
             newParams = wmsToOpenlayersOptions(newOptions);
-            changed = changed || ["LAYERS", "STYLES", "FORMAT", "TRANSPARENT", "TILED", "VERSION", "_v_", "CQL_FILTER", "SLD", "VIEWPARAMS"].reduce((found, param) => {
+            changed = changed || ["LAYERS", "STYLES", "FORMAT", "TRANSPARENT", "TILED", "VERSION", "_v_", "CQL_FILTER", "SLD", "VIEWPARAMS", "SRS", "CRS"].reduce((found, param) => {
                 if (oldParams[param] !== newParams[param]) {
                     return true;
                 }
@@ -281,6 +283,7 @@ Layers.registerType('wms', {
             }
 
             if (changed) {
+                console.log("Params has to be changed");
                 const params = Object.assign(newParams, addAuthenticationToSLD(optionsToVendorParams(newOptions) || {}, newOptions));
 
                 wmsSource.updateParams(Object.assign(params, Object.keys(oldParams || {}).reduce((previous, key) => {

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -85,18 +85,7 @@
   "userSessions": {
     "enabled": true
   },
-  "projectionDefs": [
-    {
-      "code": "EPSG:32633",
-      "def": "+proj=utm +zone=33 +datum=WGS84 +units=m +no_defs +type=crs",
-      "extent": [
-          166021.44, 0.0, 833978.56, 9329005.18
-      ],
-      "worldExtent": [
-          12.0, 0.0, 18.0, 84.0
-      ]
-    }
-  ],
+  "projectionDefs": [],
   "initialState": {
     "defaultState": {
       "catalog": {
@@ -565,15 +554,7 @@
           }
         }
       },
-       {
-  "name": "Print",
-  "cfg": {
-      "projectionOptions": {
-          "availableProjections": [{"name": "EPSG:32633", "value": "EPSG:32633"}, {"name": "EPSG:3857", "value": "EPSG:3857"}, {"name": "EPSG:4326", "value": "EPSG:4326"}],
-         "defaultProjection": "EPSG:32633"
-      }
-    }
- },
+      "Print",
       "MapImport",
       {
         "name": "MapExport"
@@ -609,7 +590,7 @@
       {
         "name": "CRSSelector",
         "cfg": {
-          "allowedRoles": ["ALL"],
+          "allowedRoles": ["ADMIN"],
           "availableProjections": [
             { "value": "EPSG:4326", "label": "EPSG:4326" },
             { "value": "EPSG:3857", "label": "EPSG:3857" }

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -85,7 +85,18 @@
   "userSessions": {
     "enabled": true
   },
-  "projectionDefs": [],
+  "projectionDefs": [
+    {
+      "code": "EPSG:32633",
+      "def": "+proj=utm +zone=33 +datum=WGS84 +units=m +no_defs +type=crs",
+      "extent": [
+          166021.44, 0.0, 833978.56, 9329005.18
+      ],
+      "worldExtent": [
+          12.0, 0.0, 18.0, 84.0
+      ]
+    }
+  ],
   "initialState": {
     "defaultState": {
       "catalog": {
@@ -554,7 +565,15 @@
           }
         }
       },
-      "Print",
+       {
+  "name": "Print",
+  "cfg": {
+      "projectionOptions": {
+          "availableProjections": [{"name": "EPSG:32633", "value": "EPSG:32633"}, {"name": "EPSG:3857", "value": "EPSG:3857"}, {"name": "EPSG:4326", "value": "EPSG:4326"}],
+         "defaultProjection": "EPSG:32633"
+      }
+    }
+ },
       "MapImport",
       {
         "name": "MapExport"
@@ -590,7 +609,7 @@
       {
         "name": "CRSSelector",
         "cfg": {
-          "allowedRoles": ["ADMIN"],
+          "allowedRoles": ["ALL"],
           "availableProjections": [
             { "value": "EPSG:4326", "label": "EPSG:4326" },
             { "value": "EPSG:3857", "label": "EPSG:3857" }

--- a/web/client/epics/__tests__/pendingChanges-test.js
+++ b/web/client/epics/__tests__/pendingChanges-test.js
@@ -78,7 +78,7 @@ describe('comparePendingChanges', () => {
                         "hidden": false,
                         "params": {},
                         "expanded": false,
-                        "cropToProjectionExtent": true
+                        "cropToProjectionExtent": undefined
                     }
                 ],
                 "groups": [],

--- a/web/client/epics/__tests__/pendingChanges-test.js
+++ b/web/client/epics/__tests__/pendingChanges-test.js
@@ -77,7 +77,8 @@ describe('comparePendingChanges', () => {
                         "useForElevation": false,
                         "hidden": false,
                         "params": {},
-                        "expanded": false
+                        "expanded": false,
+                        "cropToProjectionExtent": true
                     }
                 ],
                 "groups": [],

--- a/web/client/plugins/BackgroundSelector.jsx
+++ b/web/client/plugins/BackgroundSelector.jsx
@@ -82,6 +82,7 @@ const backgroundSelector = createSelector([
     allowDeletion,
     projection,
     disableTileGrids: !!isCesiumViewer,
+    disableCropToProjectionExtent: !!isCesiumViewer,
     enableTerrainList: !!isCesiumViewer,
     canEdit: !!(mode !== 'mobile' && mapIsEditable !== false)
 }));

--- a/web/client/translations/data.ca-ES.json
+++ b/web/client/translations/data.ca-ES.json
@@ -75,7 +75,10 @@
       "style": "Estil",
       "transparent": "Transparent",
       "singleTile": "Mosaic \u00fanic",
-      "cropToProjectionExtent": "Retallar a l'extensió de projecció",
+      "cropToProjectionExtent": {
+        "label": "Retallar a l'extensió de la projecció",
+        "tooltip": "La capa es retalla a l'extensió de la projecció quan s'afegeix al mapa amb aquesta opció activada"
+      },
       "cached": "Utilitzeu opcions de mem\u00f2ria cau",
       "styleCustom": "Utilitzeu l'estil anomenat \"{value}\"",
       "styleListLoadError": "Hi va haver un error en carregar la llista d'estils",

--- a/web/client/translations/data.ca-ES.json
+++ b/web/client/translations/data.ca-ES.json
@@ -75,6 +75,7 @@
       "style": "Estil",
       "transparent": "Transparent",
       "singleTile": "Mosaic \u00fanic",
+      "cropToProjectionExtent": "Retallar a l'extensió de projecció",
       "cached": "Utilitzeu opcions de mem\u00f2ria cau",
       "styleCustom": "Utilitzeu l'estil anomenat \"{value}\"",
       "styleListLoadError": "Hi va haver un error en carregar la llista d'estils",

--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -73,6 +73,7 @@
       "style": "Stil",
       "transparent": "Gennemsigtig",
       "singleTile": "Single Tile",
+      "cropToProjectionExtent": "Beskær til projektionens udstrækning",
       "cached": "Brug cache",
       "styleCustom": "Brug stilen med navnet \"{value}\"",
       "styleListLoadError": "Der opstod en fejl under indlæsning af liste med stilarter",

--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -73,7 +73,10 @@
       "style": "Stil",
       "transparent": "Gennemsigtig",
       "singleTile": "Single Tile",
-      "cropToProjectionExtent": "Beskær til projektionens udstrækning",
+      "cropToProjectionExtent": {
+        "label": "Beskær til projektionens udstrækning",
+        "tooltip": "Laget beskæres til projektionens udstrækning, når det tilføjes til kortet med denne indstilling aktiveret"
+      },
       "cached": "Brug cache",
       "styleCustom": "Brug stilen med navnet \"{value}\"",
       "styleListLoadError": "Der opstod en fejl under indlæsning af liste med stilarter",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -90,7 +90,10 @@
       "style": "Stil",
       "transparent": "Transparent",
       "singleTile": "Single Tile",
-      "cropToProjectionExtent": "Auf Projektionserweiterung zuschneiden",
+      "cropToProjectionExtent": {
+        "label": "Auf Projektionserweiterung zuschneiden",
+        "tooltip": "Die Ebene wird auf die Projektionserweiterung zugeschnitten, wenn sie mit aktivierter Option zur Karte hinzugefügt wird."
+      },
       "cached": "Verwenden Sie Cache-Optionen",
       "styleCustom": "Stil \"{value}\" nutzen",
       "styleListLoadError": "Es gab einen Fehler beim Laden der Liste von Stilen",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -90,6 +90,7 @@
       "style": "Stil",
       "transparent": "Transparent",
       "singleTile": "Single Tile",
+      "cropToProjectionExtent": "Auf Projektionserweiterung zuschneiden",
       "cached": "Verwenden Sie Cache-Optionen",
       "styleCustom": "Stil \"{value}\" nutzen",
       "styleListLoadError": "Es gab einen Fehler beim Laden der Liste von Stilen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -90,7 +90,10 @@
       "style": "Style",
       "transparent": "Transparent",
       "singleTile": "Single Tile",
-      "cropToProjectionExtent": "Crop To Projection Extent",
+      "cropToProjectionExtent": {
+        "label": "Crop to projection extent",
+        "tooltip": "The layer is cropped to the projection extent when added to the map with this option enabled"
+      },
       "cached": "Use cache options",
       "styleCustom": "Use style named \"{value}\"",
       "styleListLoadError": "There was an error loading the styles list",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -90,6 +90,7 @@
       "style": "Style",
       "transparent": "Transparent",
       "singleTile": "Single Tile",
+      "cropToProjectionExtent": "Crop To Projection Extent",
       "cached": "Use cache options",
       "styleCustom": "Use style named \"{value}\"",
       "styleListLoadError": "There was an error loading the styles list",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -90,6 +90,7 @@
       "style": "Estilo",
       "transparent": "Transparente",
       "singleTile": "Baldosa única",
+      "cropToProjectionExtent": "Recortar a la extensión de la proyección",
       "cached": "Cacheado",
       "styleCustom": "Use un estilo llamado \"{value} \"",
       "styleListLoadError": "Se ha producido un error al cargar la lista de estilos",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -90,7 +90,10 @@
       "style": "Estilo",
       "transparent": "Transparente",
       "singleTile": "Baldosa única",
-      "cropToProjectionExtent": "Recortar a la extensión de la proyección",
+      "cropToProjectionExtent": {
+        "label": "Recortar a la extensión de la proyección",
+        "tooltip": "La capa se recorta a la extensión de la proyección cuando se agrega al mapa con esta opción habilitada"
+      },
       "cached": "Cacheado",
       "styleCustom": "Use un estilo llamado \"{value} \"",
       "styleListLoadError": "Se ha producido un error al cargar la lista de estilos",

--- a/web/client/translations/data.fi-FI.json
+++ b/web/client/translations/data.fi-FI.json
@@ -54,7 +54,10 @@
       "style": "Tyyli",
       "transparent": "Läpinäkyvä",
       "singleTile": "Yksi tiili",
-      "cropToProjectionExtent": "Rajaa projektion laajuuteen",
+      "cropToProjectionExtent": {
+        "label": "Rajaa projektion laajuuteen",
+        "tooltip": "Taso rajataan projektion laajuuteen, kun se lisätään karttaan tämän asetuksen ollessa käytössä"
+      },
       "cached": "Käytä välimuistiasetuksia",
       "styleCustom": "Käytä tyyliä \"{value}\"",
       "styleListLoadError": "Tyyliluettelon lataamisessa tapahtui virhe",

--- a/web/client/translations/data.fi-FI.json
+++ b/web/client/translations/data.fi-FI.json
@@ -54,6 +54,7 @@
       "style": "Tyyli",
       "transparent": "Läpinäkyvä",
       "singleTile": "Yksi tiili",
+      "cropToProjectionExtent": "Rajaa projektion laajuuteen",
       "cached": "Käytä välimuistiasetuksia",
       "styleCustom": "Käytä tyyliä \"{value}\"",
       "styleListLoadError": "Tyyliluettelon lataamisessa tapahtui virhe",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -90,6 +90,7 @@
       "style": "Style",
       "transparent": "Transparent",
       "singleTile": "Tuile unique",
+      "cropToProjectionExtent": "Recadrer à l'étendue de la projection",
       "cached": "Utiliser les options de cache",
       "styleCustom": "Utiliser un style nommé \"{value} \"",
       "styleListLoadError": "Une erreur s'est produite lors du chargement de la liste des styles",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -90,7 +90,10 @@
       "style": "Style",
       "transparent": "Transparent",
       "singleTile": "Tuile unique",
-      "cropToProjectionExtent": "Recadrer à l'étendue de la projection",
+      "cropToProjectionExtent": {
+        "label": "Recadrer à l'étendue de la projection",
+        "tooltip": "La couche est recadrée à l'étendue de la projection lorsqu'elle est ajoutée à la carte avec cette option activée"
+      },
       "cached": "Utiliser les options de cache",
       "styleCustom": "Utiliser un style nommé \"{value} \"",
       "styleListLoadError": "Une erreur s'est produite lors du chargement de la liste des styles",

--- a/web/client/translations/data.hr-HR.json
+++ b/web/client/translations/data.hr-HR.json
@@ -53,6 +53,7 @@
       "style": "Stil",
       "transparent": "Prozirno",
       "singleTile": "Neopločeni prikaz",
+      "cropToProjectionExtent": "Obreži na proširenje projekcije",
       "cached": "Koristi pohranu u predmemoriju",
       "styleCustom": "Koristi stil naziva \"{value}\"",
       "styleListLoadError": "Došlo je do greške prilikom učitavanja liste stilova",

--- a/web/client/translations/data.hr-HR.json
+++ b/web/client/translations/data.hr-HR.json
@@ -53,7 +53,10 @@
       "style": "Stil",
       "transparent": "Prozirno",
       "singleTile": "Neopločeni prikaz",
-      "cropToProjectionExtent": "Obreži na proširenje projekcije",
+      "cropToProjectionExtent": {
+        "label": "Obreži na proširenje projekcije",
+        "tooltip": "Sloj se obrezuje na proširenje projekcije kada se doda na kartu s ovom opcijom omogućenom"
+      },
       "cached": "Koristi pohranu u predmemoriju",
       "styleCustom": "Koristi stil naziva \"{value}\"",
       "styleListLoadError": "Došlo je do greške prilikom učitavanja liste stilova",

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -73,7 +73,10 @@
       "style": "Style",
       "transparent": "Transparent",
       "singleTile": "Single Tile",
-      "cropToProjectionExtent": "Crop To Projection Extent",
+      "cropToProjectionExtent": {
+        "label": "Crop to projection extent",
+        "tooltip": "The layer is cropped to the projection extent when added to the map with this option enabled"
+      },
       "cached": "Use cache options",
       "styleCustom": "Use style named \"{value}\"",
       "styleListLoadError": "There was an error loading the styles list",

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -73,6 +73,7 @@
       "style": "Style",
       "transparent": "Transparent",
       "singleTile": "Single Tile",
+      "cropToProjectionExtent": "Crop To Projection Extent",
       "cached": "Use cache options",
       "styleCustom": "Use style named \"{value}\"",
       "styleListLoadError": "There was an error loading the styles list",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -90,7 +90,10 @@
       "style": "Stile",
       "transparent": "Trasparenza",
       "singleTile": "Single Tile",
-      "cropToProjectionExtent": "Crop To Projection Extent",
+      "cropToProjectionExtent": {
+        "label": "Ritaglia all'estensione della proiezione",
+        "tooltip": "Il layer viene ritagliato all'estensione della proiezione quando aggiunto alla mappa con questa opzione abilitata"
+      },
       "cached": "Usa la cache",
       "styleCustom": "Usa stile con nome \"{value}\"",
       "styleListLoadError": "Si è verificato un errore durante il caricamento della lista degli stili",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -90,6 +90,7 @@
       "style": "Stile",
       "transparent": "Trasparenza",
       "singleTile": "Single Tile",
+      "cropToProjectionExtent": "Crop To Projection Extent",
       "cached": "Usa la cache",
       "styleCustom": "Usa stile con nome \"{value}\"",
       "styleListLoadError": "Si è verificato un errore durante il caricamento della lista degli stili",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -85,7 +85,10 @@
       "style": "Stijl",
       "transparent": "Transparant",
       "singleTile": "Enkele tegel",
-      "cropToProjectionExtent": "Bijsnijden tot projectie-extensie",
+      "cropToProjectionExtent": {
+        "label": "Roteer naar projectie-extensie",
+        "tooltip": "De laag wordt bijgesneden tot de projectie-extensie wanneer deze aan de kaart wordt toegevoegd met deze optie ingeschakeld"
+      },
       "cached": "Gebruik cache-opties",
       "styleCustom": "Gebruik een stijl genaamd \"{value}\"",
       "styleListLoadError": "Er is een fout opgetreden bij het laden van de lijst met stijlen",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -85,6 +85,7 @@
       "style": "Stijl",
       "transparent": "Transparant",
       "singleTile": "Enkele tegel",
+      "cropToProjectionExtent": "Bijsnijden tot projectie-extensie",
       "cached": "Gebruik cache-opties",
       "styleCustom": "Gebruik een stijl genaamd \"{value}\"",
       "styleListLoadError": "Er is een fout opgetreden bij het laden van de lijst met stijlen",

--- a/web/client/translations/data.pt-BR.json
+++ b/web/client/translations/data.pt-BR.json
@@ -85,6 +85,7 @@
       "style": "Estilo",
       "transparent": "Transparente",
       "singleTile": "Tile Único",
+      "cropToProjectionExtent": "Recortar para a extensão da projeção",
       "cached": "Usar opções de cache",
       "styleCustom": "Usar estilo nomeado \"{value}\"",
       "styleListLoadError": "Houve um erro ao carregar a lista de estilos",

--- a/web/client/translations/data.pt-BR.json
+++ b/web/client/translations/data.pt-BR.json
@@ -85,7 +85,10 @@
       "style": "Estilo",
       "transparent": "Transparente",
       "singleTile": "Tile Único",
-      "cropToProjectionExtent": "Recortar para a extensão da projeção",
+      "cropToProjectionExtent": {
+        "label": "Recortar para a extensão da projeção",
+        "tooltip": "A camada é recortada para a extensão da projeção quando adicionada ao mapa com esta opção habilitada"
+      },
       "cached": "Usar opções de cache",
       "styleCustom": "Usar estilo nomeado \"{value}\"",
       "styleListLoadError": "Houve um erro ao carregar a lista de estilos",

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -54,6 +54,7 @@
       "style": "Estilo",
       "transparent": "Transparência",
       "singleTile": "Single Tile",
+      "cropToProjectionExtent": "Recortar para a extensão da projeção",
       "cached": "Utilizar opções de cache",
       "styleCustom": "Utilizar estilo com nome \"{value}\"",
       "styleListLoadError": "Ocorreu um erro a carregar a lista de estilos",

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -54,7 +54,10 @@
       "style": "Estilo",
       "transparent": "Transparência",
       "singleTile": "Single Tile",
-      "cropToProjectionExtent": "Recortar para a extensão da projeção",
+      "cropToProjectionExtent": {
+        "label": "Crop to projection extent",
+        "tooltip": "The layer is cropped to the projection extent when added to the map with this option enabled"
+      },
       "cached": "Utilizar opções de cache",
       "styleCustom": "Utilizar estilo com nome \"{value}\"",
       "styleListLoadError": "Ocorreu um erro a carregar a lista de estilos",

--- a/web/client/translations/data.sk-SK.json
+++ b/web/client/translations/data.sk-SK.json
@@ -66,6 +66,7 @@
       "style": "Stýl",
       "transparent": "Priehľadný",
       "singleTile": "Single Tile",
+      "cropToProjectionExtent": "Crop To Projection Extent",
       "cached": "Použiť možnosti medzipamäte",
       "styleCustom": "Použiť štýl s názvom \"{value}\"",
       "styleListLoadError": "Nastala chyba pri načítaní zoznamu štýlov",

--- a/web/client/translations/data.sk-SK.json
+++ b/web/client/translations/data.sk-SK.json
@@ -66,7 +66,10 @@
       "style": "Stýl",
       "transparent": "Priehľadný",
       "singleTile": "Single Tile",
-      "cropToProjectionExtent": "Crop To Projection Extent",
+      "cropToProjectionExtent": {
+        "label": "Crop to projection extent",
+        "tooltip": "The layer is cropped to the projection extent when added to the map with this option enabled"
+      },
       "cached": "Použiť možnosti medzipamäte",
       "styleCustom": "Použiť štýl s názvom \"{value}\"",
       "styleListLoadError": "Nastala chyba pri načítaní zoznamu štýlov",

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -85,6 +85,7 @@
       "style": "Stil",
       "transparent": "Transparent",
       "singleTile": "Single tile",
+      "cropToProjectionExtent": "Crop to projection extent",
       "cached": "Använd cachealternativ",
       "styleCustom": "Använd stil med namnet {value}",
       "styleListLoadError": "Ett fel uppstod när formatlistan skulle laddas",

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -85,7 +85,10 @@
       "style": "Stil",
       "transparent": "Transparent",
       "singleTile": "Single tile",
-      "cropToProjectionExtent": "Crop to projection extent",
+      "cropToProjectionExtent": {
+        "label": "Crop to projection extent",
+        "tooltip": "The layer is cropped to the projection extent when added to the map with this option enabled"
+      },
       "cached": "Använd cachealternativ",
       "styleCustom": "Använd stil med namnet {value}",
       "styleListLoadError": "Ett fel uppstod när formatlistan skulle laddas",

--- a/web/client/translations/data.vi-VN.json
+++ b/web/client/translations/data.vi-VN.json
@@ -694,6 +694,7 @@
       "propertiesFormatDescription": "Hiển thị kết quả thông tin tính năng dưới dạng danh sách thuộc tính",
       "propertiesFormatTitle": "THUỘC TÍNH",
       "singleTile": "Ngói đơn",
+      "cropToProjectionExtent": "Cắt theo phạm vi chiếu",
       "style": "Phong cách",
       "styleCustom": "Sử dụng kiểu có tên \"{value}\"",
       "styleListLoadError": "Có lỗi khi tải danh sách kiểu",

--- a/web/client/translations/data.vi-VN.json
+++ b/web/client/translations/data.vi-VN.json
@@ -694,7 +694,10 @@
       "propertiesFormatDescription": "Hiển thị kết quả thông tin tính năng dưới dạng danh sách thuộc tính",
       "propertiesFormatTitle": "THUỘC TÍNH",
       "singleTile": "Ngói đơn",
-      "cropToProjectionExtent": "Cắt theo phạm vi chiếu",
+      "cropToProjectionExtent": {
+        "label": "Crop to projection extent",
+        "tooltip": "The layer is cropped to the projection extent when added to the map with this option enabled"
+      },
       "style": "Phong cách",
       "styleCustom": "Sử dụng kiểu có tên \"{value}\"",
       "styleListLoadError": "Có lỗi khi tải danh sách kiểu",

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -55,7 +55,10 @@
       "style": "样式",
       "transparent": "透明度",
       "singleTile": "Single Tile",
-      "cropToProjectionExtent": "Crop To Projection Extent",
+      "cropToProjectionExtent": {
+        "label": "Crop to projection extent",
+        "tooltip": "The layer is cropped to the projection extent when added to the map with this option enabled"
+      },
       "cached": "使用缓存选项",
       "styleCustom": "使用样式 \"{value}\"",
       "styleListLoadError": "加载样式列表时出错",

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -55,6 +55,7 @@
       "style": "样式",
       "transparent": "透明度",
       "singleTile": "Single Tile",
+      "cropToProjectionExtent": "Crop To Projection Extent",
       "cached": "使用缓存选项",
       "styleCustom": "使用样式 \"{value}\"",
       "styleListLoadError": "加载样式列表时出错",

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -762,7 +762,8 @@ export const saveLayer = (layer) => {
     layer?.enableImageryOverlay !== undefined ? { enableImageryOverlay: layer.enableImageryOverlay } : {},
     layer.strategy ? { strategy: layer.strategy } : {},
     layer.geometryType ? { geometryType: layer.geometryType } : {},
-    layer.maxRecordCount ? { maxRecordCount: layer.maxRecordCount } : {});
+    layer.maxRecordCount ? { maxRecordCount: layer.maxRecordCount } : {},
+    !isNil(layer.cropToProjectionExtent) ? { cropToProjectionExtent: layer.cropToProjectionExtent } : { cropToProjectionExtent: true });
 };
 
 /**

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -763,7 +763,7 @@ export const saveLayer = (layer) => {
     layer.strategy ? { strategy: layer.strategy } : {},
     layer.geometryType ? { geometryType: layer.geometryType } : {},
     layer.maxRecordCount ? { maxRecordCount: layer.maxRecordCount } : {},
-    !isNil(layer.cropToProjectionExtent) ? { cropToProjectionExtent: layer.cropToProjectionExtent } : { cropToProjectionExtent: true });
+    !isNil(layer.cropToProjectionExtent) ? { cropToProjectionExtent: layer.cropToProjectionExtent } : {});
 };
 
 /**

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1559,6 +1559,26 @@ describe('LayersUtils', () => {
                 l => {
                     expect(l.enableDynamicLegend).toBeFalsy();
                 }
+            ],
+            // save cropToProjectionExtent as false when explicitly set
+            [
+                {
+                    cropToProjectionExtent: false
+                },
+                l => {
+                    expect(l.cropToProjectionExtent).toBe(false);
+                }
+            ],
+            // default cropToProjectionExtent to true when undefined
+            [
+                {
+                    name: "test",
+                    title: "test",
+                    type: "wms"
+                },
+                l => {
+                    expect(l.cropToProjectionExtent).toBe(true);
+                }
             ]
         ];
         layers.map(([layer, test]) => test(LayersUtils.saveLayer(layer)) );

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1288,7 +1288,7 @@ describe('LayersUtils', () => {
             "type": "Feature"
         }]);
     });
-    it('saveLayer', () => {
+    it.only('saveLayer', () => {
         const layers = [
             // no params if not present
             [
@@ -1569,7 +1569,7 @@ describe('LayersUtils', () => {
                     expect(l.cropToProjectionExtent).toBe(false);
                 }
             ],
-            // default cropToProjectionExtent to true when undefined
+            // default cropToProjectionExtent to  undefined
             [
                 {
                     name: "test",
@@ -1577,7 +1577,7 @@ describe('LayersUtils', () => {
                     type: "wms"
                 },
                 l => {
-                    expect(l.cropToProjectionExtent).toBe(true);
+                    expect(l.cropToProjectionExtent).toBe(undefined);
                 }
             ]
         ];

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1288,7 +1288,7 @@ describe('LayersUtils', () => {
             "type": "Feature"
         }]);
     });
-    it.only('saveLayer', () => {
+    it('saveLayer', () => {
         const layers = [
             // no params if not present
             [

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -255,8 +255,7 @@ describe('Test the MapUtils', () => {
             minResolution: undefined,
             maxResolution: undefined,
             disableResolutionLimits: undefined,
-            fields: undefined,
-            cropToProjectionExtent: true
+            fields: undefined
         };
         // utility function to apply defaults to layers
         const applyLayerDefaults = (layers) => layers.map((layer) => {

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -255,7 +255,8 @@ describe('Test the MapUtils', () => {
             minResolution: undefined,
             maxResolution: undefined,
             disableResolutionLimits: undefined,
-            fields: undefined
+            fields: undefined,
+            cropToProjectionExtent: true
         };
         // utility function to apply defaults to layers
         const applyLayerDefaults = (layers) => layers.map((layer) => {

--- a/web/client/utils/openlayers/WMSUtils.js
+++ b/web/client/utils/openlayers/WMSUtils.js
@@ -111,7 +111,7 @@ export const generateTileGrid = (options, map) => {
             ? customTileGridResolutions
             : scales.map(scale => scaleToResolution(scale));
         return new TileGrid({
-            extent,
+            extent: (options?.cropToProjectionExtent ?? true) ? extent : null,
             resolutions,
             tileSizes,
             tileSize: customTileGridTileSize,
@@ -126,7 +126,7 @@ export const generateTileGrid = (options, map) => {
     });
     const origin = options.origin ? options.origin : [extent[0], extent[1]];
     return new TileGrid({
-        extent,
+        extent: (options?.cropToProjectionExtent ?? true) ? extent : null, // OL also sets to null if not extent is provided.
         resolutions,
         tileSize,
         origin

--- a/web/client/utils/openlayers/__tests__/WMSUtils-test.js
+++ b/web/client/utils/openlayers/__tests__/WMSUtils-test.js
@@ -59,4 +59,24 @@ describe('Test the WMSUtil for OpenLayers', () => {
         expect(tileGrid.getOrigin()).toEqual(options.tileGrids[1].origin);
         expect().toBe();
     });
+    it('generateTileGrid sets extent when cropToProjectionExtent is true', () => {
+        const options = {
+            url: '/geoserver/wms',
+            name: 'workspace:layer',
+            srs: 'EPSG:3857',
+            cropToProjectionExtent: true
+        };
+        const tileGrid = generateTileGrid(options);
+        expect(tileGrid.getExtent()).toBeTruthy();
+    });
+    it('generateTileGrid sets null extent when cropToProjectionExtent is false', () => {
+        const options = {
+            url: '/geoserver/wms',
+            name: 'workspace:layer',
+            srs: 'EPSG:3857',
+            cropToProjectionExtent: false
+        };
+        const tileGrid = generateTileGrid(options);
+        expect(tileGrid.getExtent()).toBe(null);
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR allows users to request WMS tiles beyond the Map projection extent.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12302 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

https://github.com/user-attachments/assets/35919201-397e-4ba9-b01c-98f5316e1009


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
