### PR TITLE
Issue #11267 : Added recommendation to use externalized configuration for database setup

### DIFF
--- a/docs/developer-guide/database-setup.md
+++ b/docs/developer-guide/database-setup.md
@@ -17,6 +17,9 @@ In the following guide you will learn how to configure MapStore to use an extern
 
 MapStore has a file called `geostore-datasource-ovr.properties`. This file is on the repository in the folder `java/web/src/main/resources`, in the final `mapstore.war` package it will be copied into `WEB-INF/classes` path. It contains the set-up for the database connection. Anyway if you edit the file in `WEB-INF/classes` this file will be overridden on the next re-deploy. To preserve your configuration on every deploy you can use an environment variable, `geostore-ovr`, to configure the path to an override file in a different, external directory. In this file the user can re-define the default configuration and so set-up the database configuration.
 
+!!! tip
+    For production deployments, consider using the [externalized configuration](externalized-configuration.md) (`-Ddatadir.location=`) instead. It provides a single data directory that centralizes all MapStore configuration files (database, proxy, JSON configs, etc.) and persists across updates. The `geostore-datasource-ovr.properties` file can simply be placed inside that directory.
+
 For instance using tomcat on linux you will have to do something like this to add the environment variable to the JAVA_OPTS
 > where to add your JAVA_OPTS depends on your operating system. For instance the file could be `/etc/default/tomcat8`, or similar, in linux debian
 

--- a/docs/developer-guide/requirements.md
+++ b/docs/developer-guide/requirements.md
@@ -47,3 +47,6 @@ In production a PostgreSQL database is recommended:
 | Tool     | Link                                               | Minimum | Recommended | Maximum    |
 |----------|----------------------------------------------------|---------|-------------|------------|
 | Postgres | [link](https://www.postgresql.org/)                | 13      | 17          | 18         |
+
+!!! tip
+    If you need to configure the database connection (and other settings) for a production deployment, it is recommended to use the [externalized configuration](externalized-configuration.md) (`-Ddatadir.location=`) instead of setting only the database override file. This allows you to manage all MapStore configuration files (database, proxy, JSON configs, etc.) in a single external directory that persists across updates.


### PR DESCRIPTION
## Description

Add recommendations in the documentation to use the [externalized configuration](https://docs.mapstore.geosolutionsgroup.com/en/latest/developer-guide/externalized-configuration/) (`-Ddatadir.location=`) when setting up a production database, rather than only relying on the standalone `-Dgeostore-ovr=` approach.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Documentation improvement

## Issue

**What is the current behavior?**

The `requirements.md#database` and `database-setup.md` sections only describe the `-Dgeostore-ovr=` approach for externalizing the database configuration, without mentioning the more complete [externalized configuration](https://docs.mapstore.geosolutionsgroup.com/en/latest/developer-guide/externalized-configuration/) mechanism. Users adapting the database path would likely also want to externalize other settings, but nothing points them in that direction.

Fixes #11267

**What is the new behavior?**

A tip has been added in both pages to recommend using `-Ddatadir.location=` (externalized configuration) for production deployments, as it centralizes all MapStore configuration files (database, proxy, JSON configs, etc.) in a single directory that persists across updates.

Files updated:
- `docs/developer-guide/requirements.md`
- `docs/developer-guide/database-setup.md`

## Breaking change

**Does this PR introduce a breaking change?**
- [x] No
