### PR TITLE
#12670 Share plugin not showing in case of context resources 

### DIFF
--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -156,10 +156,11 @@ const ActionCardShareButton = connect(
 const shareButtonSelector = createSelector([
     mapIdSelector,
     dashboardResource,
-    geostoryResourceSelector
-], (mapId, dashboard, geostory) => {
+    geostoryResourceSelector,
+    currentContextSelector
+], (mapId, dashboard, geostory, context) => {
     return {
-        style: mapId || dashboard?.id || geostory?.id ? { } : { display: 'none' }
+        style: mapId || dashboard?.id || geostory?.id || context ? { } : { display: 'none' }
     };
 });
 

--- a/web/client/plugins/__tests__/Share-test.jsx
+++ b/web/client/plugins/__tests__/Share-test.jsx
@@ -66,6 +66,45 @@ describe('Share Plugin', () => {
         expect(containers.SidebarMenu).toContain({position: 1000, priority: 1, doNotHide: true});
     });
 
+    it('shows Share menu entries in a context with or without Permalink', () => {
+        const { containers } = getPluginForTest(SharePlugin, {}, {
+            ToolbarPlugin: {},
+            BurgerMenuPlugin: {},
+            SidebarMenuPlugin: {}
+        });
+
+        [
+            [{ name: 'Share' }],
+            [{ name: 'Share' }, { name: 'Permalink' }]
+        ].forEach((desktop) => {
+            const state = {
+                context: {
+                    currentContext: {
+                        plugins: { desktop }
+                    }
+                }
+            };
+
+            ['Toolbar', 'BurgerMenu', 'SidebarMenu'].forEach((container) => {
+                expect(containers[container].selector(state)).toEqual({ style: {} });
+            });
+        });
+    });
+
+    it('hides Share menu entries when there is no shareable resource or context', () => {
+        const { containers } = getPluginForTest(SharePlugin, {}, {
+            ToolbarPlugin: {},
+            BurgerMenuPlugin: {},
+            SidebarMenuPlugin: {}
+        });
+
+        ['Toolbar', 'BurgerMenu', 'SidebarMenu'].forEach((container) => {
+            expect(containers[container].selector({})).toEqual({
+                style: { display: 'none' }
+            });
+        });
+    });
+
     it('test Share plugin on close', (done) => {
         const controls = {
             share: {


### PR DESCRIPTION
## Description
In case of context maps the share plugin was not showing up.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12670 

**What is the new behavior?**
Share plugin now shows properly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
