### PR TITLE
Fix #12301 restore fallback to empty map in mapsave selector

### DIFF
--- a/web/client/selectors/mapsave.js
+++ b/web/client/selectors/mapsave.js
@@ -93,7 +93,7 @@ export const mapSaveDataSelector = createSelector(
         dynamicProjectionDefsSelector
     ],
     (map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, projectionDefs) => ({
-        map,
+        map: map || {},
         layers,
         groups,
         backgrounds,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR restores the empty object fallback for the map save selector

reported here: https://github.com/geosolutions-it/MapStore2/issues/12301#issuecomment-4406731025

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#12301

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Restore map empty object fallback

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
