### PR TITLE
Issue #11998 : ResourceDetails date i18n

### DIFF
--- a/docs/developer-guide/context-editor-config.md
+++ b/docs/developer-guide/context-editor-config.md
@@ -10,6 +10,7 @@ The configuration file has this shape:
     {
         "name": "Map",
         "mandatory": true, // <-- mandatory should not be shown in editor OR not movable and directly added to the right list.
+        "version": "1.2.3",
     }, {
         "name": "Notifications",
         "mandatory": true, // <-- mandatory should not be shown in editor OR not movable and directly added to the right list.
@@ -52,6 +53,7 @@ Each entry of `plugins` array is an object that describes the plugin, it's depen
 These are the properties allowed for the plugin entry object:
 
 * `name`: `{string}` the name (ID) of the plugin
+* `version`: `{string}` the version of the plugn
 * `title`: `{string}` the title string OR messageId (from localization file)
 * `description`: `{string}`: the description string OR messageId (from localization file)
 * `docUrl`: `{string}`: the plugin/extension specific documentation url

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -83,6 +83,23 @@ const getAvailableTools = (plugin, onShowDialog, hideUploadExtension) => {
     }];
 };
 
+const formatPluginTitle = (plugin) => {
+    var version = '';
+    if (plugin.version && plugin.version !== 'undefined') {
+        version = ' (' + plugin.version + ')';
+    }
+    if( plugin.name === 'SignalementExtension') {
+        console.log("plugin.version:" + plugin.version);
+    }
+    const title = (plugin.title || plugin.label || plugin.name) + version;
+    console.log("title:" + title +  " " + plugin.name);
+    return title;
+};
+
+const formatPluginDescription = (plugin) => {
+    return plugin.description || 'plugin name: ' + plugin.name;
+}
+
 /**
  * Converts plugin objects to Transform items
  * @param {string} editedPlugin currently edited plugin
@@ -128,9 +145,9 @@ const pluginsToItems = ({
         const isMandatory = plugin.forcedMandatory || plugin.mandatory;
         return {
             id: plugin.name,
-            title: plugin.title || plugin.label || plugin.name,
+            title: formatPluginTitle(plugin),
             cardSize: 'sm',
-            description: plugin.description || 'plugin name: ' + plugin.name,
+            description: formatPluginDescription(plugin),
             showDescriptionTooltip,
             descriptionTooltipDelay,
             mandatory: isMandatory,

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -88,12 +88,7 @@ const formatPluginTitle = (plugin) => {
     if (plugin.version && plugin.version !== 'undefined') {
         version = ' (' + plugin.version + ')';
     }
-    if( plugin.name === 'SignalementExtension') {
-        console.log("plugin.version:" + plugin.version);
-    }
-    const title = (plugin.title || plugin.label || plugin.name) + version;
-    console.log("title:" + title +  " " + plugin.name);
-    return title;
+    return (plugin.title || plugin.label || plugin.name) + version;
 };
 
 const formatPluginDescription = (plugin) => {

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -93,7 +93,7 @@ const formatPluginTitle = (plugin) => {
 
 const formatPluginDescription = (plugin) => {
     return plugin.description || 'plugin name: ' + plugin.name;
-}
+};
 
 /**
  * Converts plugin objects to Transform items

--- a/web/client/plugins/ResourcesCatalog/components/DetailsInfo.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/DetailsInfo.jsx
@@ -6,11 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useState } from 'react';
 import castArray from 'lodash/castArray';
 import isEmpty from 'lodash/isEmpty';
 import moment from 'moment';
+import React, { useEffect, useState } from 'react';
 import { Checkbox } from 'react-bootstrap';
+import { connect } from 'react-redux';
 
 import Button from '../../../components/layout/Button';
 import Tabs from './Tabs';
@@ -29,12 +30,44 @@ const replaceTemplateString = (properties, str) => {
     }, str);
 };
 
-const getDateRangeValue = (startValue, endValue, format) => {
-    if (startValue && endValue) {
-        return `${moment(startValue).format(format)} - ${moment(endValue).format(format)}`;
+const normalizeMomentLocale = (locale) => {
+    if (!locale) {
+        return 'en';
     }
-    return moment(startValue ? startValue : endValue).format(format);
+    const normalizedLocale = locale.toLowerCase();
+    if (moment.locales().includes(normalizedLocale)) {
+        return normalizedLocale;
+    }
+    const baseLocale = normalizedLocale.split('-')[0];
+    if (moment.locales().includes(baseLocale)) {
+        return baseLocale;
+    }
+    return normalizedLocale;
 };
+
+const getDefaultDateFormat = (locale) => {
+    const normalizedLocale = normalizeMomentLocale(locale);
+    return normalizedLocale.startsWith('en') ? 'MMMM Do YYYY' : 'LL';
+};
+
+const getDateRangeValue = (startValue, endValue, format, locale) => {
+    const normalizedLocale = normalizeMomentLocale(locale);
+    const dateFormat = format || getDefaultDateFormat(normalizedLocale);
+    let result;
+    if (startValue && endValue) {
+        result = `${moment(startValue).locale(normalizedLocale).format(dateFormat)} - ${moment(endValue).locale(normalizedLocale).format(dateFormat)}`;
+    } else {
+        result = moment(startValue ? startValue : endValue).locale(normalizedLocale).format(dateFormat);
+    }
+    return result;
+};
+
+const getDateValue = (value, format, locale) => {
+    const normalizedLocale = normalizeMomentLocale(locale);
+    const dateFormat = format || getDefaultDateFormat(normalizedLocale);
+    return moment(value).locale(normalizedLocale).format(dateFormat);
+};
+
 const isEmptyValue = (value) => {
     if (Array.isArray(value)) {
         return isEmpty(value);
@@ -160,7 +193,7 @@ function DetailsInfoFieldEditing({ field, onChange }) {
     return null;
 }
 
-function DetailsInfoFields({ fields, formatHref, editing, onChange, query = {}, enableFilters }) {
+function DetailsInfoFields({ fields, formatHref, editing, onChange, query = {}, enableFilters, locale }) {
     return (<FlexBox
         gap="xs"
         column
@@ -213,9 +246,12 @@ function DetailsInfoFields({ fields, formatHref, editing, onChange, query = {}, 
             if (field.type === 'date') {
                 return (
                     <DetailsInfoField key={filedIndex} field={field}>
-                        {(values) => values.map((value, idx) => (
-                            <span key={idx}>{(value?.start || value?.end) ? getDateRangeValue(value.start, value.end, field.format || 'MMMM Do YYYY') : moment(value).format(field.format || 'MMMM Do YYYY')}</span>
-                        ))}
+                        {(values) => values.map((value, idx) => {
+                            const dateStr = (value?.start || value?.end)
+                                ? getDateRangeValue(value.start, value.end, field.format, locale)
+                                : getDateValue(value, field.format, locale);
+                            return <span key={idx}>{dateStr}</span>;
+                        })}
                     </DetailsInfoField>
                 );
             }
@@ -274,8 +310,10 @@ function DetailsInfoFields({ fields, formatHref, editing, onChange, query = {}, 
     </FlexBox>);
 }
 
+const ConnectedDetailsInfoFields = connect(state => ({ locale: state?.locale?.current }))(DetailsInfoFields);
+
 const defaultTabComponents = {
-    'tab': DetailsInfoFields
+    'tab': ConnectedDetailsInfoFields
 };
 
 const parseTabItems = (items) => {

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -18,6 +18,7 @@ import {INIT, SET_CREATION_STEP, SET_WAS_TUTORIAL_SHOWN, SET_TUTORIAL_STEP, MAP_
     BACK_TO_PAGE_SHOW_CONFIRMATION, SET_SELECTED_THEME, ON_TOGGLE_CUSTOM_VARIABLES, LOAD_CONTEXT} from "../actions/contextcreator";
 import {set} from '../utils/ImmutableUtils';
 import { migrateContextConfiguration } from '../utils/ContextCreatorUtils';
+import { version } from 'process';
 
 
 const defaultPlugins = [
@@ -74,6 +75,7 @@ const makeNode = (plugin, parent = null, plugins = [], localPlugins = []) => ({
     name: plugin.name,
     title: plugin.title,
     description: plugin.description,
+    version: plugin.version,
     docUrl: plugin.docUrl, // custom documentation url (useful for plugin as extension with extension specific documentation)
     glyph: plugin.glyph,
     parent,

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -18,7 +18,6 @@ import {INIT, SET_CREATION_STEP, SET_WAS_TUTORIAL_SHOWN, SET_TUTORIAL_STEP, MAP_
     BACK_TO_PAGE_SHOW_CONFIRMATION, SET_SELECTED_THEME, ON_TOGGLE_CUSTOM_VARIABLES, LOAD_CONTEXT} from "../actions/contextcreator";
 import {set} from '../utils/ImmutableUtils';
 import { migrateContextConfiguration } from '../utils/ContextCreatorUtils';
-import { version } from 'process';
 
 
 const defaultPlugins = [


### PR DESCRIPTION
## Description
This PR improves date localization behavior in the Resources Catalog details panel.

The changes make date rendering consistent across supported locales, so each language uses its natural ordering/format while English keeps the expected ordinal format.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
- Date display in non-English locales could keep an English date instead of locale-native formatting.
- You can also link to an existing issue here: #11998

**What is the new behavior?**
- Date values now render with locale-aware formatting for non-English languages (e.g. French `18 mai 2026`), while preserving English output style where expected.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
