### PR TITLE
[Backport 2026.02.xx] Fix gzip_types in Docker nginx configuration

### DIFF
--- a/docker/mapstore.conf
+++ b/docker/mapstore.conf
@@ -23,9 +23,11 @@ server {
         application/json
         application/javascript
         application/x-javascript
-        text/xml application/xm
+        text/xml
+        application/xml
         application/xml+rss
-        text/javascript;
+        text/javascript
+        image/svg+xml;
 
     underscores_in_headers on;
     proxy_set_header HOST $host;


### PR DESCRIPTION
# Description
Backport of #12654 to `2026.02.xx`.

Fixes #12653