### PR TITLE
Fix #12417 Identify not working on COG layers loaded from GeoNode catalog

### DIFF
--- a/web/client/utils/GeoNodeUtils.js
+++ b/web/client/utils/GeoNodeUtils.js
@@ -364,8 +364,10 @@ export const resourceToLayerConfig = (resource, options) => {
             id: uuid(),
             type: 'cog',
             title,
+            url: cogUrl,
             sources: [{
-                url: cogUrl
+                url: cogUrl,
+                nodata: 0
             }],
             ...(bbox && { bbox }),
             visibility: true,

--- a/web/client/utils/__tests__/GeoNodeUtils-test.js
+++ b/web/client/utils/__tests__/GeoNodeUtils-test.js
@@ -154,6 +154,19 @@ describe('GeoNodeUtils', () => {
                 expect(newLayer.extendedParams).toEqual({ pk: 3, alternate: 'geonode:cog_layer' });
             });
 
+            it('cog layer has top-level url, sources url, and nodata', () => {
+                const newLayer = resourceToLayerConfig({
+                    alternate: 'geonode:cog_layer',
+                    subtype: 'cog',
+                    links: [{ extension: 'cog', url: '/raster.tif' }],
+                    title: 'COG',
+                    perms: [],
+                    pk: 3
+                });
+                expect(newLayer.url).toBe('/raster.tif');
+                expect(newLayer.sources).toEqual([{ url: '/raster.tif', nodata: 0 }]);
+            });
+
             it('flatgeobuf layer includes alternate in extendedParams', () => {
                 const newLayer = resourceToLayerConfig({
                     alternate: 'geonode:fgb_layer',

--- a/web/client/utils/mapinfo/__tests__/cog-test.js
+++ b/web/client/utils/mapinfo/__tests__/cog-test.js
@@ -113,4 +113,27 @@ describe("mapinfo COG utils", () => {
 
         expect(request).toEqual(expectedRequest);
     });
+
+    it("should use sources[0].url as fallback when layer.url is not set", () => {
+        const layerId = "6ba42670-f3c-21f0-8e1f-dd66f6ae634d";
+        const sourceUrl = "https://mydomain.com/cog.tif";
+        const layer = {
+            "id": layerId,
+            "format": "cog",
+            "title": "Cloud layer title",
+            "type": "cog",
+            "sources": [{ "url": sourceUrl, "nodata": 0 }],
+            "visibility": true
+        };
+        const latlng = { "lat": 40.19133465092119, "lng": -92.60925292968749 };
+        const point = {
+            "latlng": latlng,
+            "intersectedPixels": {
+                "0": { "id": layerId, "bands": { "1": 140 } }
+            }
+        };
+
+        const request = cog.buildRequest(layer, { point, currentLocale: "en-US" });
+        expect(request.url).toBe(sourceUrl);
+    });
 });

--- a/web/client/utils/mapinfo/cog.js
+++ b/web/client/utils/mapinfo/cog.js
@@ -40,7 +40,7 @@ export default {
                     ? layer.title[currentLocale] || layer.title.default
                     : layer.title
             },
-            url: layer.url
+            url: layer.url || layer?.sources?.[0]?.url
         };
     },
     getIdentifyFlow: (layer, basePath, {features = []} = {}) => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces two fixes:

- ensure the converted layer in geonode service contains the url
- add fallback in cog identify to use sources url if layer url is missing

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#12417

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Enable identify on cog layer imported from a GeoNode service

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
