### PR TITLE
#12330: RULES MANAGER - Add possibility to have an extra list of geoserver urls where cache can be invalidated

### DIFF
--- a/web/client/api/geofence/RuleService.js
+++ b/web/client/api/geofence/RuleService.js
@@ -161,7 +161,7 @@ const Api = ({addBaseUrl, addBaseUrlGS, getGeoServerInstance}) => ({
     addRule: (rule) => {
         const newRule = { ...rule };
         if (!newRule.instance) {
-            const { id: instanceId } = getGeoServerInstance();
+            const { id: instanceId } = getGeoServerInstance() || {};
             newRule.instance = { id: instanceId };
         }
         if (!newRule.grant) {

--- a/web/client/api/geoserver/geofence/RuleService.js
+++ b/web/client/api/geoserver/geofence/RuleService.js
@@ -174,7 +174,7 @@ const Api = ({ addBaseUrl, addBaseUrlGS, getGeoServerInstance }) => ({
     addRule: (rule) => {
         const newRule = { ...rule };
         if (!newRule.instance) {
-            const { id: instanceId } = getGeoServerInstance();
+            const { id: instanceId } = getGeoServerInstance() || {};
             newRule.instance = { id: instanceId };
         }
         if (!newRule.grant) {

--- a/web/client/epics/__tests__/rulemanager-test.js
+++ b/web/client/epics/__tests__/rulemanager-test.js
@@ -1,0 +1,227 @@
+import expect from 'expect';
+import MockAdapter from 'axios-mock-adapter';
+import { testEpic } from './epicTestUtils';
+import ConfigUtils from '../../utils/ConfigUtils';
+import {
+    SAVE_GS_INSTANCE,
+    CACHE_CLEAN_MULTI,
+    GS_INSTSANCE_SAVED,
+    setLoading,
+    SAVE_RULE,
+    DELETE_RULES,
+    CACHE_CLEAN,
+    DELETE_GS_INSTSANCES,
+    RULE_SAVED
+} from '../../actions/rulesmanager';
+import { success, error } from '../../actions/notifications';
+import { drawSupportReset } from '../../actions/draw';
+import rulesManagerEpics from '../rulesmanager';
+import axios from '../../libs/ajax';
+import GF_RULE from '../../test-resources/geofence/rest/rules/full_rule1.json';
+
+let mockAxios;
+
+describe('rulesmanager EPICS', () => {
+
+    beforeEach((done) => {
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+        if (ConfigUtils.removeConfigProp) {
+            ConfigUtils.removeConfigProp("additionalGsInstancesUrls");
+        }
+    });
+
+    afterEach((done) => {
+        mockAxios.restore();
+        setTimeout(done);
+        if (ConfigUtils.removeConfigProp) {
+            ConfigUtils.removeConfigProp("additionalGsInstancesUrls");
+        }
+    });
+
+    it('should handle SAVE_GS_INSTANCE (create) successfully', (done) => {
+        const newInstance = { name: 'newInstance', url: 'http://new.url' };
+
+        testEpic(
+            rulesManagerEpics.onSaveGSInstance,
+            4,
+            { type: SAVE_GS_INSTANCE, instance: newInstance },
+            (actions) => {
+                expect(actions.some(a => a.type === GS_INSTSANCE_SAVED)).toBe(true);
+                expect(actions.some(a => a.type === drawSupportReset().type)).toBe(true);
+                expect(actions.some(a => a.type === success().type && a.message === "rulesmanager.successSavedGSInstance")).toBe(true);
+                expect(actions.some(a => a.type === setLoading(false).type)).toBe(true);
+                done();
+            },
+            {}
+        );
+        done();
+    });
+    it('should handle SAVE_RULE error (duplicate)', (done) => {
+        mockAxios.onPost().reply(400, "Duplicate is exists");
+        testEpic(
+            rulesManagerEpics.onSave,
+            3,
+            { type: SAVE_RULE, rule: GF_RULE },
+            (actions) => {
+                const errAction = actions.find(a => a.type === error().type);
+                expect(errAction).toExist();
+                expect(errAction.message).toBe("rulesmanager.errorDuplicateRule");
+                done();
+            },
+            {}
+        );
+    });
+
+    it('should handle DELETE_RULES successfully', (done) => {
+        mockAxios.onDelete().reply(200);
+
+        testEpic(
+            rulesManagerEpics.onDelete,
+            4,
+            { type: DELETE_RULES, ids: [1, 2] },
+            (actions) => {
+                expect(actions.some(a => a.type === RULE_SAVED)).toBe(true);
+                done();
+            },
+            { rulesmanager: { selectedRules: [{id: 1}, {id: 2}] } }
+        );
+    });
+    it('should handle CACHE_CLEAN successfully', (done) => {
+        mockAxios.onGet().reply(200);
+
+        testEpic(
+            rulesManagerEpics.onCacheClean,
+            3,
+            { type: CACHE_CLEAN, gsInstanceUrl: 'http://test.com' },
+            (actions) => {
+                const successAction = actions.find(a => a.type === success().type);
+                expect(successAction).toExist();
+                expect(successAction.message).toBe("rulesmanager.cacheCleaned");
+                done();
+            },
+            {}
+        );
+    });
+    it('should handle CACHE_CLEAN error', (done) => {
+        mockAxios.onGet().reply(400);
+
+        testEpic(
+            rulesManagerEpics.onCacheClean,
+            3,
+            { type: CACHE_CLEAN, gsInstanceUrl: 'http://test.com' },
+            (actions) => {
+                const errAction = actions.find(a => a.type === error().type);
+                expect(errAction).toExist();
+                expect(errAction.message).toBe("rulesmanager.errorCleaningCache");
+                done();
+            },
+            {}
+        );
+    });
+    it('should expand slaves and clean cache for master and slaves', (done) => {
+        ConfigUtils.setConfigProp('additionalGsInstancesUrls', {
+            "master1": [
+                { url: "http://slave1", name: "slave1" },
+                { url: "http://slave2", name: "slave2" }
+            ]
+        });
+
+        const action = {
+            type: CACHE_CLEAN_MULTI,
+            gsInstances: [
+                { name: "master1", url: "http://master1" }
+            ]
+        };
+
+        testEpic(
+            rulesManagerEpics.onCacheCleanMulti,
+            3,
+            action,
+            (actions) => {
+                expect(actions[0].type).toEqual(setLoading(true).type);
+
+                const successAction = actions.find(a => a.type === success().type);
+                expect(successAction).toExist();
+                expect(successAction.values.instancesNames).toContain("master1");
+                expect(successAction.values.instancesNames).toContain("slave1");
+                expect(successAction.values.instancesNames).toContain("slave2");
+
+                expect(actions[actions.length - 1].type).toEqual(setLoading(false).type);
+
+                done();
+            },
+            {}
+        );
+        done();
+    });
+
+    it('should report partial failure when some slaves fail', (done) => {
+        ConfigUtils.setConfigProp('additionalGsInstancesUrls', {
+            "master1": [
+                { url: "http://slave1", name: "slave1" }
+            ]
+        });
+
+        const action = {
+            type: CACHE_CLEAN_MULTI,
+            gsInstances: [
+                { name: "master1", url: "http://master1" }
+            ]
+        };
+
+        testEpic(
+            rulesManagerEpics.onCacheCleanMulti,
+            3,
+            action,
+            (actions) => {
+                const errorAction = actions.find(a => a.type === error().type);
+                expect(errorAction).toExist();
+                expect(errorAction.values.instancesNames).toContain("slave1");
+                expect(errorAction.values.instancesNames).toNotContain("master1");
+
+                done();
+            },
+            {}
+        );
+        done();
+    });
+    it('should handle SAVE_GS_INSTANCE error (duplicate)', (done) => {
+        mockAxios.onPost().reply(400, "Instance is already exists");
+        const newInstance = { name: 'Instance', url: 'http://dup.url' };
+
+        testEpic(
+            rulesManagerEpics.onSaveGSInstance,
+            3,
+            { type: SAVE_GS_INSTANCE, instance: newInstance },
+            (actions) => {
+                const errAction = actions.find(a => a.type === error().type);
+                expect(errAction).toExist();
+                expect(errAction.message).toBe("rulesmanager.errorDuplicateGSInstance");
+                done();
+            },
+            {}
+        );
+    });
+    it('should handle DELETE_GS_INSTSANCES successfully', (done) => {
+        mockAxios.onDelete().reply(200);
+
+        testEpic(
+            rulesManagerEpics.onDeleteGSInstance,
+            4,
+            { type: DELETE_GS_INSTSANCES, ids: [1] },
+            (actions) => {
+                expect(actions.some(a => a.type === GS_INSTSANCE_SAVED)).toBe(true);
+                expect(actions.some(a => a.type === drawSupportReset().type)).toBe(true);
+
+                const successAction = actions.find(a => a.type === success().type);
+                expect(successAction).toExist();
+                expect(successAction.values.successfulNum).toBe(1);
+
+                expect(actions.some(a => a.type === setLoading(false).type)).toBe(true);
+                done();
+            },
+            { rulesmanager: { selectedGSInstances: [{id: 1, name: 'test'}] } }
+        );
+    });
+});

--- a/web/client/epics/rulesmanager.js
+++ b/web/client/epics/rulesmanager.js
@@ -6,6 +6,7 @@ import { updateRule, createRule, deleteRule, cleanCache, deleteGSInstance, creat
 
 // To do add Error management
 import { get } from 'lodash';
+import { expandInstancesWithSlaves } from '../utils/RuleServiceUtils';
 
 const saveRule = stream$ => stream$
     .mapTo({type: RULE_SAVED})
@@ -22,17 +23,22 @@ const saveRule = stream$ => stream$
 
 // for gs instances
 const saveGSInstance = stream$ => stream$
-    .mapTo({type: GS_INSTSANCE_SAVED})
+    .mapTo({ type: GS_INSTSANCE_SAVED })
     .concat(Rx.Observable.of(drawSupportReset()))
+    .concat(Rx.Observable.of(success({ title: "rulesmanager.saveGSInstancetitle", message: "rulesmanager.successSavedGSInstance" })))
     .catch(e => {
         let isDuplicate = false;
-        if (e.data) {
-            isDuplicate = e.data.indexOf("exists") === 0;
+        if (e && e.data) {
+            isDuplicate = e.data.indexOf("exists") !== -1;
         }
-        return Rx.Observable.of(error({title: "rulesmanager.errorTitle", message: isDuplicate ? "rulesmanager.errorDuplicateGSInstance" : "rulesmanager.errorUpdatingGSInstance"}));
+        return Rx.Observable.of(error({
+            title: "rulesmanager.errorTitle",
+            message: isDuplicate ? "rulesmanager.errorDuplicateGSInstance" : "rulesmanager.errorUpdatingGSInstance"
+        }));
     })
     .startWith(setLoading(true))
-    .finally(Rx.Observable.of(setLoading(false)));
+    .concat(Rx.Observable.of(setLoading(false)));
+
 export default {
     onSave: (action$, {getState}) => action$.ofType(SAVE_RULE)
         .exhaustMap(({rule}) =>
@@ -55,7 +61,12 @@ export default {
     onCacheCleanMulti: action$ => action$.ofType(CACHE_CLEAN_MULTI)
         .exhaustMap((action) => {
         // Create an array of observables, one for each instance
-            const cleanRequests = action.gsInstances.map(instance =>
+            let gsInstances = action.gsInstances || [];
+            const allInstances = expandInstancesWithSlaves(gsInstances);
+            if (allInstances.length === 0) {
+                return Rx.Observable.of(setLoading(false));
+            }
+            const cleanRequests = allInstances.map(instance =>
                 cleanCache(instance.url)
                     .map(() => ({ success: true, name: instance.name }))
                     .catch(() => {
@@ -151,6 +162,7 @@ export default {
                     return Rx.Observable.concat(...actions.map(action => Rx.Observable.of(action)));
                 })
                 .startWith(setLoading(true))
+                .concat(Rx.Observable.of(setLoading(false)))
                 .catch(() => {
 
                     // Generic fallback error
@@ -163,13 +175,14 @@ export default {
                     );
                 });
         }),
-    onSaveGSInstance: (action$, {getState}) => action$.ofType(SAVE_GS_INSTANCE)
-        .exhaustMap(({instance}) =>
-            instance.id ? updateGSInstance(instance, get(getState(), "rulesmanager.activeGSInstance", {})).let(saveGSInstance)
-                .concat(Rx.Observable.of(success({title: "rulesmanager.saveGSInstancetitle", message: "rulesmanager.successSavedGSInstance"})))
-                : createGSInstance(instance).let(saveGSInstance)
-                    .concat(Rx.Observable.of(success({title: "rulesmanager.saveGSInstancetitle", message: "rulesmanager.successSavedGSInstance"})))
+    onSaveGSInstance: (action$, { getState }) =>
+        action$.ofType(SAVE_GS_INSTANCE)
+            .exhaustMap(({ instance }) => {
+                const base$ = instance.id
+                    ? updateGSInstance(instance, get(getState(), "rulesmanager.activeGSInstance", {}))
+                    : createGSInstance(instance);
+                return base$.let(saveGSInstance);
+            })
 
-        )
 };
 

--- a/web/client/plugins/manager/RulesToolbar.jsx
+++ b/web/client/plugins/manager/RulesToolbar.jsx
@@ -17,7 +17,7 @@ import Modal from '../../components/manager/rulesmanager/ModalDialog';
 import Message from '../../components/I18N/Message';
 import {error} from '../../actions/notifications';
 import GSCleanCacheMenu from './GSCleanCacheMenu';
-import { hasConfiguredSlaves } from '../../utils/RuleServiceUtils';
+import { hasConfiguredGSSlaves } from '../../utils/RuleServiceUtils';
 
 const ToolbarWithModal = ({modalsProps, loading, ...props}) => {
     return (
@@ -215,7 +215,7 @@ const EditorToolbar = compose(
                                 } else {
                                     const masterName = selectedGSInstanceToClearCache?.name;
                                     // check if slaves gs instances configured and msterName included there
-                                    if (hasConfiguredSlaves(masterName)) {
+                                    if (hasConfiguredGSSlaves(masterName)) {
                                         // Use multi-cleaner
                                         cleanCacheMulti([selectedGSInstanceToClearCache]);
                                     } else {

--- a/web/client/plugins/manager/RulesToolbar.jsx
+++ b/web/client/plugins/manager/RulesToolbar.jsx
@@ -17,6 +17,7 @@ import Modal from '../../components/manager/rulesmanager/ModalDialog';
 import Message from '../../components/I18N/Message';
 import {error} from '../../actions/notifications';
 import GSCleanCacheMenu from './GSCleanCacheMenu';
+import { hasConfiguredSlaves } from '../../utils/RuleServiceUtils';
 
 const ToolbarWithModal = ({modalsProps, loading, ...props}) => {
     return (
@@ -212,8 +213,15 @@ const EditorToolbar = compose(
                                 // props.gsInstances is the array of [{url, name, ...}]
                                     cleanCacheMulti(gsInstances);
                                 } else {
-                                    // Fallback for single instance (if you pass the whole object there too)
-                                    cleanCache(selectedGSInstanceToClearCache.url);
+                                    const masterName = selectedGSInstanceToClearCache?.name;
+                                    // check if slaves gs instances configured and msterName included there
+                                    if (hasConfiguredSlaves(masterName)) {
+                                        // Use multi-cleaner
+                                        cleanCacheMulti([selectedGSInstanceToClearCache]);
+                                    } else {
+                                        // Fallback for single instance (if you pass the whole object there too)
+                                        cleanCache(selectedGSInstanceToClearCache.url);
+                                    }
                                 }
                             } else cleanCache();
                         }

--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -42,7 +42,8 @@ let defaultConfig = {
     backgroundGroup: "background",
     userSessions: {
         enabled: false
-    }
+    },
+    additionalGsInstancesUrls: {}
 };
 
 export const getConfigurationOptions = function(query, defaultName, extension, geoStoreBase) {

--- a/web/client/utils/RuleServiceUtils.js
+++ b/web/client/utils/RuleServiceUtils.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { castArray } from 'lodash';
+import ConfigUtils from './ConfigUtils';
 
 /**
  * Utilities for rule services (GeoFence REST API, stand-alone and GeoServer integrated)
@@ -118,3 +119,40 @@ export const convertRuleGF2GS = ({
     }
     */
 });
+/**
+ * Checks if a given GeoServer instance has configured slave instances in localConfig.
+ *
+ * This function looks up the 'additionalGsInstancesUrls' configuration using the provided
+ * instance name as the key. It returns true only if the configuration exists, is an array,
+ * and contains at least one slave entry.
+ *
+ * @param {string} instanceName - The name/key of the GeoServer master instance to check.
+ * @returns {boolean} True if the instance has one or more configured slaves, false otherwise.
+ */
+export const hasConfiguredGSSlaves = (instanceName) => {
+    if (!instanceName) return false;
+
+    const config = ConfigUtils.getConfigProp("additionalGsInstancesUrls") || {};
+    const slaves = config[instanceName];
+
+    // Check if slaves exist, is an array, and is not empty
+    return Array.isArray(slaves) && slaves.length > 0;
+};
+
+export const expandInstancesWithSlaves = (instances) => {
+    const additionalGsInstancesConfig = ConfigUtils.getConfigProp("additionalGsInstancesUrls") || {};
+    if (!instances || !Array.isArray(instances)) return [];
+
+    let expanded = [];
+    instances.forEach(instance => {
+        // Always add the master/current instance
+        expanded.push(instance);
+
+        // Check for slaves
+        const masterKey = instance.name;
+        if (additionalGsInstancesConfig[masterKey] && Array.isArray(additionalGsInstancesConfig[masterKey])) {
+            expanded = expanded.concat(additionalGsInstancesConfig[masterKey]);
+        }
+    });
+    return expanded;
+};

--- a/web/client/utils/RuleServiceUtils.js
+++ b/web/client/utils/RuleServiceUtils.js
@@ -128,6 +128,22 @@ export const convertRuleGF2GS = ({
  *
  * @param {string} instanceName - The name/key of the GeoServer master instance to check.
  * @returns {boolean} True if the instance has one or more configured slaves, false otherwise.
+ *
+ * @example
+ * // Example configuration in localConfig.json:
+ * {
+ *   "additionalGsInstancesUrls": {
+ *     "master1": [
+ *       { "url": "http://localhost:8081/geoserver1/slave1", "name": "master1/slave1" },
+ *       { "url": "http://localhost:8081/geoserver1/slave2", "name": "master1/slave2" },
+ *       { "url": "http://localhost:8081/geoserver1/slave3", "name": "master1/slave3" }
+ *     ]
+ *   }
+ * }
+ *
+ * // Usage:
+ * // hasConfiguredGSSlaves("master1") returns true
+ * // hasConfiguredGSSlaves("unknownMaster") returns false
  */
 export const hasConfiguredGSSlaves = (instanceName) => {
     if (!instanceName) return false;
@@ -138,7 +154,41 @@ export const hasConfiguredGSSlaves = (instanceName) => {
     // Check if slaves exist, is an array, and is not empty
     return Array.isArray(slaves) && slaves.length > 0;
 };
-
+/**
+ * Expands an array of GeoServer instances by appending their configured slave instances.
+ *
+ * This function iterates through the provided list of instances. For each instance, it checks
+ * if there are associated slaves defined in the 'additionalGsInstancesUrls' configuration.
+ * If found, the slaves are appended to the result array immediately after the master instance.
+ *
+ * @param {object[]} instances - An array of GeoServer instance objects. Each object must have a 'name' property used as the lookup key.
+ * @returns {object[]} A new flat array containing the original instances followed by their respective slaves.
+ *
+ * @example
+ * // Example configuration in localConfig.json:
+ * {
+ *   "additionalGsInstancesUrls": {
+ *     "master1": [
+ *       { "url": "http://localhost:8081/slave1", "name": "slave1" },
+ *       { "url": "http://localhost:8081/slave2", "name": "slave2" }
+ *     ]
+ *   }
+ * }
+ *
+ * // Input:
+ * const instances = [
+ *   { name: "master1", url: "http://localhost:8080/master" },
+ *   { name: "standalone", url: "http://localhost:8082/standalone" }
+ * ];
+ *
+ * // Output:
+ * [
+ *   { name: "master1", url: "http://localhost:8080/master" },      // Master
+ *   { url: "http://localhost:8081/slave1", name: "slave1" },        // Slave 1
+ *   { url: "http://localhost:8081/slave2", name: "slave2" },        // Slave 2
+ *   { name: "standalone", url: "http://localhost:8082/standalone" } // Standalone (no slaves)
+ * ]
+ */
 export const expandInstancesWithSlaves = (instances) => {
     const additionalGsInstancesConfig = ConfigUtils.getConfigProp("additionalGsInstancesUrls") || {};
     if (!instances || !Array.isArray(instances)) return [];

--- a/web/client/utils/__tests__/RuleServiceUtils-test.js
+++ b/web/client/utils/__tests__/RuleServiceUtils-test.js
@@ -8,7 +8,8 @@
 import GF_RULE1 from '../../test-resources/geofence/rest/rules/full_rule1.json';
 
 import GS_RULE1 from '../../test-resources/geoserver/rest/geofence/full_rule1.json';
-import { convertRuleGS2GF, convertRuleGF2GS } from '../RuleServiceUtils';
+import ConfigUtils from '../ConfigUtils';
+import { convertRuleGS2GF, convertRuleGF2GS, hasConfiguredGSSlaves, expandInstancesWithSlaves } from '../RuleServiceUtils';
 import expect from 'expect';
 describe('RuleServiceUtils', () => {
 
@@ -28,6 +29,97 @@ describe('RuleServiceUtils', () => {
                 expect(converted[k]).toEqual(GF_RULE1[k]);
             }
 
+        });
+    });
+    it("test hasConfiguredGSSlaves", () => {
+        ConfigUtils.setConfigProp('additionalGsInstancesUrls', {
+            "master1": [
+                {"url": "http://localhost:8081/geoserver1/slave1", "name": "slave1"},
+                {"url": "http://localhost:8081/geoserver1/slave2", "name": "slave2"},
+                {"url": "http://localhost:8081/geoserver1/slave3", "name": "slave3"}
+            ]
+        });
+        let hasSlaves = hasConfiguredGSSlaves('master1');
+        expect(hasSlaves).toEqual(true);
+        hasSlaves = hasConfiguredGSSlaves('master2');
+        expect(hasSlaves).toEqual(false);
+        ConfigUtils.removeConfigProp("additionalGsInstancesUrls");
+    });
+    describe('test expandInstancesWithSlaves', () => {
+        afterEach(() => {
+        // Clean up after each test
+            ConfigUtils.removeConfigProp("additionalGsInstancesUrls");
+        });
+        it("should return the same instance if no slaves are configured", () => {
+            const instances = [
+                { name: "master1", url: "http://localhost:8080/geoserver1" }
+            ];
+
+            // No config set, or empty config
+            ConfigUtils.setConfigProp('additionalGsInstancesUrls', {});
+
+            const result = expandInstancesWithSlaves(instances);
+            expect(result).toEqual(instances);
+            expect(result.length).toBe(1);
+        });
+        it("should expand a single master instance with its configured slaves", () => {
+            const instances = [
+                { name: "master1", url: "http://localhost:8080/geoserver1" }
+            ];
+
+            ConfigUtils.setConfigProp('additionalGsInstancesUrls', {
+                "master1": [
+                    { url: "http://localhost:8081/slave1", name: "slave1" },
+                    { url: "http://localhost:8081/slave2", name: "slave2" }
+                ]
+            });
+
+            const result = expandInstancesWithSlaves(instances);
+
+            expect(result.length).toBe(3); // 1 master + 2 slaves
+            expect(result[0]).toEqual({ name: "master1", url: "http://localhost:8080/geoserver1" });
+            expect(result[1]).toEqual({ url: "http://localhost:8081/slave1", name: "slave1" });
+            expect(result[2]).toEqual({ url: "http://localhost:8081/slave2", name: "slave2" });
+        });
+        it("should expand multiple masters with their respective slaves", () => {
+            const instances = [
+                { name: "master1", url: "http://localhost:8080/geoserver1" },
+                { name: "master2", url: "http://localhost:8080/geoserver2" }
+            ];
+
+            ConfigUtils.setConfigProp('additionalGsInstancesUrls', {
+                "master1": [
+                    { url: "http://localhost:8081/master1-slave1", name: "master1-slave1" }
+                ],
+                "master2": [
+                    { url: "http://localhost:8082/master2-slave1", name: "master2-slave1" },
+                    { url: "http://localhost:8082/master2-slave2", name: "master2-slave2" }
+                ]
+            });
+
+            const result = expandInstancesWithSlaves(instances);
+
+            expect(result.length).toBe(5); // 2 masters + 1 slave + 2 slaves
+        });
+
+        it("should handle instances that have no corresponding config entry", () => {
+            const instances = [
+                { name: "master1", url: "http://localhost:8080/geoserver1" },
+                { name: "unknownMaster", url: "http://localhost:8080/geoserverUnknown" }
+            ];
+
+            ConfigUtils.setConfigProp('additionalGsInstancesUrls', {
+                "master1": [
+                    { url: "http://localhost:8081/slave1", name: "slave1" }
+                ]
+            });
+
+            const result = expandInstancesWithSlaves(instances);
+
+            expect(result.length).toBe(3); // master1, slave1, unknownMaster
+            expect(result[0].name).toBe("master1");
+            expect(result[1].name).toBe("slave1");
+            expect(result[2].name).toBe("unknownMaster");
         });
     });
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR introduces root level cfg **additionalGsInstancesUrls** in **localConfig.json**, to enable invalidating Geofence rule caches on Geoserver slave/replica instances.

It is for clearing caches on GeoServer slave instances associated with a master instance. Previously, cache invalidation only targeted the explicitly selected GeoServer instance. Now, if a master instance has configured slaves (defined in localConfig.json), selecting that master for cache clearing will automatically trigger cache invalidation for all its registered slaves as well.

Example for cfg:
```
"additionalGsInstancesUrls": {
    "master1" : [
        {"url": "http://localhost:8081/geoserver1/slave1", "name": "master1/slave1"}, 
        {"url": "http://localhost:8081/geoserver1/slave2", "name": "master1/slave2"},
        {"url": "http://localhost:8081/geoserver1/slave3", "name": "master1/slave3"}
    ],
    "master2" : [
        {"url": "http://localhost:8081/geoserver2/slave1", "name": "master2/slave1"}, 
        {"url": "http://localhost:8081/geoserver2/slave", "name": "master2/slave2"},
        {"url": "http://localhost:8081/geoserver2/slave3", "name": "master2/slave3"}
    ]
}
```
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12330 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
- When invalidating Geofence cache for a single selected Geoserver instance, the system will also call the invalidate endpoint on any slave/replica instances listed under that master in additionalGsInstancesUrls (master + its slaves are cleared).

- When running “clear cache for all instances”, the system will iterate over gsInstances plus all slave entries from additionalGsInstancesUrls and call the invalidate endpoint for each unique instance.


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
