### PR TITLE
[Backport 2026.02.xx] #12542 Legend labels not visible in DynamicLegend plugin when viewing only single legend entry

### DIFF
--- a/web/client/plugins/DynamicLegend/components/DynamicLegend.jsx
+++ b/web/client/plugins/DynamicLegend/components/DynamicLegend.jsx
@@ -19,6 +19,8 @@ import { DEFAULT_PANEL_WIDTH } from '../../../utils/LayoutUtils';
 import '../assets/dynamicLegend.css';
 import Text from '../../../components/layout/Text';
 
+export const DYNAMIC_LEGEND_WMS_OPTIONS = "forceLabels:on;countMatched:true;fontAntiAliasing:true;";
+
 /**
  * Main component for the DynamicLegend plugin.
  *
@@ -105,7 +107,7 @@ const DynamicLegend = ({
                     zoom: currentZoomLvl,
                     layerOptions: {
                         legendOptions: {
-                            WMSLegendOptions: "countMatched:true;fontAntiAliasing:true;",
+                            WMSLegendOptions: DYNAMIC_LEGEND_WMS_OPTIONS,
                             legendWidth: 12,
                             legendHeight: 12,
                             mapBbox

--- a/web/client/plugins/DynamicLegend/components/__tests__/DynamicLegend-test.jsx
+++ b/web/client/plugins/DynamicLegend/components/__tests__/DynamicLegend-test.jsx
@@ -10,7 +10,7 @@ import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import DynamicLegend from '../DynamicLegend';
+import DynamicLegend, { DYNAMIC_LEGEND_WMS_OPTIONS } from '../DynamicLegend';
 
 describe('DynamicLegend Component', () => {
     let container;
@@ -75,5 +75,9 @@ describe('DynamicLegend Component', () => {
         ReactDOM.render(<DynamicLegend {...defaultProps} />, container);
         const layerTreeIsExisting = container.querySelectorAll('.ms-layers-tree');
         expect(layerTreeIsExisting).toBeTruthy();
+    });
+
+    it('should preserve forced labels in dynamic legend WMS options', () => {
+        expect(DYNAMIC_LEGEND_WMS_OPTIONS).toBe('forceLabels:on;countMatched:true;fontAntiAliasing:true;');
     });
 });


### PR DESCRIPTION
# Description
Backport of #12544 to `2026.02.xx`.

Fixes #12542