### PR TITLE
[Backport 2026.02.xx] #12617 - Ignore arcgis feature layer type from Print

### DIFF
--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -293,10 +293,11 @@ function mergeItems(standard, overrides) {
         .map(item => overrideItem(item, overrides))
         .map(handleRemoved);
 }
+const UNSUPPORTED_LAYER_TYPES = ["arcgis-feature", "cog"];
 
 function filterLayer(layer = {}) {
-    // Skip layer with error and type cog
-    return !layer.loadingError && layer.type !== "cog";
+    // Skip layer with error and unsupported type
+    return !layer.loadingError && !UNSUPPORTED_LAYER_TYPES.includes(layer.type);
 }
 
 export default {


### PR DESCRIPTION
# Description
Backport of #12626 to `2026.02.xx`.

Fixes #12617