### PR TITLE
[Backport 2026.01.xx] #12354: fix Issue with mouse coordinates for certain CRS not showing lat, lng for custom geographic CRSs

### DIFF
--- a/web/client/components/mapcontrols/mouseposition/MousePosition.jsx
+++ b/web/client/components/mapcontrols/mouseposition/MousePosition.jsx
@@ -76,10 +76,10 @@ const MousePosition = (props) => {
         let {x, y, z} = mousePosition ? mousePosition : [null, null];
         if (!x && !y && !z) {
             // if we repoject null coordinates we can end up with -0.00 instead of 0.00
-            return {x: 0, y: 0, z};
+            ({x, y} = {x: 0, y: 0, z});
         } else if (proj4js.defs(mousePosition.crs) !== proj4js.defs(crs)) {
             const reprojected = reproject([x, y], mousePosition.crs, crs);
-            return {x: reprojected.x, y: reprojected.y, z};
+            ({x, y} = {x: reprojected.x, y: reprojected.y, z});
         }
         let units = getUnits(crs);
         if (units === "degrees") {

--- a/web/client/components/mapcontrols/mouseposition/__tests__/MousePosition-test.js
+++ b/web/client/components/mapcontrols/mouseposition/__tests__/MousePosition-test.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import MousePosition from '../MousePosition';
+import ConfigUtils from '../../../../utils/ConfigUtils';
 
 describe('MousePosition', () => {
     beforeEach((done) => {
@@ -46,7 +47,33 @@ describe('MousePosition', () => {
         const cmpDom = cmp.querySelector('#mouse-position');
         expect(cmpDom).toNotExist();
     });
+    it('handles custom geographic CRS rather than 4326', () => {
+        // geographic CRS rather than 4326
+        ConfigUtils.setConfigProp('projectionDefs', [
+            {
+                code: "EPSG:4258",
+                def: "+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs +type=crs +axis=neu",
+                extent: [-180, -90, 180, 90],
+                worldExtent: [-180, -90, 180, 90]
+            }
+        ]);
+        const customCrs = 'EPSG:4326';
+        ReactDOM.render(
+            <MousePosition
+                id="mouse-position"
+                enabled
+                mousePosition={{x: 37.7749, y: -122.4194, crs: customCrs}}
+                crs={customCrs}
+            />,
+            document.getElementById("container")
+        );
 
+        const cmpDom = document.getElementById("container");
+        const text = cmpDom.textContent;
+
+        expect(text).toEqual('Lat: - 122° 25\' 9.839999999985594\'\'Lng: 37° 46\' 29.640000000008513\'\'');
+        ConfigUtils.removeConfigProp('projectionDefs');
+    });
     it('checks no position', () => {
         ReactDOM.render(<MousePosition id="mouse-position" enabled/>, document.getElementById("container"));
         const cmp = document.getElementById("container");


### PR DESCRIPTION
# Description
Backport of #12357 to `2026.01.xx`.

Fixes #12354