### PR TITLE
#12437 The Style editor crashes for certain FGB layers

### DIFF
--- a/web/client/plugins/styleeditor/VectorStyleEditor.jsx
+++ b/web/client/plugins/styleeditor/VectorStyleEditor.jsx
@@ -227,9 +227,9 @@ function VectorStyleEditor({
     useEffect(() => {
         if (!loading && request) {
             setLoading(true);
-            (request
+            Promise.resolve(request
                 ? request(layer)
-                : Promise.resolve(layer))
+                : layer)
                 .then(({ properties, format, geometryType, fields } = {}) => {
                     const newLayer = {
                         ...layer,

--- a/web/client/plugins/tocitemssettings/__tests__/defaultSettingsTabs-test.js
+++ b/web/client/plugins/tocitemssettings/__tests__/defaultSettingsTabs-test.js
@@ -284,4 +284,49 @@ describe('TOCItemsSettings - VectorStyleEditor rendered items', () => {
         });
         expect(result.Component).toBeTruthy();
     });
+
+    it('VectorStyleEditor initializes a flatgeobuf layer from source metadata columns', (done) => {
+        const mockStore = configureMockStore()({});
+        const PROPS = {
+            ...BASE_STYLE_TEST_DATA,
+            element: {
+                id: 'flatgeobuf-layer',
+                type: 'flatgeobuf',
+                url: 'base/web/client/test-resources/flatgeobuf/UScounties_subset.fgb',
+                sourceMetadata: {
+                    geometryType: 6,
+                    columns: [
+                        { name: 'STATE_NAME' },
+                        { name: 'STATE_FIPS' }
+                    ]
+                }
+            },
+            onUpdateNode: (id, nodeType, update) => {
+                try {
+                    expect(id).toBe('flatgeobuf-layer');
+                    expect(nodeType).toBe('layers');
+                    expect(update.properties).toEqual({
+                        STATE_NAME: '',
+                        STATE_FIPS: ''
+                    });
+                    expect(update.geometryType).toBe('polygon');
+                    expect(update.style).toEqual({
+                        format: 'geostyler',
+                        body: {},
+                        metadata: {
+                            editorType: 'visual'
+                        }
+                    });
+                } catch (e) {
+                    done(e);
+                    return;
+                }
+                done();
+            }
+        };
+
+        act(async() => {
+            ReactDOM.render(<Provider store={mockStore}><VectorStyleEditor {...PROPS}/></Provider>, document.querySelector('#container'));
+        });
+    });
 });


### PR DESCRIPTION

## Description
The Style editor crashes for certain FGB layers. This was because the component tries to always get properties using promise and resolve it but in case of FlatGeoBuf the columns are already there and are not passed as a promise. Also added a test for VectorStyleEditor Component for flatgeobuf layer.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#12437 

**What is the new behavior?**
The style editor does not crash and works as expected.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

