### PR TITLE
Fix #12377 Update position of InfoPopover for table and counter widgets

### DIFF
--- a/web/client/plugins/widgetbuilder/LayerSelector.jsx
+++ b/web/client/plugins/widgetbuilder/LayerSelector.jsx
@@ -40,6 +40,7 @@ export default ({ onClose = () => { }, onItemClick, onLayerChoice = () => { }, s
                 trigger={false}
                 glyph="warning-sign"
                 bsStyle="warning"
+                placement="left"
                 title={<Message msgId="widgets.builder.errors.noWidgetsAvailableTitle" />}
                 text={<HTML msgId="widgets.builder.errors.noWidgetsAvailableDescription"/>} /> : null}
         </BuilderHeader>}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes the position problem of the info popover for table and counter widgets.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12377

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Fix info popover position for counter and table widgets 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
