### PR TITLE
Issue #708: Add option to hide and reorder Share panel tabs

### DIFF
--- a/docs/developer-guide/context-editor-config.md
+++ b/docs/developer-guide/context-editor-config.md
@@ -10,6 +10,7 @@ The configuration file has this shape:
     {
         "name": "Map",
         "mandatory": true, // <-- mandatory should not be shown in editor OR not movable and directly added to the right list.
+        "version": "1.2.3",
     }, {
         "name": "Notifications",
         "mandatory": true, // <-- mandatory should not be shown in editor OR not movable and directly added to the right list.
@@ -52,6 +53,7 @@ Each entry of `plugins` array is an object that describes the plugin, it's depen
 These are the properties allowed for the plugin entry object:
 
 * `name`: `{string}` the name (ID) of the plugin
+* `version`: `{string}` the version of the plugn
 * `title`: `{string}` the title string OR messageId (from localization file)
 * `description`: `{string}`: the description string OR messageId (from localization file)
 * `docUrl`: `{string}`: the plugin/extension specific documentation url

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -83,6 +83,23 @@ const getAvailableTools = (plugin, onShowDialog, hideUploadExtension) => {
     }];
 };
 
+const formatPluginTitle = (plugin) => {
+    var version = '';
+    if (plugin.version && plugin.version !== 'undefined') {
+        version = ' (' + plugin.version + ')';
+    }
+    if( plugin.name === 'SignalementExtension') {
+        console.log("plugin.version:" + plugin.version);
+    }
+    const title = (plugin.title || plugin.label || plugin.name) + version;
+    console.log("title:" + title +  " " + plugin.name);
+    return title;
+};
+
+const formatPluginDescription = (plugin) => {
+    return plugin.description || 'plugin name: ' + plugin.name;
+}
+
 /**
  * Converts plugin objects to Transform items
  * @param {string} editedPlugin currently edited plugin
@@ -128,9 +145,9 @@ const pluginsToItems = ({
         const isMandatory = plugin.forcedMandatory || plugin.mandatory;
         return {
             id: plugin.name,
-            title: plugin.title || plugin.label || plugin.name,
+            title: formatPluginTitle(plugin),
             cardSize: 'sm',
-            description: plugin.description || 'plugin name: ' + plugin.name,
+            description: formatPluginDescription(plugin),
             showDescriptionTooltip,
             descriptionTooltipDelay,
             mandatory: isMandatory,

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -88,12 +88,7 @@ const formatPluginTitle = (plugin) => {
     if (plugin.version && plugin.version !== 'undefined') {
         version = ' (' + plugin.version + ')';
     }
-    if( plugin.name === 'SignalementExtension') {
-        console.log("plugin.version:" + plugin.version);
-    }
-    const title = (plugin.title || plugin.label || plugin.name) + version;
-    console.log("title:" + title +  " " + plugin.name);
-    return title;
+    return (plugin.title || plugin.label || plugin.name) + version;
 };
 
 const formatPluginDescription = (plugin) => {

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -93,7 +93,7 @@ const formatPluginTitle = (plugin) => {
 
 const formatPluginDescription = (plugin) => {
     return plugin.description || 'plugin name: ' + plugin.name;
-}
+};
 
 /**
  * Converts plugin objects to Transform items

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -237,18 +237,17 @@ class SharePanel extends React.Component {
         }
         return orig;
     };
+    
+    getEmbedEventKey = (tabs = []) => {
+        return tabs.length + 1;
+    };
 
-    getEmbedEventKey = (itemTabs = []) => {
-        return itemTabs.length + 3; // 2 Default panels (direct, social)
-    }
-
-    getShareTabs = (itemTabs = []) => {
-        return  {
-            ...SHARE_TABS,
-            ...itemTabs?.map(({tabName} = {}, index) => ({[tabName]: 2 + (index + 1)})).reduce((f, c) => ({...f, ...c}), {}),
-            embed: this.getEmbedEventKey(itemTabs)
-        };
-    }
+    getShareTabs = (tabs = []) => {
+        return tabs.reduce((acc, tab) => {
+            acc[tab.key] = tab.eventKey;
+            return acc;
+        }, {});
+    };
 
     getHideIntabs = (itemTabs = []) => {
         return [
@@ -256,14 +255,22 @@ class SharePanel extends React.Component {
             ...itemTabs?.map(({tabName, hideAdvancedSettingsInTab} = {}) => hideAdvancedSettingsInTab ? tabName : "")
         ];
     }
+        
+    prepareTabs = (tabs, { hideTabs = [], tabsOrder = [] }) => {
+        const normalizedOrder = tabsOrder.map(t => t.toLowerCase());
 
-    getCurrenTab = (itemTabs = []) => {
-        const embedEventKey = this.getEmbedEventKey(itemTabs);
-        return (
-            (!this.props.embedPanel && this.state.eventKey === embedEventKey)
-            || (isEmpty(itemTabs) && this.state.eventKey > (this.props.embedPanel ? 3 : 2))
-        ) ? 1 : this.state.eventKey; // fallback to tab link if embed is disabled and selected at the same time
-    }
+        return tabs
+            .filter(tab => !hideTabs.includes(tab.key.toLowerCase()))
+            .sort((a, b) => {
+                const ia = normalizedOrder.indexOf(a.key.toLowerCase());
+                const ib = normalizedOrder.indexOf(b.key.toLowerCase());
+                return (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
+            })
+            .map((tab, index) => ({
+                ...tab,
+                eventKey: index + 1
+            }));
+    };
 
     render() {
         // ************************ CHANGE URL PARAMETER FOR EMBED CODE ****************************
@@ -275,30 +282,79 @@ class SharePanel extends React.Component {
             shareEmbeddedUrl = this.generateUrl(shareEmbeddedUrl, this.props.shareUrlRegex, this.props.shareUrlReplaceString);
         }
 
-        const itemTabs = this.props.items?.filter(({target} = {}) => target === 'tabs') ?? [];
-        const embedEventKey = this.getEmbedEventKey(itemTabs);
-        const currentTab = this.getCurrenTab(itemTabs);
         const shareApiUrl = this.props.shareApiUrl || cleanShareUrl || location.href;
         const social = <ShareSocials sharedTitle={this.props.sharedTitle} shareUrl={shareUrl} getCount={this.props.getCount}/>;
         const direct = <div><ShareLink shareUrl={shareUrl} bbox={this.props.bbox}/><ShareQRCode shareUrl={shareUrl}/></div>;
         const code = (<div><ShareEmbed shareUrl={shareEmbeddedUrl} {...this.props.embedOptions} />
             {this.props.showAPI ? <ShareApi baseUrl={shareApiUrl} shareUrl={shareUrl} shareConfigUrl={this.props.shareConfigUrl} version={this.props.version}/> : null}</div>);
-
-        const SHARE_TABS_UPDATED = this.getShareTabs(itemTabs);
-        const tabs = (<Tabs defaultActiveKey={currentTab} id="sharePanel-tabs" onSelect={(eventKey) => this.setState({ eventKey })}>
-            <Tab eventKey={1} title={<Message msgId="share.direct" />}>{currentTab === 1 && direct}</Tab>
-            <Tab eventKey={2} title={<Message msgId="share.social" />}>{currentTab === 2 && social}</Tab>
-            {!isEmpty(itemTabs)
-                ? itemTabs.map(({title, component: Component}, index) => {
-                    const eventKey = 2 + (index + 1);
-                    return <Tab eventKey={eventKey} title={title}>{currentTab === eventKey && <Component shareUrl={shareUrl} />}</Tab>;
-                })
-                : null
-            }
-            {/* Keep embed panel at the last */}
-            {this.props.embedPanel ? <Tab eventKey={embedEventKey} title={<Message msgId="share.code" />}>{currentTab === embedEventKey && code}</Tab> : null}
-        </Tabs>);
+        const itemTabs = this.props.items?.filter(({ target }) => target === 'tabs') ?? [];
         const hideInTabs = this.getHideIntabs(itemTabs);
