### PR TITLE
[Backport 2026.02.xx] COG layers are loading data even if not visible  #12360

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -23,7 +23,16 @@ import '../plugins/TMSLayer';
 import '../plugins/WFSLayer';
 import '../plugins/ElevationLayer';
 import '../plugins/ArcGISLayer';
+<<<<<<< HEAD
 import '../plugins/FlatGeobufLayer';
+=======
+import '../plugins/COGLayer';
+import {
+    invalidateCappedLoadExtents,
+    isMeaningfulCappedExtentRefinement,
+    registerCappedLoadExtent
+} from '../plugins/FlatGeobufLayer';
+>>>>>>> 22f800f (COG layers are loading data even if not visible  #12360 (#12488))
 
 import {
     setStore,
@@ -3629,6 +3638,56 @@ describe('Openlayers layer', () => {
         expect(loadCount).toBe(0);
         source.dispatchEvent('featuresloadend');
         expect(loadCount).toBe(1);
+    });
+
+    describe('COG', () => {
+        const cogOptions = {
+            id: 'cog-layer',
+            type: 'cog',
+            title: 'COG layer',
+            visibility: false,
+            sources: [{
+                url: 'data:image/tiff;base64,'
+            }],
+            sourceMetadata: {
+                crs: 'EPSG:3857'
+            }
+        };
+
+        it('does not create an OpenLayers layer while initially hidden', () => {
+            const layer = ReactDOM.render(
+                <OpenlayersLayer
+                    type="cog"
+                    options={cogOptions}
+                    map={map}/>,
+                document.getElementById("container")
+            );
+
+            expect(layer.layer).toBe(null);
+            expect(map.getLayers().getLength()).toBe(0);
+        });
+
+        it('creates the OpenLayers layer when visibility changes from hidden to visible', () => {
+            const layer = ReactDOM.render(
+                <OpenlayersLayer
+                    type="cog"
+                    options={cogOptions}
+                    map={map}/>,
+                document.getElementById("container")
+            );
+
+            ReactDOM.render(
+                <OpenlayersLayer
+                    type="cog"
+                    options={{...cogOptions, visibility: true}}
+                    map={map}/>,
+                document.getElementById("container")
+            );
+
+            expect(layer.layer).toBeTruthy();
+            expect(layer.layer.getSource()).toBeTruthy();
+            expect(map.getLayers().getLength()).toBe(1);
+        });
     });
 
     describe('FlatGeobuf', () => {

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -24,11 +24,7 @@ import '../plugins/WFSLayer';
 import '../plugins/ElevationLayer';
 import '../plugins/ArcGISLayer';
 import '../plugins/COGLayer';
-import {
-    invalidateCappedLoadExtents,
-    isMeaningfulCappedExtentRefinement,
-    registerCappedLoadExtent
-} from '../plugins/FlatGeobufLayer';
+import '../plugins/FlatGeobufLayer';
 
 import {
     setStore,

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -23,16 +23,12 @@ import '../plugins/TMSLayer';
 import '../plugins/WFSLayer';
 import '../plugins/ElevationLayer';
 import '../plugins/ArcGISLayer';
-<<<<<<< HEAD
-import '../plugins/FlatGeobufLayer';
-=======
 import '../plugins/COGLayer';
 import {
     invalidateCappedLoadExtents,
     isMeaningfulCappedExtentRefinement,
     registerCappedLoadExtent
 } from '../plugins/FlatGeobufLayer';
->>>>>>> 22f800f (COG layers are loading data even if not visible  #12360 (#12488))
 
 import {
     setStore,

--- a/web/client/components/map/openlayers/plugins/COGLayer.js
+++ b/web/client/components/map/openlayers/plugins/COGLayer.js
@@ -16,7 +16,7 @@ import { isProjectionAvailable } from '../../../../utils/ProjectionUtils';
 import { getRequestConfigurationByUrl } from '../../../../utils/SecurityUtils';
 import { updateUrlParams } from '../../../../utils/URLUtils';
 
-function create(options) {
+function getSource(options) {
     let sources = [];
     let sourceOptions = {};
     if (options.sources && options.sources.length > 0) {
@@ -32,17 +32,27 @@ function create(options) {
             };
         });
     }
+    return new GeoTIFF({
+        convertToRGB: 'auto', // CMYK, YCbCr, CIELab, and ICCLab images will automatically be converted to RGB
+        sourceOptions,
+        sources,
+        wrapX: true
+    });
+}
+
+function create(options) {
+    // GeoTIFF sources fetch eagerly on creation (unlike WMS, which loads on demand),
+    // so `visible: false` won't prevent requests. Skip creating hidden layers;
+    // `update` recreates them when they become visible.
+    if (options.visibility === false) {
+        return null;
+    }
     const layerOl = new TileLayer({
         msId: options.id,
         style: get(options, 'style.body'),
         opacity: options.opacity !== undefined ? options.opacity : 1,
-        visible: options.visibility,
-        source: new GeoTIFF({
-            convertToRGB: 'auto', // CMYK, YCbCr, CIELab, and ICCLab images will automatically be converted to RGB
-            sourceOptions,
-            sources,
-            wrapX: true
-        }),
+        visible: true,
+        source: getSource(options),
         enablePickFeatures: true,
         zIndex: options.zIndex,
         minResolution: options.minResolution,
@@ -55,6 +65,12 @@ function create(options) {
 Layers.registerType('cog', {
     create,
     update(layer, newOptions, oldOptions, map) {
+        if (!layer && newOptions.visibility !== false) {
+            return create(newOptions, map);
+        }
+        if (!layer) {
+            return null;
+        }
         if (newOptions.srs !== oldOptions.srs
             || !isEqual(newOptions.style, oldOptions.style)
             || !isEqual(newOptions.security, oldOptions.security)


### PR DESCRIPTION
# Description
Backport of #12488 to `2026.02.xx`.

Fixes #12360