### PR TITLE
infra: update to use ssh keys instead of password for publishing arti…

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Setup SSH Agent
         uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.MAPSTORE_MAVEN_SSH_KEY }}
+          ssh-private-key: ${{ secrets.GS_MAVEN_MAPSTORE2_KEY }}
       - name: Trust Maven Host
         run: ssh-keyscan -H maven.geo-solutions.it >> ~/.ssh/known_hosts
       - name: Set up Maven Central Repository
@@ -217,7 +217,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           server-id: geosolutions
-          server-username: MAPSTORE_MAVEN_USERNAME
+          server-username: MAVEN_USERNAME
 
       - name: Publish maven packages
         # Here it deploys only java modules and root, needed for MS project builds.
@@ -228,4 +228,4 @@ jobs:
           # deploys also the root module, needed for dependencies
           mvn deploy --non-recursive
         env:
-          MAPSTORE_MAVEN_USERNAME: ${{ secrets.MAPSTORE_MAVEN_USERNAME }}
+          MAVEN_USERNAME: ${{ secrets.GS_MAVEN_MAPSTORE2_USERNAME }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -205,26 +205,27 @@ jobs:
       ############
       # Publish
       ##########
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MAPSTORE_MAVEN_SSH_KEY }}
+      - name: Trust Maven Host
+        run: ssh-keyscan -H maven.geo-solutions.it >> ~/.ssh/known_hosts
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'temurin'
           server-id: geosolutions
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          server-username: MAPSTORE_MAVEN_USERNAME
+
       - name: Publish maven packages
         # Here it deploys only java modules and root, needed for MS project builds.
         # Product, binary modules are to big to be hosted on the repository in snapshots, so they are skipped
         run: |
-          # Setup SSH keys for SFTP
-          mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          # add geo-solutions.it to known hosts to avoid prompts
-          ssh-keyscan -H maven.geo-solutions.it >> ~/.ssh/known_hosts
           # deploys java packages
           mvn clean install deploy -f java/pom.xml
           # deploys also the root module, needed for dependencies
           mvn deploy --non-recursive
         env:
-          MAVEN_USERNAME: ${{ secrets.GS_MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.GS_MAVEN_PASSWORD }}
+          MAPSTORE_MAVEN_USERNAME: ${{ secrets.MAPSTORE_MAVEN_USERNAME }}

--- a/java/services/pom.xml
+++ b/java/services/pom.xml
@@ -163,7 +163,7 @@
             <!--.............................................-->
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ssh</artifactId>
+                <artifactId>wagon-ssh-external</artifactId>
                 <version>3.5.3</version>
             </extension>
         </extensions>
@@ -171,7 +171,7 @@
    <distributionManagement>
         <repository>
             <id>geosolutions</id>
-            <url>sftp://maven.geo-solutions.it/</url>
+            <url>scpexe://maven.geo-solutions.it/</url>
         </repository>
     </distributionManagement>
     <profiles>

--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -108,7 +108,7 @@
             <!--.............................................-->
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ssh</artifactId>
+                <artifactId>wagon-ssh-external</artifactId>
                 <version>3.5.3</version>
             </extension>
         </extensions>
@@ -117,7 +117,7 @@
    <distributionManagement>
         <repository>
             <id>geosolutions</id>
-            <url>sftp://maven.geo-solutions.it/</url>
+            <url>scpexe://maven.geo-solutions.it/</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
    <distributionManagement>
         <repository>
             <id>geosolutions</id>
-            <url>sftp://maven.geo-solutions.it/</url>
+            <url>scpexe://maven.geo-solutions.it/</url>
         </repository>
     </distributionManagement>
 
@@ -464,7 +464,7 @@
         <extensions>
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ssh</artifactId>
+                <artifactId>wagon-ssh-external</artifactId>
                 <version>3.5.3</version>
             </extension>
         </extensions>


### PR DESCRIPTION
## Related Open Issue
Fix https://github.com/geosolutions-it/MapStore2/issues/11751
Fix https://github.com/geosolutions-it/support/issues/6199

## Description
The goal is to use ssh public keys for authenticating to maven repository. Earlier implementaion of `wagon-ssh` has several downsides (eg: no support for newer crpt algo, custom settings.xml, no support of openssh keys etc), hence is replace with `wagon-ssh-external` that uses the host's ssh executeable to perform those actions.


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:


## Issue

**What is the current behavior?**
Github and Jenkins build/publish jobs uses username/password to authenticate to maven repository.

**What is the new behavior?**
Use of ssh-keys for authentication to maven repository with `wagon-ssh-external` plugin and updated github actions.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] Yes, if things break, it can affect the publishing in http://maven.geo-solutions.it/
 - [ ] No

## Rollback
Rollback would include reverting the PR, that should enable existing `user/password based` workflow. As a precaution existing secrets are left intact and to be deleted only when ssh-key based workflow is working.
```
GS_MAVEN_USERNAME
GS_MAVEN_PASSWORD
```