### PR TITLE
About/details panel configured to show at startup does not appear consistently when map is loaded in a context  #12441

### DIFF
--- a/web/client/epics/__tests__/details-test.js
+++ b/web/client/epics/__tests__/details-test.js
@@ -12,11 +12,13 @@ import { createEpicMiddleware, combineEpics } from 'redux-observable';
 
 import {
     closeDetailsPanelEpic,
-    fetchDataForDetailsPanel
+    fetchDataForDetailsPanel,
+    openDetailsPanelOnStartup
 } from '../details';
 
 import {
     CLOSE_DETAILS_PANEL,
+    OPEN_DETAILS_PANEL,
     closeDetailsPanel,
     openDetailsPanel,
     UPDATE_DETAILS
@@ -26,6 +28,7 @@ import { testEpic, addTimeoutEpic } from './epicTestUtils';
 import ConfigUtils from '../../utils/ConfigUtils';
 import { SHOW_NOTIFICATION } from '../../actions/notifications';
 import { TOGGLE_CONTROL, SET_CONTROL_PROPERTY } from '../../actions/controls';
+import { reducersLoaded } from '../../actions/storemanager';
 
 const baseUrl = "base/web/client/test-resources/geostore/";
 const mapId = 1;
@@ -153,6 +156,34 @@ describe('details epics tests for map', () => {
                 present: {
                     info: {}
                 }
+            }
+        });
+    });
+    it('test openDetailsPanelOnStartup opens details when context and details metadata are ready', (done) => {
+        testEpic(openDetailsPanelOnStartup, 1, reducersLoaded(['details']), ([action]) => {
+            expect(action.type).toBe(OPEN_DETAILS_PANEL);
+            done();
+        }, {
+            ...mapTestState,
+            map: {
+                present: {
+                    info: {
+                        attributes: {
+                            details: encodeURIComponent(detailsUri),
+                            detailsSettings: JSON.stringify({
+                                showAtStartup: true
+                            })
+                        }
+                    }
+                }
+            },
+            controls: {
+                details: {
+                    enabled: false
+                }
+            },
+            context: {
+                loading: false
             }
         });
     });

--- a/web/client/epics/__tests__/details-test.js
+++ b/web/client/epics/__tests__/details-test.js
@@ -20,6 +20,7 @@ import {
     CLOSE_DETAILS_PANEL,
     OPEN_DETAILS_PANEL,
     closeDetailsPanel,
+    detailsLoaded,
     openDetailsPanel,
     UPDATE_DETAILS
 } from '../../actions/details';
@@ -29,6 +30,7 @@ import ConfigUtils from '../../utils/ConfigUtils';
 import { SHOW_NOTIFICATION } from '../../actions/notifications';
 import { TOGGLE_CONTROL, SET_CONTROL_PROPERTY } from '../../actions/controls';
 import { reducersLoaded } from '../../actions/storemanager';
+import { closeTutorial } from '../../actions/tutorial';
 
 const baseUrl = "base/web/client/test-resources/geostore/";
 const mapId = 1;
@@ -159,33 +161,49 @@ describe('details epics tests for map', () => {
             }
         });
     });
-    it('test openDetailsPanelOnStartup opens details when context and details metadata are ready', (done) => {
+    const autoOpenState = {
+        ...mapTestState,
+        map: {
+            present: {
+                info: {
+                    attributes: {
+                        details: encodeURIComponent(detailsUri),
+                        detailsSettings: JSON.stringify({
+                            showAtStartup: true
+                        })
+                    }
+                }
+            }
+        },
+        controls: {
+            details: {
+                enabled: false
+            }
+        },
+        context: {
+            loading: false
+        }
+    };
+
+    it('test openDetailsPanelOnStartup opens details when the Details reducer is ready', (done) => {
         testEpic(openDetailsPanelOnStartup, 1, reducersLoaded(['details']), ([action]) => {
             expect(action.type).toBe(OPEN_DETAILS_PANEL);
             done();
-        }, {
-            ...mapTestState,
-            map: {
-                present: {
-                    info: {
-                        attributes: {
-                            details: encodeURIComponent(detailsUri),
-                            detailsSettings: JSON.stringify({
-                                showAtStartup: true
-                            })
-                        }
-                    }
-                }
-            },
-            controls: {
-                details: {
-                    enabled: false
-                }
-            },
-            context: {
-                loading: false
-            }
-        });
+        }, autoOpenState);
+    });
+
+    it('test openDetailsPanelOnStartup opens details when details metadata is loaded', (done) => {
+        testEpic(openDetailsPanelOnStartup, 1, detailsLoaded(mapId, detailsUri, {showAtStartup: true}), ([action]) => {
+            expect(action.type).toBe(OPEN_DETAILS_PANEL);
+            done();
+        }, autoOpenState);
+    });
+
+    it('test openDetailsPanelOnStartup opens details after closing tutorial', (done) => {
+        testEpic(openDetailsPanelOnStartup, 1, closeTutorial(), ([action]) => {
+            expect(action.type).toBe(OPEN_DETAILS_PANEL);
+            done();
+        }, autoOpenState);
     });
 });
 

