### PR TITLE
Backport c040 issues with 3D terrain switch and elevation in 3D mode

### DIFF
--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -448,6 +448,13 @@ class CesiumLayer extends React.Component {
         if (this._isProxy === undefined && newProps?.options?.url) {
             const urls = castArray(newProps.options.url);
             return axios(urls[0], { noProxy: true })
+                // this request is used only to detect if the layer needs the proxy,
+                // a failure (e.g. CORS error) is expected and must not produce an unhandled rejection
+                // preventing the error avoids an unhandled rejection in console.
+                .catch(() => {
+                    console.warn(`Failed to detect proxy for ${urls[0]}. This is expected if the server does not support CORS.`);
+                    return null;
+                })
                 .finally(() => {
                     this._isProxy = !!getProxyCacheByUrl(urls[0]);
                     this.updateLayer(newProps, this.props);

--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -341,14 +341,14 @@ class CesiumLayer extends React.Component {
             {
                 ...newProps.options,
                 securityToken: newProps.securityToken,
-                forceProxy: this._isProxy,
+                forceProxy: newProps.options?.forceProxy || this._isProxy,
                 imageryLayersTreeUpdatedCount: newProps.imageryLayersTreeUpdatedCount,
                 position: newProps.position
             },
             {
                 ...oldProps.options,
                 securityToken: oldProps.securityToken,
-                forceProxy: this._prevIsProxy,
+                forceProxy: oldProps.options?.forceProxy || this._prevIsProxy,
                 imageryLayersTreeUpdatedCount: oldProps.imageryLayersTreeUpdatedCount,
                 position: oldProps.position
             },
@@ -457,7 +457,17 @@ class CesiumLayer extends React.Component {
                 })
                 .finally(() => {
                     this._isProxy = !!getProxyCacheByUrl(urls[0]);
-                    this.updateLayer(newProps, this.props);
+                    // the layer was created with the forceProxy value coming from its options,
+                    // recreate it through updateLayer only when the detection requires a different proxy setup,
+                    // otherwise the already created layer must simply be added to the map
+                    const createdWithProxy = !!newProps?.options?.forceProxy;
+                    const needsProxy = createdWithProxy || this._isProxy;
+                    if (createdWithProxy === needsProxy) {
+                        this._addLayer(newProps);
+                        this.updateZIndex(newProps.position);
+                    } else {
+                        this.updateLayer(newProps, this.props);
+                    }
                     this._prevIsProxy = this._isProxy;
                 });
         }

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -1896,6 +1896,51 @@ describe('Cesium layer', () => {
         expect(cmp.layer).toBeTruthy();
         expect(cmp.layer.getElevation).toBeTruthy();
     });
+    it('should add the elevation layer to the map imagery layers after the proxy detection', (done) => {
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url: 'https://host-sample/geoserver/wms',
+            name: 'workspace:layername',
+            visibility: true
+        };
+        const cmp = ReactDOM.render(
+            <CesiumLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        // the proxy detection request is asynchronous,
+        // once completed the elevation layer must be part of the imagery layers
+        // so Cesium can request its tiles and make them available to the getElevation function
+        waitFor(() => expect(map.imageryLayers.length).toBe(1))
+            .then(() => {
+                expect(map.imageryLayers._layers[0]._imageryProvider.getElevation).toBeTruthy();
+                expect(cmp.layer.getElevation).toBeTruthy();
+                done();
+            }).catch(done);
+    });
+    it('should add the elevation layer to the map imagery layers when forceProxy is set in the options', (done) => {
+        const options = {
+            type: 'elevation',
+            provider: 'wms',
+            url: 'https://host-sample/geoserver/wms',
+            name: 'workspace:layername',
+            visibility: true,
+            forceProxy: true
+        };
+        ReactDOM.render(
+            <CesiumLayer
+                type={options.type}
+                options={options}
+                map={map}
+            />, document.getElementById('container'));
+        waitFor(() => expect(map.imageryLayers.length).toBe(1))
+            .then(() => {
+                expect(map.imageryLayers._layers[0]._imageryProvider.getElevation).toBeTruthy();
+                done();
+            }).catch(done);
+    });
     it('creates a arcgis layer', (done) => {
         const options = {
             type: 'arcgis',

--- a/web/client/components/map/cesium/__tests__/Layer-test.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test.jsx
@@ -12,7 +12,7 @@ import expect from 'expect';
 import * as Cesium from 'cesium';
 import { waitFor } from '@testing-library/react';
 
-import '../../../../utils/cesium/Layers';
+import Layers from '../../../../utils/cesium/Layers';
 import '../plugins/OSMLayer';
 import '../plugins/TileProviderLayer';
 import '../plugins/WMSLayer';
@@ -1815,6 +1815,68 @@ describe('Cesium layer', () => {
         expect(cmp).toBeTruthy();
         expect(cmp.layer).toBeTruthy();
         expect(cmp.layer.terrainProvider).toBeTruthy();
+    });
+    it('should not reset the globe terrain provider when the terrain layer is recreated on update', (done) => {
+        const options = {
+            type: "terrain",
+            provider: "wms",
+            url: "/geoserver/wms",
+            name: "workspace:layername",
+            visibility: true,
+            options: {
+                crs: 'CRS:84'
+            }
+        };
+        const layer = Layers.createLayer('terrain', options, map);
+        layer.add();
+        // updating one of the watched properties recreates the layer implementation,
+        // this must not detach the terrain currently applied to the scene
+        // while the new one is loading (see #12579 regression)
+        Layers.updateLayer('terrain', layer, { ...options, securityToken: 'token' }, options, map);
+        layer.terrainProvider.then((provider) => {
+            return waitFor(() => expect(map.scene.globe.terrainProvider).toBe(provider));
+        }).then(() => done()).catch(done);
+    });
+    it('should not override the active terrain when removing a deselected terrain layer', (done) => {
+        const wmsOptions = {
+            type: "terrain",
+            provider: "wms",
+            url: "/geoserver/wms",
+            name: "workspace:layername",
+            visibility: true,
+            options: {
+                crs: 'CRS:84'
+            }
+        };
+        const ellipsoidOptions = {
+            type: "terrain",
+            provider: "ellipsoid",
+            visibility: false
+        };
+        // the ellipsoid terrain is initially the active one
+        const ellipsoidLayer = Layers.createLayer('terrain', ellipsoidOptions, map);
+        ellipsoidLayer.add();
+        // the wms terrain gets activated, then the deselected ellipsoid layer is removed,
+        // the scene must keep the wms terrain (see terrain switch from background selector)
+        const wmsLayer = Layers.createLayer('terrain', wmsOptions, map);
+        wmsLayer.add();
+        ellipsoidLayer.remove();
+        wmsLayer.terrainProvider.then((provider) => {
+            return waitFor(() => expect(map.scene.globe.terrainProvider).toBe(provider));
+        }).then(() => done()).catch(done);
+    });
+    it('should fallback to the ellipsoid terrain when the terrain provider fails to load', (done) => {
+        const options = {
+            type: "terrain",
+            provider: "cesium",
+            // connection refused, simulates an unreachable server or a CORS error
+            url: "https://localhost:1/terrain/",
+            visibility: true
+        };
+        const layer = Layers.createLayer('terrain', options, map);
+        layer.add();
+        waitFor(() => expect(map.scene.globe.terrainProvider instanceof Cesium.EllipsoidTerrainProvider).toBe(true))
+            .then(() => done()).catch(done);
     });
     it('should create am elevation layer from wms layer', () => {
         const options = {

--- a/web/client/components/map/cesium/plugins/ElevationLayer.js
+++ b/web/client/components/map/cesium/plugins/ElevationLayer.js
@@ -155,6 +155,7 @@ Layers.registerType('elevation', {
     create,
     update: (layer, newOptions, oldOptions, map) => {
         if (!isEqual(oldOptions.security, newOptions.security)
+            || oldOptions.forceProxy !== newOptions.forceProxy
             || !isEqual(oldOptions.requestRuleRefreshHash, newOptions.requestRuleRefreshHash)) {
             return create(newOptions, map);
         }

--- a/web/client/components/map/cesium/plugins/OSMLayer.js
+++ b/web/client/components/map/cesium/plugins/OSMLayer.js
@@ -11,6 +11,6 @@ import * as Cesium from 'cesium';
 
 Layers.registerType('osm', () => {
     return new Cesium.OpenStreetMapImageryProvider({
-        url: '//a.tile.openstreetmap.org/'
+        url: 'https://tile.openstreetmap.org/'
     });
 });

--- a/web/client/components/map/cesium/plugins/TerrainLayer.js
+++ b/web/client/components/map/cesium/plugins/TerrainLayer.js
@@ -51,7 +51,6 @@ function cesiumIonOptionsMapping(config) {
 }
 
 const createLayer = (config, map) => {
-    map.terrainProvider = undefined;
     let terrainProvider;
     let terrain;
     let url;
@@ -99,12 +98,29 @@ const createLayer = (config, map) => {
         add: () => {
             if (terrainProvider) {
                 terrain = new Cesium.Terrain(terrainProvider);
+                // if the terrain provider fails to load (e.g. unreachable server or CORS error)
+                // fallback to the default ellipsoid terrain to avoid a completely black scene
+                terrain.errorEvent.addEventListener((error) => {
+                    console.error('Error while loading the terrain provider, falling back to the ellipsoid terrain', error);
+                    if (map._msCurrentTerrain === terrain) {
+                        terrain = new Cesium.Terrain(new Cesium.EllipsoidTerrainProvider());
+                        map.scene.setTerrain(terrain);
+                        map._msCurrentTerrain = terrain;
+                    }
+                });
                 map.scene.setTerrain(terrain);
+                map._msCurrentTerrain = terrain;
             }
         },
         remove: () => {
-            terrain = new Cesium.Terrain(new Cesium.EllipsoidTerrainProvider());
-            map.scene.setTerrain(terrain);
+            // reset the scene terrain only if this layer is the one currently applied,
+            // removing a deselected or hidden terrain layer must not override
+            // a terrain that has just been activated (e.g. switching terrain from the background selector)
+            if (terrain && map._msCurrentTerrain === terrain) {
+                terrain = new Cesium.Terrain(new Cesium.EllipsoidTerrainProvider());
+                map.scene.setTerrain(terrain);
+                map._msCurrentTerrain = terrain;
+            }
         }
     };
 };


### PR DESCRIPTION
In draft, waiting for approval

## Description

Backport to `c040-2026.01.xx` of the following fixes:

- #12581 
    - **Fix #12579 Terrain switch and black on load issues**: keeps the active terrain when a terrain layer is recreated on update or a deselected terrain layer is removed, and falls back to the ellipsoid terrain when the terrain provider fails to load (e.g. unreachable server or CORS error), avoiding a completely black globe.
- https://github.com/geosolutions-it/MapStore2/pull/12591 
    - **Fix #12583 Elevation in MousePosition not shown in 3D**: the elevation layer is now added to the Cesium imagery layers after the proxy detection, it is recreated when the detection requires a different proxy setup, and an explicit `forceProxy` option in the layer configuration takes precedence over the detection.

The 2D elevation fix (#12589) is not included on purpose: this branch does not contain #12356, so it is not affected by that regression.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**

#12579, #12583

**What is the new behavior?**

Terrain switch works correctly and the globe no longer turns black when the terrain provider fails to load; the elevation is shown by the MousePosition plugin in 3D.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