+       
+        const {
+            tabsOrder = ["permalink", "direct", "social", "embed"],
+            hideTabs = []
+        } = this.props.options || {};
+
+        let baseTabs = [
+            {
+                key: "direct",
+                label: <Message msgId="share.direct" />,
+                content: direct
+            },
+            {
+                key: "social",
+                label: <Message msgId="share.social" />,
+                content: social
+            }
+        ];
+
+        let allTabs = [
+            ...baseTabs,
+            ...itemTabs.map(({ title, tabName, component: Component }, index) => ({
+                key: (tabName || `custom-tab-${index}`),
+                label: title,
+                content: <Component shareUrl={shareUrl} />
+            }))
+        ];
+
+        allTabs = this.prepareTabs(allTabs, { hideTabs, tabsOrder });
+
+        const embedEventKey = this.getEmbedEventKey(allTabs);
+        
+        const isValidTab =
+            allTabs.some(t => t.eventKey === this.state.eventKey) ||
+            this.state.eventKey === embedEventKey;
+
+        const currentTab = isValidTab
+            ? this.state.eventKey
+            : allTabs[0]?.eventKey || 1;
+
+        const SHARE_TABS_UPDATED = this.getShareTabs(allTabs);
+
+        const tabs = (
+        <Tabs
+            activeKey={currentTab}
+            id="sharePanel-tabs"
+            onSelect={(eventKey) => this.setState({ eventKey })}
+        >
+            {allTabs.map(tab => (
+            <Tab key={tab.key} eventKey={tab.eventKey} title={tab.label}>
+                {currentTab === tab.eventKey && tab.content}
+            </Tab>
+            ))}
+
+            {this.props.embedPanel && (
+            <Tab
+                key="embed"
+                eventKey={embedEventKey}
+                title={<Message msgId="share.code" />}
+            >
+                {currentTab === embedEventKey && code}
+            </Tab>
+            )}
+        </Tabs>
+        );
+
         let sharePanel =
             (<ResizableModal
                 id={this.props.modal ? "share-panel-dialog-modal" : "share-panel-dialog"}

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -447,6 +447,10 @@
           "advancedSettings": {
             "bbox": true,
             "centerAndZoom": true
+          },        
+          "options": {
+            "tabsOrder": ["permalink", "direct", "embed"],
+            "hideTabs": ["social"]
           }
         }
       },

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -18,6 +18,7 @@ import {INIT, SET_CREATION_STEP, SET_WAS_TUTORIAL_SHOWN, SET_TUTORIAL_STEP, MAP_
     BACK_TO_PAGE_SHOW_CONFIRMATION, SET_SELECTED_THEME, ON_TOGGLE_CUSTOM_VARIABLES, LOAD_CONTEXT} from "../actions/contextcreator";
 import {set} from '../utils/ImmutableUtils';
 import { migrateContextConfiguration } from '../utils/ContextCreatorUtils';
