### PR TITLE
Issue #12355 : Sample localConfig.json uses old syntax

### DIFF
--- a/docs/developer-guide/context-editor-config.md
+++ b/docs/developer-guide/context-editor-config.md
@@ -10,6 +10,7 @@ The configuration file has this shape:
     {
         "name": "Map",
         "mandatory": true, // <-- mandatory should not be shown in editor OR not movable and directly added to the right list.
+        "version": "1.2.3",
     }, {
         "name": "Notifications",
         "mandatory": true, // <-- mandatory should not be shown in editor OR not movable and directly added to the right list.
@@ -52,6 +53,7 @@ Each entry of `plugins` array is an object that describes the plugin, it's depen
 These are the properties allowed for the plugin entry object:
 
 * `name`: `{string}` the name (ID) of the plugin
+* `version`: `{string}` the version of the plugn
 * `title`: `{string}` the title string OR messageId (from localization file)
 * `description`: `{string}`: the description string OR messageId (from localization file)
 * `docUrl`: `{string}`: the plugin/extension specific documentation url

--- a/project/standard/templates/configs/pluginsConfig.json
+++ b/project/standard/templates/configs/pluginsConfig.json
@@ -322,8 +322,10 @@
         "editCRS": true,
         "showLabels": true,
         "showToggle": true,
-        "filterAllowedCRS": ["EPSG:4326", "EPSG:3857"],
-        "additionalCRS": {}
+        "availableProjections": [
+          { "value": "EPSG:4326", "label": "EPSG:4326" },
+          { "value": "EPSG:3857", "label": "EPSG:3857" }
+        ]
       }
     },
     {

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -83,6 +83,23 @@ const getAvailableTools = (plugin, onShowDialog, hideUploadExtension) => {
     }];
 };
 
+const formatPluginTitle = (plugin) => {
+    var version = '';
+    if (plugin.version && plugin.version !== 'undefined') {
+        version = ' (' + plugin.version + ')';
+    }
+    if( plugin.name === 'SignalementExtension') {
+        console.log("plugin.version:" + plugin.version);
+    }
+    const title = (plugin.title || plugin.label || plugin.name) + version;
+    console.log("title:" + title +  " " + plugin.name);
+    return title;
+};
+
+const formatPluginDescription = (plugin) => {
+    return plugin.description || 'plugin name: ' + plugin.name;
+}
+
 /**
  * Converts plugin objects to Transform items
  * @param {string} editedPlugin currently edited plugin
@@ -128,9 +145,9 @@ const pluginsToItems = ({
         const isMandatory = plugin.forcedMandatory || plugin.mandatory;
         return {
             id: plugin.name,
-            title: plugin.title || plugin.label || plugin.name,
+            title: formatPluginTitle(plugin),
             cardSize: 'sm',
-            description: plugin.description || 'plugin name: ' + plugin.name,
+            description: formatPluginDescription(plugin),
             showDescriptionTooltip,
             descriptionTooltipDelay,
             mandatory: isMandatory,

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -88,12 +88,7 @@ const formatPluginTitle = (plugin) => {
     if (plugin.version && plugin.version !== 'undefined') {
         version = ' (' + plugin.version + ')';
     }
-    if( plugin.name === 'SignalementExtension') {
-        console.log("plugin.version:" + plugin.version);
-    }
-    const title = (plugin.title || plugin.label || plugin.name) + version;
-    console.log("title:" + title +  " " + plugin.name);
-    return title;
+    return (plugin.title || plugin.label || plugin.name) + version;
 };
 
 const formatPluginDescription = (plugin) => {

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -93,7 +93,7 @@ const formatPluginTitle = (plugin) => {
 
 const formatPluginDescription = (plugin) => {
     return plugin.description || 'plugin name: ' + plugin.name;
-}
+};
 
 /**
  * Converts plugin objects to Transform items

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -569,8 +569,10 @@
           "editCRS": true,
           "showLabels": true,
           "showToggle": true,
-          "filterAllowedCRS": ["EPSG:4326", "EPSG:3857"],
-          "additionalCRS": {}
+          "availableProjections": [
+            { "value": "EPSG:4326", "label": "EPSG:4326" },
+            { "value": "EPSG:3857", "label": "EPSG:3857" }
+          ]
         }
       },
       {

--- a/web/client/configs/pluginsConfig.json
+++ b/web/client/configs/pluginsConfig.json
@@ -324,8 +324,10 @@
         "editCRS": true,
         "showLabels": true,
         "showToggle": true,
-        "filterAllowedCRS": ["EPSG:4326", "EPSG:3857"],
-        "additionalCRS": {}
+        "availableProjections": [
+          { "value": "EPSG:4326", "label": "EPSG:4326" },
+          { "value": "EPSG:3857", "label": "EPSG:3857" }
+        ]
       }
     },
     {

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -18,6 +18,7 @@ import {INIT, SET_CREATION_STEP, SET_WAS_TUTORIAL_SHOWN, SET_TUTORIAL_STEP, MAP_
     BACK_TO_PAGE_SHOW_CONFIRMATION, SET_SELECTED_THEME, ON_TOGGLE_CUSTOM_VARIABLES, LOAD_CONTEXT} from "../actions/contextcreator";
 import {set} from '../utils/ImmutableUtils';
 import { migrateContextConfiguration } from '../utils/ContextCreatorUtils';
+import { version } from 'process';
 
 
 const defaultPlugins = [
@@ -74,6 +75,7 @@ const makeNode = (plugin, parent = null, plugins = [], localPlugins = []) => ({
     name: plugin.name,
     title: plugin.title,
     description: plugin.description,
+    version: plugin.version,
     docUrl: plugin.docUrl, // custom documentation url (useful for plugin as extension with extension specific documentation)
     glyph: plugin.glyph,
     parent,

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -18,7 +18,6 @@ import {INIT, SET_CREATION_STEP, SET_WAS_TUTORIAL_SHOWN, SET_TUTORIAL_STEP, MAP_
     BACK_TO_PAGE_SHOW_CONFIRMATION, SET_SELECTED_THEME, ON_TOGGLE_CUSTOM_VARIABLES, LOAD_CONTEXT} from "../actions/contextcreator";
 import {set} from '../utils/ImmutableUtils';
 import { migrateContextConfiguration } from '../utils/ContextCreatorUtils';
-import { version } from 'process';
 
 
 const defaultPlugins = [


### PR DESCRIPTION
## Description

Update sample configuration files to replace deprecated `filterAllowedCRS` and `additionalCRS` properties with the new `availableProjections` format, as described in the [migration guide](https://docs.mapstore.geosolutionsgroup.com/en/latest/developer-guide/mapstore-migration-guide/).

The `availableProjections` property uses an array of objects with `value` and `label` fields, which unifies the behavior previously split between `filterAllowedCRS` and `additionalCRS`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Issue

**What is the current behavior?**

The sample `localConfig.json` and `pluginsConfig.json` files still use the deprecated `filterAllowedCRS` and `additionalCRS` properties for `MousePosition` and `CRSSelector` plugins.

Fixes #12355

**What is the new behavior?**

The three configuration files now use `availableProjections` with the correct object array format:
```json
"availableProjections": [
  { "value": "EPSG:4326", "label": "EPSG:4326" },
  { "value": "EPSG:3857", "label": "EPSG:3857" }
]
```

Files updated:
- `web/client/configs/localConfig.json`
- `web/client/configs/pluginsConfig.json`
- `project/standard/templates/configs/pluginsConfig.json`

## Breaking change

**Does this PR introduce a breaking change?**
- [x] No
