### PR TITLE
Fix #12301 zoom to extent with padding null throw an error

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -676,7 +676,11 @@ class OpenlayersMap extends React.Component {
         }
         this.map.getView().fit(bounds, {
             size: this.map.getSize(),
-            padding: padding && [padding.top || 0, padding.right || 0, padding.bottom || 0, padding.left || 0],
+            // mapPaddingSelector returns null while the layout epic is mid-computation
+            // (e.g. during a setView swap on projection change). Pass undefined in that
+            // case so OL applies its own [0,0,0,0] default - passing null reaches
+            // View.fitInternal where padding[1] dereferences and throws.
+            ...(padding ? { padding: [padding.top || 0, padding.right || 0, padding.bottom || 0, padding.left || 0] } : {}),
             maxZoom,
             duration,
             nearest

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -1068,6 +1068,26 @@ describe('OpenlayersMap', () => {
         expect(spy.calls[0]).toBeTruthy(); // first is called by initial render
     });
 
+    it('test ZOOM_TO_EXTENT_HOOK with null padding', () => {
+        // mapPaddingSelector can return null while the layout epic is mid-computation
+        // (e.g. during a setView swap on projection change). The hook must not throw.
+        MapUtils.registerHook(MapUtils.ZOOM_TO_EXTENT_HOOK, undefined);
+
+        const map = ReactDOM.render(<OpenlayersMap
+            id="mymap"
+            center={{ y: 0, x: 0 }}
+            zoom={11}
+            registerHooks
+            mapOptions={{ zoomAnimation: false }}
+            style={{ width: 200, height: 200 }}
+        />,
+        document.getElementById("map"));
+        expect(map).toBeTruthy();
+        const hook = MapUtils.getHook(MapUtils.ZOOM_TO_EXTENT_HOOK);
+        expect(hook).toBeTruthy();
+        expect(() => hook([0, 0, 20, 20], { crs: "EPSG:4326", duration: 0, padding: null })).toNotThrow();
+    });
+
     it('create attribution with container', () => {
         let map = ReactDOM.render(<OpenlayersMap id="ol-map" center={{y: 43.9, x: 10.3}} zoom={11} mapOptions={{attribution: {container: 'body'}}}/>, document.getElementById("map"));
         expect(map).toBeTruthy();


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR address a problem that happens when mapPaddingSelector is null.
This is not replicable from the core MapStore but it could happen on GeoNode while switching projections inside a dataset

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#12301

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Hardening of the zoom to hook inside openlayers map

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
