### PR TITLE
Fix #12302 Set cropToProjectionExtent to false by default behavior

### DIFF
--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -262,7 +262,7 @@ export default class extends React.Component {
                                     {!this.props.isCesiumActive && <Checkbox
                                         disabled={!!this.props.element.singleTile}
                                         key="cropToProjectionExtent" value="cropToProjectionExtent"
-                                        checked={this.props.element && (this.props.element.cropToProjectionExtent !== undefined ? this.props.element.cropToProjectionExtent : true )}
+                                        checked={!!this.props?.element?.cropToProjectionExtent}
                                         onChange={(e) => this.props.onChange("cropToProjectionExtent", e.target.checked)}>
                                         <Message msgId="layerProperties.cropToProjectionExtent.label" />&nbsp;<InfoPopover text={<Message msgId="layerProperties.cropToProjectionExtent.tooltip" />} />
                                     </Checkbox>}

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -197,7 +197,7 @@ describe('test Layer Properties Display module component', () => {
         expect(isLocalizedLayerStylesOption).toBeTruthy();
     });
 
-    it('tests Display component renders crop to projection extent enabled by default', () => {
+    it('tests Display component renders crop to projection extent disabled by default', () => {
         const l = {
             name: 'layer00',
             title: 'Layer',
@@ -213,7 +213,7 @@ describe('test Layer Properties Display module component', () => {
         ReactDOM.render(<Display element={l} settings={settings}/>, document.getElementById("container"));
         const cropToProjectionExtentInput = document.querySelector("input[value='cropToProjectionExtent']");
         expect(cropToProjectionExtentInput).toBeTruthy();
-        expect(cropToProjectionExtentInput.checked).toBeTruthy();
+        expect(cropToProjectionExtentInput.checked).toBeFalsy();
         expect(cropToProjectionExtentInput.disabled).toBeFalsy();
     });
 

--- a/web/client/components/background/BackgroundDialog.jsx
+++ b/web/client/components/background/BackgroundDialog.jsx
@@ -182,7 +182,7 @@ export default class BackgroundDialog extends React.Component {
                 {!this.props.disableCropToProjectionExtent && <Checkbox
                     disabled={!!this.props.layer.singleTile}
                     key="cropToProjectionExtent" value="cropToProjectionExtent"
-                    checked={({ ...this.props.layer, ...this.state }.cropToProjectionExtent ?? true)}
+                    checked={!!({ ...this.props.layer, ...this.state }.cropToProjectionExtent)}
                     onChange={(e) => this.setState({ cropToProjectionExtent: e.target.checked })}>
                     <Message msgId="layerProperties.cropToProjectionExtent.label" />&nbsp;<InfoPopover text={<Message msgId="layerProperties.cropToProjectionExtent.tooltip" />} />
                 </Checkbox>}

--- a/web/client/components/background/__tests__/BackgroundDialog-test.jsx
+++ b/web/client/components/background/__tests__/BackgroundDialog-test.jsx
@@ -84,7 +84,7 @@ describe('test BackgroundDialog', () => {
         expect(wmsCacheOptionsToolbar).toBeTruthy();
     });
 
-    it('should render crop to projection checkbox enabled and checked by default', () => {
+    it('should render crop to projection checkbox enabled and unchecked by default', () => {
         ReactDOM.render(<BackgroundDialog
             layer={{
                 type: 'wms',
@@ -97,7 +97,7 @@ describe('test BackgroundDialog', () => {
         const cropToProjectionExtent = document.querySelector('input[value="cropToProjectionExtent"]');
         expect(cropToProjectionExtent).toBeTruthy();
         expect(cropToProjectionExtent.disabled).toBe(false);
-        expect(cropToProjectionExtent.checked).toBe(true);
+        expect(cropToProjectionExtent.checked).toBe(false);
     });
 
     it('should not render crop to projection checkbox when disabled via props', () => {

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -112,7 +112,7 @@ export default ({
             <Checkbox
                 disabled={!!service?.layerOptions?.singleTile}
                 onChange={(e) => onChangeServiceProperty("layerOptions", { ...service.layerOptions, cropToProjectionExtent: e.target.checked })}
-                checked={!isNil(service?.layerOptions?.cropToProjectionExtent) ? service.layerOptions.cropToProjectionExtent : true}>
+                checked={!!service?.layerOptions?.cropToProjectionExtent}>
                 <Message msgId="layerProperties.cropToProjectionExtent.label" />&nbsp;<InfoPopover text={<Message msgId="layerProperties.cropToProjectionExtent.tooltip" />} />
             </Checkbox>
         </FormGroup>}

--- a/web/client/utils/openlayers/WMSUtils.js
+++ b/web/client/utils/openlayers/WMSUtils.js
@@ -111,7 +111,7 @@ export const generateTileGrid = (options, map) => {
             ? customTileGridResolutions
             : scales.map(scale => scaleToResolution(scale));
         return new TileGrid({
-            extent: (options?.cropToProjectionExtent ?? true) ? extent : null,
+            extent: options?.cropToProjectionExtent ? extent : null,
             resolutions,
             tileSizes,
             tileSize: customTileGridTileSize,
@@ -126,7 +126,7 @@ export const generateTileGrid = (options, map) => {
     });
     const origin = options.origin ? options.origin : [extent[0], extent[1]];
     return new TileGrid({
-        extent: (options?.cropToProjectionExtent ?? true) ? extent : null, // OL also sets to null if not extent is provided.
+        extent: options?.cropToProjectionExtent ? extent : null, // OL also sets to null if not extent is provided.
         resolutions,
         tileSize,
         origin


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR proposes to switch the default behavior to visualize the full WMS by default and to avoid clipping to the projection extension. A user can still clip the layer by default

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#12302

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Change the default behavior of WMS layer with cropToProjectionExtent to false by defualt

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
