### PR TITLE
[Backport 2026.02.xx] Update OSM base URL in PrintUtils.js

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -888,7 +888,7 @@ export const specCreators = {
     },
     osm: {
         map: (layer = {}) => ({
-            "baseURL": "http://a.tile.openstreetmap.org/",
+            "baseURL": "https://tile.openstreetmap.org/",
             "opacity": getOpacity(layer),
             "singleTile": false,
             "type": "OSM",


### PR DESCRIPTION
# Description
Backport of #12633 to `2026.02.xx`.

Fixes #