### PR TITLE
Fix #12620 cyclomedia orb issue

### DIFF
--- a/web/client/plugins/StreetView/StreetView.jsx
+++ b/web/client/plugins/StreetView/StreetView.jsx
@@ -99,7 +99,7 @@ const StreetViewPluginContainer = connect(() => ({}), {
  *        }
  *    ```
  *    - `providerSettings` (optional). The settings specific for the provider. It is an object with the following properties:
- *      - `providerSettings.StreetSmartApiURL` (optional). The URL of the StreetSmart API. Default: `https://streetsmart.cyclomedia.com/api/v23.7/StreetSmartApi.js`.
+ *      - `providerSettings.StreetSmartApiURL` (optional). The URL of the StreetSmart API. Must be a `https://` URL on a `cyclomedia.com` host, otherwise the default is used. Default: `https://streetsmart.cyclomedia.com/api/v26.1/StreetSmartApi.js`.
  *      - `providerSettings.srs` (optional). Coordinate reference system code to use for the API. Default: `EPSG:4326`. Note that the SRS used here must be supported by the StreetSmart API **and** defined in `localConfig.json` file, in `projectionDefs`.
  *      - `providerSettings.credentials` (optional). The credentials to store for the Cyclomedia API. It is an object with `username` and `password` properties.
  *        - **Important Note**: The plugin provides the possibility to configure the credentials in the plugin configuration, but in this case you have to be aware

--- a/web/client/plugins/StreetView/api/cyclomedia.js
+++ b/web/client/plugins/StreetView/api/cyclomedia.js
@@ -7,7 +7,7 @@ import {STREET_VIEW_DATA_LAYER_ID} from '../constants';
  * Now it's not possible because of conflicts with the `react-dnd` library.
  */
 export const loadAPI = () => (new Promise((r) => r()));
-// https://streetsmart.cyclomedia.com/api/v23.14/documentation/
+// https://streetsmart.cyclomedia.com/api/v26.1/documentation/
 // export const loadAPI = () => import('@cyclomedia/streetsmart-api').then((module) =>  module.default);
 /**
  * Get the Cyclomedia API instance (because the API is loaded in an iframe and fully handled in it, here it is not needed)

--- a/web/client/plugins/StreetView/components/CyclomediaView/CyclomediaView.js
+++ b/web/client/plugins/StreetView/components/CyclomediaView/CyclomediaView.js
@@ -19,6 +19,20 @@ const PROJECTION_NOT_AVAILABLE = "Projection not available";
 const isInvalidCredentials = (error) => {
     return error?.message?.indexOf?.("code 401");
 };
+const DEFAULT_STREET_SMART_API_URL = "https://streetsmart.cyclomedia.com/api/v26.1/StreetSmartApi.js";
+/**
+ * Checks that the configured StreetSmart API URL is a `cyclomedia.com` host, consistent with the
+ * other cyclomedia endpoints used by this provider.
+ * @private
+ */
+const isValidStreetSmartApiURL = (url) => {
+    try {
+        const { protocol, hostname } = new URL(url);
+        return protocol === 'https:' && (hostname === 'cyclomedia.com' || hostname.endsWith('.cyclomedia.com'));
+    } catch (e) {
+        return false;
+    }
+};
 /**
  * Parses the error message to show to the user in the alert an user friendly message
  * @private
@@ -89,7 +103,7 @@ const EmptyView = ({initializing, initialized, StreetSmartApi, mapPointVisible, 
 
 /**
  * CyclomediaView component. It uses the Cyclomedia API to show the street view.
- * API Documentation at https://streetsmart.cyclomedia.com/api/v23.14/documentation/
+ * API Documentation at https://streetsmart.cyclomedia.com/api/v26.1/documentation/
  * This component is a wrapper of the Cyclomedia API. It uses an iframe to load the API, because actually the API uses and initializes react-dnd,
  * that must be unique in the application and it is already created and initialized by MapStore.
  * @param {object} props the component props
@@ -107,7 +121,9 @@ const EmptyView = ({initializing, initialized, StreetSmartApi, mapPointVisible, 
  */
 
 const CyclomediaView = ({ apiKey, style, location = {}, setPov = () => {}, setLocation = () => {}, mapPointVisible, providerSettings = {}, refreshLayer = () => {}, onClose = () => {}}) => {
-    const StreetSmartApiURL = providerSettings?.StreetSmartApiURL ?? "https://streetsmart.cyclomedia.com/api/v23.7/StreetSmartApi.js";
+    const StreetSmartApiURL = isValidStreetSmartApiURL(providerSettings?.StreetSmartApiURL)
+        ? providerSettings.StreetSmartApiURL
+        : DEFAULT_STREET_SMART_API_URL;
     const scripts = providerSettings?.scripts ?? `
     <script type="text/javascript" src="https://unpkg.com/react@18.2.0/umd/react.production.min.js"></script>
     <script type="text/javascript" src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"></script>

--- a/web/client/plugins/StreetView/components/CyclomediaView/CyclomediaView.js
+++ b/web/client/plugins/StreetView/components/CyclomediaView/CyclomediaView.js
@@ -16,6 +16,7 @@ const CTButton = withConfirm(withTooltip(Button));
 import CyclomediaCredentials from './Credentials';
 import EmptyStreetView from '../EmptyStreetView';
 const PROJECTION_NOT_AVAILABLE = "Projection not available";
+const API_LOAD_FAILED = "StreetSmart API failed to load";
 const isInvalidCredentials = (error) => {
     return error?.message?.indexOf?.("code 401");
 };
@@ -26,6 +27,10 @@ const DEFAULT_STREET_SMART_API_URL = "https://streetsmart.cyclomedia.com/api/v26
  * @private
  */
 const isValidStreetSmartApiURL = (url) => {
+    if (url === '') {
+        // explicit empty string disables loading an external script (e.g. tests injecting their own mock via `scripts`)
+        return true;
+    }
     try {
         const { protocol, hostname } = new URL(url);
         return protocol === 'https:' && (hostname === 'cyclomedia.com' || hostname.endsWith('.cyclomedia.com'));
@@ -51,6 +56,9 @@ const getErrorMessage = (error, msgParams = {}) => {
     }
     if (error?.message?.indexOf?.("not logged in") >= 0) {
         return <HTML msgId="streetView.cyclomedia.errors.notLoggedIn" />;
+    }
+    if (error?.message?.indexOf?.(API_LOAD_FAILED) >= 0) {
+        return <Message msgId="streetView.cyclomedia.errors.apiLoadFailed" msgParams={msgParams} />;
     }
     return error?.message ?? "Unknown error";
 };
@@ -381,7 +389,12 @@ const CyclomediaView = ({ apiKey, style, location = {}, setPov = () => {}, setLo
             : null}
         <iframe key="iframe" ref={viewer} onLoad={() => {
             setTargetElement(viewer.current?.contentDocument.querySelector('#ms-street-smart-viewer-container'));
-            setStreetSmartApi(viewer.current?.contentWindow.StreetSmartApi);
+            const api = viewer.current?.contentWindow.StreetSmartApi;
+            if (!api) {
+                setError(new Error(API_LOAD_FAILED));
+                return;
+            }
+            setStreetSmartApi(api);
         }} style={{ ...style, display: showPanoramaViewer ? 'block' : 'none'}}  srcDoc={srcDoc}>
 
         </iframe>

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -4623,7 +4623,8 @@
         "errors": {
           "notLoggedIn": "Nicht angemeldet",
           "invalidCredentials": "Ungültige Anmeldeinformationen",
-          "projectionNotAvailable": "Die konfigurierte Projektion {srs} ist nicht verfügbar. Bitte kontaktieren Sie den Administrator."
+          "projectionNotAvailable": "Die konfigurierte Projektion {srs} ist nicht verfügbar. Bitte kontaktieren Sie den Administrator.",
+          "apiLoadFailed": "Die Street Smart API konnte nicht geladen werden. Bitte überprüfen Sie Ihre Netzwerkverbindung oder kontaktieren Sie den Administrator."
         },
         "reloadAPI": "API neu laden"
       },

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -4592,7 +4592,8 @@
         "errors": {
           "notLoggedIn": "You are not logged in",
           "invalidCredentials": "Invalid credentials",
-          "projectionNotAvailable": "The projection {srs} configured is not available. Please contact the administrator."
+          "projectionNotAvailable": "The projection {srs} configured is not available. Please contact the administrator.",
+          "apiLoadFailed": "Failed to load the Street Smart API. Please check your network connection or contact the administrator."
         },
         "reloadAPI": "Reload API"
       },

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -4580,7 +4580,8 @@
         "errors": {
           "notLoggedIn": "No ha iniciado sesión",
           "invalidCredentials": "Credenciales inválidas",
-          "projectionNotAvailable": "La proyección {srs} configurada no está disponible. Por favor, contacte al administrador."
+          "projectionNotAvailable": "La proyección {srs} configurada no está disponible. Por favor, contacte al administrador.",
+          "apiLoadFailed": "No se pudo cargar la API de Street Smart. Compruebe su conexión de red o contacte al administrador."
         },
         "reloadAPI": "Recargar API"
       },

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -4584,7 +4584,8 @@
         "errors": {
           "notLoggedIn": "Vous n'êtes pas connecté",
           "invalidCredentials": "Identifiants invalides",
-          "projectionNotAvailable": "La projection {srs} configurée n'est pas disponible. Veuillez contacter l'administrateur."
+          "projectionNotAvailable": "La projection {srs} configurée n'est pas disponible. Veuillez contacter l'administrateur.",
+          "apiLoadFailed": "Impossible de charger l'API Street Smart. Vérifiez votre connexion réseau ou contactez l'administrateur."
         },
         "reloadAPI": "Recharger l'API"
       },

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -4584,7 +4584,8 @@
         "errors": {
           "notLoggedIn": "Non sei loggato",
           "invalidCredentials": "Credenziali non valide",
-          "projectionNotAvailable": "La proiezione {srs} configurata non è disponibile. Contattare l'amministratore."
+          "projectionNotAvailable": "La proiezione {srs} configurata non è disponibile. Contattare l'amministratore.",
+          "apiLoadFailed": "Impossibile caricare l'API di Street Smart. Verificare la connessione di rete o contattare l'amministratore."
         },
         "reloadAPI": "Ricarica API"
       },


### PR DESCRIPTION
## Description

Cyclomedia's StreetSmart API endpoint hardcoded as default (`v23.7`) has been retired. Their server now falls back to serving their own web app shell (HTML, `200 OK`) instead of a 404, which Chrome blocks as an opaque response (`net::ERR_BLOCKED_BY_ORB`) when loaded as a script — so `window.StreetSmartApi` never gets defined and the plugin silently gets stuck.

Bump the default to the current `v26.1`, restrict `providerSettings.StreetSmartApiURL` to `cyclomedia.com` hosts (falls back to default otherwise), and surface a proper error message instead of an infinite loading spinner when the API script fails to load for any reason.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Opening the Cyclomedia Street View plugin, entering credentials and submitting shows no images — no error, no feedback, the panel just stays empty/stuck loading.
#12620

**What is the new behavior?**
The plugin loads the current, live StreetSmart API version (`v26.1`) by default, so images are displayed correctly after login. If the configured `StreetSmartApiURL` doesn't point to a `cyclomedia.com` host, the default is used instead. If the API script still fails to load for any reason (network issue, future version retirement, etc.), the plugin shows a clear error message instead of hanging indefinitely on the loading spinner.

## Breaking change
**Does this PR introduce a breaking change?**
 - [x] No

## Other useful information

- No new automated test covers the new "API failed to load" error path specifically — existing test suite passes (fixed a regression it would've otherwise hit, unrelated to the fix itself: `StreetSmartApiURL: ''` used by the test to inject a mock is preserved as a valid override).
- Cyclomedia doesn't version their API with a stable long-term alias — `v26.1` will eventually be retired the same way `v23.7` was. Worth keeping in mind for a future maintenance pass.
