### PR TITLE
WMS additional condition to prevent Tile exception reloding

### DIFF
--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -34,7 +34,15 @@ import { OL_VECTOR_FORMATS, applyStyle } from '../../../../utils/openlayers/Vect
 
 import { proxySource, getWMSURLs, wmsToOpenlayersOptions, toOLAttributions, generateTileGrid } from '../../../../utils/openlayers/WMSUtils';
 
+const failTiles = new Set(); // registry of fail tile urls to prevent reloading loops
+
 const loadFunction = (options, headers) => function(image, src) {
+
+    if (failTiles.has(src)) {  // avoids custom reload in cases of tiles that have already returned exceptions
+        image.setState(3);
+        return;
+    }
+
     // fixes #3916, see https://gis.stackexchange.com/questions/175057/openlayers-3-wms-styling-using-sld-body-and-post-request
     let img = image.getImage();
     let newSrc = proxySource(options.forceProxy, src);
@@ -67,6 +75,7 @@ const loadFunction = (options, headers) => function(image, src) {
             }
         }).catch(e => {
             image.setState(3);
+            failTiles.add(src);
             console.error(e);
         });
     } else {
@@ -89,6 +98,7 @@ const loadFunction = (options, headers) => function(image, src) {
                 }).catch(errorMessage => {
                     image.getImage().src = null;   // needed to trigger the MS imageloaderror event in Map.onLayerError
                     image.setState(3);            // set error state for tile and removed from the queue to prevent reloading loops
+                    failTiles.add(src);           // indexing fail url tile to prevent reloading loops
                     console.error(errorMessage);  // show ogc exception in console for debugging
                 });
         } else {


### PR DESCRIPTION
## Description
Fix https://github.com/geosolutions-it/MapStore2/issues/12371

Improves with the conditions of the previous PRs https://github.com/geosolutions-it/MapStore2/pull/12372
Avoiding re-running the custom tile loading function in cases where the tiles have been verified as containing errors returned by geoserver.
This additional check not appears to in OpenLayers docs.
https://openlayers.org/en/v7.4.0/apidoc/module-ol_Tile.html#~LoadFunction

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

#12371

**What is the new behavior?**

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
The following pr is testable only in environments where custom headers for the WMS layer are active