### PR TITLE
[Backport 2026.02.xx] Fixed #12579 - Fixed terrain switch and black on load issues

### DIFF
--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -448,6 +448,13 @@ class CesiumLayer extends React.Component {
         if (this._isProxy === undefined && newProps?.options?.url) {
             const urls = castArray(newProps.options.url);
             return axios(urls[0], { noProxy: true })
+                // this request is used only to detect if the layer needs the proxy,
+                // a failure (e.g. CORS error) is expected and must not produce an unhandled rejection
+                // preventing the error avoids an unhandled rejection in console.
+                .catch(() => {
+                    console.warn(`Failed to detect proxy for ${urls[0]}. This is expected if the server does not support CORS.`);
+                    return null;
+                })
                 .finally(() => {
                     this._isProxy = !!getProxyCacheByUrl(urls[0]);
                     this.updateLayer(newProps, this.props);

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -12,7 +12,7 @@ import expect from 'expect';
 import * as Cesium from 'cesium';
 import { waitFor } from '@testing-library/react';
 
-import '../../../../utils/cesium/Layers';
+import Layers from '../../../../utils/cesium/Layers';
 import '../plugins/OSMLayer';
 import '../plugins/TileProviderLayer';
 import '../plugins/WMSLayer';
@@ -1816,6 +1816,68 @@ describe('Cesium layer', () => {
         expect(cmp).toBeTruthy();
         expect(cmp.layer).toBeTruthy();
         expect(cmp.layer.terrainProvider).toBeTruthy();
+    });
+    it('should not reset the globe terrain provider when the terrain layer is recreated on update', (done) => {
+        const options = {
+            type: "terrain",
+            provider: "wms",
+            url: "/geoserver/wms",
+            name: "workspace:layername",
+            visibility: true,
+            options: {
+                crs: 'CRS:84'
+            }
+        };
+        const layer = Layers.createLayer('terrain', options, map);
+        layer.add();
+        // updating one of the watched properties recreates the layer implementation,
+        // this must not detach the terrain currently applied to the scene
+        // while the new one is loading (see #12579 regression)
+        Layers.updateLayer('terrain', layer, { ...options, securityToken: 'token' }, options, map);
+        layer.terrainProvider.then((provider) => {
+            return waitFor(() => expect(map.scene.globe.terrainProvider).toBe(provider));
+        }).then(() => done()).catch(done);
+    });
+    it('should not override the active terrain when removing a deselected terrain layer', (done) => {
+        const wmsOptions = {
+            type: "terrain",
+            provider: "wms",
+            url: "/geoserver/wms",
+            name: "workspace:layername",
+            visibility: true,
+            options: {
+                crs: 'CRS:84'
+            }
+        };
+        const ellipsoidOptions = {
+            type: "terrain",
+            provider: "ellipsoid",
+            visibility: false
+        };
+        // the ellipsoid terrain is initially the active one
+        const ellipsoidLayer = Layers.createLayer('terrain', ellipsoidOptions, map);
+        ellipsoidLayer.add();
+        // the wms terrain gets activated, then the deselected ellipsoid layer is removed,
+        // the scene must keep the wms terrain (see terrain switch from background selector)
+        const wmsLayer = Layers.createLayer('terrain', wmsOptions, map);
+        wmsLayer.add();
+        ellipsoidLayer.remove();
+        wmsLayer.terrainProvider.then((provider) => {
+            return waitFor(() => expect(map.scene.globe.terrainProvider).toBe(provider));
+        }).then(() => done()).catch(done);
+    });
+    it('should fallback to the ellipsoid terrain when the terrain provider fails to load', (done) => {
+        const options = {
+            type: "terrain",
+            provider: "cesium",
+            // connection refused, simulates an unreachable server or a CORS error
+            url: "https://localhost:1/terrain/",
+            visibility: true
+        };
+        const layer = Layers.createLayer('terrain', options, map);
+        layer.add();
+        waitFor(() => expect(map.scene.globe.terrainProvider instanceof Cesium.EllipsoidTerrainProvider).toBe(true))
+            .then(() => done()).catch(done);
     });
     it('should create am elevation layer from wms layer', () => {
         const options = {

--- a/web/client/components/map/cesium/plugins/OSMLayer.js
+++ b/web/client/components/map/cesium/plugins/OSMLayer.js
@@ -11,6 +11,6 @@ import * as Cesium from 'cesium';
 
 Layers.registerType('osm', () => {
     return new Cesium.OpenStreetMapImageryProvider({
-        url: '//a.tile.openstreetmap.org/'
+        url: 'https://tile.openstreetmap.org/'
     });
 });

--- a/web/client/components/map/cesium/plugins/TerrainLayer.js
+++ b/web/client/components/map/cesium/plugins/TerrainLayer.js
@@ -51,7 +51,6 @@ function cesiumIonOptionsMapping(config) {
 }
 
 const createLayer = (config, map) => {
-    map.terrainProvider = undefined;
     let terrainProvider;
     let terrain;
     let url;
@@ -99,12 +98,29 @@ const createLayer = (config, map) => {
         add: () => {
             if (terrainProvider) {
                 terrain = new Cesium.Terrain(terrainProvider);
+                // if the terrain provider fails to load (e.g. unreachable server or CORS error)
+                // fallback to the default ellipsoid terrain to avoid a completely black scene
+                terrain.errorEvent.addEventListener((error) => {
+                    console.error('Error while loading the terrain provider, falling back to the ellipsoid terrain', error);
+                    if (map._msCurrentTerrain === terrain) {
+                        terrain = new Cesium.Terrain(new Cesium.EllipsoidTerrainProvider());
+                        map.scene.setTerrain(terrain);
+                        map._msCurrentTerrain = terrain;
+                    }
+                });
                 map.scene.setTerrain(terrain);
+                map._msCurrentTerrain = terrain;
             }
         },
         remove: () => {
-            terrain = new Cesium.Terrain(new Cesium.EllipsoidTerrainProvider());
-            map.scene.setTerrain(terrain);
+            // reset the scene terrain only if this layer is the one currently applied,
+            // removing a deselected or hidden terrain layer must not override
+            // a terrain that has just been activated (e.g. switching terrain from the background selector)
+            if (terrain && map._msCurrentTerrain === terrain) {
+                terrain = new Cesium.Terrain(new Cesium.EllipsoidTerrainProvider());
+                map.scene.setTerrain(terrain);
+                map._msCurrentTerrain = terrain;
+            }
         }
     };
 };


### PR DESCRIPTION
# Description
Backport of #12581 to `2026.02.xx`.

Fixes #null,12579