### PR TITLE
Filter is not correctly applied after editing a GeoNode catalog service  #12480

### DIFF
--- a/web/client/components/catalog/__tests__/Catalog-test.jsx
+++ b/web/client/components/catalog/__tests__/Catalog-test.jsx
@@ -55,8 +55,8 @@ describe('Test Catalog panel', () => {
                     maxRecords: 12,
                     text: '',
                     options: {
-                        filters: undefined,
-                        sort: undefined,
+                        filters: {},
+                        sort: '-date',
                         service: SERVICE
                     }
                 });
@@ -202,8 +202,8 @@ describe('Test Catalog panel', () => {
                     maxRecords: 12,
                     text: '',
                     options: {
-                        filters: undefined,
-                        sort: undefined,
+                        filters: {},
+                        sort: '-date',
                         service: SERVICE
                     }
                 });

--- a/web/client/components/catalog/datasets/Catalog.jsx
+++ b/web/client/components/catalog/datasets/Catalog.jsx
@@ -150,7 +150,7 @@ const Catalog = ({
     useEffect(() => {
         clearSelection?.();
         if (shouldAutoload(selectedService, services)) {
-            search({ searchText });
+            search({ searchText, filters, sort });
         }
         setShowFilters(false);
     }, [services, mode]);

--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -172,7 +172,9 @@ describe('catalog Epics', () => {
                     type: "csw",
                     url: "url",
                     filter: "test"
-                }
+                },
+                filters: {'filter{category.identifier.in}': ['environment']},
+                sort: '-date'
             });
             done();
         }, {
@@ -186,7 +188,11 @@ describe('catalog Epics', () => {
                         filter: "test"
                     }
                 },
-                pageSize: 2
+                pageSize: 2,
+                searchOptions: {
+                    filters: {'filter{category.identifier.in}': ['environment']},
+                    sort: '-date'
+                }
             },
             layers: {
                 selected: ["TEST"],
@@ -305,6 +311,23 @@ describe('catalog Epics', () => {
                     expect(true).toBe(false);
                 }
             });
+            done();
+        }, { });
+    });
+    it('recordSearchEpic preserves filters and sort in search options', (done) => {
+        const NUM_ACTIONS = 2;
+        const filters = {'filter{category.identifier.in}': ['environment']};
+        testEpic(addTimeoutEpic(recordSearchEpic), NUM_ACTIONS, textSearch({
+            format: "csw",
+            url: "base/web/client/test-resources/csw/getRecordsResponseDC.xml",
+            startPosition: 1,
+            maxRecords: 1,
+            text: "a",
+            options: {filters, sort: '-date'}
+        }), (actions) => {
+            const recordsLoadedAction = actions.find(({type}) => type === RECORD_LIST_LOADED);
+            expect(recordsLoadedAction.searchOptions.filters).toEqual(filters);
+            expect(recordsLoadedAction.searchOptions.sort).toBe('-date');
             done();
         }, { });
     });

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -154,7 +154,9 @@ export default (API) => ({
                             url,
                             startPosition,
                             maxRecords,
-                            text
+                            text,
+                            filters: options?.filters,
+                            sort: options?.sort
                         }, result)]);
                     })
                     .startWith(isNewService ? savingService(true) : setLoading(true))


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR keeps catalog filters active after editing a service or typing in the search field.

https://github.com/user-attachments/assets/f77f8951-bb47-485e-b14c-3b16a0f874a5



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12480

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Filter and shorter gets preseved even after other interactions like resaving catalog and searcing by text.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
