### PR TITLE
Issue #10504 : Layer image preview when file has a description

### DIFF
--- a/web/client/api/catalog/CSW.js
+++ b/web/client/api/catalog/CSW.js
@@ -90,7 +90,7 @@ function getThumbnailFromDc(dc, options) {
     const URI = dc?.URI && castArray(dc.URI);
     let thumbURL;
     if (URI) {
-        const thumb = head(URI.filter(uri => uri.name === 'thumbnail')) || head(URI.filter(uri => !uri.name && uri.protocol?.indexOf('image/') > -1));
+        const thumb = head(URI.filter(uri => uri.name === 'thumbnail')) || head(URI.filter(uri => uri.protocol?.indexOf('image/') > -1));
         thumbURL = thumb ? thumb.value : null;
     }
     if (!thumbURL && dc && dc.references) {

--- a/web/client/api/catalog/__tests__/CSW-test.js
+++ b/web/client/api/catalog/__tests__/CSW-test.js
@@ -694,6 +694,22 @@ describe('Test correctness of the CSW catalog APIs', () => {
         expect(records[0].thumbnail).toBe("/thumb");
     });
 
+    it('csw with DC thumbnail from dc:URI with non-thumbnail name and image protocol (#10504)', () => {
+        const cswRecords = [{
+            dc: {
+                URI: [{
+                    TYPE_NAME: 'DC_1_1.URI',
+                    protocol: 'image/png',
+                    name: 'My description',
+                    value: 'https://site.com/img/fish.png'
+                }]
+            }
+        }];
+        const records = getCatalogRecords({ records: cswRecords }, {});
+        expect(records.length).toBe(1);
+        expect(records[0].thumbnail).toBe('https://site.com/img/fish.png');
+    });
+
     it('csw with DC references, no url, with thumbnail, with uri', () => {
         const cswRecords = [{
             dc: {


### PR DESCRIPTION
## Description
This pull request fixes the layer preview handling in CSW metadata parsing.

When a record includes a file-based preview and also contains a description, the preview image was not consistently exposed/used.
This change ensures the preview image is correctly picked and displayed in that case.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
For issue https://github.com/geosolutions-it/MapStore2/issues/10504, layer image preview coming from file metadata is not properly handled when a description is present, leading to missing or incorrect preview behavior.

**What is the new behavior?**
The CSW parsing logic now correctly handles this metadata combination and preserves the expected layer image preview.
A test case was added/updated to cover this scenario.

Fixes https://github.com/geosolutions-it/MapStore2/issues/10504

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
