### PR TITLE
Improve visibility of the currently selected time in the slider widget  #12440

### DIFF
--- a/web/client/components/widgets/builder/wizard/filter/FilterSlider.jsx
+++ b/web/client/components/widgets/builder/wizard/filter/FilterSlider.jsx
@@ -135,15 +135,7 @@ const FilterSlider = ({
         <FormGroup className={`ms-filter-slider${noSelectionClass}${showTicksClass}`}>
             <div className="ms-filter-slider-items" style={containerStyle}>
                 {showSelectedValue && (
-                    <div
-                        className="ms-filter-slider-selected-value"
-                        style={{
-                            marginBottom: 8,
-                            textAlign: 'right',
-                            fontSize: 10,
-                            fontWeight: 400
-                        }}
-                    >
+                    <div className="ms-filter-slider-selected-value">
                         {hasExplicitSelection
                             ? selectedDisplayValue
                             : <Message msgId="widgets.filterWidget.sliderNotSelected" />}

--- a/web/client/themes/default/less/sliders.less
+++ b/web/client/themes/default/less/sliders.less
@@ -252,6 +252,32 @@
     padding-left: 25px;
     padding-right: 25px;
 }
+
+.ms-filter-slider-selected-value {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin-bottom: 8px;
+    margin-left: auto;
+    padding: 2px 6px;
+    width: fit-content;
+    max-width: 100%;
+    border-radius: @border-radius-base;
+    background-color: fade(@ms-primary, 10%);
+    text-align: right;
+    color: @ms-primary;
+    font-size: @font-size-base;
+    font-weight: bold;
+}
+
+.ms-filter-slider.ms-filter-slider--no-selection {
+    .ms-filter-slider-selected-value {
+        background-color: transparent;
+        color: inherit;
+        font-weight: normal;
+    }
+}
+
 .ms-filter-slider.ms-filter-slider--no-selection {
     .mapstore-slider .noUi-target.noUi-horizontal .noUi-base .noUi-origin .noUi-handle {
         opacity: 0;

--- a/web/client/themes/default/less/sliders.less
+++ b/web/client/themes/default/less/sliders.less
@@ -265,8 +265,8 @@
     border-radius: @border-radius-base;
     background-color: fade(@ms-primary, 10%);
     text-align: right;
+    font-size: 12px;
     color: @ms-primary;
-    font-size: @font-size-base;
     font-weight: bold;
 }
 

--- a/web/client/themes/default/less/sliders.less
+++ b/web/client/themes/default/less/sliders.less
@@ -264,8 +264,9 @@
     max-width: 100%;
     border-radius: @border-radius-base;
     background-color: fade(@ms-primary, 10%);
+    border: 1px solid @ms-primary;
     text-align: right;
-    font-size: 12px;
+    font-size: 11px;
     color: @ms-primary;
     font-weight: bold;
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR enhances the style for the selected value on the slider. So that it can be easily visible
<img width="423" height="303" alt="image" src="https://github.com/user-attachments/assets/979d68f1-aa16-4a4c-85e1-868635257d65" />


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12440

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The selected value is easily visible.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
