### PR TITLE
#12611 UI Overlap: TOC and Attribute Table on Edit mode 

### DIFF
--- a/web/client/plugins/TOC/actions/__tests__/toc-test.js
+++ b/web/client/plugins/TOC/actions/__tests__/toc-test.js
@@ -8,8 +8,8 @@
 import expect from 'expect';
 
 import {
-    consumeTOCInitialization,
-    TOC_INITIALIZATION_CONSUMED,
+    initializeTOC,
+    TOC_INITIALIZED,
     updateTOCConfig,
     UPDATE_TOC_CONFIG
 } from '../toc';
@@ -21,10 +21,10 @@ describe('toc actions', () => {
         expect(action.type).toBe(UPDATE_TOC_CONFIG);
         expect(action.payload).toBe(payload);
     });
-    it('consumeTOCInitialization', () => {
+    it('initializeTOC', () => {
         const mapLoadedCount = 2;
-        const action = consumeTOCInitialization(mapLoadedCount);
-        expect(action.type).toBe(TOC_INITIALIZATION_CONSUMED);
+        const action = initializeTOC(mapLoadedCount);
+        expect(action.type).toBe(TOC_INITIALIZED);
         expect(action.mapLoadedCount).toBe(mapLoadedCount);
     });
 });

--- a/web/client/plugins/TOC/actions/__tests__/toc-test.js
+++ b/web/client/plugins/TOC/actions/__tests__/toc-test.js
@@ -8,6 +8,8 @@
 import expect from 'expect';
 
 import {
+    consumeTOCInitialization,
+    TOC_INITIALIZATION_CONSUMED,
     updateTOCConfig,
     UPDATE_TOC_CONFIG
 } from '../toc';
@@ -18,5 +20,11 @@ describe('toc actions', () => {
         const action = updateTOCConfig(payload);
         expect(action.type).toBe(UPDATE_TOC_CONFIG);
         expect(action.payload).toBe(payload);
+    });
+    it('consumeTOCInitialization', () => {
+        const mapLoadedCount = 2;
+        const action = consumeTOCInitialization(mapLoadedCount);
+        expect(action.type).toBe(TOC_INITIALIZATION_CONSUMED);
+        expect(action.mapLoadedCount).toBe(mapLoadedCount);
     });
 });

--- a/web/client/plugins/TOC/actions/toc.js
+++ b/web/client/plugins/TOC/actions/toc.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 export const UPDATE_TOC_CONFIG = 'TOC:UPDATE_CONFIG';
+export const TOC_INITIALIZATION_CONSUMED = 'TOC:INITIALIZATION_CONSUMED';
 /**
  * update configuration for table of content
  * @param {object} payload properties to update
@@ -14,4 +15,14 @@ export const UPDATE_TOC_CONFIG = 'TOC:UPDATE_CONFIG';
 export const updateTOCConfig = (payload) => ({
     type: UPDATE_TOC_CONFIG,
     payload
+});
+
+/**
+ * mark a table of content initialization as consumed
+ * @param {number} mapLoadedCount current map configuration load count
+ * @return {object} of type `TOC_INITIALIZATION_CONSUMED` with mapLoadedCount
+ */
+export const consumeTOCInitialization = (mapLoadedCount) => ({
+    type: TOC_INITIALIZATION_CONSUMED,
+    mapLoadedCount
 });

--- a/web/client/plugins/TOC/actions/toc.js
+++ b/web/client/plugins/TOC/actions/toc.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 export const UPDATE_TOC_CONFIG = 'TOC:UPDATE_CONFIG';
-export const TOC_INITIALIZATION_CONSUMED = 'TOC:INITIALIZATION_CONSUMED';
+export const TOC_INITIALIZED = 'TOC:INITIALIZED';
 /**
  * update configuration for table of content
  * @param {object} payload properties to update
@@ -18,11 +18,11 @@ export const updateTOCConfig = (payload) => ({
 });
 
 /**
- * mark a table of content initialization as consumed
+ * mark a table of content initialized
  * @param {number} mapLoadedCount current map configuration load count
- * @return {object} of type `TOC_INITIALIZATION_CONSUMED` with mapLoadedCount
+ * @return {object} of type `TOC_INITIALIZED` with mapLoadedCount
  */
