### PR TITLE
Remove LayersSelection from pluginsConfig

### DIFF
--- a/project/standard/templates/configs/pluginsConfig.json
+++ b/project/standard/templates/configs/pluginsConfig.json
@@ -159,13 +159,6 @@
       "description": "plugins.Permalink.description"
     },
     {
-      "name": "LayersSelection",
-      "glyph": "hand-down",
-      "title": "plugins.LayersSelection.title",
-      "description": "plugins.LayersSelection.description",
-      "dependencies": ["SidebarMenu"]
-    },
-    {
       "name": "BackgroundSelector",
       "title": "plugins.BackgroundSelector.title",
       "description": "plugins.BackgroundSelector.description"

--- a/web/client/configs/pluginsConfig.json
+++ b/web/client/configs/pluginsConfig.json
@@ -159,13 +159,6 @@
       "description": "plugins.Permalink.description"
     },
     {
-      "name": "LayersSelection",
-      "glyph": "hand-down",
-      "title": "plugins.LayersSelection.title",
-      "description": "plugins.LayersSelection.description",
-      "dependencies": ["SidebarMenu"]
-    },
-    {
       "name": "BackgroundSelector",
       "title": "plugins.BackgroundSelector.title",
       "description": "plugins.BackgroundSelector.description"


### PR DESCRIPTION
## Description
This PR removes the LayersSelection plugin from pluginsConfig

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Task
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
- #12641

**What is the new behavior?**
User will not be able create context with LayersSelection plugin

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