+import { version } from 'process';
 
 
 const defaultPlugins = [
@@ -74,6 +75,7 @@ const makeNode = (plugin, parent = null, plugins = [], localPlugins = []) => ({
     name: plugin.name,
     title: plugin.title,
     description: plugin.description,
+    version: plugin.version,
     docUrl: plugin.docUrl, // custom documentation url (useful for plugin as extension with extension specific documentation)
     glyph: plugin.glyph,
     parent,

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -18,7 +18,6 @@ import {INIT, SET_CREATION_STEP, SET_WAS_TUTORIAL_SHOWN, SET_TUTORIAL_STEP, MAP_
     BACK_TO_PAGE_SHOW_CONFIRMATION, SET_SELECTED_THEME, ON_TOGGLE_CUSTOM_VARIABLES, LOAD_CONTEXT} from "../actions/contextcreator";
 import {set} from '../utils/ImmutableUtils';
 import { migrateContextConfiguration } from '../utils/ContextCreatorUtils';
-import { version } from 'process';
 
 
 const defaultPlugins = [


### PR DESCRIPTION
## Description
This PR implements the feature requested in https://github.com/georchestra/mapstore2-georchestra/issues/708, allowing configuration of Share panel tabs.

 - [x] Feature

## Changes
- Added support for tabsOrder configuration to customize the order of tabs
- Added support for hideTabs configuration to hide specific tabs
- Tabs are dynamically filtered and sorted based on configuration

Example :  

"cfg": {
  "options": {
    "tabsOrder": ["permalink", "direct", "embed"],
    "hideTabs": ["social"]
  }
}

## Breaking change
 - [x] No
