### PR TITLE
Fix #12583 Elevation in MousePosition not shown in 3D

### DIFF
--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -341,14 +341,14 @@ class CesiumLayer extends React.Component {
             {
                 ...newProps.options,
                 securityToken: newProps.securityToken,
-                forceProxy: this._isProxy,
+                forceProxy: newProps.options?.forceProxy || this._isProxy,
                 imageryLayersTreeUpdatedCount: newProps.imageryLayersTreeUpdatedCount,
                 position: newProps.position
             },
             {
                 ...oldProps.options,
                 securityToken: oldProps.securityToken,
-                forceProxy: this._prevIsProxy,
+                forceProxy: oldProps.options?.forceProxy || this._prevIsProxy,
                 imageryLayersTreeUpdatedCount: oldProps.imageryLayersTreeUpdatedCount,
                 position: oldProps.position
             },
@@ -457,7 +457,17 @@ class CesiumLayer extends React.Component {
                 })
                 .finally(() => {
                     this._isProxy = !!getProxyCacheByUrl(urls[0]);
-                    this.updateLayer(newProps, this.props);
+                    // the layer was created with the forceProxy value coming from its options,
+                    // recreate it through updateLayer only when the detection requires a different proxy setup,
+                    // otherwise the already created layer must simply be added to the map
+                    const createdWithProxy = !!newProps?.options?.forceProxy;
+                    const needsProxy = createdWithProxy || this._isProxy;
+                    if (createdWithProxy === needsProxy) {
+                        this._addLayer(newProps);
+                        this.updateZIndex(newProps.position);
+                    } else {
+                        this.updateLayer(newProps, this.props);
+                    }
                     this._prevIsProxy = this._isProxy;
                 });
         }

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -32,6 +32,7 @@ import {setStore} from '../../../../utils/SecurityUtils';
 import ConfigUtils from '../../../../utils/ConfigUtils';
 import MockAdapter from 'axios-mock-adapter';
 import axios from '../../../../libs/ajax';
+import { setProxyCacheByUrl } from '../../../../utils/ProxyUtils';
 import { isMeaningfulCappedRectRefinement } from '../../../../utils/FlatGeobufLayerUtils';
 
 const tilesetMock = {
@@ -1896,6 +1897,78 @@ describe('Cesium layer', () => {
         expect(cmp).toBeTruthy();
         expect(cmp.layer).toBeTruthy();
         expect(cmp.layer.getElevation).toBeTruthy();
+    });
+    it('should add the elevation layer to the map imagery layers when no proxy is needed', (done) => {
+        const url = 'https://host-sample/geoserver/wms';
+        // the detection request succeeds, the server is reachable without the proxy
+        mockAxios.onGet(url).reply(200);
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url,
+            name: 'workspace:layername',
+            visibility: true
+        };
+        const cmp = ReactDOM.render(
+            <CesiumLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        // the proxy detection request is asynchronous,
+        // once completed the elevation layer must be part of the imagery layers
+        // so Cesium can request its tiles and make them available to the getElevation function
+        waitFor(() => expect(map.imageryLayers.length).toBe(1))
+            .then(() => {
+                expect(map.imageryLayers._layers[0]._imageryProvider.getElevation).toBeTruthy();
+                expect(cmp.layer.getElevation).toBeTruthy();
+                done();
+            }).catch(done);
+    });
+    it('should add the elevation layer to the map imagery layers when forceProxy is set in the options', (done) => {
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url: 'https://host-sample/geoserver/wms',
+            name: 'workspace:layername',
+            visibility: true,
+            forceProxy: true
+        };
+        ReactDOM.render(
+            <CesiumLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        waitFor(() => expect(map.imageryLayers.length).toBe(1))
+            .then(() => {
+                expect(map.imageryLayers._layers[0]._imageryProvider.getElevation).toBeTruthy();
+                done();
+            }).catch(done);
+    });
+    it('should recreate the elevation layer with the proxy and add it when the proxy detection fails', (done) => {
+        const url = 'https://host-failing-cors/geoserver/wms';
+        // a network/CORS-like failure of the detection request marks the url as in need of the proxy
+        mockAxios.onGet(url).networkError();
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url,
+            name: 'workspace:layername',
+            visibility: true
+        };
+        ReactDOM.render(
+            <CesiumLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        waitFor(() => expect(map.imageryLayers.length).toBe(1))
+            .then(() => {
+                expect(map.imageryLayers._layers[0]._imageryProvider.getElevation).toBeTruthy();
+                setProxyCacheByUrl(url, undefined);
+                done();
+            }).catch(done);
     });
     it('creates a arcgis layer', (done) => {
         const options = {

--- a/web/client/components/map/cesium/plugins/ElevationLayer.js
+++ b/web/client/components/map/cesium/plugins/ElevationLayer.js
@@ -155,6 +155,7 @@ Layers.registerType('elevation', {
     create,
     update: (layer, newOptions, oldOptions, map) => {
         if (!isEqual(oldOptions.security, newOptions.security)
+            || oldOptions.forceProxy !== newOptions.forceProxy
             || !isEqual(oldOptions.requestRuleRefreshHash, newOptions.requestRuleRefreshHash)) {
             return create(newOptions, map);
         }


### PR DESCRIPTION
## Description

This PR fixes the elevation value shown by the MousePosition plugin (`showElevation: true`) in 3D, when an `elevation` layer is configured.

The Cesium elevation layer was created but never added to the map imagery layers: the async proxy detection in `Layer.jsx` always delegated to the update flow, and the `elevation` layer type does not recreate the layer when nothing changed, so it was never added and its tiles were never requested. Now, after the detection, the already created layer is directly added when its proxy setup is correct, and it is recreated through the update flow only when the detection requires a different one (the `elevation` type now also recreates on `forceProxy` change).

An explicit `forceProxy: true` in the layer options was also overridden by the detection result: the explicit option now takes precedence, so the proxy can be forced by configuration for servers that reject browser requests with an HTTP error while exposing valid CORS headers.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**

#12583

**What is the new behavior?**

The altitude is shown by the MousePosition plugin while moving the mouse in 3D, for maps with a configured `elevation` layer.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

## Other useful information

The affected code is also present in the `2026.01.xx` based branches: the fix applies cleanly there and should be backported. Verified with a WMS `application/bil16` DEM (`sf:sfdem` on gs-stable) used both as elevation layer and as WMS terrain; a reproduction context is attached to the issue.
