### PR TITLE
Fix #12301 Improve parsing of axis orientation

### DIFF
--- a/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
+++ b/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
@@ -27,11 +27,7 @@ describe('GeometryDetails', () => {
 
     it('creates the GeometryDetails component with Circle selection', () => {
         let geometry = {
-            center: {
-                srs: "EPSG:900913",
-                x: -1764074.344349588,
-                y: 5854757.632510748
-            },
+            center: [-1764074.344349588, 5854757.632510748],
             projection: "EPSG:900913",
             radius: 836584.05,
             type: "Polygon"

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -607,7 +607,7 @@ class OpenlayersMap extends React.Component {
         */
         const viewOptions = Object.assign({}, {
             projection: normalizeSRS(projection),
-            center: [center.x, center.y],
+            center: [center?.x || 0, center?.y || 0],
             zoom: zoom,
             minZoom: limits.minZoom,
             // allow to zoom to level 0 and see world wrapping
@@ -628,7 +628,9 @@ class OpenlayersMap extends React.Component {
 
         if (!centerIsUpdated) {
             let center = reproject({ x: newProps.center.x, y: newProps.center.y }, 'EPSG:4326', newProps.projection, true);
-            view.setCenter([center.x, center.y]);
+            if (center) {
+                view.setCenter([center.x, center.y]);
+            }
         }
         if (this.props.editScale) {
             // this is for map print only
@@ -645,7 +647,7 @@ class OpenlayersMap extends React.Component {
 
     normalizeCenter = (center) => {
         let c = reproject({ x: center[0], y: center[1] }, this.props.projection, 'EPSG:4326', true);
-        return [c.x, c.y];
+        return [c?.x || 0, c?.y || 0];
     };
 
     setMousePointer = (pointer) => {

--- a/web/client/test-resources/wmc/exported-context.wmc
+++ b/web/client/test-resources/wmc/exported-context.wmc
@@ -67,7 +67,7 @@
         </Style>
       </StyleList>
       <Extension>
-        <ol:maxExtent minx="20036580.680365965" miny="-20037508.34" maxx="-20036580.68036596" maxy="20037508.34"/>
+        <ol:maxExtent minx="-20037508.34" miny="-20037508.34" maxx="20037508.34" maxy="20037508.34"/>
         <ol:singleTile>false</ol:singleTile>
         <ol:transparent>true</ol:transparent>
         <ol:isBaseLayer>false</ol:isBaseLayer>

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -140,7 +140,16 @@ export const reproject = (point, source, dest, normalize = true) => {
     if (sourceProj && destProj) {
         let p = isArray(point) ? Proj4js.toPoint(point) : Proj4js.toPoint([point.x, point.y]);
 
-        const transformed = Object.assign({}, source === dest ? numberize(p) : Proj4js.transform(sourceProj, destProj, numberize(p)), {srs: dest});
+        let transformed;
+        try {
+            const result = source === dest ? numberize(p) : Proj4js.transform(sourceProj, destProj, numberize(p));
+            if (!result || !isFinite(result.x) || !isFinite(result.y)) {
+                return null;
+            }
+            transformed = Object.assign({}, result, {srs: dest});
+        } catch (e) {
+            return null;
+        }
         if (normalize) {
             return normalizePoint(transformed);
         }

--- a/web/client/utils/ProjectionRegistry.js
+++ b/web/client/utils/ProjectionRegistry.js
@@ -8,9 +8,13 @@
 
 import proj4 from 'proj4';
 import { registerGridFiles } from './ProjectionUtils';
+import { normalizeUnit } from './MapUtils';
 
 const registry = new Map(); // code → { code, def, extent, worldExtent, ... }
 const listeners = [];
+
+// Projections natively supported by proj4.
+const PROJ4_NATIVE_CODES = new Set(['EPSG:4326', 'EPSG:3857', 'EPSG:900913', 'CRS:84']);
 
 const FORMAT = {
     PROJ4: 'proj4',
@@ -57,7 +61,7 @@ export function register(projDef) {
 
     const { def: normalizedDef, supported } = toDef(def);
 
-    if (supported) {
+    if (supported && !proj4.defs(code)) {
         proj4.defs(code, normalizedDef);
     }
     const proj4Metadata = proj4.defs(code);
@@ -67,8 +71,10 @@ export function register(projDef) {
     // mark it supported so map-library adapters pick it up.
     const isSupported = supported || !!proj4Metadata;
 
-    const isGeographic = proj4Metadata?.projName === 'longlat';
-    const axisOrientation = projDef?.axisOrientation || (isGeographic ? 'neu' : (proj4Metadata?.axis || 'enu'));
+    const isGeographic = ['longlat', 'latlong'].includes(proj4Metadata?.projName)
+        || normalizeUnit(proj4Metadata?.units) === 'degrees';
+    // proj4 reports axis 'enu' even for geographic CRS - default to 'neu' (OGC/ISO lat-first order) and let projDef.axisOrientation override if needed
+    const axisOrientation = projDef?.axisOrientation || proj4Metadata?.axis || (isGeographic ? 'neu' : 'enu');
     const units = projDef?.units || proj4Metadata?.units || 'm';
 
     const entry = {
@@ -137,9 +143,6 @@ export function getByCode(code) {
     return registry.get(code) ?? null;
 }
 
-// Projections natively supported by proj4.
-const PROJ4_NATIVE_CODES = new Set(['EPSG:4326', 'EPSG:3857', 'EPSG:900913', 'CRS:84']);
-
 export function isRegistered(code) {
     return registry.has(code) || PROJ4_NATIVE_CODES.has(code);
 }
@@ -149,13 +152,22 @@ export function isRegistered(code) {
 // calculations). EPSG:4326 / EPSG:3857 are intentionally excluded - OL ships
 // them with specific axis orientations and re-registering would overwrite
 // those built-ins.
-const BUILTIN_DEFS = [{
-    code: "EPSG:4269",
-    def: "+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs",
-    axisOrientation: "neu",
-    extent: [-172.54, 23.81, -47.74, 86.46],
-    worldExtent: [-172.54, 23.81, -47.74, 86.46]
-}];
+const BUILTIN_DEFS = [
+    {
+        code: "EPSG:4269",
+        def: "+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs",
+        axisOrientation: "neu",
+        extent: [-172.54, 23.81, -47.74, 86.46],
+        worldExtent: [-172.54, 23.81, -47.74, 86.46]
+    },
+    {
+        code: "CRS:84",
+        def: "+proj=longlat +datum=WGS84 +no_defs",
+        axisOrientation: "enu",
+        extent: [-180, -90, 180, 90],
+        worldExtent: [-180, -90, 180, 90]
+    }
+];
 BUILTIN_DEFS.forEach(register);
 
 const ProjectionRegistry = {

--- a/web/client/utils/ProjectionRegistry.js
+++ b/web/client/utils/ProjectionRegistry.js
@@ -67,7 +67,8 @@ export function register(projDef) {
     // mark it supported so map-library adapters pick it up.
     const isSupported = supported || !!proj4Metadata;
 
-    const axisOrientation = projDef?.axisOrientation || proj4Metadata?.axis || 'enu';
+    const isGeographic = proj4Metadata?.projName === 'longlat';
+    const axisOrientation = projDef?.axisOrientation || (isGeographic ? 'neu' : (proj4Metadata?.axis || 'enu'));
     const units = projDef?.units || proj4Metadata?.units || 'm';
 
     const entry = {

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -68,6 +68,13 @@ describe('CoordinatesUtils', () => {
         expect(transformed3).toNotExist();
         expect(transformed3).toEqual(null);
     });
+    it('reproject returns null for a point outside the destination projection domain', () => {
+        // EPSG:6931 is North Pole LAEA - the South Pole [0, -90] is the antipodal
+        // point and causes proj4 to throw or produce non-finite coordinates.
+        Proj4js.defs('EPSG:6931', '+proj=laea +lat_0=90 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');
+        const result = reproject([0, -90], 'EPSG:4326', 'EPSG:6931');
+        expect(result).toBe(null);
+    });
     it('convert lat lon to mercator', () => {
         var point = [45, 13];
 

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -46,6 +46,7 @@ import {
 } from '../CoordinatesUtils';
 
 import Proj4js from 'proj4';
+import { register, unRegister } from '../ProjectionRegistry';
 
 describe('CoordinatesUtils', () => {
     afterEach((done) => {
@@ -71,9 +72,15 @@ describe('CoordinatesUtils', () => {
     it('reproject returns null for a point outside the destination projection domain', () => {
         // EPSG:6931 is North Pole LAEA - the South Pole [0, -90] is the antipodal
         // point and causes proj4 to throw or produce non-finite coordinates.
-        Proj4js.defs('EPSG:6931', '+proj=laea +lat_0=90 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');
+        register({
+            code: 'EPSG:6931',
+            def: '+proj=laea +lat_0=90 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs',
+            extent: [-9009964.76, -9009964.76, 9009964.76, 9009964.76],
+            worldExtent: [-180, 0, 180, 90]
+        });
         const result = reproject([0, -90], 'EPSG:4326', 'EPSG:6931');
         expect(result).toBe(null);
+        unRegister('EPSG:6931');
     });
     it('convert lat lon to mercator', () => {
         var point = [45, 13];

--- a/web/client/utils/__tests__/ProjectionRegistry-test.js
+++ b/web/client/utils/__tests__/ProjectionRegistry-test.js
@@ -21,6 +21,21 @@ const crs2000wkt = {
     "extent": [270929.956129349, 2002224.11122865, 302793.271930239, 2026749.06945627],
     "worldExtent": [-63.22, 18.11, -62.92, 18.33]
 };
+// Geographic CRS defined as a proj4 string (no explicit +axis= parameter)
+const crs4674proj4 = {
+    "code": "EPSG:4674",
+    "def": "+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs",
+    "extent": [-122.19, -59.87, -25.28, 32.72],
+    "worldExtent": [-122.19, -59.87, -25.28, 32.72]
+};
+// Geographic CRS defined as WKT with longitude-first AXIS (non-EPSG-standard order,
+// common output from GeoServer / ESRI tools)
+const crs4674wktLonFirst = {
+    "code": "EPSG:4674",
+    "def": "GEOGCS[\"SIRGAS 2000\", \n  DATUM[\"Sistema de Referencia Geocentrico para las AmericaS 2000\", \n    SPHEROID[\"GRS 1980\", 6378137.0, 298.257222101, AUTHORITY[\"EPSG\",\"7019\"]], \n    TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], \n    AUTHORITY[\"EPSG\",\"6674\"]], \n  PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], \n  UNIT[\"degree\", 0.017453292519943295], \n  AXIS[\"Geodetic longitude\", EAST], \n  AXIS[\"Geodetic latitude\", NORTH], \n  AUTHORITY[\"EPSG\",\"4674\"]]",
+    "extent": [-122.19, -59.87, -25.28, 32.72],
+    "worldExtent": [-122.19, -59.87, -25.28, 32.72]
+};
 
 describe('ProjectionRegistry', () => {
     afterEach(() => {
@@ -94,5 +109,30 @@ describe('ProjectionRegistry', () => {
             }
         });
         register(crs3003proj4);
+    });
+    it('geographic CRS defined via proj4 string gets axisOrientation neu', () => {
+        register(crs4674proj4);
+        const projection = getByCode(crs4674proj4.code);
+        expect(projection.axisOrientation).toBe('neu');
+    });
+    it('geographic CRS defined via WKT with longitude-first AXIS gets axisOrientation neu', () => {
+        register(crs4674wktLonFirst);
+        const projection = getByCode(crs4674wktLonFirst.code);
+        expect(projection.axisOrientation).toBe('neu');
+    });
+    it('projected CRS defined via WKT with ENU AXIS gets axisOrientation enu', () => {
+        register(crs2000wkt);
+        const projection = getByCode(crs2000wkt.code);
+        expect(projection.axisOrientation).toBe('enu');
+    });
+    it('explicit axisOrientation in projDef overrides the geographic default', () => {
+        register({ ...crs4674proj4, axisOrientation: 'enu' });
+        const projection = getByCode(crs4674proj4.code);
+        expect(projection.axisOrientation).toBe('enu');
+    });
+    it('projected CRS defined via proj4 string defaults to axisOrientation enu', () => {
+        register(crs3003proj4);
+        const projection = getByCode(crs3003proj4.code);
+        expect(projection.axisOrientation).toBe('enu');
     });
 });

--- a/web/client/utils/__tests__/ProjectionRegistry-test.js
+++ b/web/client/utils/__tests__/ProjectionRegistry-test.js
@@ -28,14 +28,6 @@ const crs4674proj4 = {
     "extent": [-122.19, -59.87, -25.28, 32.72],
     "worldExtent": [-122.19, -59.87, -25.28, 32.72]
 };
-// Geographic CRS defined as WKT with longitude-first AXIS (non-EPSG-standard order,
-// common output from GeoServer / ESRI tools)
-const crs4674wktLonFirst = {
-    "code": "EPSG:4674",
-    "def": "GEOGCS[\"SIRGAS 2000\", \n  DATUM[\"Sistema de Referencia Geocentrico para las AmericaS 2000\", \n    SPHEROID[\"GRS 1980\", 6378137.0, 298.257222101, AUTHORITY[\"EPSG\",\"7019\"]], \n    TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], \n    AUTHORITY[\"EPSG\",\"6674\"]], \n  PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], \n  UNIT[\"degree\", 0.017453292519943295], \n  AXIS[\"Geodetic longitude\", EAST], \n  AXIS[\"Geodetic latitude\", NORTH], \n  AUTHORITY[\"EPSG\",\"4674\"]]",
-    "extent": [-122.19, -59.87, -25.28, 32.72],
-    "worldExtent": [-122.19, -59.87, -25.28, 32.72]
-};
 
 describe('ProjectionRegistry', () => {
     afterEach(() => {
@@ -113,11 +105,6 @@ describe('ProjectionRegistry', () => {
     it('geographic CRS defined via proj4 string gets axisOrientation neu', () => {
         register(crs4674proj4);
         const projection = getByCode(crs4674proj4.code);
-        expect(projection.axisOrientation).toBe('neu');
-    });
-    it('geographic CRS defined via WKT with longitude-first AXIS gets axisOrientation neu', () => {
-        register(crs4674wktLonFirst);
-        const projection = getByCode(crs4674wktLonFirst.code);
         expect(projection.axisOrientation).toBe('neu');
     });
     it('projected CRS defined via WKT with ENU AXIS gets axisOrientation enu', () => {

--- a/web/client/utils/__tests__/ProjectionRegistry-test.js
+++ b/web/client/utils/__tests__/ProjectionRegistry-test.js
@@ -135,4 +135,9 @@ describe('ProjectionRegistry', () => {
         const projection = getByCode(crs3003proj4.code);
         expect(projection.axisOrientation).toBe('enu');
     });
+    it('explicit axisOrientation enu is preserved for a geographic CRS like CRS:84', () => {
+        register({ code: 'CRS:84', def: '+proj=longlat +datum=WGS84 +no_defs', axisOrientation: 'enu', extent: [-180, -90, 180, 90], worldExtent: [-180, -90, 180, 90] });
+        const projection = getByCode('CRS:84');
+        expect(projection.axisOrientation).toBe('enu');
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Axis orientation was not correctly parsed for some geographic projections,
this PR includes a fix to use `neu` orientation when the matadata projName is `longlat`.

Address this comment https://github.com/geosolutions-it/MapStore2/issues/12301#issuecomment-4407212930

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#12301

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Correct rendering for geographic projections

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
