### PR TITLE
[Backport 2026.01.xx] Fix #11762 :Added support for downloading vector layers as GeoJSON.

### DIFF
--- a/web/client/epics/__tests__/layerdownload-test.js
+++ b/web/client/epics/__tests__/layerdownload-test.js
@@ -14,8 +14,9 @@ import { toggleControl, TOGGLE_CONTROL } from '../../actions/controls';
 import { download } from '../../actions/layers';
 import { DOWNLOAD_OPTIONS_CHANGE, downloadFeatures } from '../../actions/layerdownload';
 import { QUERY_CREATE } from '../../actions/wfsquery';
-import { closeExportDownload, openDownloadTool, startFeatureExportDownload } from '../layerdownload';
-import { testEpic } from './epicTestUtils';
+import { closeExportDownload, openDownloadTool, startFeatureExportDownload, downloadVectorLayerAsGeoJSON } from '../layerdownload';
+import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
+import FileSaver from 'file-saver';
 
 describe('layerdownload Epics', () => {
     let mockAxios;
@@ -130,5 +131,128 @@ describe('layerdownload Epics', () => {
             state
         );
     });
-
+    it('downloadVectorLayerAsGeoJSON - downloads a vector layer as GeoJSON and emits no actions', (done) => {
+        const saveAsSpy = expect.spyOn(FileSaver, 'saveAs').andCallThrough();
+        const layer = {
+            type: 'vector',
+            name: 'my-vector-layer',
+            features: [{ type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} }]
+        };
+        testEpic(
+            addTimeoutEpic(downloadVectorLayerAsGeoJSON, 100),
+            1,
+            download(layer),
+            (actions) => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                expect(saveAsSpy.calls.length).toBe(1);
+                const [blob, filename] = saveAsSpy.calls[0].arguments;
+                expect(filename).toBe('my-vector-layer.geojson');
+                expect(blob.type).toBe('application/geo+json;charset=utf-8');
+                saveAsSpy.restore();
+                done();
+            }
+        );
+    });
+    it('downloadVectorLayerAsGeoJSON - uses layer title as filename when name is missing', (done) => {
+        const saveAsSpy = expect.spyOn(FileSaver, 'saveAs').andCallThrough();
+        const layer = { type: 'vector', title: 'My Title Layer', features: [] };
+        testEpic(
+            addTimeoutEpic(downloadVectorLayerAsGeoJSON, 100),
+            1,
+            download(layer),
+            (actions) => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                const [, filename] = saveAsSpy.calls[0].arguments;
+                expect(filename).toBe('My Title Layer.geojson');
+                saveAsSpy.restore();
+                done();
+            }
+        );
+    });
+    it('downloadVectorLayerAsGeoJSON - uses layer id as filename when name and title are missing', (done) => {
+        const saveAsSpy = expect.spyOn(FileSaver, 'saveAs').andCallThrough();
+        const layer = { type: 'vector', id: 'layer-123', features: [] };
+        testEpic(
+            addTimeoutEpic(downloadVectorLayerAsGeoJSON, 100),
+            1,
+            download(layer),
+            (actions) => {
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                const [, filename] = saveAsSpy.calls[0].arguments;
+                expect(filename).toBe('layer-123.geojson');
+                saveAsSpy.restore();
+                done();
+            }
+        );
+    });
+    it('downloadVectorLayerAsGeoJSON - falls back to vector-layer.geojson when no identifier is present', (done) => {
+        const saveAsSpy = expect.spyOn(FileSaver, 'saveAs').andCallThrough();
+        const layer = { type: 'vector', features: [] };
+        testEpic(
+            addTimeoutEpic(downloadVectorLayerAsGeoJSON, 100),
+            1,
+            download(layer),
+            (actions) => {
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                const [, filename] = saveAsSpy.calls[0].arguments;
+                expect(filename).toBe('vector-layer.geojson');
+                saveAsSpy.restore();
+                done();
+            }
+        );
+    });
+    it('downloadVectorLayerAsGeoJSON - includes features in the GeoJSON blob', (done) => {
+        const saveAsSpy = expect.spyOn(FileSaver, 'saveAs').andCallThrough();
+        const feature = { type: 'Feature', geometry: { type: 'Point', coordinates: [1, 2] }, properties: { foo: 'bar' } };
+        const layer = { type: 'vector', name: 'test', features: [feature] };
+        testEpic(
+            addTimeoutEpic(downloadVectorLayerAsGeoJSON, 100),
+            1,
+            download(layer),
+            (actions) => {
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                const [blob] = saveAsSpy.calls[0].arguments;
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    const parsed = JSON.parse(e.target.result);
+                    expect(parsed.type).toBe('FeatureCollection');
+                    expect(parsed.features.length).toBe(1);
+                    expect(parsed.features[0].properties.foo).toBe('bar');
+                    saveAsSpy.restore();
+                    done();
+                };
+                reader.readAsText(blob);
+            }
+        );
+    });
+    it('downloadVectorLayerAsGeoJSON - does NOT trigger for non-vector layers', (done) => {
+        const saveAsSpy = expect.spyOn(FileSaver, 'saveAs').andCallThrough();
+        const layer = { type: 'wms', name: 'wms-layer', url: 'http://geoserver/wms' };
+        testEpic(
+            addTimeoutEpic(downloadVectorLayerAsGeoJSON, 100),
+            1,
+            download(layer),
+            (actions) => {
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                expect(saveAsSpy.calls.length).toBe(0);
+                saveAsSpy.restore();
+                done();
+            }
+        );
+    });
+    it('openDownloadTool - does NOT open the export tool for a vector layer', (done) => {
+        const layer = { type: 'vector', name: 'my-vector', features: [] };
+        testEpic(
+            addTimeoutEpic(openDownloadTool, 100),
+            1,
+            download(layer),
+            (actions) => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                done();
+            }
+        );
+    });
 });

