### PR TITLE
#12616 Edit Icons for NON-ADMIN role users does not work 

### DIFF
--- a/web/client/components/catalog/__tests__/CatalogServiceSelector-test.jsx
+++ b/web/client/components/catalog/__tests__/CatalogServiceSelector-test.jsx
@@ -25,10 +25,10 @@ describe('Test CatalogServiceSelect', () => {
         ReactDOM.render(<CatalogServiceSelect services={{}} />, document.getElementById("container"));
         expect(document.getElementById('container')).toBeTruthy();
         expect(document.querySelector('input')).toBeTruthy();
-        expect(document.querySelector('.glyphicon-plus')).toBeTruthy();
-        expect(document.querySelector('.glyphicon-pencil')).toBeTruthy();
+        expect(document.querySelector('.glyphicon-plus')).toBeFalsy();
+        expect(document.querySelector('.glyphicon-pencil')).toBeFalsy();
     });
-    it('keeps edit and delete disabled without permissions', () => {
+    it('hides add, edit and delete without permissions', () => {
         ReactDOM.render(<CatalogServiceSelect
             services={{
                 csw: {
@@ -43,12 +43,11 @@ describe('Test CatalogServiceSelect', () => {
         />, document.getElementById("container"));
         expect(document.getElementById('container')).toBeTruthy();
         const serviceButtons = document.querySelectorAll('.ms-catalog-service-btn');
-        expect(serviceButtons.length).toBe(2);
-        expect(serviceButtons[1].disabled).toBe(true);
+        expect(serviceButtons.length).toBe(0);
         const deleteButton = document.querySelector('.ms-catalog-service-delete-btn');
-        expect(deleteButton.disabled).toBe(true);
+        expect(deleteButton).toBeFalsy();
     });
-    it('enables edit and delete with permissions and selected service', () => {
+    it('enables add, edit and delete with permissions and selected service', () => {
         ReactDOM.render(<CatalogServiceSelect
             services={{
                 csw: {
@@ -63,9 +62,23 @@ describe('Test CatalogServiceSelect', () => {
         />, document.getElementById("container"));
         const serviceButtons = document.querySelectorAll('.ms-catalog-service-btn');
         expect(serviceButtons.length).toBe(2);
+        expect(serviceButtons[0].disabled).toBe(false);
         expect(serviceButtons[1].disabled).toBe(false);
         const deleteButton = document.querySelector('.ms-catalog-service-delete-btn');
         expect(deleteButton.disabled).toBe(false);
+    });
+    it('disables edit and delete with permissions and without a selected service', () => {
+        ReactDOM.render(<CatalogServiceSelect
+            services={{}}
+            canEdit
+            onDeleteService={() => {}}
+        />, document.getElementById("container"));
+        const serviceButtons = document.querySelectorAll('.ms-catalog-service-btn');
+        expect(serviceButtons.length).toBe(2);
+        expect(serviceButtons[0].disabled).toBe(false);
+        expect(serviceButtons[1].disabled).toBe(true);
+        const deleteButton = document.querySelector('.ms-catalog-service-delete-btn');
+        expect(deleteButton.disabled).toBe(true);
     });
     it('calls delete service callback', () => {
         const actions = {

--- a/web/client/components/catalog/datasets/CatalogServiceSelect.jsx
+++ b/web/client/components/catalog/datasets/CatalogServiceSelect.jsx
@@ -52,28 +52,28 @@ const CatalogServiceSelect = ({
                     onChange={(val) => onChangeSelectedService(val && val.value ? val.value : "", val?.service)}
                     placeholder={<Message msgId="catalog.servicePlaceholder" />}
                 />
-                <InputGroup.Addon>
+                {canEdit ? <InputGroup.Addon>
                     <Button
                         className= "ms-catalog-service-btn"
                         onClick={() => onConfigureClick('edit', true)}
                     >
                         <Glyphicon glyph="plus" />
                     </Button>
-                </InputGroup.Addon>
-                <InputGroup.Addon>
+                </InputGroup.Addon> : null}
+                {canEdit ? <InputGroup.Addon>
                     <Button
                         className= "ms-catalog-service-btn"
                         onClick={() => onConfigureClick('edit', false)}
-                        disabled={!canEdit || !isServiceValid}
+                        disabled={!isServiceValid}
                     >
                         <Glyphicon glyph="pencil" />
                     </Button>
-                </InputGroup.Addon>
-                {onDeleteService ? <InputGroup.Addon>
+                </InputGroup.Addon> : null}
+                {canEdit && onDeleteService ? <InputGroup.Addon>
                     <Button
                         className= "ms-catalog-service-delete-btn"
                         onClick={handleDeleteService}
-                        disabled={!canEdit || !isServiceValid}
+                        disabled={!isServiceValid}
                     >
                         <Glyphicon glyph="trash" />
                     </Button>


### PR DESCRIPTION
## Description
This issue occurs in context map type resource when catalog plugin is added. While adding catalog plugin make sure the plugin config as follows:

```json
{
  "cfg": {
    "editingAllowedRoles": ["ADMIN"]
  },
  "override": {}
}
```
As expected result mentioned in #12616 not logged user should not see +,edit or delete button.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#12616 

**What is the new behavior?**
Add edit and delete icons are not shown to users that do not have `canEdit` permission.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
