### PR TITLE
Replace lifecycle functions with UNSAFE_ versions

### DIFF
--- a/web/client/components/TOC/enhancers/tocItemsSettings.js
+++ b/web/client/components/TOC/enhancers/tocItemsSettings.js
@@ -27,8 +27,8 @@ export const settingsState = compose(
  * - onSave: triggers onHideSettings
  * Lifecycle:
  * - UNSAFE_componentWillMount: set original and initial settings of current node
- * - componentWillReceiveProps: in case of missing description of node, it sends a get capabilities requiest to retrieve data of layer
- * - componentWillUpdate: check if current settings are not expanded and next are expanded to restore initial and original settings of component
+ * - UNSAFE_componentWillReceiveProps: in case of missing description of node, it sends a get capabilities requiest to retrieve data of layer
+ * - UNSAFE_componentWillUpdate: check if current settings are not expanded and next are expanded to restore initial and original settings of component
  * @memberof enhancers.settingsLifecycle
  * @class
  */
@@ -48,7 +48,7 @@ export const settingsLifecycle = compose(
         }
     }),
     lifecycle({
-        componentWillReceiveProps(newProps) {
+        UNSAFE_componentWillReceiveProps(newProps) {
             // an empty description does not trigger the single layer getCapabilites,
             // it does only for missing description
             const {
@@ -60,7 +60,7 @@ export const settingsLifecycle = compose(
                 onRetrieveLayerData(newProps.element);
             }
         },
-        componentWillUpdate(newProps) {
+        UNSAFE_componentWillUpdate(newProps) {
             const {
                 initialActiveTab = 'general',
                 settings = {},

--- a/web/client/components/TOC/enhancers/tocItemsSettings.js
+++ b/web/client/components/TOC/enhancers/tocItemsSettings.js
@@ -27,7 +27,7 @@ export const settingsState = compose(
  * - onSave: triggers onHideSettings
  * Lifecycle:
  * - UNSAFE_componentWillMount: set original and initial settings of current node
- * - UNSAFE_componentWillReceiveProps: in case of missing description of node, it sends a get capabilities requiest to retrieve data of layer
+ * - UNSAFE_componentWillReceiveProps: in case of missing description of node, it sends a get capabilities request to retrieve data of layer
  * - UNSAFE_componentWillUpdate: check if current settings are not expanded and next are expanded to restore initial and original settings of component
  * @memberof enhancers.settingsLifecycle
  * @class

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -89,7 +89,7 @@ class DownloadOptions extends React.Component {
         this.props.formatOptionsFetch(this.props.layer);
     };
 
-    componentWillReceiveProps = (newProps) => {
+    UNSAFE_componentWillReceiveProps = (newProps) => {
         if ( !isEqual( this.props.formats, newProps.formats)) {
             const format = get(newProps, "downloadOptions.selectedFormat") || get(head(newProps.formats), "name");
             newProps.onChange("selectedFormat", format);

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -57,7 +57,7 @@ export const identifyHandlers = withHandlers({
 /**
  * Basic identify lifecycle used in Identify plugin with IdentifyContainer component
  * - componentDidMount: show cursor on map as pointer if enabled props is true
- * - componentWillReceiveProps:
+ * - UNSAFE_componentWillReceiveProps:
  *      - changes pointer enable true/false - TODO: move it in an epic
  *      - set index to 0 to when responses are changed to avoid empty view if index is greater than current responses length
  * @memberof components.data.identify.enhancers.identify
@@ -120,7 +120,7 @@ export const identifyLifecycle = compose(
             hideMarker();
             purgeResults();
         },
-        componentWillReceiveProps(newProps) {
+        UNSAFE_componentWillReceiveProps(newProps) {
             const {
                 hideMarker = () => {},
                 purgeResults = () => {},

--- a/web/client/components/map/enhancers/mapType.js
+++ b/web/client/components/map/enhancers/mapType.js
@@ -31,7 +31,7 @@ function mapType(Component) {
             this._isMounted = true;
         }
 
-        componentWillUpdate(newProps) {
+        UNSAFE_componentWillUpdate(newProps) {
             if (newProps.mapType !== this.props.mapType) {
                 this.setPlugins(newProps);
             }

--- a/web/client/components/misc/enhancers/stickySupport.jsx
+++ b/web/client/components/misc/enhancers/stickySupport.jsx
@@ -66,7 +66,7 @@ export default () => WrappedComponent =>
             this.update(this.props.scrollContainerSelector);
         }
 
-        componentWillReceiveProps(newProps) {
+        UNSAFE_componentWillReceiveProps(newProps) {
             if (this._stickybits
             && (newProps.viewWidth !== this.props.viewWidth
             || newProps.viewHeight !== this.props.viewHeight)) {

--- a/web/client/libs/numeric-input/NumericInput.jsx
+++ b/web/client/libs/numeric-input/NumericInput.jsx
@@ -192,7 +192,7 @@ class NumericInput extends Component {
      *     2. Then trim it.
      *     3. Then parse it to number (delegating to this.props.parse if any)
      */
-    componentWillReceiveProps(props) {
+    UNSAFE_componentWillReceiveProps(props) {
         this._isStrict = !!props.strict;
         let nextState = this._propsToState(props);
         if (Object.keys(nextState).length) {
@@ -206,7 +206,7 @@ class NumericInput extends Component {
     /**
      * Save the input selection right before rendering
      */
-    componentWillUpdate() {
+    UNSAFE_componentWillUpdate() {
         this.saveSelection();
     }
 


### PR DESCRIPTION
## Description
This PR replaces componentWillReceiveProps and componentWillUpdate with the UNSAFE_componentWillReceiveProps and UNSAFE_componentWillUpdate lifecycle functions.

This change is necessary is to make sure that our legacy components will work with react 17+ see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html

This change was done as a part of the React 19 upgrade, see #12500 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12500
We are currently using the componentWillReceiveProps and componentWillUpdate lifecycle functions.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
We will no longer use the componentWillReceiveProps and componentWillUpdate lifecycle functions, and will instead us.e the UNSAFE_componentWillReceiveProps and UNSAFE_componentWillUpdate  versions that are compatible with react 17+

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
