### PR TITLE
Fix #12376 New Catalog: Advanced settings issue on Dashboard

### DIFF
--- a/web/client/components/catalog/editor/AdvancedSettings/WMSDomainAliases.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/WMSDomainAliases.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import {FormControl, FormGroup, ControlLabel, Glyphicon, Button} from "react-bootstrap";
-import {debounce, size, map, omit, toInteger} from "lodash";
+import {debounce, size, map, omit, toInteger, values as toValues} from "lodash";
 import Message from "../../../I18N/Message";
 import InfoPopover from "../../../widgets/widget/InfoPopover";
 import React, {useState, useCallback, useEffect} from "react";
@@ -34,7 +34,10 @@ export default ({
     );
 
     useEffect(() => {
-        onDomainAliasChangeDebounced(aliases);
+        // Emit an array of non-empty strings. The internal `aliases` state uses
+        // a keyed object to keep React row keys stable across add/remove, but
+        // consumers (and buildServiceUrl) expect an array.
+        onDomainAliasChangeDebounced(toValues(aliases).filter(Boolean));
     }, [aliases]);
 
     const onChange = (k) => ({ target }) => setAliases((a) => ({...a, [k]: target.value}));

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/WMSDomainAliases-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/WMSDomainAliases-test.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2026, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+import TestUtils from 'react-dom/test-utils';
+
+import WMSDomainAliases from '../WMSDomainAliases';
+
+// Internal debounce in the component is 300ms; tests wait a bit longer.
+const DEBOUNCE_WAIT = 350;
+
+describe('WMSDomainAliases component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('emits an array (not an object) when no aliases exist initially', (done) => {
+        const onChangeServiceProperty = expect.createSpy();
+        ReactDOM.render(
+            <WMSDomainAliases service={{ type: 'wms', url: '' }} onChangeServiceProperty={onChangeServiceProperty} />,
+            document.getElementById('container')
+        );
+        setTimeout(() => {
+            try {
+                expect(onChangeServiceProperty.calls.length).toBeGreaterThan(0);
+                const [property, value] = onChangeServiceProperty.calls[0].arguments;
+                expect(property).toBe('domainAliases');
+                expect(Array.isArray(value)).toBe(true);
+                expect(value).toEqual([]);
+                done();
+            } catch (e) { done(e); }
+        }, DEBOUNCE_WAIT);
+    });
+
+    it('emits an array of typed values after the user edits the first row', (done) => {
+        const onChangeServiceProperty = expect.createSpy();
+        ReactDOM.render(
+            <WMSDomainAliases service={{ type: 'wms', url: '' }} onChangeServiceProperty={onChangeServiceProperty} />,
+            document.getElementById('container')
+        );
+        const input = document.querySelector('#alias-0');
+        expect(input).toExist();
+        TestUtils.Simulate.change(input, { target: { value: 'http://alias-a' } });
+        setTimeout(() => {
+            try {
+                const lastCall = onChangeServiceProperty.calls[onChangeServiceProperty.calls.length - 1];
+                expect(lastCall.arguments[0]).toBe('domainAliases');
+                expect(Array.isArray(lastCall.arguments[1])).toBe(true);
+                expect(lastCall.arguments[1]).toEqual(['http://alias-a']);
+                done();
+            } catch (e) { done(e); }
+        }, DEBOUNCE_WAIT);
+    });
+
+    it('starts from a pre-existing array of aliases and emits an array after edits', (done) => {
+        const onChangeServiceProperty = expect.createSpy();
+        ReactDOM.render(
+            <WMSDomainAliases
+                service={{ type: 'wms', url: '', domainAliases: ['http://existing'] }}
+                onChangeServiceProperty={onChangeServiceProperty}
+            />,
+            document.getElementById('container')
+        );
+        const input = document.querySelector('#alias-0');
+        expect(input).toExist();
+        expect(input.value).toBe('http://existing');
+        TestUtils.Simulate.change(input, { target: { value: 'http://updated' } });
+        setTimeout(() => {
+            try {
+                const lastCall = onChangeServiceProperty.calls[onChangeServiceProperty.calls.length - 1];
+                expect(Array.isArray(lastCall.arguments[1])).toBe(true);
+                expect(lastCall.arguments[1]).toEqual(['http://updated']);
+                done();
+            } catch (e) { done(e); }
+        }, DEBOUNCE_WAIT);
+    });
+});

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -79,8 +79,13 @@ export const getRecordLinks = ({ references = [] } = {}) => {
 
 export const buildServiceUrl = (service) => {
     switch (service.type) {
-    case "wms":
-        return [service.url, ...(service.domainAliases ?? [])].join(',');
+    case "wms": {
+        const aliases = service.domainAliases;
+        const aliasArray = Array.isArray(aliases)
+            ? aliases
+            : (aliases ? Object.values(aliases).filter(Boolean) : []);
+        return [service.url, ...aliasArray].join(',');
+    }
     default:
         return service.url;
     }

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -46,6 +46,24 @@ describe('Test the CatalogUtils', () => {
         expect(mergedURL3).toBe("https://a.example.com/wms,https://b.example.com/wms,https://c.example.com/wms");
         expect(mergedURL4).toBe("https://a.example.com/wms,https://b.example.com/wms");
     });
+    it('buildServiceUrl accepts object-shape domainAliases (legacy data)', () => {
+        const serviceObjectShape = {
+            type: "wms",
+            url: "https://a.example.com/wms",
+            domainAliases: { 0: "https://b.example.com/wms", 1: "https://c.example.com/wms" }
+        };
+        expect(CatalogUtils.buildServiceUrl(serviceObjectShape))
+            .toBe("https://a.example.com/wms,https://b.example.com/wms,https://c.example.com/wms");
+    });
+    it('buildServiceUrl drops empty values from object-shape domainAliases', () => {
+        const serviceObjectShape = {
+            type: "wms",
+            url: "https://a.example.com/wms",
+            domainAliases: { 0: "", 1: "https://b.example.com/wms", 2: "" }
+        };
+        expect(CatalogUtils.buildServiceUrl(serviceObjectShape))
+            .toBe("https://a.example.com/wms,https://b.example.com/wms");
+    });
     it("updateServiceData", () => {
         let records = [{"url": "https://example.tif", sourceMetadata: {crs: "EPSG:3003"}}];
         let options = {service: {type: CatalogUtils.COG_LAYER_TYPE, records: [{url: "https://example.tif"}]}};


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The dashboard widget catalog now uses Catalog + withCatalogRequests not CompactCatalog anymore. The old CompactCatalog was using directly catalog.url, the new implementation instead build the service url using buildServiceUrl(service) where domainAliases could be malformed in some situation.

This PR improve the WMSDomainAliases to emit an array and CatalogUtils to ensure domainAliases is an array.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#12376

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The WMS catalog does not break the app on save inside dashboard apps

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
