### PR TITLE
Add Copilot and copilot-swe-agent to contributors

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -3,6 +3,8 @@
     "dependabot[bot]",
     "dependabot-preview[bot]",
     "github-actions[bot]",
+    "Copilot",
+    "copilot-swe-agent[bot]",
     "afabiani",
     "giohappy",
     "allyoucanmap",


### PR DESCRIPTION
Trying to see if cana apply copilot CLA. 
As for doc both 

    "Copilot",
    "copilot-swe-agent[bot]",

are valid, depending on the context.

This should allow PRs like [this](https://github.com/geosolutions-it/MapStore2/pull/12400) to be merged