### PR TITLE
Fix #12301 projection export workflow and unregistered projection warning

### DIFF
--- a/web/client/epics/mapexport.js
+++ b/web/client/epics/mapexport.js
@@ -22,6 +22,7 @@ import { mapOptionsToSaveSelector } from '../selectors/mapsave';
 import { basicError } from '../utils/NotificationUtils';
 import { getErrorMessage } from '../utils/LocaleUtils';
 import {textSearchConfigSelector, bookmarkSearchConfigSelector} from '../selectors/searchconfig';
+import { dynamicProjectionDefsSelector } from '../selectors/projections';
 
 function MapExportError(title, message) {
     this.title = title;
@@ -36,7 +37,8 @@ const saveMap = (state, addBbox = false) => {
         backgroundListSelector(state),
         textSearchConfigSelector(state),
         bookmarkSearchConfigSelector(state),
-        mapOptionsToSaveSelector(state)
+        mapOptionsToSaveSelector(state),
+        dynamicProjectionDefsSelector(state)
     );
 
     return addBbox ? {

--- a/web/client/epics/maptemplates.js
+++ b/web/client/epics/maptemplates.js
@@ -26,6 +26,7 @@ import { configureMap, mapInfoLoaded } from '../actions/config';
 import { wrapStartStop } from '../observables/epics';
 import { toMapConfig } from '../utils/ogc/WMC';
 import {hideMapinfoMarker, purgeMapInfoResults} from "../actions/mapInfo";
+import { dynamicProjectionDefsSelector } from '../selectors/projections';
 
 const errorToMessageId = (e = {}, getState = () => {}) => {
     let message = `context.errors.template.unknownError`;
@@ -117,8 +118,9 @@ export const mergeTemplateEpic = (action$, store) => action$
                 const textSearchConfig = textSearchConfigSelector(state);
                 const bookmarkSearchConfig = bookmarkSearchConfigSelector(state);
                 const additionalOptions = mapOptionsToSaveSelector(state);
+                const projectionDefs = dynamicProjectionDefsSelector(state);
 
-                const currentConfig = MapUtils.saveMapConfiguration(map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions);
+                const currentConfig = MapUtils.saveMapConfiguration(map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, projectionDefs);
 
                 return (isString(data) ? Observable.defer(() => toMapConfig(data, false)) : Observable.of(data))
                     .switchMap(config => Observable.of(

--- a/web/client/plugins/CRSSelector/containers/CRSSelector.jsx
+++ b/web/client/plugins/CRSSelector/containers/CRSSelector.jsx
@@ -29,6 +29,7 @@ import { isCesium } from '../../../selectors/maptype';
 import { userRoleSelector } from '../../../selectors/security';
 import { getAvailableCRS, normalizeSRS } from '../../../utils/CoordinatesUtils';
 import { getAvailableProjectionsFromConfig, getProjection } from '../../../utils/ProjectionUtils';
+import { isRegistered } from '../../../utils/ProjectionRegistry';
 import ButtonRB from '../../../components/misc/Button';
 import FlexBox from '../../../components/layout/FlexBox';
 import useClickOutside from '../../../hooks/useClickOutside';
@@ -69,6 +70,7 @@ registerCustomSaveHandler('crsSelector', (state) => {
 });
 
 const Button = tooltip(ButtonRB);
+const TooltipGlyphicon = tooltip(Glyphicon);
 
 const getLabel = (crs) => {
     if (crs.label === crs.value) return crs.value;
@@ -102,7 +104,8 @@ const Selector = ({
     onZoomToProjectionExtent = () => {},
     currentBackground,
     onError = () => {},
-    canEditProjection = true
+    canEditProjection = true,
+    unregisteredProjections = []
 }) => {
     const [toggled, setToggled] = useState(false);
     const [openAvailableProjections, setOpenAvailableProjections] = useState(false);
@@ -133,10 +136,8 @@ const Selector = ({
     };
 
     const list = useMemo(() => {
-        if (projectionsConfig && projectionsConfig.projectionList) {
-            return projectionsConfig.projectionList;
-        }
-        return availableProjections;
+        const base = projectionsConfig?.projectionList || availableProjections;
+        return base.filter(p => isRegistered(p.value));
     }, [availableCRS, availableProjections, projectionsConfig]);
 
     const filteredList = useMemo(() => {
@@ -236,6 +237,14 @@ const Selector = ({
             >
                 <Glyphicon glyph="zoom-to" />
             </Button>
+            {unregisteredProjections.length > 0 && (
+                <TooltipGlyphicon
+                    glyph="warning-sign"
+                    className="ms-crs-unregistered-warning-button"
+                    tooltip={<Message msgId="crsSelector.unregisteredProjections" msgParams={{ projections: unregisteredProjections.map(p => p.value).join(', ') }}/>}
+                    tooltipPosition="top"
+                />
+            )}
             {isAllowedToSwitch && canEditProjection && (
                 <>
                     <Button
@@ -295,6 +304,7 @@ Selector.propTypes = {
     allowedRoles: PropTypes.array,
     currentRole: PropTypes.string,
     availableProjections: PropTypes.array,
+    unregisteredProjections: PropTypes.array,
     projectionDefsEndpoint: PropTypes.string,
     projectionsConfig: PropTypes.object,
     setConfig: PropTypes.func,
@@ -363,7 +373,9 @@ const CRSSelector = connect(
     (stateProps, dispatchProps, ownProps) => {
         const { pluginCfg, ...otherProps } = ownProps || {};
         const { filterAllowedCRS = [], additionalCRS = {} } = pluginCfg || {};
-        const availableProjections = pluginCfg?.availableProjections || getAvailableProjectionsFromConfig(filterAllowedCRS, additionalCRS);
+        const rawProjections = pluginCfg?.availableProjections || getAvailableProjectionsFromConfig(filterAllowedCRS, additionalCRS);
+        const availableProjections = rawProjections.filter(p => isRegistered(p.value));
+        const unregisteredProjections = rawProjections.filter(p => !isRegistered(p.value));
         const projectionDefsEndpoint = pluginCfg?.projectionDefsEndpoint;
         return {
             ...otherProps,
@@ -371,7 +383,8 @@ const CRSSelector = connect(
             ...dispatchProps,
             ...(pluginCfg || {}),
             projectionDefsEndpoint,
-            availableProjections
+            availableProjections,
+            unregisteredProjections
         };
     }
 )(Selector);

--- a/web/client/plugins/CRSSelector/containers/CRSSelector.jsx
+++ b/web/client/plugins/CRSSelector/containers/CRSSelector.jsx
@@ -136,8 +136,10 @@ const Selector = ({
     };
 
     const list = useMemo(() => {
-        const base = projectionsConfig?.projectionList || availableProjections;
-        return base.filter(p => isRegistered(p.value));
+        if (projectionsConfig?.projectionList) {
+            return projectionsConfig.projectionList;
+        }
+        return availableProjections;
     }, [availableCRS, availableProjections, projectionsConfig]);
 
     const filteredList = useMemo(() => {

--- a/web/client/plugins/CRSSelector/containers/CRSSelector.less
+++ b/web/client/plugins/CRSSelector/containers/CRSSelector.less
@@ -138,6 +138,7 @@
                     border-color: var(--ms-focus-color);
                 }
 
+
                 .glyphicon-star {
                     margin-right: 2px;
                 }
@@ -152,6 +153,13 @@
         justify-content: center;
         height: 20px;
         width: 20px;
+    }
+
+    .ms-crs-unregistered-warning-button {
+        color: var(--ms-warning-color, #f0ad4e);
+        font-size: 1em;
+        display: flex;
+        align-items: center;
     }
 }
 

--- a/web/client/plugins/mapEditor/enhancers/editor.js
+++ b/web/client/plugins/mapEditor/enhancers/editor.js
@@ -23,6 +23,7 @@ import {backgroundListSelector} from '../../../selectors/backgroundselector';
 import {mapOptionsToSaveSelector} from '../../../selectors/mapsave';
 import {textSearchConfigSelector, bookmarkSearchConfigSelector} from '../../../selectors/searchconfig';
 import MapUtils from '../../../utils/MapUtils';
+import { dynamicProjectionDefsSelector } from '../../../selectors/projections';
 
 
 const saveSelector = createSelector(
@@ -33,8 +34,9 @@ const saveSelector = createSelector(
     textSearchConfigSelector,
     bookmarkSearchConfigSelector,
     mapSelector,
-    (layers, groups, backgrounds, additionalOptions, textSearchConfig, bookmarkSearchConfig, map) =>
-        ({layers, groups, backgrounds, additionalOptions, textSearchConfig, bookmarkSearchConfig, map})
+    dynamicProjectionDefsSelector,
+    (layers, groups, backgrounds, additionalOptions, textSearchConfig, bookmarkSearchConfig, map, projectionDefs) =>
+        ({layers, groups, backgrounds, additionalOptions, textSearchConfig, bookmarkSearchConfig, map, projectionDefs})
 );
 
 
@@ -48,9 +50,9 @@ export default compose(
         onClick: ({hide, owner}) => () => {
             hide(owner);
         },
-        save: ({save, owner, map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions}) => () => {
+        save: ({save, owner, map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, projectionDefs}) => () => {
             const mapData = MapUtils.saveMapConfiguration(map, layers, groups,
-                backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions);
+                backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, projectionDefs);
 
             return save({
                 ...mapData.map,

--- a/web/client/selectors/mapsave.js
+++ b/web/client/selectors/mapsave.js
@@ -92,17 +92,15 @@ export const mapSaveDataSelector = createSelector(
         mapOptionsToSaveSelector,
         dynamicProjectionDefsSelector
     ],
-    (map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, dynamicDefs) => ({
-        map: {
-            ...(map || {}),
-            ...(dynamicDefs?.length && { projections: { defs: dynamicDefs } })
-        },
+    (map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, projectionDefs) => ({
+        map,
         layers,
         groups,
         backgrounds,
         textSearchConfig,
         bookmarkSearchConfig,
-        additionalOptions
+        additionalOptions,
+        projectionDefs
     })
 );
 
@@ -114,8 +112,17 @@ export const mapSaveDataSelector = createSelector(
  * @return the map to save
  */
 export const mapSaveSelector = state => {
-    const { map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions } = mapSaveDataSelector(state);
-    return MapUtils.saveMapConfiguration(map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions);
+    const { map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, projectionDefs } = mapSaveDataSelector(state);
+    return MapUtils.saveMapConfiguration(
+        map,
+        layers,
+        groups,
+        backgrounds,
+        textSearchConfig,
+        bookmarkSearchConfig,
+        additionalOptions,
+        projectionDefs
+    );
 };
 /**
  * Selector to identify pending changes.

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -341,7 +341,7 @@
       "loadingProjection": "Projektionsdefinition wird geladen...",
       "failedToLoad": "Laden der Projektion fehlgeschlagen. Klicken zum Wiederholen",
       "zoomToProjectionExtent": "Auf Projektionsausdehnung zoomen",
-      "unregisteredProjections": "Die folgenden Projektionen sind konfiguriert, aber nicht registriert: {projections}"
+      "unregisteredProjections": "Die folgenden Projektionen wurden konfiguriert, sind aber nicht verfügbar: {projections}"
     },
     "menu": "Menü",
     "options": "Optionen",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -340,7 +340,8 @@
       "removeProjection": "Diese Projektion entfernen",
       "loadingProjection": "Projektionsdefinition wird geladen...",
       "failedToLoad": "Laden der Projektion fehlgeschlagen. Klicken zum Wiederholen",
-      "zoomToProjectionExtent": "Auf Projektionsausdehnung zoomen"
+      "zoomToProjectionExtent": "Auf Projektionsausdehnung zoomen",
+      "unregisteredProjections": "Die folgenden Projektionen sind konfiguriert, aber nicht registriert: {projections}"
     },
     "menu": "Menü",
     "options": "Optionen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -341,7 +341,7 @@
       "loadingProjection": "Loading projection definition...",
       "failedToLoad": "Failed to load projection. Click to retry",
       "zoomToProjectionExtent": "Zoom to projection extent",
-      "unregisteredProjections": "The following projections are configured but not registered: {projections}"
+      "unregisteredProjections": "The following projections were configured but not available: {projections}"
     },
     "menu": "Menu",
     "options": "Options",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -340,7 +340,8 @@
       "removeProjection": "Remove this projection",
       "loadingProjection": "Loading projection definition...",
       "failedToLoad": "Failed to load projection. Click to retry",
-      "zoomToProjectionExtent": "Zoom to projection extent"
+      "zoomToProjectionExtent": "Zoom to projection extent",
+      "unregisteredProjections": "The following projections are configured but not registered: {projections}"
     },
     "menu": "Menu",
     "options": "Options",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -341,7 +341,7 @@
       "loadingProjection": "Cargando definición de la proyección...",
       "failedToLoad": "Error al cargar la proyección. Haga clic para reintentar",
       "zoomToProjectionExtent": "Ampliar a la extensión de la proyección",
-      "unregisteredProjections": "Las siguientes proyecciones están configuradas pero no registradas: {projections}"
+      "unregisteredProjections": "Las siguientes proyecciones fueron configuradas pero no están disponibles: {projections}"
     },
     "menu": "Menú",
     "options": "Opciones",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -340,7 +340,8 @@
       "removeProjection": "Eliminar esta proyección",
       "loadingProjection": "Cargando definición de la proyección...",
       "failedToLoad": "Error al cargar la proyección. Haga clic para reintentar",
-      "zoomToProjectionExtent": "Ampliar a la extensión de la proyección"
+      "zoomToProjectionExtent": "Ampliar a la extensión de la proyección",
+      "unregisteredProjections": "Las siguientes proyecciones están configuradas pero no registradas: {projections}"
     },
     "menu": "Menú",
     "options": "Opciones",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -340,7 +340,8 @@
       "removeProjection": "Supprimer cette projection",
       "loadingProjection": "Chargement de la définition de la projection...",
       "failedToLoad": "Échec du chargement de la projection. Cliquez pour réessayer",
-      "zoomToProjectionExtent": "Zoomer sur l'étendue de la projection"
+      "zoomToProjectionExtent": "Zoomer sur l'étendue de la projection",
+      "unregisteredProjections": "Les projections suivantes sont configurées mais non enregistrées : {projections}"
     },
     "menu": "Menu",
     "options": "Options",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -341,7 +341,7 @@
       "loadingProjection": "Chargement de la définition de la projection...",
       "failedToLoad": "Échec du chargement de la projection. Cliquez pour réessayer",
       "zoomToProjectionExtent": "Zoomer sur l'étendue de la projection",
-      "unregisteredProjections": "Les projections suivantes sont configurées mais non enregistrées : {projections}"
+      "unregisteredProjections": "Les projections suivantes ont été configurées mais ne sont pas disponibles : {projections}"
     },
     "menu": "Menu",
     "options": "Options",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -341,7 +341,7 @@
       "loadingProjection": "Caricamento definizione proiezione...",
       "failedToLoad": "Caricamento della proiezione non riuscito. Fai clic per riprovare",
       "zoomToProjectionExtent": "Zoom all'estensione della proiezione",
-      "unregisteredProjections": "Le seguenti proiezioni sono configurate ma non registrate: {projections}"
+      "unregisteredProjections": "Le seguenti proiezioni sono state configurate ma non sono disponibili: {projections}"
     },
     "menu": "Menu",
     "options": "Opzioni",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -340,7 +340,8 @@
       "removeProjection": "Rimuovi questa proiezione",
       "loadingProjection": "Caricamento definizione proiezione...",
       "failedToLoad": "Caricamento della proiezione non riuscito. Fai clic per riprovare",
-      "zoomToProjectionExtent": "Zoom all'estensione della proiezione"
+      "zoomToProjectionExtent": "Zoom all'estensione della proiezione",
+      "unregisteredProjections": "Le seguenti proiezioni sono configurate ma non registrate: {projections}"
     },
     "menu": "Menu",
     "options": "Opzioni",

--- a/web/client/utils/GeostoreUtils.js
+++ b/web/client/utils/GeostoreUtils.js
@@ -202,8 +202,8 @@ export const composeMapConfiguration = (mapData) => {
     if (!mapData || isEmpty(mapData)) {
         return null;
     }
-    const { map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions } = mapData;
-    return MapUtils.saveMapConfiguration(map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions);
+    const { map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, projectionDefs } = mapData;
+    return MapUtils.saveMapConfiguration(map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, projectionDefs);
 };
 
 /**

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -748,7 +748,7 @@ export const groupSaveFormatted = (node) => {
 };
 
 
-export function saveMapConfiguration(currentMap, currentLayers, currentGroups, currentBackgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions) {
+export function saveMapConfiguration(currentMap, currentLayers, currentGroups, currentBackgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, projectionDefs) {
 
     const map = {
         center: currentMap.center,
@@ -760,7 +760,7 @@ export function saveMapConfiguration(currentMap, currentLayers, currentGroups, c
         mapOptions: currentMap.mapOptions || {},
         ...(currentMap.visualizationMode && { visualizationMode: currentMap.visualizationMode }),
         ...(currentMap.viewerOptions && { viewerOptions: currentMap.viewerOptions }),
-        ...(currentMap.projections && { projections: currentMap.projections })
+        ...(projectionDefs?.length && { projections: { defs: projectionDefs } })
     };
 
     const layers = currentLayers.map((layer) => {

--- a/web/client/utils/ProjectionRegistry.js
+++ b/web/client/utils/ProjectionRegistry.js
@@ -136,9 +136,11 @@ export function getByCode(code) {
     return registry.get(code) ?? null;
 }
 
+// Projections natively supported by proj4.
+const PROJ4_NATIVE_CODES = new Set(['EPSG:4326', 'EPSG:3857', 'EPSG:900913', 'CRS:84']);
+
 export function isRegistered(code) {
-    const has = registry.has(code);
-    return has;
+    return registry.has(code) || PROJ4_NATIVE_CODES.has(code);
 }
 
 // CRS that are not built into OpenLayers but are commonly required by the

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -1791,6 +1791,33 @@ describe('Test the MapUtils', () => {
             });
         });
 
+        it('should include projectionDefs in map.projections when provided', () => {
+            const mapConfig = {
+                center: {crs: 'EPSG:4326', x: 0, y: 0},
+                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                projection: 'EPSG:900913',
+                units: 'm',
+                mapInfoControl: true,
+                zoom: 10
+            };
+            const projectionDefs = [
+                { code: 'EPSG:3003', def: '+proj=tmerc', label: 'Monte Mario' }
+            ];
+            const saved = saveMapConfiguration(mapConfig, [], [], [], '', {}, {}, projectionDefs);
+            expect(saved.map.projections).toEqual({ defs: projectionDefs });
+        });
+        it('should not include projections in map when projectionDefs is empty', () => {
+            const mapConfig = {
+                center: {crs: 'EPSG:4326', x: 0, y: 0},
+                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                projection: 'EPSG:900913',
+                units: 'm',
+                mapInfoControl: true,
+                zoom: 10
+            };
+            const saved = saveMapConfiguration(mapConfig, [], [], [], '', {}, {}, []);
+            expect(saved.map.projections).toNotExist();
+        });
     });
 
     it('test getIdFromUri ', () => {

--- a/web/client/utils/__tests__/ProjectionRegistry-test.js
+++ b/web/client/utils/__tests__/ProjectionRegistry-test.js
@@ -7,7 +7,7 @@
  */
 import expect from 'expect';
 
-import { register, getByCode, getAll, registerAll, onRegister, isRegistered, unRegisterAll } from '../ProjectionRegistry';
+import { register, getByCode, getAll, registerAll, onRegister, isRegistered, unRegister, unRegisterAll } from '../ProjectionRegistry';
 
 const crs3003proj4 = {
     "code": "EPSG:3003",
@@ -52,6 +52,28 @@ describe('ProjectionRegistry', () => {
         register(crs2000wkt);
         expect(isRegistered(crs2000wkt.code)).toBe(true);
         expect(isRegistered(crs3003proj4.code)).toBe(false);
+    });
+    it('should return true for proj4 native codes even when not in the custom registry', () => {
+        unRegisterAll();
+        expect(isRegistered('EPSG:4326')).toBe(true);
+        expect(isRegistered('EPSG:3857')).toBe(true);
+        expect(isRegistered('EPSG:900913')).toBe(true);
+        expect(isRegistered('CRS:84')).toBe(true);
+    });
+    it('should return false for a code that was registered and then unregistered', () => {
+        register(crs3003proj4);
+        expect(isRegistered(crs3003proj4.code)).toBe(true);
+        unRegister(crs3003proj4.code);
+        expect(isRegistered(crs3003proj4.code)).toBe(false);
+    });
+    it('should return false for all custom codes after unRegisterAll', () => {
+        register(crs3003proj4);
+        register(crs2000wkt);
+        unRegisterAll();
+        expect(isRegistered(crs3003proj4.code)).toBe(false);
+        expect(isRegistered(crs2000wkt.code)).toBe(false);
+        // native codes must survive unRegisterAll
+        expect(isRegistered('EPSG:4326')).toBe(true);
     });
     it('registerall should register multiple projections', () => {
         registerAll([crs3003proj4, crs2000wkt]).then(() => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR address problems found in this comment https://github.com/geosolutions-it/MapStore2/issues/12301#issuecomment-4389503991

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

 #12301

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Projections are persisted also in exported maps and a warning is displayed when a projection is not registered

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