--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -183,8 +183,41 @@ const restoreExportDataResultsFromCookie = (state) => {
     return Rx.Observable.empty();
 };
 
+const getVectorLayerGeoJSON = (layer = {}) => ({
+    type: 'FeatureCollection',
+    features: layer?.features || []
+});
+
+const getVectorLayerDownloadFileName = (layer = {}) => {
+    const fileName = layer?.name || layer?.title || layer?.id || 'vector-layer';
+    return `${fileName}.geojson`;
+};
+
+export const downloadVectorLayerAsGeoJSON = (action$) =>
+    action$.ofType(DOWNLOAD)
+        .filter(({ layer }) => layer?.type === 'vector')
+        .switchMap(({ layer }) => {
+            try {
+                const geoJSON = getVectorLayerGeoJSON(layer);
+                saveAs(
+                    new Blob([JSON.stringify(geoJSON)], { type: 'application/geo+json;charset=utf-8' }),
+                    getVectorLayerDownloadFileName(layer)
+                );
+                return Rx.Observable.empty();
+            } catch (e) {
+                return Rx.Observable.of(error({
+                    error: e,
+                    title: 'layerdownload.error.title',
+                    message: 'layerdownload.error.invalidOutputFormat',
+                    autoDismiss: 5,
+                    position: 'tr'
+                }));
+            }
+        });
+
 export const openDownloadTool = (action$) =>
     action$.ofType(DOWNLOAD)
+        .filter(({ layer }) => layer?.type !== 'vector')
         .switchMap((action) => {
             return Rx.Observable.from([
                 toggleControl("layerdownload"),

--- a/web/client/plugins/LayerDownload.jsx
+++ b/web/client/plugins/LayerDownload.jsx
@@ -64,17 +64,13 @@ const LayerDownloadButton = connect(() => ({}), {
 }) => {
     const ItemComponent = itemComponent;
     const layer = selectedNodes?.[0]?.node;
-    if ([statusTypes.LAYER].includes(status) && (layer?.type === 'wms' || layer?.search) && !layer?.error) {
+    if ([statusTypes.LAYER].includes(status) && (layer?.type === 'wms' || layer?.search || (layer?.type === 'vector' && layer?.rowViewer !== 'annotations')) && !layer?.error) {
         return (
             <ItemComponent
                 {...props}
                 glyph="download"
                 tooltipId={'toc.toolDownloadTooltip'}
-                onClick={() => onClick({
-                    url: layer.search?.url || layer.url,
-                    name: layer.name,
-                    id: layer.id
-                })}
+                onClick={() => onClick(layer)}
             />
         );
     }


### PR DESCRIPTION
# Description
Backport of #12322 to `2026.01.xx`.

Fixes #11762