### PR TITLE
Fix #12589 Elevation in MousePosition not shown in 2D

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -179,7 +179,7 @@ class OpenlayersMap extends React.Component {
             if (this.props.onClick && !this.map.disabledListeners.singleclick) {
                 const latLng = this.coordinateToLatLng(event.coordinate);
                 if (!latLng) return;
-                const { pos, lat, lng } = latLng;
+                const { lat, lng } = latLng;
                 /*
                  * Handle special case for vector features with handleClickOnLayer=true
                  * Modifies the clicked point coordinates to center the marker and sets the layerInfo for
@@ -213,7 +213,7 @@ class OpenlayersMap extends React.Component {
                     latlng: {
                         lat: finalLat,
                         lng: finalLng,
-                        z: this.getElevation(pos, event.pixel)
+                        z: this.getElevation(event.coordinate, event.pixel)
                     },
                     rawPos: event.coordinate.slice(),
                     modifiers: {
@@ -534,10 +534,12 @@ class OpenlayersMap extends React.Component {
         if (!event.dragging && event.coordinate) {
             const latLng = this.coordinateToLatLng(event.coordinate);
             if (!latLng) return;
-            const { pos, lat, lng } = latLng;
+            const { lat, lng } = latLng;
             const intersectedFeatures = this.getIntersectedFeatures(this.map, event?.pixel);
             const intersectedPixels = this.getIntersectedPixels(this.map, event?.pixel);
-            const elevation = this.getElevation(pos, event.pixel);
+            // the elevation lookup works with the native map coordinate,
+            // the tile grid of the elevation layer is expressed in map projection units
+            const elevation = this.getElevation(event.coordinate, event.pixel);
             this.props.onMouseMove({
                 y: lat || 0.0,
                 x: lng || 0.0,

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -36,6 +36,7 @@ import {
 } from '../../../../utils/SecurityUtils';
 import ConfigUtils from '../../../../utils/ConfigUtils';
 import { ServerTypes } from '../../../../utils/LayersUtils';
+import { addElevationTile, getElevationKey } from '../../../../utils/ElevationUtils';
 
 
 import { Map, View } from 'ol';
@@ -3455,6 +3456,38 @@ describe('Openlayers layer', () => {
         expect(cmp).toBeTruthy();
         expect(cmp.layer).toBeTruthy();
         expect(cmp.layer.get('getElevation')).toBeTruthy();
+    });
+    it('should return the elevation value at a map coordinate from the loaded tiles of the elevation layer', () => {
+        const options = {
+            id: 'elevation-layer',
+            type: 'elevation',
+            provider: 'wms',
+            url: 'https://host-sample/geoserver/wms',
+            name: 'workspace:layername',
+            visibility: true
+        };
+        const cmp = ReactDOM.render(
+            <OpenlayersLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        const layer = cmp.layer;
+        const tileGrid = layer.getSource().getTileGrid();
+        // the lookup coordinate is expressed in the map projection (EPSG:3857)
+        const coordinate = [1252344, 5430086];
+        const z = 12;
+        const [, x, y] = tileGrid.getTileCoordForCoordAndZ(coordinate, z);
+        // simulate a tile stored by the tileLoadFunction with a constant height of 1500 meters
+        const tileSize = 256;
+        const buffer = new ArrayBuffer(tileSize * tileSize * 2);
+        const dataView = new DataView(buffer);
+        for (let i = 0; i < tileSize * tileSize; i++) {
+            dataView.setInt16(i * 2, 1500, false);
+        }
+        addElevationTile(buffer, [z, x, y], getElevationKey(x, y, z, options.id));
+        layer.get('requestedZoomLevels').push(z);
+        expect(layer.get('getElevation')(coordinate)).toBe(1500);
     });
     it('wms layer should refresh source when loadingError changes to Error', () => {
         var refreshCalled = false;

--- a/web/client/components/map/openlayers/plugins/ElevationLayer.js
+++ b/web/client/components/map/openlayers/plugins/ElevationLayer.js
@@ -17,6 +17,8 @@ import  {
 } from '../../../../utils/ElevationUtils';
 import TileLayer from 'ol/layer/Tile';
 import TileWMS from 'ol/source/TileWMS';
+import { transform } from 'ol/proj';
+import CoordinatesUtils from '../../../../utils/CoordinatesUtils';
 import {
     proxySource,
     getWMSURLs,
@@ -25,29 +27,33 @@ import {
     generateTileGrid
 } from '../../../../utils/openlayers/WMSUtils';
 
-function getTileFromCoords(layer, pos) {
-    const map = layer.get('map');
-    const tileGrid = layer.getSource().getTileGrid();
-    return tileGrid.getTileCoordForCoordAndZ(pos, map.getView().getZoom());
-}
-
 function getElevation(pos) {
     try {
-        const tilePoint = getTileFromCoords(this, pos);
-        const [z, x, y] = tilePoint;
+        const map = this.get('map');
         const tileGrid = this.getSource().getTileGrid();
         const tileSize = tileGrid.getTileSize();
-        const extent = tileGrid.getTileCoordExtent(tilePoint);
         const tileSizeArray = isArray(tileSize) ? tileSize : [tileSize, tileSize];
-        const elevation = getElevationFunc(
-            getElevationKey(x, y, z, this.get('msId')),
-            getTileRelativePixel(pos, extent, tileSizeArray),
-            tileSizeArray[0],
-            this.get('nodata'),
-            this.get('littleEndian')
-        );
-        if (elevation.available) {
-            return elevation.value;
+        // pos is the mouse event coordinate in map projection,
+        // the tile grid could use a different projection (see srs option)
+        const coords = transform(pos, map.getView().getProjection(), this.get('gridProjection'));
+        // lookup the value from the most detailed requested tile level,
+        // the level used by the renderer cannot be deduced from the map zoom
+        // when the tile grid projection is different from the map one
+        const zoomLevels = this.get('requestedZoomLevels') || [];
+        for (let i = 0; i < zoomLevels.length; i++) {
+            const tilePoint = tileGrid.getTileCoordForCoordAndZ(coords, zoomLevels[i]);
+            const [z, x, y] = tilePoint;
+            const extent = tileGrid.getTileCoordExtent(tilePoint);
+            const elevation = getElevationFunc(
+                getElevationKey(x, y, z, this.get('msId')),
+                getTileRelativePixel(coords, extent, tileSizeArray),
+                tileSizeArray[0],
+                this.get('nodata'),
+                this.get('littleEndian')
+            );
+            if (elevation.available) {
+                return elevation.value;
+            }
         }
         return '';
     } catch (e) {
@@ -59,6 +65,7 @@ const createWMSElevationLayer = (options, map) => {
     const urls = getWMSURLs(isArray(options.url) ? options.url : [options.url]);
     let queryParameters = wmsToOpenlayersOptions(options) || {};
     queryParameters = addAuthenticationParameter(urls[0] || '', queryParameters, options.securityToken, options.security?.sourceId);
+    const requestedZoomLevels = [];
     const layer = new TileLayer({
         msId: options.id,
         opacity: options.opacity !== undefined ? options.opacity : 1,
@@ -80,6 +87,10 @@ const createWMSElevationLayer = (options, map) => {
                 const coords = imageTile.getTileCoord();
                 imageTile.getImage().src = "";
                 const [z, x, y] = coords;
+                if (!requestedZoomLevels.includes(z)) {
+                    requestedZoomLevels.push(z);
+                    requestedZoomLevels.sort((a, b) => b - a);
+                }
                 loadTile(newSrc, coords, getElevationKey(x, y, z, options.id));
             }
         })
@@ -87,6 +98,9 @@ const createWMSElevationLayer = (options, map) => {
     layer.set('map', map);
     layer.set('nodata', options.nodata);
     layer.set('littleEndian', options?.littleEndian ?? options?.littleendian ?? false);
+    // same projection used by generateTileGrid to build the tile grid
+    layer.set('gridProjection', CoordinatesUtils.normalizeSRS(options.srs || map?.getView()?.getProjection()?.getCode() || 'EPSG:3857', options.allowedSRS));
+    layer.set('requestedZoomLevels', requestedZoomLevels);
     layer.set('getElevation', getElevation.bind(layer));
 
     if (!map.get('msElevationLayers')) {


### PR DESCRIPTION
## Description

This PR fixes the elevation value shown by the MousePosition plugin (`showElevation: true`) in 2D, broken by a regression of #12356.

The mousemove/click handlers passed lon/lat degrees to the elevation lookup, while the elevation layer resolves the tile in tile grid units, using the map zoom as tile level. The handlers now pass the native map coordinate, and the layer transforms it to the tile grid projection and resolves the value from the tile levels actually requested by the renderer, instead of relying on the map zoom (this also makes the lookup work when the tile grid projection differs from the map one).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**

#12589

**What is the new behavior?**

The altitude is shown by the MousePosition plugin while moving the mouse in 2D, for maps with a configured `elevation` layer.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

## Other useful information

No backport needed: the `2026.01.xx` based branches do not include #12356 and are not affected.
