### PR TITLE
WMS print legend fails for ArcGIS due to duplicate version parameters  #12496

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -778,7 +778,6 @@ export const specCreators = {
                                     ...getWMSLegendConfig({layer, legendOptions, mapBbox: spec.bbox, mapSize: spec.size, projection: spec.projection, format: LEGEND_FORMAT.IMAGE}),
                                     TRANSPARENT: true,
                                     EXCEPTIONS: "application/vnd.ogc.se_xml",
-                                    VERSION: "1.1.1",
                                     SCALE: spec.scale,
                                     ...getLegendIconsSize(spec, layer),
                                     ...(spec.language ? {LANGUAGE: spec.language} : {})

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -526,6 +526,18 @@ describe('PrintUtils', () => {
             done();
         }).catch(done);
     });
+    it('wms layer generation for legend includes only the layer version', (done) => {
+        getMapfishLayersSpecification([{...layer, version: "1.3.0"}], { projection: "EPSG:3857" }, {}, 'legend').then(specs => {
+            expect(specs).toExist();
+            expect(specs.length).toBe(1);
+            const legendUrl = specs[0].classes[0].icons[0];
+            // Count both version and VERSION query parameters.
+            const versionParams = legendUrl.match(/[?&]version=/gi) || [];
+            expect(versionParams.length).toBe(1);
+            expect(legendUrl.indexOf('version=1.3.0')).toBeGreaterThan(0);
+            done();
+        }).catch(done);
+    });
     it('vector layer default point style', () => {
         const style = getOlDefaultStyle({ features: [{ geometry: { type: "Point" } }] });
         expect(style).toExist();


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR removes the hardcoded VERSION=1.1.1 from WMS print legend requests.
The print legend URL already receives the WMS version from `getWMSLegendConfig()` using layer.version, defaulting to 1.3.0. The hardcoded value was redundant and could create conflicting requests like version=1.3.0&VERSION=1.1.1, which breaks ArcGIS WMS legends.

This also aligns print legend behavior with TOC legends, which do not inject a hardcoded WMS version.

<img width="622" height="424" alt="image" src="https://github.com/user-attachments/assets/52628c56-7d01-446c-970e-46a81b299b87" />


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12496

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Legend rendered properly for ARCGIS WMS also.


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
