### PR TITLE
#12617 - Ignore arcgis feature layer type from Print

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -297,7 +297,7 @@ const UNSUPPORTED_LAYER_TYPES = ["arcgis-feature", "cog"];
 
 function filterLayer(layer = {}) {
     // Skip layer with error and unsupported type
-    return !layer.loadingError && !UNSUPPORTED_LAYER_TYPES.includes(layer.type); 
+    return !layer.loadingError && !UNSUPPORTED_LAYER_TYPES.includes(layer.type);
 }
 
 export default {

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -293,10 +293,11 @@ function mergeItems(standard, overrides) {
         .map(item => overrideItem(item, overrides))
         .map(handleRemoved);
 }
+const UNSUPPORTED_LAYER_TYPES = ["arcgis-feature", "cog"];
 
 function filterLayer(layer = {}) {
-    // Skip layer with error and type cog
-    return !layer.loadingError && layer.type !== "cog";
+    // Skip layer with error and unsupported type
+    return !layer.loadingError && !UNSUPPORTED_LAYER_TYPES.includes(layer.type); 
 }
 
 export default {


### PR DESCRIPTION
## Description
This PR temporarily skips `arcgis-feature` type layer from Print tool (preview and create pdf) based on this [comment](https://github.com/geosolutions-it/MapStore2/issues/12617#issuecomment-4933727255), as the print support is not available yet.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Task

## Issue

**What is the current behavior?**
- #12617

**What is the new behavior?**
Until print support is explicitly provided arcgis-feature layer type is excluded from Print tool

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
