### PR TITLE
[Backport 2026.01.xx] Fix className attribute in SnapshotPanel.jsx

### DIFF
--- a/web/client/components/mapcontrols/Snapshot/SnapshotPanel.jsx
+++ b/web/client/components/mapcontrols/Snapshot/SnapshotPanel.jsx
@@ -243,7 +243,7 @@ class SnapshotPanel extends React.Component {
                 </Row>
                 {this.renderError()}
 
-                <Row key="buttons" htopclassName="pull-right" style={{marginTop: "5px"}}>
+                <Row key="buttons" className="pull-right" style={{marginTop: "5px"}}>
                     { this.renderButton(!isGoogleLayer && snapshotReady)}
                     { this.renderTaintedMessage()}
                     {this.renderSnapshotQueue()}


### PR DESCRIPTION
# Description
Backport of #11989 to `2026.01.xx`.

Fixes #