### PR TITLE
[Backport 2026.02.xx] WMS print legend fails for ArcGIS due to duplicate version parameters  #12496

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -778,7 +778,6 @@ export const specCreators = {
                                     ...getWMSLegendConfig({layer, legendOptions, mapBbox: spec.bbox, mapSize: spec.size, projection: spec.projection, format: LEGEND_FORMAT.IMAGE}),
                                     TRANSPARENT: true,
                                     EXCEPTIONS: "application/vnd.ogc.se_xml",
-                                    VERSION: "1.1.1",
                                     SCALE: spec.scale,
                                     ...getLegendIconsSize(spec, layer),
                                     ...(spec.language ? {LANGUAGE: spec.language} : {})

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -526,6 +526,18 @@ describe('PrintUtils', () => {
             done();
         }).catch(done);
     });
+    it('wms layer generation for legend includes only the layer version', (done) => {
+        getMapfishLayersSpecification([{...layer, version: "1.3.0"}], { projection: "EPSG:3857" }, {}, 'legend').then(specs => {
+            expect(specs).toExist();
+            expect(specs.length).toBe(1);
+            const legendUrl = specs[0].classes[0].icons[0];
+            // Count both version and VERSION query parameters.
+            const versionParams = legendUrl.match(/[?&]version=/gi) || [];
+            expect(versionParams.length).toBe(1);
+            expect(legendUrl.indexOf('version=1.3.0')).toBeGreaterThan(0);
+            done();
+        }).catch(done);
+    });
     it('vector layer default point style', () => {
         const style = getOlDefaultStyle({ features: [{ geometry: { type: "Point" } }] });
         expect(style).toExist();


### PR DESCRIPTION
# Description
Backport of #12498 to `2026.02.xx`.

Fixes #12496