### PR TITLE
[Backport 2026.02.xx] Fix #12604 Tests failing on Chrome 150 due to floating point differences

### DIFF
--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -724,11 +724,13 @@ describe('search Epics', () => {
                 expect(actions[0].bbox).toEqual([8.69736995, 44.46808721, 8.7002344, 44.4699759]);
                 const popupAction = actions[1];
                 expect(popupAction.type).toBe(ADD_MAP_POPUP);
-                expect(popupAction.popup?.position?.coordinates?.[0]).toBe(
-                    968346.2286324208
+                // reprojected values are compared with a tolerance because floating point
+                // results of transcendental functions can differ across browser versions
+                expect(popupAction.popup?.position?.coordinates?.[0]?.toFixed(6)).toBe(
+                    (968346.2286324208).toFixed(6)
                 );
-                expect(popupAction.popup?.position?.coordinates?.[1]).toBe(
-                    5538315.133325616
+                expect(popupAction.popup?.position?.coordinates?.[1]?.toFixed(6)).toBe(
+                    (5538315.133325616).toFixed(6)
                 );
                 done();
             },

--- a/web/client/plugins/Annotations/utils/__tests__/AnnotationsUtils-test.js
+++ b/web/client/plugins/Annotations/utils/__tests__/AnnotationsUtils-test.js
@@ -508,7 +508,10 @@ describe('AnnotationsUtils', () => {
         });
     });
     it('annotationsToGeoJSON with length and area measures', () => {
-        expect(annotationsToGeoJSON(annotationsTest)).toEqual(annotationsTestResult);
+        // round numbers to 12 significant digits because floating point results
+        // of transcendental functions can differ across browser versions
+        const roundNumbers = value => JSON.parse(JSON.stringify(value, (key, val) => typeof val === 'number' ? Number(val.toPrecision(12)) : val));
+        expect(roundNumbers(annotationsToGeoJSON(annotationsTest))).toEqual(roundNumbers(annotationsTestResult));
     });
     it('geoJSONToAnnotations', () => {
         const geoJSON = {

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -499,7 +499,7 @@ describe('CoordinatesUtils', () => {
     });
 
     it('test getWMSBoundingBox', () => {
-        expect(getWMSBoundingBox([
+        const bbox = getWMSBoundingBox([
             {
                 $: {
                     SRS: 'EPSG:3857',
@@ -518,12 +518,13 @@ describe('CoordinatesUtils', () => {
                     maxy: "90"
                 }
             }
-        ])).toEqual({
-            minx: 11.074215226957271,
-            miny: 43.70759642778742,
-            maxx: 11.425777726908334,
-            maxy: 43.96119355022118
-        });
+        ]);
+        // reprojected values are compared with a tolerance because floating point
+        // results of transcendental functions can differ across browser versions
+        expect(bbox.minx.toFixed(8)).toBe((11.074215226957271).toFixed(8));
+        expect(bbox.miny.toFixed(8)).toBe((43.70759642778742).toFixed(8));
+        expect(bbox.maxx.toFixed(8)).toBe((11.425777726908334).toFixed(8));
+        expect(bbox.maxy.toFixed(8)).toBe((43.96119355022118).toFixed(8));
     });
     it('test fetchProjRemotely with fake url', () => {
         expect(typeof fetchProjRemotely("EPSG:3044", "base/web/client/test-resources/wms/projDef_3044.txt")).toBe("object");

--- a/web/client/utils/mapinfo/__tests__/arcgis-test.js
+++ b/web/client/utils/mapinfo/__tests__/arcgis-test.js
@@ -45,15 +45,21 @@ describe('mapinfo arcgis utils', () => {
             "intersectedFeatures": []
         };
         const request = arcgis.buildRequest(layer, { point, map, currentLocale: 'en-US' });
-        expect(request).toEqual({
+        // bounds are compared with a tolerance because floating point results
+        // of transcendental functions can differ across browser versions
+        const expectedBounds = [
+            -76.69000174947232,
+            34.669673599384076,
+            -76.33843924947232,
+            34.95830926327919
+        ];
+        request.request.bounds.forEach((value, idx) => {
+            expect(value.toFixed(8)).toBe(expectedBounds[idx].toFixed(8));
+        });
+        expect({ ...request, request: { ...request.request, bounds: undefined } }).toEqual({
             request: {
                 outputFormat: 'application/json',
-                bounds: [
-                    -76.69000174947232,
-                    34.669673599384076,
-                    -76.33843924947232,
-                    34.95830926327919
-                ]
+                bounds: undefined
             },
             metadata: {
                 title: 'Title'

--- a/web/client/utils/ogc/__tests__/WMC-test.js
+++ b/web/client/utils/ogc/__tests__/WMC-test.js
@@ -333,16 +333,22 @@ describe('WMC tests', () => {
         });
     });
     describe('WMC export tests', () => {
+        // round decimal numbers embedded in the exported text because floating point
+        // results of transcendental functions can differ across browser versions
+        const normalizeNumbers = line => line.replace(/-?\d+\.\d+/g, match => Number(match).toFixed(6));
+        const compareLines = (exported, context) => {
+            const exportedLines = exported.split('\n').map(r => normalizeNumbers(r.trim())).filter(e => e);
+            const contextLines = context.split('\n').map(r => normalizeNumbers(r.trim())).filter(e => e);
+
+            zip(exportedLines, contextLines).forEach(([exportedLine, contextLine], i) =>
+                expect({text: exportedLine, line: i + 1}).toEqual({text: contextLine, line: i + 1}));
+        };
         it('toWMC', () =>
             Promise.all([
                 axios.get('base/web/client/test-resources/wmc/config.json'),
                 axios.get('base/web/client/test-resources/wmc/exported-context.wmc')
             ]).then(([{data: config}, {data: context}]) => {
-                const exportedLines = toWMC(config, {}).split('\n').map(r => r.trim()).filter(e => e);
-                const contextLines = context.split('\n').map(r => r.trim()).filter(e => e);
-
-                zip(exportedLines, contextLines).forEach(([exportedLine, contextLine], i) =>
-                    expect({text: exportedLine, line: i + 1}).toEqual({text: contextLine, line: i + 1}));
+                compareLines(toWMC(config, {}), context);
             })
         );
         it('Empty maxExtent should not fail', () => {
@@ -351,11 +357,7 @@ describe('WMC tests', () => {
                 axios.get('base/web/client/test-resources/wmc/exported-context.wmc')
             ]).then(([{data: config}, {data: context}]) => {
                 const _config = omit(config, "map.maxExtent"); // remove mapExtent
-                const exportedLines = toWMC(_config, {}).split('\n').map(r => r.trim()).filter(e => e);
-                const contextLines = context.split('\n').map(r => r.trim()).filter(e => e);
-
-                zip(exportedLines, contextLines).forEach(([exportedLine, contextLine], i) =>
-                    expect({text: exportedLine, line: i + 1}).toEqual({text: contextLine, line: i + 1}));
+                compareLines(toWMC(_config, {}), context);
             });
         });
         it('bbox should take precedence over maxExtent', () => {
@@ -375,10 +377,7 @@ describe('WMC tests', () => {
                         }, crs: "EPSG:900913"}
                     }
                 };
-                const exportedLines = toWMC(_config, {}).split('\n').map(r => r.trim()).filter(e => e);
-                const contextLines = context.split('\n').map(r => r.trim()).filter(e => e);
-                zip(exportedLines, contextLines).forEach(([exportedLine, contextLine], i) =>
-                    expect({text: exportedLine, line: i + 1}).toEqual({text: contextLine, line: i + 1}));
+                compareLines(toWMC(_config, {}), context);
             });
         });
     });


### PR DESCRIPTION
# Description
Backport of #12605 to `2026.02.xx`.

Fixes #12604