--- a/web/client/epics/__tests__/tutorial-test.js
+++ b/web/client/epics/__tests__/tutorial-test.js
@@ -8,13 +8,12 @@
 
 import expect from 'expect';
 
-import { getActionsFromStepEpic, switchTutorialEpic, switchGeostoryTutorialEpic, openDetailsPanelEpic } from '../tutorial';
-import { SETUP_TUTORIAL, updateTutorial, initTutorial, closeTutorial } from '../../actions/tutorial';
+import { getActionsFromStepEpic, switchTutorialEpic, switchGeostoryTutorialEpic } from '../tutorial';
+import { SETUP_TUTORIAL, updateTutorial, initTutorial } from '../../actions/tutorial';
 import { geostoryLoaded, setEditing } from '../../actions/geostory';
 import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
 import { onLocationChanged } from 'connected-react-router';
 import { setApi, getApi } from '../../api/userPersistedStorage';
-import { OPEN_DETAILS_PANEL } from './../../actions/details';
 
 describe('tutorial Epics', () => {
     const GEOSTORY_EDIT_STEPS = [{
@@ -578,94 +577,6 @@ describe('tutorial Epics', () => {
                             translationHTML: "default",
                             selector: "#intro-tutorial"
                         }]
-                    }
-                }
-            });
-        });
-    });
-    describe('openDetailsPanelEpic tests', () => {
-        it('should open the details panel if it is a (Map) and it has showAtStartup set to true', (done) => {
-            const NUM_ACTIONS = 1;
-
-            testEpic(openDetailsPanelEpic, NUM_ACTIONS, closeTutorial(), (actions) => {
-                expect(actions.length).toBe(NUM_ACTIONS);
-                const [action] = actions;
-                expect(action.type).toBe(OPEN_DETAILS_PANEL);
-                done();
-            }, {
-                map: {
-                    present: {
-                        mapId: "123",
-                        info: {
-                            attributes: {
-                                detailsSettings: {
-                                    showAtStartup: true
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-        });
-        it('should open the details panel if it is a (Dashboard) and it has showAtStartup set to true', (done) => {
-            const NUM_ACTIONS = 1;
-
-            testEpic(openDetailsPanelEpic, NUM_ACTIONS, closeTutorial(), (actions) => {
-                expect(actions.length).toBe(NUM_ACTIONS);
-                const [action] = actions;
-                expect(action.type).toBe(OPEN_DETAILS_PANEL);
-                done();
-            }, {
-                dashboard: {
-                    resource: {
-                        id: "123",
-                        attributes: {
-                            detailsSettings: {
-                                showAtStartup: true
-                            }
-                        }
-                    }
-                }
-            });
-        });
-        it('should open the details panel if it is a(Map) and it has showAtStartup set to false', (done) => {
-            const NUM_ACTIONS = 1;
-
-            testEpic(addTimeoutEpic(openDetailsPanelEpic, 100), NUM_ACTIONS, closeTutorial(), (actions) => {
-                expect(actions.length).toBe(NUM_ACTIONS);
-                const [action] = actions;
-                expect(action.type).toBe(TEST_TIMEOUT);
-                done();
-            }, {
-                map: {
-                    present: {
-                        mapId: "123",
-                        info: {
-                            detailsSettings: {
-                                showAtStartup: false
-                            }
-                        }
-                    }
-                }
-            });
-        });
-        it('should open the details panel if it is a (Dashboard) and it has showAtStartup set to false', (done) => {
-            const NUM_ACTIONS = 1;
-
-            testEpic(addTimeoutEpic(openDetailsPanelEpic, 100), NUM_ACTIONS, closeTutorial(), (actions) => {
-                expect(actions.length).toBe(NUM_ACTIONS);
-                const [action] = actions;
-                expect(action.type).toBe(TEST_TIMEOUT);
-                done();
-            }, {
-                dashboard: {
-                    resource: {
-                        id: "123",
-                        attributes: {
-                            detailsSettings: {
-                                showAtStartup: false
-                            }
-                        }
                     }
                 }
             });

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -30,7 +30,7 @@ import { mapIdSelector } from '../selectors/map';
 import { getDashboardId } from '../selectors/dashboard';
 import { DASHBOARD_LOADED } from '../actions/dashboard';
 import {loadUserSession, USER_SESSION_LOADED, userSessionStartSaving, saveMapConfig} from '../actions/usersession';
-import { detailsLoaded, openDetailsPanel } from '../actions/details';
+import { detailsLoaded } from '../actions/details';
 import {userSessionEnabledSelector, buildSessionName} from "../selectors/usersession";
 import {getRequestParameterValue} from "../utils/QueryParamsUtils";
 import { EMPTY_RESOURCE_VALUE } from '../utils/MapInfoUtils';
@@ -223,7 +223,6 @@ export const storeDetailsInfoEpic = (action$, store) =>
             return !!mapId;
         })
         .switchMap(({mapId, info: {attributes}}) => {
-            const isTutorialRunning = store.getState()?.tutorial?.run;
             let details = attributes?.details;
             let detailsSettings;
             try {
@@ -235,16 +234,12 @@ export const storeDetailsInfoEpic = (action$, store) =>
             if (!details || details === EMPTY_RESOURCE_VALUE) {
                 return Observable.empty();
             }
-            return Observable.from([
-                detailsLoaded(mapId, details, detailsSettings),
-                ...(detailsSettings.showAtStartup && !isTutorialRunning ? [openDetailsPanel()] : [])]
-            );
+            return Observable.of(detailsLoaded(mapId, details, detailsSettings));
         });
 export const storeDetailsInfoDashboardEpic = (action$, store) =>
     action$.ofType(DASHBOARD_LOADED)
         .switchMap(() => {
             const dashboardId = getDashboardId(store.getState());
-            const isTutorialRunning = store.getState()?.tutorial?.run;
             return !dashboardId
                 ? Observable.empty()
                 : Observable.fromPromise(
@@ -263,10 +258,7 @@ export const storeDetailsInfoDashboardEpic = (action$, store) =>
                         detailsSettings = {};
                     }
 
-                    return Observable.of(
-                        detailsLoaded(dashboardId, details.value, detailsSettings),
-                        ...(detailsSettings.showAtStartup && !isTutorialRunning ? [openDetailsPanel()] : [])
-                    );
+                    return Observable.of(detailsLoaded(dashboardId, details.value, detailsSettings));
                 });
         });
 

--- a/web/client/epics/details.js
+++ b/web/client/epics/details.js
@@ -12,6 +12,7 @@ import { LOCATION_CHANGE } from 'connected-react-router';
 import {
     OPEN_DETAILS_PANEL,
     CLOSE_DETAILS_PANEL,
+    DETAILS_LOADED,
     NO_DETAILS_AVAILABLE,
     updateDetails,
     closeDetailsPanel,
@@ -34,6 +35,7 @@ import { VISUALIZATION_MODE_CHANGED } from '../actions/maptype';
 import { REDUCERS_LOADED } from '../actions/storemanager';
 import { detailsSettingsSelector, detailsUriSelector } from '../selectors/details';
 import { EMPTY_RESOURCE_VALUE } from '../utils/MapInfoUtils';
+import { CLOSE_TUTORIAL } from '../actions/tutorial';
 
 export const fetchDataForDetailsPanel = (action$, store) =>
     action$.ofType(OPEN_DETAILS_PANEL)
@@ -90,10 +92,9 @@ const parseDetailsSettings = (detailsSettings) => {
 };
 
 export const openDetailsPanelOnStartup = (action$, store) =>
-    action$.ofType(REDUCERS_LOADED)
+    action$.ofType(DETAILS_LOADED, REDUCERS_LOADED, CLOSE_TUTORIAL)
         .filter((action) => action.type !== REDUCERS_LOADED || isDetailsReducerLoaded(action.reducers))
         .delay(100)
-        // Retry startup auto-open after the Details plugin has registered.
         .filter(() => {
             const state = store.getState();
             const detailsUri = detailsUriSelector(state);

--- a/web/client/epics/details.js
+++ b/web/client/epics/details.js
@@ -14,7 +14,8 @@ import {
     CLOSE_DETAILS_PANEL,
     NO_DETAILS_AVAILABLE,
     updateDetails,
-    closeDetailsPanel
+    closeDetailsPanel,
+    openDetailsPanel
 } from '../actions/details';
 import { toggleControl, setControlProperty } from '../actions/controls';
 import { MAP_SAVED } from '../actions/config';
@@ -30,7 +31,9 @@ import GeoStoreApi from '../api/GeoStoreDAO';
 import { getIdFromUri } from '../utils/MapUtils';
 import { basicError } from '../utils/NotificationUtils';
 import { VISUALIZATION_MODE_CHANGED } from '../actions/maptype';
-import { detailsUriSelector } from '../selectors/details';
+import { REDUCERS_LOADED } from '../actions/storemanager';
+import { detailsSettingsSelector, detailsUriSelector } from '../selectors/details';
+import { EMPTY_RESOURCE_VALUE } from '../utils/MapInfoUtils';
 
 export const fetchDataForDetailsPanel = (action$, store) =>
     action$.ofType(OPEN_DETAILS_PANEL)
@@ -68,3 +71,38 @@ export const closeDetailsPanelOn3DToggle = (action$) =>
         .switchMap(() => {
             return Rx.Observable.of(closeDetailsPanel());
         });
+
+const isDetailsReducerLoaded = (reducers) =>
+    Array.isArray(reducers) ? reducers.indexOf('details') !== -1 : !!reducers?.details;
+
+const parseDetailsSettings = (detailsSettings) => {
+    if (!detailsSettings) {
+        return {};
+    }
+    if (typeof detailsSettings === 'string') {
+        try {
+            return JSON.parse(detailsSettings) || {};
+        } catch (e) {
+            return {};
+        }
+    }
+    return detailsSettings;
+};
+
+export const openDetailsPanelOnStartup = (action$, store) =>
+    action$.ofType(REDUCERS_LOADED)
+        .filter((action) => action.type !== REDUCERS_LOADED || isDetailsReducerLoaded(action.reducers))
+        .delay(100)
+        // Retry startup auto-open after the Details plugin has registered.
+        .filter(() => {
+            const state = store.getState();
+            const detailsUri = detailsUriSelector(state);
+            const detailsSettings = parseDetailsSettings(detailsSettingsSelector(state));
+            return !state?.context?.loading
+                && detailsUri
+                && detailsUri !== EMPTY_RESOURCE_VALUE
+                && detailsSettings?.showAtStartup
+                && !state?.tutorial?.run
+                && !state?.controls?.details?.enabled;
+        })
+        .switchMap(() => Rx.Observable.of(openDetailsPanel()));

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -11,13 +11,11 @@ import Rx from 'rxjs';
 import {
     START_TUTORIAL,
     UPDATE_TUTORIAL,
-    CLOSE_TUTORIAL,
     INIT_TUTORIAL,
     CHANGE_PRESET,
     closeTutorial,
     setupTutorial
 } from '../actions/tutorial';
-import { openDetailsPanel } from '../actions/details';
 import { CHANGE_MAP_VIEW } from '../actions/map';
 import { modeSelector } from '../selectors/geostory';
 import { CHANGE_MODE } from '../actions/geostory';
@@ -28,7 +26,6 @@ import { isEmpty, isArray, isObject } from 'lodash';
 import { getApi, getItemKey } from '../api/userPersistedStorage';
 import {REDUCERS_LOADED} from "../actions/storemanager";
 import { VISUALIZATION_MODE_CHANGED } from '../actions/maptype';
-import { detailsSettingsSelector } from '../selectors/details';
 
 const findTutorialId = path => path.match(/\/(viewer)\/(\w+)\/(\d+)/) && path.replace(/\/(viewer)\/(\w+)\/(\d+)/, "$2")
     || path.match(/\/(\w+)\/(\d+)/) && path.replace(/\/(\w+)\/(\d+)/, "$1")
@@ -165,26 +162,10 @@ export const getActionsFromStepEpic = (action$) =>
  * @type {Object}
  */
 
-export const openDetailsPanelEpic = (action$, store) =>
-    action$.ofType(CLOSE_TUTORIAL)
-        .filter(() => {
-            const state = store.getState();
-            let detailsSettings = detailsSettingsSelector(state);
-            if (detailsSettings && typeof detailsSettings === 'string') {
-                detailsSettings = JSON.parse(detailsSettings);
-            }
-            return detailsSettings?.showAtStartup;
-        })
-        .switchMap( () => {
-            return Rx.Observable.of(openDetailsPanel());
-        });
-
-
 export default {
     closeTutorialEpic,
     switchTutorialEpic,
     getActionsFromStepEpic,
     changePresetEpic,
-    switchGeostoryTutorialEpic,
-    openDetailsPanelEpic
+    switchGeostoryTutorialEpic
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The About panel sometimes did not open on startup, even when “Show at startup” was enabled, because the open action could run before the Details plugin was ready during slow context loading.

This PR now retry the startup open after the Details plugin is registered, and only open it if the map has details, “Show at startup” is enabled, and the panel is not already open.

To test the throttle to 3G and test the context map with “Show at startup” enabled.


https://github.com/user-attachments/assets/b9758876-b613-4b09-8a1b-3ece3814a5cd




**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12441

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
So the About panel will be opened regarless of the network speed when “Show at startup”  is enabled

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
