### PR TITLE
#12487 Catalog dialog view is not correctly persisted when configured as default

### DIFF
--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -245,7 +245,7 @@ describe('catalog Epics', () => {
         }, { controls: { metadataexplorer: { enabled: true } }});
     });
 
-    it('catalogCloseEpic should reset metadataexplorer panel to true', (done) => {
+    it('catalogCloseEpic should preserve metadataexplorer panel', (done) => {
         const NUM_ACTIONS = 3;
         testEpic(catalogCloseEpic, NUM_ACTIONS, catalogClose(), (actions) => {
             expect(actions.length).toBe(NUM_ACTIONS);
@@ -253,8 +253,7 @@ describe('catalog Epics', () => {
             expect(actions[0].control).toBe('metadataexplorer');
             expect(actions[0].properties).toEqual({
                 enabled: false,
-                group: null,
-                panel: true
+                group: null
             });
             done();
         }, {

--- a/web/client/epics/__tests__/maplayout-test.js
+++ b/web/client/epics/__tests__/maplayout-test.js
@@ -215,6 +215,10 @@ describe('map layout epics', () => {
             const state = { controls: { metadataexplorer: { enabled: true, group: "parent" } } };
             testEpic(updateMapLayoutEpic, 1, setControlProperties("metadataexplorer", "enabled", true, "group", "parent"), epicResult(done), state);
         });
+        it('metadataexplorer in dialog mode does not reserve right panel space', done => {
+            const state = { controls: { metadataexplorer: { enabled: true, panel: false } } };
+            testEpic(updateMapLayoutEpic, 1, setControlProperty("metadataexplorer", "panel", false), epicResult(done, 0), state);
+        });
         it('userExtensions', (done) => {
             const state = { controls: { userExtensions: { enabled: true, group: "parent" } } };
             testEpic(updateMapLayoutEpic, 1, setControlProperties("userExtensions", "enabled", true, "group", "parent"), epicResult(done), state);

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -631,7 +631,7 @@ export default (API) => ({
                 const metadataSource = metadataSourceSelector(state);
                 const stashedService = stashedServiceSelector(state);
                 return Rx.Observable.of(...([
-                    setControlProperties('metadataexplorer', "enabled", false, "group", null, "panel", true),
+                    setControlProperties('metadataexplorer', "enabled", false, "group", null),
                     changeCatalogMode("view"),
                     resetCatalog()
                 ].concat(metadataSource === 'backgroundSelector' ?

--- a/web/client/plugins/Catalog/containers/Catalog.jsx
+++ b/web/client/plugins/Catalog/containers/Catalog.jsx
@@ -48,6 +48,7 @@ import {
 import {
     isActiveSelector,
     authkeyParamNameSelector,
+    catalogPanelSelector,
     groupSelector,
     layerErrorSelector,
     loadingErrorSelector,
@@ -114,6 +115,7 @@ const Catalog = ({
     zoomToLayer = true,
     onError,
     group,
+    catalogPanel,
     authkeyParamNames,
     crs,
     enableImageryOverlay,
@@ -127,7 +129,8 @@ const Catalog = ({
 }, context) => {
     const { loadedPlugins } = context;
     const addonsItems = usePluginItems({ items: items, loadedPlugins }).filter(({ target }) => target === 'url-addon');
-    const [panel, setPanel] = useState(defaultView !== 'dialog');
+    const defaultPanel = defaultView !== 'dialog';
+    const panel = catalogPanel ?? defaultPanel;
     const [loadingLayers, setLoadingLayers] = useState([]);
 
     useEffect(() => {
@@ -135,6 +138,9 @@ const Catalog = ({
             editingAllowedRoles,
             editingAllowedGroups
         });
+        if (catalogPanel === undefined) {
+            onSetCatalogPanel(defaultPanel);
+        }
         return () => {
             closeCatalog();
         };
@@ -320,9 +326,7 @@ const Catalog = ({
                             tooltipPosition="bottom"
                             tooltipId={panel ? <Message msgId="catalog.gridView" /> : <Message msgId="catalog.listView" />}
                             onClick={() => {
-                                const newPanel = !panel;
-                                setPanel(newPanel);
-                                onSetCatalogPanel?.(newPanel);
+                                onSetCatalogPanel(!panel);
                             }}
                             square
                         >
@@ -331,12 +335,7 @@ const Catalog = ({
                         <ButtonWithTooltip
                             tooltipPosition="bottom"
                             tooltipId={<Message msgId="catalog.close" />}
-                            onClick={() => {
-                                closeCatalog();
-                                if (!panel) {
-                                    setPanel(true);
-                                }
-                            }}
+                            onClick={closeCatalog}
                             square
                         >
                             <Glyphicon glyph="1-close" />
@@ -394,6 +393,7 @@ const layerCatalogSelector = createStructuredSelector({
     dockStyle: state => mapLayoutValuesSelector(state, { height: true, right: true }, true),
     // controls
     group: groupSelector,
+    catalogPanel: catalogPanelSelector,
     // backgorund
     source: metadataSourceSelector,
     modalParams: modalParamsSelector

--- a/web/client/plugins/__tests__/Catalog-test.jsx
+++ b/web/client/plugins/__tests__/Catalog-test.jsx
@@ -8,8 +8,35 @@
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
 import CatalogPlugin from '../Catalog';
 import { getPluginForTest } from './pluginsTestUtils';
+import { setControlProperty } from '../../actions/controls';
+import { catalogClose } from '../../actions/catalog';
+
+const ACTIVE_CATALOG_STATE = {
+    controls: {
+        metadataexplorer: {
+            enabled: true
+        }
+    }
+};
+
+const expectDialogView = () => {
+    expect(document.querySelector('.ms-catalog-grid-wrapper')).toBeTruthy();
+    expect(document.querySelector('.ms-catalog.grid')).toBeTruthy();
+    expect(document.querySelector('.ms-catalog-panel')).toBeFalsy();
+};
+
+const expectPanelView = () => {
+    expect(document.querySelector('.ms-catalog-panel')).toBeTruthy();
+    expect(document.querySelector('.ms-catalog.list')).toBeTruthy();
+    expect(document.querySelector('.ms-catalog-grid-wrapper')).toBeFalsy();
+};
+
+const openCatalog = (store) => store.dispatch(setControlProperty('metadataexplorer', 'enabled', true));
+const closeCatalog = (store) => store.dispatch(catalogClose());
+const waitForUpdates = (callback) => setTimeout(callback, 0);
 
 describe('Catalog Plugin', () => {
     beforeEach(() => {
@@ -47,5 +74,96 @@ describe('Catalog Plugin', () => {
             expect(actions.map(a => a.type).includes("CATALOG:CATALOG_CLOSE")).toBeTruthy();
             done();
         }, 0);
+    });
+    it('renders in dialog mode when configured as default view', (done) => {
+        const {Plugin, store} = getPluginForTest(CatalogPlugin, ACTIVE_CATALOG_STATE);
+        ReactDOM.render(<Plugin defaultView="dialog" />, document.getElementById("container"));
+
+        waitForUpdates(() => {
+            try {
+                expectDialogView();
+                expect(store.getState().controls.metadataexplorer.panel).toBe(false);
+            } catch (e) {
+                done(e);
+                return;
+            }
+            done();
+        });
+    });
+    it('keeps default dialog mode after close and reopen when view button is untouched', (done) => {
+        const {Plugin, store} = getPluginForTest(CatalogPlugin, ACTIVE_CATALOG_STATE);
+        ReactDOM.render(<Plugin defaultView="dialog" />, document.getElementById("container"));
+
+        waitForUpdates(() => {
+            try {
+                expectDialogView();
+                closeCatalog(store);
+            } catch (e) {
+                done(e);
+                return;
+            }
+            waitForUpdates(() => {
+                try {
+                    expect(document.querySelector('.ms-catalog')).toBeFalsy();
+                    openCatalog(store);
+                } catch (e) {
+                    done(e);
+                    return;
+                }
+                waitForUpdates(() => {
+                    try {
+                        expectDialogView();
+                        expect(store.getState().controls.metadataexplorer.panel).toBe(false);
+                    } catch (e) {
+                        done(e);
+                        return;
+                    }
+                    done();
+                });
+            });
+        });
+    });
+    it('keeps user selected panel mode after close and reopen', (done) => {
+        const {Plugin, store} = getPluginForTest(CatalogPlugin, ACTIVE_CATALOG_STATE);
+        ReactDOM.render(<Plugin defaultView="dialog" />, document.getElementById("container"));
+
+        waitForUpdates(() => {
+            try {
+                expectDialogView();
+                const toggleButton = document.querySelector('.glyphicon-minus').parentNode;
+                TestUtils.Simulate.click(toggleButton);
+            } catch (e) {
+                done(e);
+                return;
+            }
+            waitForUpdates(() => {
+                try {
+                    expectPanelView();
+                    closeCatalog(store);
+                } catch (e) {
+                    done(e);
+                    return;
+                }
+                waitForUpdates(() => {
+                    try {
+                        expect(document.querySelector('.ms-catalog')).toBeFalsy();
+                        openCatalog(store);
+                    } catch (e) {
+                        done(e);
+                        return;
+                    }
+                    waitForUpdates(() => {
+                        try {
+                            expectPanelView();
+                            expect(store.getState().controls.metadataexplorer.panel).toBe(true);
+                        } catch (e) {
+                            done(e);
+                            return;
+                        }
+                        done();
+                    });
+                });
+            });
+        });
     });
 });

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -31,6 +31,7 @@ export const selectedStaticServiceTypeSelector =
 export const tileSizeOptionsSelector = state => get(state, 'catalog.default.tileSizes', [256, 512]);
 
 export const groupSelector = (state) => get(state, "controls.metadataexplorer.group");
+export const catalogPanelSelector = (state) => get(state, "controls.metadataexplorer.panel");
 export const savingSelector = (state) => get(state, "catalog.saving");
 export const resultSelector = (state) => get(state, "catalog.result");
 export const serviceListOpenSelector = (state) => get(state, "catalog.openCatalogServiceList");


### PR DESCRIPTION
## Description
Currently the type of Catalog window was being reset to `panel` from `dialog` on close even when default is set as mentioned in #12487 . Use the config mentioned in the issue in order to test the fix.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**

#12487 

**What is the new behavior?**
The view type is correctly persisted.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No