### PR TITLE
Identify does not center the marker when clicking outside of the projection maxium extent  #12476

### DIFF
--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -74,6 +74,7 @@ import { configureMap } from '../../actions/config';
 import { changeVisualizationMode } from './../../actions/maptype';
 import { FORCE_UPDATE_MAP_LAYOUT } from '../../actions/maplayout';
 import { VisualizationModes } from '../../utils/MapTypeUtils';
+import ProjectionRegistry from '../../utils/ProjectionRegistry';
 
 const TEST_MAP_STATE = {
     present: {
@@ -94,6 +95,13 @@ const TEST_MAP_STATE = {
             crs: 'EPSG:3857'
         }
     }
+};
+
+const EPSG_32636_DEF = {
+    code: 'EPSG:32636',
+    def: '+proj=utm +zone=36 +datum=WGS84 +units=m +no_defs +type=crs',
+    extent: [166021.44, 0.0, 833978.56, 9329005.18],
+    worldExtent: [30.0, 0.0, 36.0, 84.0]
 };
 
 describe('identify Epics', () => {
@@ -967,6 +975,63 @@ describe('identify Epics', () => {
                 }
             });
             done();
+        };
+
+        testEpic(zoomToVisibleAreaEpic, 2, sentActions, expectedAction, state);
+    });
+
+    it('test center to visible area outside projection extent', (done) => {
+        // remove previous hook
+        registerHook('RESOLUTION_HOOK', undefined);
+        ProjectionRegistry.register(EPSG_32636_DEF);
+
+        const state = {
+            mapInfo: {
+                centerToMarker: true
+            },
+            map: {
+                present: {
+                    ...TEST_MAP_STATE.present,
+                    projection: 'EPSG:32636'
+                }
+            },
+            maplayout: {
+                boundingMapRect: {
+                    left: 500,
+                    bottom: 250
+                }
+            },
+            projections: {
+                staticDefs: [EPSG_32636_DEF]
+            }
+        };
+
+        const sentActions = [featureInfoClick({ latlng: { lat: 43.7711, lng: 11.2486 } }), loadFeatureInfo()];
+
+        const expectedAction = actions => {
+            try {
+                expect(actions.length).toBe(2);
+                actions.map((action) => {
+                    switch (action.type) {
+                    case ZOOM_TO_POINT:
+                        expect(action.zoom).toBe(4);
+                        expect(Number.isFinite(action.pos.x)).toBe(true);
+                        expect(Number.isFinite(action.pos.y)).toBe(true);
+                        expect(action.crs).toBe('EPSG:4326');
+                        break;
+                    case UPDATE_CENTER_TO_MARKER:
+                        expect(action.status).toBe('enabled');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                ProjectionRegistry.unRegister(EPSG_32636_DEF.code);
+                done();
+            } catch (e) {
+                ProjectionRegistry.unRegister(EPSG_32636_DEF.code);
+                done(e);
+            }
         };
 
         testEpic(zoomToVisibleAreaEpic, 2, sentActions, expectedAction, state);

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -46,9 +46,9 @@ import {
 import { centerToMarkerSelector, getSelectedLayers, layersSelector, queryableLayersSelector, queryableSelectedLayersSelector, rawGroupsSelector, selectedNodesSelector } from '../selectors/layers';
 import { modeSelector, getAttributeFilters, isFeatureGridOpen } from '../selectors/featuregrid';
 import { spatialFieldSelector } from '../selectors/queryform';
-import { mapSelector, projectionDefsSelector, projectionSelector, isMouseMoveIdentifyActiveSelector } from '../selectors/map';
+import { mapSelector, projectionSelector, isMouseMoveIdentifyActiveSelector } from '../selectors/map';
 import { boundingMapRectSelector } from '../selectors/maplayout';
-import { centerToVisibleArea, isInsideVisibleArea, isPointInsideExtent, reprojectBbox} from '../utils/CoordinatesUtils';
+import { centerToVisibleArea, isInsideVisibleArea } from '../utils/CoordinatesUtils';
 import { floatingIdentifyDelaySelector } from '../selectors/localConfig';
 import { createControlEnabledSelector, measureSelector } from '../selectors/controls';
 import { localizedLayerStylesEnvSelector } from '../selectors/localizedLayerStyles';
@@ -272,11 +272,6 @@ export const zoomToVisibleAreaEpic = (action$, store) =>
                         return Rx.Observable.from([updateCenterToMarker('disabled'), hideMapinfoMarker()]);
                     }
                     const map = mapSelector(state);
-                    const mapProjection = projectionSelector(state);
-                    const projectionDefs = projectionDefsSelector(state);
-                    const currentprojectionDefs = find(projectionDefs, {'code': mapProjection});
-                    const projectionExtent = currentprojectionDefs && currentprojectionDefs.extent;
-                    const reprojectExtent = projectionExtent && reprojectBbox(projectionExtent, mapProjection, "EPSG:4326");
                     const boundingMapRect = boundingMapRectSelector(state);
                     const coords = action.point && action.point && action.point.latlng;
                     const resolution = getCurrentResolution(Math.round(map.zoom), 0, 21, 96);
@@ -299,9 +294,6 @@ export const zoomToVisibleAreaEpic = (action$, store) =>
                     // exclude cesium with cartographic options
                     if (!map || !layoutBounds || !coords || action.point.cartographic || isFeatInsideVisibleArea || isMouseMoveIdentifyActiveSelector(state) || skipZooming) {
                         return Rx.Observable.of(updateCenterToMarker('disabled'));
-                    }
-                    if (reprojectExtent && !isPointInsideExtent(coords, reprojectExtent)) {
-                        return Rx.Observable.empty();
                     }
                     const center = centerToVisibleArea(coords, map, layoutBounds, resolution);
                     if (featureBbox && isQueryJustOneLayer) {


### PR DESCRIPTION
## Description
This PR fixes the Identify marker position when clicking outside the configured projection extent. The removed check was only checking the extent before moving the map. No regression is expected. Only removed that check.

https://github.com/user-attachments/assets/7b78b3ba-c078-457b-ae23-f1997e910c6d






**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
 - [x] Bugfix

## Issue

**What is the current behavior?**
#12476


**What is the new behavior?**

The Identify marker is centered in the visible map area even when the clicked point is outside the configured projection extent. This is allowed because the extent check was not protecting the identity request itself. It was only preventing the UI recentering step after a successful Identify.

## Breaking change
**Does this PR introduce a breaking change?**
 - [x] No

## Other useful information