-export const consumeTOCInitialization = (mapLoadedCount) => ({
-    type: TOC_INITIALIZATION_CONSUMED,
+export const initializeTOC = (mapLoadedCount) => ({
+    type: TOC_INITIALIZED,
     mapLoadedCount
 });

--- a/web/client/plugins/TOC/index.js
+++ b/web/client/plugins/TOC/index.js
@@ -43,7 +43,7 @@ import tooltip from '../../components/misc/enhancers/tooltip';
 import localizedProps from '../../components/misc/enhancers/localizedProps';
 import { registerCustomSaveHandler } from '../../selectors/mapsave';
 import toc from './reducers/toc';
-import { consumeTOCInitialization } from './actions/toc';
+import { initializeTOC } from './actions/toc';
 import { setControlProperty } from '../../actions/controls';
 import Message from '../../components/I18N/Message';
 const Button = tooltip(ButtonRB);
@@ -368,7 +368,7 @@ function TOC({
     toolbarButtonProps,
     init,
     onOpen,
-    onInitializationConsumed
+    onInitialize
 }, context) {
     const activateParameter = (allow, activate) => {
         const isUserAdmin = user && user.role === 'ADMIN' || false;
@@ -435,12 +435,12 @@ function TOC({
     // when default open is true
     useEffect(() => {
         if (init) {
-            onInitializationConsumed(init);
+            onInitialize(init);
             if (defaultOpen) {
                 onOpen();
             }
         }
-    }, [init, defaultOpen, onInitializationConsumed, onOpen]);
+    }, [init, defaultOpen, onInitialize, onOpen]);
 
     const targetTree = singleDefaultGroup ? tree?.[0]?.nodes : tree;
     const isEmpty = targetTree?.length === 0;
@@ -637,7 +637,7 @@ const ConnectedTOC = connect(tocSelector, {
     onChange: updateNode,
     onSelectNode: selectNode,
     onOpen: setControlProperty.bind(null, 'drawer', 'enabled', true),
-    onInitializationConsumed: consumeTOCInitialization
+    onInitialize: initializeTOC
 })(TOC);
 
 export default createPlugin('TOC', {

--- a/web/client/plugins/TOC/index.js
+++ b/web/client/plugins/TOC/index.js
@@ -43,6 +43,7 @@ import tooltip from '../../components/misc/enhancers/tooltip';
 import localizedProps from '../../components/misc/enhancers/localizedProps';
 import { registerCustomSaveHandler } from '../../selectors/mapsave';
 import toc from './reducers/toc';
+import { consumeTOCInitialization } from './actions/toc';
 import { setControlProperty } from '../../actions/controls';
 import Message from '../../components/I18N/Message';
 const Button = tooltip(ButtonRB);
@@ -366,7 +367,8 @@ function TOC({
     visualizationMode,
     toolbarButtonProps,
     init,
-    onOpen
+    onOpen,
+    onInitializationConsumed
 }, context) {
     const activateParameter = (allow, activate) => {
         const isUserAdmin = user && user.role === 'ADMIN' || false;
@@ -432,10 +434,13 @@ function TOC({
     // automatically open the toc
     // when default open is true
     useEffect(() => {
-        if (init && defaultOpen) {
-            onOpen();
+        if (init) {
+            onInitializationConsumed(init);
+            if (defaultOpen) {
+                onOpen();
+            }
         }
-    }, [init]);
+    }, [init, defaultOpen, onInitializationConsumed, onOpen]);
 
     const targetTree = singleDefaultGroup ? tree?.[0]?.nodes : tree;
     const isEmpty = targetTree?.length === 0;
@@ -569,10 +574,12 @@ const getTOCConfig = (state, props) => {
     const config = state?.toc?.config || {};
     const layers = layersSelector(state).filter(({ group }) => group !== 'background');
     const mapLoadedCount = state?.toc?.mapLoadedCount;
-    const defaultOpen = config.defaultOpen ?? props?.defaultOpen;
+    const initializedMapLoadedCount = state?.toc?.initializedMapLoadedCount;
     return {
-        // use the mapLoadedCount as trigger for the toc initialization
-        init: mapLoadedCount ? `${mapLoadedCount}:${!!defaultOpen}` : false,
+        // consume defaultOpen once for each map configuration load
+        init: mapLoadedCount && mapLoadedCount !== initializedMapLoadedCount
+            ? mapLoadedCount
+            : false,
         defaultOpen: config.defaultOpen ?? props?.defaultOpen,
         theme: config.theme ?? props?.theme,
         hideOpacitySlider: config.hideOpacitySlider ?? props?.hideOpacitySlider ?? props?.activateOpacityTool,
@@ -629,7 +636,8 @@ const ConnectedTOC = connect(tocSelector, {
     onSort: moveNode,
     onChange: updateNode,
     onSelectNode: selectNode,
-    onOpen: setControlProperty.bind(null, 'drawer', 'enabled', true)
+    onOpen: setControlProperty.bind(null, 'drawer', 'enabled', true),
+    onInitializationConsumed: consumeTOCInitialization
 })(TOC);
 
 export default createPlugin('TOC', {

--- a/web/client/plugins/TOC/reducers/__tests__/toc-test.js
+++ b/web/client/plugins/TOC/reducers/__tests__/toc-test.js
@@ -7,7 +7,10 @@
 */
 import expect from 'expect';
 
-import { updateTOCConfig } from '../../actions/toc';
+import {
+    consumeTOCInitialization,
+    updateTOCConfig
+} from '../../actions/toc';
 import { configureMap } from '../../../../actions/config';
 
 import toc from '../toc';
@@ -16,6 +19,17 @@ describe('toc reducer', () => {
     it('should init with configureMap', () => {
         const state = toc({}, configureMap());
         expect(state.mapLoadedCount).toBe(1);
+    });
+    it('should consume each map configuration initialization once', () => {
+        const firstMapState = toc({}, configureMap());
+        expect(firstMapState.initializedMapLoadedCount).toNotExist();
+
+        const initializedState = toc(firstMapState, consumeTOCInitialization(firstMapState.mapLoadedCount));
+        expect(initializedState.initializedMapLoadedCount).toBe(1);
+
+        const secondMapState = toc(initializedState, configureMap());
+        expect(secondMapState.mapLoadedCount).toBe(2);
+        expect(secondMapState.initializedMapLoadedCount).toBe(1);
     });
     it('should update config with updateTOCConfig', () => {
         const state = toc({ config: { defaultOpen: true }}, updateTOCConfig({ defaultOpen: false }));

--- a/web/client/plugins/TOC/reducers/__tests__/toc-test.js
+++ b/web/client/plugins/TOC/reducers/__tests__/toc-test.js
@@ -8,7 +8,7 @@
 import expect from 'expect';
 
 import {
-    consumeTOCInitialization,
+    initializeTOC,
     updateTOCConfig
 } from '../../actions/toc';
 import { configureMap } from '../../../../actions/config';
@@ -24,7 +24,7 @@ describe('toc reducer', () => {
         const firstMapState = toc({}, configureMap());
         expect(firstMapState.initializedMapLoadedCount).toNotExist();
 
-        const initializedState = toc(firstMapState, consumeTOCInitialization(firstMapState.mapLoadedCount));
+        const initializedState = toc(firstMapState, initializeTOC(firstMapState.mapLoadedCount));
         expect(initializedState.initializedMapLoadedCount).toBe(1);
 
         const secondMapState = toc(initializedState, configureMap());

--- a/web/client/plugins/TOC/reducers/toc.js
+++ b/web/client/plugins/TOC/reducers/toc.js
@@ -8,7 +8,7 @@
 
 import { MAP_CONFIG_LOADED } from '../../../actions/config';
 import {
-    TOC_INITIALIZATION_CONSUMED,
+    TOC_INITIALIZED,
     UPDATE_TOC_CONFIG
 } from '../actions/toc';
 
@@ -32,7 +32,7 @@ function toc(state = {}, action) {
             }
         };
     }
-    case TOC_INITIALIZATION_CONSUMED: {
+    case TOC_INITIALIZED: {
         return {
             ...state,
             initializedMapLoadedCount: action.mapLoadedCount

--- a/web/client/plugins/TOC/reducers/toc.js
+++ b/web/client/plugins/TOC/reducers/toc.js
@@ -7,7 +7,10 @@
  */
 
 import { MAP_CONFIG_LOADED } from '../../../actions/config';
-import { UPDATE_TOC_CONFIG } from '../actions/toc';
+import {
+    TOC_INITIALIZATION_CONSUMED,
+    UPDATE_TOC_CONFIG
+} from '../actions/toc';
 
 function toc(state = {}, action) {
     switch (action.type) {
@@ -27,6 +30,12 @@ function toc(state = {}, action) {
                 ...state?.config,
                 ...action.payload
             }
+        };
+    }
+    case TOC_INITIALIZATION_CONSUMED: {
+        return {
+            ...state,
+            initializedMapLoadedCount: action.mapLoadedCount
         };
     }
     default:

--- a/web/client/plugins/__tests__/TOC-test.jsx
+++ b/web/client/plugins/__tests__/TOC-test.jsx
@@ -20,6 +20,8 @@ import FeatureEditor from '../FeatureEditor';
 import TOCItemsSettings from '../TOCItemsSettings';
 import FilterLayer from '../FilterLayer';
 import WidgetsBuilder from '../WidgetsBuilder';
+import { configureMap } from '../../actions/config';
+import { setControlProperty } from '../../actions/controls';
 
 const dndContext = dragDropContext(TestBackend);
 
@@ -51,6 +53,72 @@ describe('TOCPlugin Plugin', () => {
         const WrappedPlugin = dndContext(Plugin);
         ReactDOM.render(<WrappedPlugin />, document.getElementById("container"));
         expect(document.getElementsByClassName('ms-toc-container').length).toBe(1);
+    });
+
+    describe('defaultOpen initialization', () => {
+        const getInitialState = (defaultOpen) => ({
+            controls: {
+                drawer: {
+                    enabled: false
+                }
+            },
+            toc: {
+                mapLoadedCount: 1,
+                config: {
+                    defaultOpen
+                }
+            }
+        });
+
+        it('opens and consumes the initialization when defaultOpen is true', (done) => {
+            const { Plugin, store } = getPluginForTest(TOCPlugin, getInitialState(true));
+            const WrappedPlugin = dndContext(Plugin);
+            ReactDOM.render(<WrappedPlugin />, document.getElementById("container"));
+
+            setTimeout(() => {
+                expect(store.getState().controls.drawer.enabled).toBe(true);
+                expect(store.getState().toc.initializedMapLoadedCount).toBe(1);
+                done();
+            });
+        });
+
+        it('does not reopen on remount but opens on the next map load', (done) => {
+            const { Plugin, store } = getPluginForTest(TOCPlugin, getInitialState(true));
+            const WrappedPlugin = dndContext(Plugin);
+            ReactDOM.render(<WrappedPlugin />, document.getElementById("container"));
+
+            setTimeout(() => {
+                expect(store.getState().controls.drawer.enabled).toBe(true);
+                store.dispatch(setControlProperty('drawer', 'enabled', false));
+                ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+                ReactDOM.render(<WrappedPlugin />, document.getElementById("container"));
+
+                setTimeout(() => {
+                    expect(store.getState().controls.drawer.enabled).toBe(false);
+                    expect(store.getState().toc.initializedMapLoadedCount).toBe(1);
+
+                    store.dispatch(configureMap({ toc: { defaultOpen: true }}));
+                    setTimeout(() => {
+                        expect(store.getState().controls.drawer.enabled).toBe(true);
+                        expect(store.getState().toc.mapLoadedCount).toBe(2);
+                        expect(store.getState().toc.initializedMapLoadedCount).toBe(2);
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('consumes the initialization without opening when defaultOpen is false', (done) => {
+            const { Plugin, store } = getPluginForTest(TOCPlugin, getInitialState(false));
+            const WrappedPlugin = dndContext(Plugin);
+            ReactDOM.render(<WrappedPlugin />, document.getElementById("container"));
+
+            setTimeout(() => {
+                expect(store.getState().controls.drawer.enabled).toBe(false);
+                expect(store.getState().toc.initializedMapLoadedCount).toBe(1);
+                done();
+            });
+        });
     });
 
     it('TOCPlugin shows annotations layer in openlayers mapType', () => {


### PR DESCRIPTION
## Description
This issue occurs when `Open on Map Initialization` is selected in ToC settings.

What was happening is that when this option was turned on then it will automatically open when map initialized (like map load and refresh) but issue was when we enter edit mode in attribute table then ToC is unmounted and re-mounted again on changing to view mode. `onOpen()` is triggered again.

Solution: I added an action and reducer to track if the opening of ToC on map initialization has already happened or not. So, on remount also the ToC does not automatically reopen.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12611 

**What is the new behavior?**
Now ToC does not automatically reopen on entering view mode on attribute table, only ToC logo appears.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No