### PR TITLE
[Backport 2026.02.xx] Bump webpack-dev-server from 5.2.4 to 5.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "webpack": "5.104.1",
     "webpack-bundle-size-analyzer": "2.0.2",
     "webpack-cli": "5.1.4",
-    "webpack-dev-server": "5.2.4"
+    "webpack-dev-server": "5.2.5"
   },
   "dependencies": {
     "@babel/standalone": "7.23.9",


### PR DESCRIPTION
# Description
Backport of #12533 to `2026.02.xx`.

Fixes #