### PR TITLE
Fix #12309 - Add usergroups to default monitoredState

### DIFF
--- a/docs/developer-guide/expressions.md
+++ b/docs/developer-guide/expressions.md
@@ -33,11 +33,11 @@ The expression syntax can potentially be applied to every configuration. However
 
 ## State Access and `monitorState`
 
-The `state('name')` function allows you to access a "slice" of the Redux store. However, for performance and security reasons, only specific parts of the state are exposed. These are defined in the `monitorState` section of your `localConfig.json`.
+The `state('name')` function allows you to access a "slice" of the Redux store. However, for performance and security reasons, only specific parts of the state are exposed.
 
 ### Default Monitored States
 
-The following aliases are usually available out-of-the-box in the standard version of MapStore:
+The following aliases are available out-of-the-box in the standard version of MapStore:
 
 | Alias | Path in Redux Store | Purpose |
 | --- | --- | --- |
@@ -50,11 +50,11 @@ The following aliases are usually available out-of-the-box in the standard versi
 | `resourceCanEdit` | `resources.initialSelectedResource.canEdit` | Permission on current resource |
 | `usergroups` | (internal selector) | User's groups (`groupName`) array (only enabled ones) |
 
-They are configured by default in the `monitoredState` section of the standard `localConfig.json`, allowing them to be customized.
+They are available by default and they do not require any additional configuration. You can use them directly in your expressions, for example: `{state('userrole') == 'admin'}`.
 
 ### Customizing Monitored State
 
-You can extend this list in `localConfig.json` to expose any part of the MapStore state to your expressions:
+You can extend the set of monitored states by adding entries in `localConfig.json` `monitorState` property. Each entry should specify a `name` (the alias used in expressions) and a `path` (the path in the Redux store). For example:
 
 ```json
 "monitorState": [
@@ -64,6 +64,8 @@ You can extend this list in `localConfig.json` to expose any part of the MapStor
 ```
 
 *Usage:* `{state('myCustomValue') == 'active'}`
+
+Redefining an existing alias (e.g., `userrole`) will override the default path, allowing you to point it to a different part of the state if needed.
 
 ## Core Syntax & Operators
 

--- a/docs/developer-guide/expressions.md
+++ b/docs/developer-guide/expressions.md
@@ -48,6 +48,7 @@ The following aliases are usually available out-of-the-box in the standard versi
 | `userrole` | `security.user.role` | Current user's role |
 | `printEnabled` | `print.capabilities` | Printing availability |
 | `resourceCanEdit` | `resources.initialSelectedResource.canEdit` | Permission on current resource |
+| `usergroups` | (internal selector) | User's groups (`groupName`) array (only enabled ones) |
 
 They are configured by default in the `monitoredState` section of the standard `localConfig.json`, allowing them to be customized.
 

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -20,6 +20,16 @@ This is a list of things to check if you want to update from a previous version 
 - Optionally check also accessory files like `.eslinrc`, if you want to keep aligned with lint standards.
 - Follow the instructions below, in order, from your version to the one you want to update to.
 
+## Migration from 2026.01.00 to 2026.02.00
+
+### Monitored state available by default
+
+Several monitored state entries have been added to the default configuration of MapStore and they are now available by default without the need to add them in the `monitorState` section of `localConfig.json`.
+
+The entries you have configured will still work by overriding the default ones, anyway, in order to reduce the configuration, you should remove the entries if they are already available by default.
+
+The entries that you can remove because are available by default are documented in the [State Access and monitorState](./expressions.md#state-access-and-monitorstate) guide.
+
 ## Migration from 2025.02.02 to 2026.01.00
 
 ### Database update

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -66,22 +66,7 @@
       }
     }
   ],
-  "monitorState": [
-    { "name": "router", "path": "router.location.pathname" },
-    { "name": "browser", "path": "browser" },
-    { "name": "geostorymode", "path": "geostory.mode" },
-    { "name": "featuregridmode", "path": "featuregrid.mode" },
-    { "name": "userrole", "path": "security.user.role" },
-    { "name": "printEnabled", "path": "print.capabilities" },
-    {
-      "name": "resourceCanEdit",
-      "path": "resources.initialSelectedResource.canEdit"
-    },
-    {
-      "name": "resourceDetails",
-      "path": "resources.initialSelectedResource.attributes.details"
-    }
-  ],
+  "monitorState": [],
   "userSessions": {
     "enabled": true
   },

