### PR TITLE
Fix #12349 CRS compatibility check fails when terrain layer is a part of background group.

### DIFF
--- a/web/client/plugins/CRSSelector/__tests__/CRSSelector-test.jsx
+++ b/web/client/plugins/CRSSelector/__tests__/CRSSelector-test.jsx
@@ -425,4 +425,69 @@ describe('CRSSelector Plugin', () => {
         expect(document.getElementsByClassName('ms-crs-selector-container').length).toBe(1);
         expect(document.getElementsByClassName('ms-crs-settings-button').length).toBe(1);
     });
+
+    it('switches to custom CRS with terrain background', (done) => {
+        const { Plugin } = getPluginForTest(CRSSelectorPlugin, {
+            map: {
+                projection: "EPSG:3003"
+            },
+            layers: {
+                flat: [{
+                    group: "background",
+                    visibility: true,
+                    type: "terrain"
+                }]
+            },
+            localConfig: {
+                projectionDefs: [{
+                    "code": "EPSG:3003",
+                    "def": "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
+                    "extent": [1241482.0019, 973563.1609, 1830078.9331, 5215189.0853],
+                    "worldExtent": [6.6500, 8.8000, 12.0000, 47.0500]
+                }]
+            },
+            security: {
+                user: {
+                    role: "USER"
+                }
+            }
+        });
+
+        const actions = {
+            onError: () => {},
+            setCrs: () => {}
+        };
+        const spyError = expect.spyOn(actions, 'onError');
+        const spySet = expect.spyOn(actions, 'setCrs');
+
+        ReactDOM.render(<Plugin
+            pluginCfg={{
+                onError: actions.onError,
+                setCrs: actions.setCrs,
+                availableProjections: [
+                    ...defaultAvailableProjections,
+                    { value: "EPSG:3003", label: "EPSG:3003" }
+                ],
+                allowedRoles: ["ALL"]
+            }}
+        />, document.getElementById("container"));
+        const dropdown = document.querySelector('.ms-crs-dropdown');
+        expect(dropdown).toExist();
+        const toggleButton = dropdown.querySelector('.ms-crs-select-button');
+        ReactTestUtils.Simulate.click(toggleButton);
+        setTimeout(() => {
+            const menuItems = Array.from(document.querySelectorAll('.dropdown-menu li'));
+            const menuItem = menuItems.find(li => li.textContent.includes('EPSG:3003'));
+            if (menuItem) {
+                ReactTestUtils.Simulate.click(menuItem);
+                setTimeout(() => {
+                    expect(spyError).toNotHaveBeenCalled();
+                    expect(spySet).toHaveBeenCalledWith("EPSG:3003");
+                    done();
+                }, 100);
+            } else {
+                done();
+            }
+        }, 100);
+    });
 });

--- a/web/client/plugins/CRSSelector/containers/CRSSelector.jsx
+++ b/web/client/plugins/CRSSelector/containers/CRSSelector.jsx
@@ -114,7 +114,7 @@ const Selector = ({
     }, toggled);
 
     const changeCrs = (crs) => {
-        const allowedLayerTypes = ["wms", "osm", "tileprovider", "empty"];
+        const allowedLayerTypes = ["wms", "osm", "tileprovider", "terrain", "empty"];
         if (indexOf(allowedLayerTypes, currentBackground?.type) > -1
             || (currentBackground.allowedSRS && has(currentBackground.allowedSRS, crs))
         ) {


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes CRS compatibility check fails when terrain layer is a part of background group.

The fix for this is to add also "terrain" as a allowedLayerTypes https://github.com/geosolutions-it/MapStore2/blob/master/web/client/plugins/CRSSelector/containers/CRSSelector.jsx#L117


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12349 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

https://github.com/user-attachments/assets/92d8dd88-32bb-460a-a734-2a9681f22b2d

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
