### PR TITLE
Fix #12618: preserve and scope <style> in HTML GetFeatureInfo responses

### DIFF
--- a/web/client/components/data/identify/viewers/HTMLViewer.jsx
+++ b/web/client/components/data/identify/viewers/HTMLViewer.jsx
@@ -9,7 +9,7 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
-import HtmlRenderer from '../../../misc/HtmlRenderer';
+import ShadowHtml from '../../../misc/ShadowHtml';
 
 const regexpBody = /^[\s\S]*<body>([\s\S]*)<\/body>[\s\S]*$/i;
 const regexpStyle = /(<style[\s\=\w\/\"]*>[^<]*<\/style>)/i;
@@ -31,7 +31,9 @@ class HTMLViewer extends React.Component {
         style = style.replace(/body[,]+/g, '');
         // gets feature info managing an eventually empty response
         let content = response.replace(regexpBody, '$1').trim();
-        return <HtmlRenderer html={style + content} />;
+        // rendered in a shadow root (ShadowHtml) so the WMS <style> block is scoped
+        // to this panel and does not restyle the rest of the application.
+        return <ShadowHtml html={style + content} />;
     }
 }
 

--- a/web/client/components/data/identify/viewers/__tests__/viewers-test.jsx
+++ b/web/client/components/data/identify/viewers/__tests__/viewers-test.jsx
@@ -43,7 +43,27 @@ describe('Identity Viewers', () => {
         const cmpDom = ReactDOM.findDOMNode(cmp);
         expect(cmpDom).toExist();
 
-        expect(cmpDom.getElementsByClassName("testclass").length).toBe(1);
+        // content is rendered inside a shadow root, so it is not reachable via the
+        // host's normal DOM queries — query the shadow root instead.
+        expect(cmpDom.getElementsByClassName("testclass").length).toBe(0);
+        expect(cmpDom.shadowRoot).toExist();
+        expect(cmpDom.shadowRoot.querySelectorAll(".testclass").length).toBe(1);
+    });
+
+    it('HTMLViewer scopes the response <style> block inside the shadow root', () => {
+        const response = "<html><head><style>table.featureInfo{border:1px solid #ddd;}</style></head><body><table class='featureInfo'><tr><td>value</td></tr></table></body></html>";
+        const cmp = ReactDOM.render(<HTMLViewer response={response} />, document.getElementById("container"));
+        const cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom.shadowRoot).toExist();
+        // <style> preserved (regression #12618) but confined to the shadow root
+        expect(cmpDom.shadowRoot.querySelector("style")).toExist();
+        expect(cmpDom.shadowRoot.querySelector("table.featureInfo")).toExist();
+        // and it does NOT leak into the main document (light DOM has no style,
+        // and no document stylesheet carries the WMS rule)
+        expect(cmpDom.querySelector("style")).toNotExist();
+        const leaked = Array.from(document.querySelectorAll("style"))
+            .some((s) => s.textContent.indexOf("table.featureInfo") !== -1);
+        expect(leaked).toBe(false);
     });
 
     it('test TextViewer', () => {

--- a/web/client/components/misc/ShadowHtml.jsx
+++ b/web/client/components/misc/ShadowHtml.jsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, { useLayoutEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { sanitizeHtml } from '../../utils/HtmlSanitizer';
+
+/**
+ * Renders an HTML fragment inside a shadow root, so any <style> block it carries
+ * (e.g. from a WMS GetFeatureInfo HTML response) is scoped to this subtree instead
+ * of leaking into the whole document, and the application theme does not override
+ * the server-provided styling.
+ *
+ * The HTML is sanitized with DOMPurify before injection (scripts and event handlers
+ * are removed there); the shadow root's job here is CSS isolation, not sanitization.
+ *
+ * @param {string} html - untrusted HTML string
+ */
+const ShadowHtml = ({ html, id, style = { color: '#000000' } }) => {
+    const hostRef = useRef(null);
+    useLayoutEffect(() => {
+        const host = hostRef.current;
+        if (!host) {
+            return;
+        }
+        const root = host.shadowRoot || host.attachShadow({ mode: 'open' });
+        root.innerHTML = sanitizeHtml(html);
+    }, [html]);
+    // inherited properties (color, font) cross the shadow boundary from the host,
+    // so the default text color is preserved for the injected content.
+    return <div id={id} style={style} ref={hostRef} />;
+};
+
+ShadowHtml.propTypes = {
+    html: PropTypes.string,
+    id: PropTypes.string,
+    style: PropTypes.object
+};
+
+export default ShadowHtml;

--- a/web/client/components/misc/ShadowHtml.jsx
+++ b/web/client/components/misc/ShadowHtml.jsx
@@ -15,9 +15,6 @@ import { sanitizeHtml } from '../../utils/HtmlSanitizer';
  * of leaking into the whole document, and the application theme does not override
  * the server-provided styling.
  *
- * The HTML is sanitized with DOMPurify before injection (scripts and event handlers
- * are removed there); the shadow root's job here is CSS isolation, not sanitization.
- *
  * @param {string} html - untrusted HTML string
  */
 const ShadowHtml = ({ html, id, style = { color: '#000000' } }) => {

--- a/web/client/utils/HtmlSanitizer.js
+++ b/web/client/utils/HtmlSanitizer.js
@@ -15,15 +15,31 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
     }
 });
 
-// Sanitize CSS inside <style> elements: strip @import (external resource loading)
-// and url() with non-data schemes (data exfiltration via background-image).
+// Decode CSS backslash escapes (e.g. `u\72 l(` → `url(`) so escaped syntax
+// can't smuggle external-resource loaders past the checks below.
+const decodeCssEscapes = (css) => css
+    // A hex escape consumes one optional trailing whitespace; per CSS Syntax that
+    // whitespace set is space/tab/newline/carriage-return/form-feed, and \r\n counts
+    // as a single terminator. Match the browser exactly, else escaped url()/@import
+    // decode differently here than in the CSS parser and slip past the checks.
+    .replace(/\\([0-9a-fA-F]{1,6})(?:\r\n|[ \t\n\r\f])?/g, (match, hex) => {
+        const codePoint = parseInt(hex, 16);
+        return codePoint > 0 && codePoint <= 0x10FFFF ? String.fromCodePoint(codePoint) : '�';
+    })
+    .replace(/\\([^0-9a-fA-F\n])/g, '$1');
+
+// Sanitize CSS inside <style> elements: strip @import and image-set() (external
+// resource loading) and url() with non-data schemes (data exfiltration via
+// background-image). Escapes are decoded first so `\75rl(` can't bypass the checks.
 // <style> is needed for GetFeatureInfo HTML responses from WMS servers (HTMLViewer).
 DOMPurify.addHook('uponSanitizeElement', (node, data) => {
     if (data.tagName === 'style') {
-        const dangerous = /@import|url\s*\(\s*(?!['"]?data:)/i;
-        if (dangerous.test(node.textContent)) {
-            node.textContent = node.textContent
+        const decoded = decodeCssEscapes(node.textContent);
+        const dangerous = /@import|image-set\s*\(|url\s*\(\s*(?!['"]?data:)/i;
+        if (dangerous.test(decoded)) {
+            node.textContent = decoded
                 .replace(/@import[^;]*;?/gi, '')
+                .replace(/(-webkit-)?image-set\s*\([^)]*\)/gi, 'none')
                 .replace(/url\s*\(\s*(?!['"]?data:)[^)]*\)/gi, 'none');
         }
     }
@@ -86,7 +102,11 @@ const HTML_CONFIG = {
         // GeoStory scroll-to-section interaction links (onclick is stripped; handled via event delegation in Text.jsx)
         'data-geostory-interaction-type', 'data-geostory-interaction-params', 'data-geostory-interaction-name'
     ],
-    ADD_ATTR: ['allow']
+    ADD_ATTR: ['allow'],
+    // Without FORCE_BODY, the HTML parser hoists leading head-eligible elements
+    // (e.g. the <style> block of a WMS GetFeatureInfo HTML response) into <head>,
+    // which DOMPurify then discards. See #12618.
+    FORCE_BODY: true
 };
 
 /**

--- a/web/client/utils/HtmlSanitizer.js
+++ b/web/client/utils/HtmlSanitizer.js
@@ -103,9 +103,6 @@ const HTML_CONFIG = {
         'data-geostory-interaction-type', 'data-geostory-interaction-params', 'data-geostory-interaction-name'
     ],
     ADD_ATTR: ['allow'],
-    // Without FORCE_BODY, the HTML parser hoists leading head-eligible elements
-    // (e.g. the <style> block of a WMS GetFeatureInfo HTML response) into <head>,
-    // which DOMPurify then discards. See #12618.
     FORCE_BODY: true
 };
 

--- a/web/client/utils/HtmlSanitizer.js
+++ b/web/client/utils/HtmlSanitizer.js
@@ -28,9 +28,6 @@ const decodeCssEscapes = (css) => css
     })
     .replace(/\\([^0-9a-fA-F\n])/g, '$1');
 
-// Sanitize CSS inside <style> elements: strip @import and image-set() (external
-// resource loading) and url() with non-data schemes (data exfiltration via
-// background-image). Escapes are decoded first so `\75rl(` can't bypass the checks.
 // <style> is needed for GetFeatureInfo HTML responses from WMS servers (HTMLViewer).
 DOMPurify.addHook('uponSanitizeElement', (node, data) => {
     if (data.tagName === 'style') {

--- a/web/client/utils/__tests__/HtmlSanitizer-test.js
+++ b/web/client/utils/__tests__/HtmlSanitizer-test.js
@@ -67,20 +67,20 @@ describe('HtmlSanitizer', () => {
         });
 
         it('still sanitizes CSS inside a leading style block', () => {
-            const result = sanitizeHtml('<style>@import "https://evil.example/x.css"; div { background: url(https://evil.example/leak) }</style><p>hi</p>');
+            const result = sanitizeHtml('<style>@import "https://untr.example/x.css"; div { background: url(https://evil.example/leak) }</style><p>hi</p>');
             expect(result).toContain('<style>');
             expect(result).toNotContain('@import');
-            expect(result).toNotContain('https://evil.example');
+            expect(result).toNotContain('https://untr.example');
         });
 
         it('blocks url() smuggled via CSS backslash escapes', () => {
-            const result = sanitizeHtml('<style>div { background: u\\72 l(https://evil.example/leak) }</style><p>hi</p>');
-            expect(result).toNotContain('evil.example');
+            const result = sanitizeHtml('<style>div { background: u\\72 l(https://untr.example/leak) }</style><p>hi</p>');
+            expect(result).toNotContain('untr.example');
         });
 
         it('blocks external resource loading via image-set()', () => {
-            const result = sanitizeHtml('<style>div { background: image-set("https://evil.example/leak" 1x) }</style><p>hi</p>');
-            expect(result).toNotContain('evil.example');
+            const result = sanitizeHtml('<style>div { background: image-set("https://untr.example/leak" 1x) }</style><p>hi</p>');
+            expect(result).toNotContain('untr.example');
         });
 
         it('keeps benign CSS escapes intact (decoded)', () => {
@@ -92,8 +92,8 @@ describe('HtmlSanitizer', () => {
         it('blocks url() smuggled via form-feed/CR-terminated CSS escapes', () => {
             // hex escape terminated by form-feed (\f) and carriage-return (\r):
             // the browser consumes these as the escape terminator, so the decoder must too.
-            expect(sanitizeHtml('<style>div { background: u\\72\fl(https://evil.example/leak) }</style><p>hi</p>')).toNotContain('evil.example');
-            expect(sanitizeHtml('<style>div { background: u\\72\rl(https://evil.example/leak) }</style><p>hi</p>')).toNotContain('evil.example');
+            expect(sanitizeHtml('<style>div { background: u\\72\fl(https://untr.example/leak) }</style><p>hi</p>')).toNotContain('untr.example');
+            expect(sanitizeHtml('<style>div { background: u\\72\rl(https://untr.example/leak) }</style><p>hi</p>')).toNotContain('untr.example');
         });
 
         it('handles null input without throwing', () => {

--- a/web/client/utils/__tests__/HtmlSanitizer-test.js
+++ b/web/client/utils/__tests__/HtmlSanitizer-test.js
@@ -58,6 +58,44 @@ describe('HtmlSanitizer', () => {
             expect(result).toContain('referrerpolicy');
         });
 
+        it('preserves a leading style block (GetFeatureInfo HTML from WMS)', () => {
+            const input = '<style>table.featureInfo, table.featureInfo td, table.featureInfo th { border: 1px solid #ddd; }</style><table class="featureInfo"><tr><th>name</th></tr><tr><td>value</td></tr></table>';
+            const result = sanitizeHtml(input);
+            expect(result).toContain('<style>');
+            expect(result).toContain('table.featureInfo');
+            expect(result).toContain('<table class="featureInfo">');
+        });
+
+        it('still sanitizes CSS inside a leading style block', () => {
+            const result = sanitizeHtml('<style>@import "https://evil.example/x.css"; div { background: url(https://evil.example/leak) }</style><p>hi</p>');
+            expect(result).toContain('<style>');
+            expect(result).toNotContain('@import');
+            expect(result).toNotContain('https://evil.example');
+        });
+
+        it('blocks url() smuggled via CSS backslash escapes', () => {
+            const result = sanitizeHtml('<style>div { background: u\\72 l(https://evil.example/leak) }</style><p>hi</p>');
+            expect(result).toNotContain('evil.example');
+        });
+
+        it('blocks external resource loading via image-set()', () => {
+            const result = sanitizeHtml('<style>div { background: image-set("https://evil.example/leak" 1x) }</style><p>hi</p>');
+            expect(result).toNotContain('evil.example');
+        });
+
+        it('keeps benign CSS escapes intact (decoded)', () => {
+            const result = sanitizeHtml('<style>td::after { content: "\\2014"; color: red }</style><table><tr><td>v</td></tr></table>');
+            expect(result).toContain('<style>');
+            expect(result).toContain('color: red');
+        });
+
+        it('blocks url() smuggled via form-feed/CR-terminated CSS escapes', () => {
+            // hex escape terminated by form-feed (\f) and carriage-return (\r):
+            // the browser consumes these as the escape terminator, so the decoder must too.
+            expect(sanitizeHtml('<style>div { background: u\\72\fl(https://evil.example/leak) }</style><p>hi</p>')).toNotContain('evil.example');
+            expect(sanitizeHtml('<style>div { background: u\\72\rl(https://evil.example/leak) }</style><p>hi</p>')).toNotContain('evil.example');
+        });
+
         it('handles null input without throwing', () => {
             expect(() => sanitizeHtml(null)).toNotThrow();
             expect(sanitizeHtml(null)).toBe('');

--- a/web/client/utils/__tests__/HtmlSanitizer-test.js
+++ b/web/client/utils/__tests__/HtmlSanitizer-test.js
@@ -67,7 +67,7 @@ describe('HtmlSanitizer', () => {
         });
 
         it('still sanitizes CSS inside a leading style block', () => {
-            const result = sanitizeHtml('<style>@import "https://untr.example/x.css"; div { background: url(https://evil.example/leak) }</style><p>hi</p>');
+            const result = sanitizeHtml('<style>@import "https://untr.example/x.css"; div { background: url(https://untr.example/leak) }</style><p>hi</p>');
             expect(result).toContain('<style>');
             expect(result).toNotContain('@import');
             expect(result).toNotContain('https://untr.example');


### PR DESCRIPTION
## Description

Because DOMPurify parses its input as a full document, the leading `<style>` block that WMS servers (e.g. GeoServer) return in HTML GetFeatureInfo responses was hoisted into `<head>` and then dropped, leaving the `featureInfo` attribute table unstyled. This PR restores the styling by preserving that `<style>` block, scopes it to the identify panel via a shadow root so it can no longer restyle the rest of the application, and hardens the CSS sanitizer against external-resource loaders in a malicious style block.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#12618 — with HTML Feature Info format, the attribute table is rendered without its original styling (missing borders, header background, padding).

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
- The `<style>` block of the WMS HTML GetFeatureInfo response is preserved (`FORCE_BODY` in the DOMPurify config), so the `featureInfo` table renders with its server-provided styling again.
- That HTML is now rendered inside a shadow root (`ShadowHtml` component), so the WMS `<style>` is scoped to the identify panel instead of leaking into and restyling the whole application. HTML is still sanitized with DOMPurify befor provides CSS isolation, not
sanitization.
- The CSS sanitizer hook now also bls that previously slipped through:
`url()` smuggled via CSS backslash eng the full CSS whitespace terminator
set) and `image-set()`.

## Breaking change
**Does this PR introduce a breaking , remove the other)
 - [x] No

## Other useful information

