### PR TITLE
Fix #12353 Click events not working outside the projection extent

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -177,70 +177,54 @@ class OpenlayersMap extends React.Component {
         map.on('moveend', this.updateMapInfoState);
         map.on('singleclick', (event) => {
             if (this.props.onClick && !this.map.disabledListeners.singleclick) {
-                let pos = event.coordinate.slice();
-                let projectionExtent = this.getExtent(this.map, this.props);
-                if (this.props.projection === 'EPSG:4326') {
-                    pos[0] = normalizeLng(pos[0]);
-                }
-                if (this.props.projection === 'EPSG:900913' || this.props.projection === 'EPSG:3857') {
-                    pos = toLonLat(pos, this.props.projection);
-                    projectionExtent = reprojectBbox(projectionExtent, this.props.projection, "EPSG:4326");
-                }
-                // prevent user from clicking outside the projection extent
-                if (pos[0] >= projectionExtent[0] && pos[0] <= projectionExtent[2] &&
-                    pos[1] >= projectionExtent[1] && pos[1] <= projectionExtent[3]) {
-                    let coords;
-                    if (this.props.projection !== 'EPSG:900913' && this.props.projection !== 'EPSG:3857') {
-                        coords = reproject(pos, this.props.projection, "EPSG:4326");
-                    } else {
-                        coords = { x: pos[0], y: pos[1] };
-                    }
-
-                    let layerInfo;
-                    this.markerPresent = false;
-                    /*
-                     * Handle special case for vector features with handleClickOnLayer=true
-                     * Modifies the clicked point coordinates to center the marker and sets the layerInfo for
-                     * the clickPoint event (used as flag to show or hide marker)
-                     */
-                    map.forEachFeatureAtPixel(event.pixel, (feature, layer) => {
-                        if (layer && layer.get('handleClickOnLayer')) {
-                            const geom = feature.getGeometry();
-                            // TODO: We should find out a better way to identify it then checking geometry type
-                            if (!this.markerPresent && geom.getType() === "Point") {
-                                this.markerPresent = true;
-                                layerInfo = layer.get('msId');
-                                const arr = toLonLat(geom.getFirstCoordinate(), this.props.projection);
-                                coords = { x: arr[0], y: arr[1] };
-                            }
+                const latLng = this.coordinateToLatLng(event.coordinate);
+                if (!latLng) return;
+                const { pos, lat, lng } = latLng;
+                /*
+                 * Handle special case for vector features with handleClickOnLayer=true
+                 * Modifies the clicked point coordinates to center the marker and sets the layerInfo for
+                 * the clickPoint event (used as flag to show or hide marker)
+                 */
+                let markerCoords;
+                let layerInfo;
+                this.markerPresent = false;
+                map.forEachFeatureAtPixel(event.pixel, (feature, layer) => {
+                    if (layer && layer.get('handleClickOnLayer')) {
+                        const geom = feature.getGeometry();
+                        // TODO: We should find out a better way to identify it then checking geometry type
+                        if (!this.markerPresent && geom.getType() === "Point") {
+                            this.markerPresent = true;
+                            layerInfo = layer.get('msId');
+                            const arr = toLonLat(geom.getFirstCoordinate(), this.props.projection);
+                            markerCoords = { x: arr[0], y: arr[1] };
                         }
-                    });
-                    const intersectedFeatures = this.getIntersectedFeatures(map, event?.pixel);
-                    const tLng = normalizeLng(coords.x);
+                    }
+                });
+                const finalLat = markerCoords ? markerCoords.y : lat;
+                const finalLng = markerCoords ? normalizeLng(markerCoords.x) : lng;
+                const intersectedFeatures = this.getIntersectedFeatures(map, event?.pixel);
+                const intersectedPixels = this.getIntersectedPixels(map, event?.pixel);
 
-                    const intersectedPixels = this.getIntersectedPixels(map, event?.pixel);
-
-                    this.props.onClick({
-                        pixel: {
-                            x: event.pixel[0],
-                            y: event.pixel[1]
-                        },
-                        latlng: {
-                            lat: coords.y,
-                            lng: tLng,
-                            z: this.getElevation(pos, event.pixel)
-                        },
-                        rawPos: event.coordinate.slice(),
-                        modifiers: {
-                            alt: event.originalEvent.altKey,
-                            ctrl: event.originalEvent.ctrlKey,
-                            metaKey: event.originalEvent.metaKey, // MAC OS
-                            shift: event.originalEvent.shiftKey
-                        },
-                        intersectedFeatures,
-                        intersectedPixels
-                    }, layerInfo);
-                }
+                this.props.onClick({
+                    pixel: {
+                        x: event.pixel[0],
+                        y: event.pixel[1]
+                    },
+                    latlng: {
+                        lat: finalLat,
+                        lng: finalLng,
+                        z: this.getElevation(pos, event.pixel)
+                    },
+                    rawPos: event.coordinate.slice(),
+                    modifiers: {
+                        alt: event.originalEvent.altKey,
+                        ctrl: event.originalEvent.ctrlKey,
+                        metaKey: event.originalEvent.metaKey, // MAC OS
+                        shift: event.originalEvent.shiftKey
+                    },
+                    intersectedFeatures,
+                    intersectedPixels
+                }, layerInfo);
             }
         });
         const mouseMove = throttle(this.mouseMoveEvent, 100);
@@ -398,11 +382,6 @@ class OpenlayersMap extends React.Component {
         );
     };
 
-    getExtent = (map, props) => {
-        const view = map.getView();
-        return view.getProjection().getExtent() || msGetProjection(props.projection).extent;
-    };
-
     /**
      *
      * @param {zoom} map
@@ -514,22 +493,38 @@ class OpenlayersMap extends React.Component {
         );
     }
 
+    coordinateToLatLng = (coordinate) => {
+        const [rawX, rawY] = coordinate;
+        if (!Number.isFinite(rawX) || !Number.isFinite(rawY)) {
+            return null;
+        }
+        const projection = this.props.projection;
+        const isWebMercator = projection === 'EPSG:900913' || projection === 'EPSG:3857';
+        const pos = isWebMercator
+            ? toLonLat([rawX, rawY], projection)
+            : projection === 'EPSG:4326'
+                ? [normalizeLng(rawX), rawY]
+                : [rawX, rawY];
+        const coords = isWebMercator
+            ? { x: pos[0], y: pos[1] }
+            : reproject(pos, projection, 'EPSG:4326');
+        if (!coords || !Number.isFinite(coords.x) || !Number.isFinite(coords.y)) {
+            return null;
+        }
+        return { pos, lat: coords.y, lng: normalizeLng(coords.x) };
+    };
+
     mouseMoveEvent = (event) => {
         if (!event.dragging && event.coordinate) {
-            let pos = event.coordinate.slice();
-            let coords = toLonLat(pos, this.props.projection);
-            let tLng = coords[0] / 360 % 1 * 360;
-            if (tLng < -180) {
-                tLng = tLng + 360;
-            } else if (tLng > 180) {
-                tLng = tLng - 360;
-            }
+            const latLng = this.coordinateToLatLng(event.coordinate);
+            if (!latLng) return;
+            const { pos, lat, lng } = latLng;
             const intersectedFeatures = this.getIntersectedFeatures(this.map, event?.pixel);
             const intersectedPixels = this.getIntersectedPixels(this.map, event?.pixel);
             const elevation = this.getElevation(pos, event.pixel);
             this.props.onMouseMove({
-                y: coords[1] || 0.0,
-                x: tLng || 0.0,
+                y: lat || 0.0,
+                x: lng || 0.0,
                 z: elevation,
                 crs: "EPSG:4326",
                 pixel: {
@@ -537,12 +532,12 @@ class OpenlayersMap extends React.Component {
                     y: event.pixel[1]
                 },
                 latlng: {
-                    lat: coords[1],
-                    lng: tLng,
+                    lat,
+                    lng,
                     z: elevation
                 },
-                lat: coords[1],
-                lng: tLng,
+                lat,
+                lng,
                 rawPos: event.coordinate.slice(),
                 intersectedFeatures,
                 intersectedPixels
@@ -551,22 +546,19 @@ class OpenlayersMap extends React.Component {
     };
 
     updateMapInfoState = () => {
-        let view = this.map.getView();
-        let tempCenter = view.getCenter();
-        let projectionExtent = this.getExtent(this.map, this.props);
+        const view = this.map.getView();
         const crs = view.getProjection().getCode();
-        // some projections are repeated on the x axis
-        // and they need to be updated also if the center is outside of the projection extent
-        const wrappedProjections = ['EPSG:3857', 'EPSG:900913', 'EPSG:4326'];
-        // prevent user from dragging outside the projection extent
-        if (wrappedProjections.indexOf(crs) !== -1
-            || (tempCenter && tempCenter[0] >= projectionExtent[0] && tempCenter[0] <= projectionExtent[2] &&
-                tempCenter[1] >= projectionExtent[1] && tempCenter[1] <= projectionExtent[3])) {
-            let c = this.normalizeCenter(view.getCenter());
-            let bbox = view.calculateExtent(this.map.getSize());
-            let size = {
-                width: this.map.getSize()[0],
-                height: this.map.getSize()[1]
+        const mapSize = this.map.getSize();
+        const c = this.normalizeCenter(view.getCenter());
+        const bbox = view.calculateExtent(mapSize);
+        const bboxIsValid = bbox?.length === 4
+            && bbox.every(Number.isFinite)
+            && bbox[0] < bbox[2]
+            && bbox[1] < bbox[3];
+        if (bboxIsValid) {
+            const size = {
+                width: mapSize[0],
+                height: mapSize[1]
             };
             this.props.onMapViewChanges(
                 {
@@ -663,17 +655,26 @@ class OpenlayersMap extends React.Component {
         }
     };
 
-    zoomToExtentHandler = (extent, { padding, crs = 'EPSG:4326', maxZoom: zoomLevel, duration, nearest} = {})=> {
-        let bounds = reprojectBbox(extent, crs, this.props.projection);
+    zoomToExtentHandler = (extent, { padding, crs = 'EPSG:4326', maxZoom: zoomLevel, duration, nearest } = {}) => {
+        const projected = reprojectBbox(extent, crs, this.props.projection);
         // TODO: improve this to manage all degenerated bounding boxes.
-        if (bounds && bounds[0] === bounds[2] && bounds[1] === bounds[3] &&
-        crs === "EPSG:4326" && isArray(extent) && extent[0] === -180 && extent[1] === -90) {
-            bounds = this.map.getView().getProjection().getExtent();
+        const isWorldExtent = projected && projected[0] === projected[2] && projected[1] === projected[3]
+            && crs === "EPSG:4326" && isArray(extent) && extent[0] === -180 && extent[1] === -90;
+        const rawBounds = isWorldExtent ? this.map.getView().getProjection().getExtent() : projected;
+        // Normalize axis order: some projections (e.g. polar stereographic) invert Y,
+        // causing reprojectBbox to return miny > maxy. OL rejects such extents as empty.
+        const bounds = rawBounds ? [
+            Math.min(rawBounds[0], rawBounds[2]),
+            Math.min(rawBounds[1], rawBounds[3]),
+            Math.max(rawBounds[0], rawBounds[2]),
+            Math.max(rawBounds[1], rawBounds[3])
+        ] : rawBounds;
+        if (!bounds || !bounds.every(Number.isFinite)) {
+            return;
         }
-        let maxZoom = zoomLevel;
-        if (bounds && bounds[0] === bounds[2] && bounds[1] === bounds[3] && isNil(maxZoom)) {
-            maxZoom = 21; // TODO: allow to this maxZoom to be customizable
-        }
+        const isDegenerate = bounds[0] === bounds[2] && bounds[1] === bounds[3];
+        // TODO: allow maxZoom to be customizable
+        const maxZoom = isDegenerate && isNil(zoomLevel) ? 21 : zoomLevel;
         this.map.getView().fit(bounds, {
             size: this.map.getSize(),
             // mapPaddingSelector returns null while the layout epic is mid-computation

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -1041,7 +1041,8 @@ describe('OpenlayersMap', () => {
             zoom={11}
             registerHooks
             mapOptions={{ zoomAnimation: false }}
-            onMapViewChanges={testHandlers.onMapViewChanges} />,
+            onMapViewChanges={testHandlers.onMapViewChanges}
+            style={{ width: 200, height: 200 }} />,
         document.getElementById("map"));
         const olMap = map.map;
         olMap.on('moveend', () => {
@@ -1086,6 +1087,49 @@ describe('OpenlayersMap', () => {
         const hook = MapUtils.getHook(MapUtils.ZOOM_TO_EXTENT_HOOK);
         expect(hook).toBeTruthy();
         expect(() => hook([0, 0, 20, 20], { crs: "EPSG:4326", duration: 0, padding: null })).toNotThrow();
+    });
+
+    it('test ZOOM_TO_EXTENT_HOOK does not throw when reprojectBbox returns null (unregistered source CRS)', () => {
+        MapUtils.registerHook(MapUtils.ZOOM_TO_EXTENT_HOOK, undefined);
+        const map = ReactDOM.render(<OpenlayersMap
+            id="mymap"
+            center={{ y: 0, x: 0 }}
+            zoom={4}
+            registerHooks
+            style={{ width: 200, height: 200 }}
+        />, document.getElementById("map"));
+        expect(map).toBeTruthy();
+        const hook = MapUtils.getHook(MapUtils.ZOOM_TO_EXTENT_HOOK);
+        expect(hook).toBeTruthy();
+        // reprojectBbox returns null for an unregistered CRS → early return, no throw
+        expect(() => hook([0, 0, 20, 20], { crs: "EPSG:UNKNOWN_FAKE", duration: 0 })).toNotThrow();
+    });
+
+    it('test ZOOM_TO_EXTENT_HOOK does not throw with polar projection that produces inverted Y bounds', () => {
+        // EPSG:3996 (WGS 84 / IBCAO Polar Stereographic) inverts the Y axis for
+        // sub-polar coordinates: reprojectBbox returns miny > maxy, which OL rejects
+        // as an empty extent. The normalization step must reorder the axes before fit().
+        const projDef = {
+            code: "EPSG:3996",
+            def: "+proj=stere +lat_0=90 +lat_ts=75 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            extent: [-9036842, -9036842, 9036842, 9036842]
+        };
+        ProjectionRegistry.register(projDef);
+        MapUtils.registerHook(MapUtils.ZOOM_TO_EXTENT_HOOK, undefined);
+        const map = ReactDOM.render(<OpenlayersMap
+            id="mymap"
+            center={{ y: 80, x: 0 }}
+            zoom={4}
+            projection="EPSG:3996"
+            registerHooks
+            mapOptions={{ zoomAnimation: false }}
+            style={{ width: 200, height: 200 }}
+        />, document.getElementById("map"));
+        expect(map).toBeTruthy();
+        const hook = MapUtils.getHook(MapUtils.ZOOM_TO_EXTENT_HOOK);
+        expect(hook).toBeTruthy();
+        expect(() => hook([-125.0, 24.8, -66.7, 49.5], { crs: "EPSG:4326", duration: 0 })).toNotThrow();
+        ProjectionRegistry.unRegisterAll();
     });
 
     it('create attribution with container', () => {
@@ -1217,7 +1261,7 @@ describe('OpenlayersMap', () => {
         expect(attributions.length).toBe(2);
     });
 
-    it('test updateMapInfoState with custom projection 3003 (not listed in wrappedProjections)', () => {
+    it('test updateMapInfoState with custom projection 3003 fires even when center is outside extent', () => {
 
         const CENTER_OUTSIDE_OF_MAX_EXTENT = {
             x: 50,
@@ -1255,9 +1299,10 @@ describe('OpenlayersMap', () => {
             zoom={11}
             mapOptions={{ attribution: { container: 'body' } }}
             projection={projectionDefs[0].code}
+            style={{ width: 200, height: 200 }}
         />, document.getElementById("map"));
 
-        expect(spyOnMapViewChanges.calls.length).toBe(0);
+        expect(spyOnMapViewChanges.calls.length).toBe(1);
         ProjectionRegistry.unRegisterAll();
     });
 
@@ -1280,6 +1325,7 @@ describe('OpenlayersMap', () => {
             zoom={11}
             mapOptions={{ attribution: { container: 'body' } }}
             projection={'EPSG:3857'}
+            style={{ width: 200, height: 200 }}
         />, document.getElementById("map"));
 
         expect(spyOnMapViewChanges.calls.length).toBe(1);
@@ -1304,6 +1350,7 @@ describe('OpenlayersMap', () => {
             zoom={11}
             mapOptions={{ attribution: { container: 'body' } }}
             projection={'EPSG:4326'}
+            style={{ width: 200, height: 200 }}
         />, document.getElementById("map"));
 
         expect(spyOnMapViewChanges.calls.length).toBe(1);
@@ -1328,6 +1375,7 @@ describe('OpenlayersMap', () => {
             zoom={11}
             mapOptions={{ attribution: { container: 'body' } }}
             projection={'EPSG:900913'}
+            style={{ width: 200, height: 200 }}
         />, document.getElementById("map"));
 
         expect(spyOnMapViewChanges.calls.length).toBe(1);
@@ -1538,6 +1586,80 @@ describe('OpenlayersMap', () => {
         expect(map.map.getLayers().getArray()[0].getSource().getTileGrid().getResolutions().length).toBe(3);
         expect(map.map.getLayers().getArray()[0].getSource().getTileGrid().getOrigin()).toEqual(options.tileGrids[1].origin);
     });
+    describe('coordinateToLatLng', () => {
+        it('returns null for NaN coordinate', () => {
+            const map = ReactDOM.render(
+                <OpenlayersMap center={{ y: 43.9, x: 10.3 }} zoom={11} />,
+                document.getElementById("map")
+            );
+            expect(map.coordinateToLatLng([NaN, NaN])).toBe(null);
+        });
+        it('returns correct lat/lng for EPSG:4326 coordinate', () => {
+            const map = ReactDOM.render(
+                <OpenlayersMap projection="EPSG:4326" center={{ y: 43.9, x: 10.3 }} zoom={11} />,
+                document.getElementById("map")
+            );
+            const result = map.coordinateToLatLng([10.3, 43.9]);
+            expect(result).toBeTruthy();
+            expect(result.lat).toBe(43.9);
+            expect(result.lng).toBe(10.3);
+        });
+        it('normalizes longitude > 180 in EPSG:4326', () => {
+            const map = ReactDOM.render(
+                <OpenlayersMap projection="EPSG:4326" center={{ y: 43.9, x: 10.3 }} zoom={11} />,
+                document.getElementById("map")
+            );
+            const result = map.coordinateToLatLng([190, 43.9]);
+            expect(result).toBeTruthy();
+            expect(result.lng).toBe(-170);
+        });
+        it('returns correct lat/lng for EPSG:3857 coordinate', () => {
+            const map = ReactDOM.render(
+                <OpenlayersMap projection="EPSG:3857" center={{ y: 43.9, x: 10.3 }} zoom={11} />,
+                document.getElementById("map")
+            );
+            const [x, y] = transform([10.3, 43.9], 'EPSG:4326', 'EPSG:3857');
+            const result = map.coordinateToLatLng([x, y]);
+            expect(result).toBeTruthy();
+            expect(result.lat.toFixed(1)).toBe('43.9');
+            expect(result.lng.toFixed(1)).toBe('10.3');
+        });
+    });
+
+    it('singleclick does not call onClick for coordinates producing invalid lat/lng', () => {
+        const testHandlers = { handler: () => {} };
+        const spy = expect.spyOn(testHandlers, 'handler');
+        const map = ReactDOM.render(
+            <OpenlayersMap projection="EPSG:4326" center={{ y: 43.9, x: 10.3 }} zoom={11}
+                onClick={testHandlers.handler} />,
+            document.getElementById("map")
+        );
+        map.map.dispatchEvent({
+            type: 'singleclick',
+            coordinate: [NaN, NaN],
+            pixel: [100, 100],
+            originalEvent: {}
+        });
+        expect(spy.calls.length).toEqual(0);
+    });
+
+    it('pointermove does not call onMouseMove for coordinates producing invalid lat/lng', () => {
+        const testHandlers = { handler: () => {} };
+        const spy = expect.spyOn(testHandlers, 'handler');
+        const map = ReactDOM.render(
+            <OpenlayersMap projection="EPSG:4326" center={{ y: 43.9, x: 10.3 }} zoom={11}
+                onMouseMove={testHandlers.handler} />,
+            document.getElementById("map")
+        );
+        map.map.dispatchEvent({
+            type: 'pointermove',
+            coordinate: [NaN, NaN],
+            pixel: [100, 100],
+            dragging: false
+        });
+        expect(spy.calls.length).toEqual(0);
+    });
+
     describe("hookRegister", () => {
         it("default", () => {
             const map = ReactDOM.render(<OpenlayersMap id="mymap" center={{y: 43.9, x: 10.3}} zoom={11}/>, document.getElementById("map"));


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces following changes:

- align behaviours of click and mouse move events
- limit the click events only when the reprojected point is not finite
- allow to trigger CHANGE_MAP_VIEW when the bbox is valid
- validate bounding box before triggering fit action

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12353

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Allow to click outside of the projection maximum extent

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
