### PR TITLE
Revert "Bump http-proxy to v1.7-SNAPSHOT in main pom.xml"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <!-- MapStore‑specific -->
         <geostore-webapp.version>2.6-SNAPSHOT</geostore-webapp.version>
         <print-lib.version>2.3.5</print-lib.version>
-        <http_proxy.version>1.7-SNAPSHOT</http_proxy.version>
+        <http_proxy.version>1.6-SNAPSHOT</http_proxy.version>
 
         <!-- Commons extras -->
         <commons-lang-version>2.3</commons-lang-version>


### PR DESCRIPTION
Reverts geosolutions-it/MapStore2#12535

after the http-proxy bump to  1.7 ( [PR](https://github.com/geosolutions-it/MapStore2/pull/12535) ). A classpath conflict between the  Log4j/SLF4J 2.x  jars versions is preventing  /mapstore  from starting.
Also endpoint tests are failing because mapstore doesn't start.

Probably the Update to http-proxy 1.7 need to wait for [this PR](https://github.com/geosolutions-it/MapStore2/pull/12428) to be merged and log4j to be properly checked for alignment