--- a/web/client/selectors/__tests__/context-test.js
+++ b/web/client/selectors/__tests__/context-test.js
@@ -31,9 +31,7 @@ describe('context selectors', () => {
     it('currentContextSelector', () => {
         expect(currentContextSelector(stateMocker(setContext(CONTEXT_DATA)))).toEqual(CONTEXT_DATA);
     });
-    it('contextMonitoredStateSelector', () => {
-        expect(contextMonitoredStateSelector(stateMocker())).toBe('{}');
-    });
+
     it('isLoadingSelector', () => {
         expect(isLoadingSelector(stateMocker(loading(true)))).toBe(true);
     });

--- a/web/client/selectors/__tests__/context-test.js
+++ b/web/client/selectors/__tests__/context-test.js
@@ -10,7 +10,6 @@ import ConfigUtils from '../../utils/ConfigUtils';
 
 import {
     currentContextSelector,
-    contextMonitoredStateSelector,
     isLoadingSelector,
     pluginsSelector,
     resourceSelector,

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -16,6 +16,7 @@ import {combineReducers as originalCombineReducers} from 'redux';
 import {wrapEpics} from "./EpicsUtils";
 import { randomInt } from './RandomUtils';
 import { pluginUtilsExpressionEvaluation } from './ExpressionUtils';
+import { userGroupsEnabledSelector } from '../selectors/security';
 
 /**
  * Loads a script inside the current page.
@@ -76,7 +77,7 @@ const dynamicFederation = (scope, module) => {
     })
 };
 
-const defaultMonitoredState = [{name: "mapType", path: 'maptype.mapType'}, {name: "user", path: 'security.user'}];
+const defaultMonitoredState = [{name: "mapType", path: 'maptype.mapType'}, {name: "user", path: 'security.user'}, {name: "usergroups", selector: userGroupsEnabledSelector}];
 
 export const getFromPlugins = curry((selector, plugins) => Object.keys(plugins).map((name) => plugins[name][selector])
     .reduce((previous, current) => ({ ...previous, ...current }), {}));
@@ -128,13 +129,15 @@ export const combineEpics = (plugins, epics = {}, epicWrapper) => {
  */
 export const filterState = memoize((state, monitor) => {
     return monitor.reduce((previous, current) => {
+        const value = current.selector ? current.selector(state) : get(state, current.path);
         return Object.assign(previous, {
-            [current.name]: get(state, current.path)
+            [current.name]: value
         });
     }, {});
 }, (state, monitor) => {
     return monitor.reduce((previous, current) => {
-        return previous + JSON.stringify(get(state, current.path));
+        const value = current.selector ? current.selector(state) : get(state, current.path);
+        return previous + JSON.stringify(value);
     }, '');
 });
 

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -77,7 +77,19 @@ const dynamicFederation = (scope, module) => {
     })
 };
 
-const defaultMonitoredState = [{name: "mapType", path: 'maptype.mapType'}, {name: "user", path: 'security.user'}, {name: "usergroups", selector: userGroupsEnabledSelector}];
+const defaultMonitoredState = [
+    { name: "browser", path: "browser" },
+    { name: "router", path: "router.location.pathname" },
+    { name: "user", path: 'security.user'},
+    { name: "userrole", path: "security.user.role" },
+    { name: "usergroups", selector: userGroupsEnabledSelector },
+    { name: "resourceCanEdit", path: "resources.initialSelectedResource.canEdit" },
+    { name: "resourceDetails", path: "resources.initialSelectedResource.attributes.details" },
+    { name: "printEnabled", path: "print.capabilities" },
+    { name: "geostorymode", path: "geostory.mode" },
+    { name: "featuregridmode", path: "featuregrid.mode" },
+    {name: "mapType", path: 'maptype.mapType'}
+];
 
 export const getFromPlugins = curry((selector, plugins) => Object.keys(plugins).map((name) => plugins[name][selector])
     .reduce((previous, current) => ({ ...previous, ...current }), {}));

--- a/web/client/utils/__tests__/PluginsUtils-test.js
+++ b/web/client/utils/__tests__/PluginsUtils-test.js
@@ -116,6 +116,33 @@ describe('PluginsUtils', () => {
     it('getMonitoredState', () => {
         expect(PluginsUtils.getMonitoredState({maptype: {mapType: "leaflet"}}).mapType).toBe("leaflet");
     });
+    it('getMonitoredState includes usergroups from security state', () => {
+        const state = {
+            security: {
+                user: {
+                    groups: {
+                        group: [
+                            {groupName: "everyone", enabled: true},
+                            {groupName: "editors", enabled: true},
+                            {groupName: "disabled-group", enabled: false}
+                        ]
+                    }
+                }
+            }
+        };
+        const monitored = PluginsUtils.getMonitoredState(state);
+        expect(monitored.usergroups).toExist();
+        expect(monitored.usergroups.length).toBe(2);
+        expect(monitored.usergroups).toInclude("everyone");
+        expect(monitored.usergroups).toInclude("editors");
+        expect(monitored.usergroups).toExclude("disabled-group");
+    });
+    it('getMonitoredState returns empty usergroups when user has no groups', () => {
+        const state = { security: { user: {} } };
+        const monitored = PluginsUtils.getMonitoredState(state);
+        expect(monitored.usergroups).toExist();
+        expect(monitored.usergroups.length).toBe(0);
+    });
 
     it('handleExpression in case there is a chaining within the expression that needs to access available state', () => {
         const state = {groups: ["ADMIN", "NORMAL_USER"]};


### PR DESCRIPTION
## Description

This support easy configuration for usergroups

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Fix #12309

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
