### PR TITLE
#12612 Catalog: Clearing level search bar does not refresh the list

### DIFF
--- a/web/client/components/catalog/__tests__/Catalog-test.jsx
+++ b/web/client/components/catalog/__tests__/Catalog-test.jsx
@@ -80,6 +80,34 @@ describe('Test Catalog panel', () => {
             }
         });
     });
+    it('clears layer selections when submitting a search', () => {
+        const SERVICE = {
+            type: 'csw',
+            url: 'http://sample.service/catalog',
+            title: 'csw'
+        };
+        const actions = {
+            onChangeText: () => {},
+            clearSelection: () => {}
+        };
+        const spyOnChangeText = expect.spyOn(actions, 'onChangeText');
+        const spyOnClearSelection = expect.spyOn(actions, 'clearSelection');
+        ReactDOM.render(<Catalog
+            services={{ csw: SERVICE }}
+            selectedService="csw"
+            selectedFormat="csw"
+            searchText="layer"
+            onChangeText={actions.onChangeText}
+            clearSelection={actions.clearSelection}
+        />, document.getElementById('container'));
+
+        const searchButton = document.querySelector('.glyphicon-search').closest('button');
+        TestUtils.Simulate.click(searchButton);
+
+        expect(spyOnClearSelection.calls.length).toBe(1);
+        expect(spyOnChangeText.calls.length).toBe(1);
+        expect(spyOnChangeText.calls[0].arguments[0]).toBe('layer');
+    });
     it('clears search text and active filters while preserving sort', () => {
         const SERVICE = {
             type: 'geonode',

--- a/web/client/components/catalog/__tests__/Catalog-test.jsx
+++ b/web/client/components/catalog/__tests__/Catalog-test.jsx
@@ -36,7 +36,7 @@ describe('Test Catalog panel', () => {
         const catalog = document.querySelector('.ms-catalog');
         expect(catalog).toBeTruthy();
     });
-    it('clears search text and refreshes the first page with a single search', () => {
+    it('clears search text and layer selections, then refreshes the first page with a single search', () => {
         const SERVICE = {
             type: 'csw',
             url: 'http://sample.service/catalog',
@@ -44,9 +44,11 @@ describe('Test Catalog panel', () => {
         };
         const actions = {
             onChangeText: () => {},
+            clearSelection: () => {},
             onSearch: () => {}
         };
         const spyOnChangeText = expect.spyOn(actions, 'onChangeText');
+        const spyOnClearSelection = expect.spyOn(actions, 'clearSelection');
         const spyOnSearch = expect.spyOn(actions, 'onSearch');
         ReactDOM.render(<Catalog
             services={{ csw: SERVICE }}
@@ -54,6 +56,7 @@ describe('Test Catalog panel', () => {
             selectedFormat="csw"
             searchText="layer"
             onChangeText={actions.onChangeText}
+            clearSelection={actions.clearSelection}
             onSearch={actions.onSearch}
         />, document.getElementById('container'));
 
@@ -62,6 +65,7 @@ describe('Test Catalog panel', () => {
 
         expect(spyOnChangeText.calls.length).toBe(1);
         expect(spyOnChangeText.calls[0].arguments).toEqual(['', { skipAutoSearch: true }]);
+        expect(spyOnClearSelection.calls.length).toBe(1);
         expect(spyOnSearch.calls.length).toBe(1);
         expect(spyOnSearch.calls[0].arguments[0]).toEqual({
             format: 'csw',

--- a/web/client/components/catalog/__tests__/Catalog-test.jsx
+++ b/web/client/components/catalog/__tests__/Catalog-test.jsx
@@ -36,6 +36,94 @@ describe('Test Catalog panel', () => {
         const catalog = document.querySelector('.ms-catalog');
         expect(catalog).toBeTruthy();
     });
+    it('clears search text and refreshes the first page with a single search', () => {
+        const SERVICE = {
+            type: 'csw',
+            url: 'http://sample.service/catalog',
+            title: 'csw'
+        };
+        const actions = {
+            onChangeText: () => {},
+            onSearch: () => {}
+        };
+        const spyOnChangeText = expect.spyOn(actions, 'onChangeText');
+        const spyOnSearch = expect.spyOn(actions, 'onSearch');
+        ReactDOM.render(<Catalog
+            services={{ csw: SERVICE }}
+            selectedService="csw"
+            selectedFormat="csw"
+            searchText="layer"
+            onChangeText={actions.onChangeText}
+            onSearch={actions.onSearch}
+        />, document.getElementById('container'));
+
+        const clearButton = document.querySelector('.glyphicon-1-close').closest('button');
+        TestUtils.Simulate.click(clearButton);
+
+        expect(spyOnChangeText.calls.length).toBe(1);
+        expect(spyOnChangeText.calls[0].arguments).toEqual(['', { skipAutoSearch: true }]);
+        expect(spyOnSearch.calls.length).toBe(1);
+        expect(spyOnSearch.calls[0].arguments[0]).toEqual({
+            format: 'csw',
+            url: 'http://sample.service/catalog',
+            startPosition: 1,
+            maxRecords: 12,
+            text: '',
+            options: {
+                filters: {},
+                sort: '-date',
+                service: SERVICE
+            }
+        });
+    });
+    it('clears search text and active filters while preserving sort', () => {
+        const SERVICE = {
+            type: 'geonode',
+            url: 'http://sample.service/geonode',
+            title: 'GeoNode'
+        };
+        const filters = {
+            'filter{category.identifier.in}': ['environment']
+        };
+        const actions = {
+            onChangeText: () => {},
+            onSearch: () => {}
+        };
+        const spyOnChangeText = expect.spyOn(actions, 'onChangeText');
+        const spyOnSearch = expect.spyOn(actions, 'onSearch');
+        ReactDOM.render(<Catalog
+            services={{ geonode: SERVICE }}
+            selectedService="geonode"
+            selectedFormat="geonode"
+            searchText="layer"
+            searchOptions={{
+                url: 'http://sample.service/geonode',
+                filters,
+                sort: 'title'
+            }}
+            onChangeText={actions.onChangeText}
+            onSearch={actions.onSearch}
+        />, document.getElementById('container'));
+
+        const clearButton = document.querySelector('.glyphicon-1-close').closest('button');
+        TestUtils.Simulate.click(clearButton);
+
+        expect(spyOnChangeText.calls.length).toBe(1);
+        expect(spyOnChangeText.calls[0].arguments).toEqual(['', { skipAutoSearch: true }]);
+        expect(spyOnSearch.calls.length).toBe(1);
+        expect(spyOnSearch.calls[0].arguments[0]).toEqual({
+            format: 'geonode',
+            url: 'http://sample.service/geonode',
+            startPosition: 1,
+            maxRecords: 12,
+            text: '',
+            options: {
+                filters: {},
+                sort: 'title',
+                service: SERVICE
+            }
+        });
+    });
     it('triggers search on autoload service', (done) => {
         const SERVICE = {
             type: "csw",

--- a/web/client/components/catalog/__tests__/CatalogSearchInput-test.jsx
+++ b/web/client/components/catalog/__tests__/CatalogSearchInput-test.jsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import expect from 'expect';
+import TestUtils from 'react-dom/test-utils';
 import CatalogSearchInput from '../datasets/CatalogSearchInput';
 
 describe('CatalogSearchInput component', () => {
@@ -28,5 +29,22 @@ describe('CatalogSearchInput component', () => {
         />, document.getElementById('container'));
         const node = document.querySelector('.ms-resources-search-field');
         expect(node).toBeTruthy();
+    });
+    it('should invoke reset once when clicking the clear button', () => {
+        const actions = {
+            onReset: () => {}
+        };
+        const spyOnReset = expect.spyOn(actions, 'onReset');
+        ReactDOM.render(<CatalogSearchInput
+            searchText="layer"
+            onChangeText={() => {}}
+            onReset={actions.onReset}
+            currentService={{ type: 'csw' }}
+        />, document.getElementById('container'));
+
+        const clearButton = document.querySelector('.glyphicon-1-close').closest('button');
+        TestUtils.Simulate.click(clearButton);
+
+        expect(spyOnReset.calls.length).toBe(1);
     });
 });

--- a/web/client/components/catalog/datasets/Catalog.jsx
+++ b/web/client/components/catalog/datasets/Catalog.jsx
@@ -296,6 +296,7 @@ const Catalog = ({
         <CatalogSearchInput
             searchText={searchText}
             onChangeText={(text, opts) => {
+                clearSelection?.();
                 onChangeText(text, opts);
             }}
             enableFilters={serviceCapabilities.filterSupport}

--- a/web/client/components/catalog/datasets/Catalog.jsx
+++ b/web/client/components/catalog/datasets/Catalog.jsx
@@ -283,6 +283,12 @@ const Catalog = ({
         search({ searchText, filters, sort: newSort, start: searchOptions?.startPosition });
     };
 
+    const onReset = () => {
+        onChangeText('', { skipAutoSearch: true });
+        setFilters({});
+        search({ searchText: '', filters: {}, sort });
+    };
+
     const hasActiveFilters = useMemo(() => serviceCapabilities.filterSupport && Object.keys(filters).length > 0, [serviceCapabilities.filterSupport, filters]);
 
     const searchInputNode = (
@@ -293,7 +299,7 @@ const Catalog = ({
             }}
             enableFilters={serviceCapabilities.filterSupport}
             onToggleFilters={() => setShowFilters(!showFilters)}
-            onResetFilters={() => onFilterChange({}, true)}
+            onReset={onReset}
             includeSearchButton={includeSearchButton}
             onShowSecurityModal={onShowSecurityModal}
             onSetProtectedServices={onSetProtectedServices}

--- a/web/client/components/catalog/datasets/Catalog.jsx
+++ b/web/client/components/catalog/datasets/Catalog.jsx
@@ -286,6 +286,7 @@ const Catalog = ({
     const onReset = () => {
         onChangeText('', { skipAutoSearch: true });
         setFilters({});
+        clearSelection?.();
         search({ searchText: '', filters: {}, sort });
     };
 

--- a/web/client/components/catalog/datasets/CatalogSearchInput.jsx
+++ b/web/client/components/catalog/datasets/CatalogSearchInput.jsx
@@ -46,7 +46,7 @@ const CatalogSearchInput = ({
     onChangeText,
     enableFilters,
     onToggleFilters,
-    onResetFilters,
+    onReset,
     includeSearchButton = true,
     onShowSecurityModal,
     onSetProtectedServices,
@@ -64,11 +64,6 @@ const CatalogSearchInput = ({
             onChangeText(value);
         }
     };
-    const handleReset = () => {
-        onChangeText("", { skipAutoSearch: true });
-        onResetFilters?.();
-    };
-
     const isServiceSelected = !!currentService;
 
     return (
@@ -109,7 +104,7 @@ const CatalogSearchInput = ({
                 glyph={'1-close'}
                 onClick={() => {
                     if (isServiceSelected) {
-                        handleReset();
+                        onReset?.();
                     }
                 }}
                 disabled={!isServiceSelected}


### PR DESCRIPTION
## Description
Call `onReset` that clears search and re-fetches list so that list returns to its initial state when search is cleared on catalog.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12612 

**What is the new behavior?**
Clearing search refreshes list to its initial state

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
