### PR TITLE
Fix #12665 - Exclude backend outputs from dev server static watch in project template

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -22,6 +22,39 @@ This is a list of things to check if you want to update from a previous version 
 
 ## Migration from 2026.01.02 to 2026.02.00
 
+### Dev server static configuration moved to the webpack configuration files
+
+webpack-dev-server 5 (introduced with this release) watches the static directories by default and triggers a full page reload on every file change. Projects used to pass `--static .` on the command line, so the whole project root was watched: the logs and temporary files written by the local backend (`web/target`, `mapstore.log`) continuously triggered reloads, making the dev environment unusable (see [#12665](https://github.com/geosolutions-it/MapStore2/issues/12665)).
+
+In your project:
+
+- remove `--static .` from the `fe:start` and `fe:start-prod` scripts in `package.json` (make also sure `fe:start-prod` points to `prod-webpack.config.js`)
+- add the `devServer` configuration to your `webpack.config.js` and `prod-webpack.config.js`, as in the current project templates:
+
+```javascript
+const { devServer } = require('./MapStore2/build/devServer');
+
+module.exports = require('./MapStore2/build/buildConfig')({
+    // ...existing configuration...
+    devServer: {
+        devMiddleware: { publicPath: '/dist/' },
+        ...devServer,
+        static: [{
+            directory: __dirname,
+            watch: {
+                ignored: [
+                    '**/web/target/**',
+                    '**/logs/**',
+                    '**/*.log',
+                    '**/node_modules/**',
+                    '**/.git/**'
+                ]
+            }
+        }]
+    }
+});
+```
+
 ### Custom map resolutions moved from `new.json` to the `CRSSelector` plugin
 
 Custom map resolutions used to be declared in the default map configuration (`new.json`, or the project-level equivalent) under `mapOptions.view.resolutions`. That location was tied to a single projection and was not kept in sync when the CRS was changed at runtime, which could leave saved maps with a projection that did not match the persisted resolutions.

--- a/project/standard/templates/prod-webpack.config.js
+++ b/project/standard/templates/prod-webpack.config.js
@@ -4,6 +4,7 @@ const themeEntries = require('./MapStore2/build/themes.js').themeEntries;
 const extractThemesPlugin = require('./MapStore2/build/themes.js').extractThemesPlugin;
 const ModuleFederationPlugin = require('./MapStore2/build/moduleFederation').plugin;
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { devServer } = require('./MapStore2/build/devServer');
 
 const paths = {
     base: __dirname,
@@ -78,5 +79,23 @@ module.exports = require('./MapStore2/build/buildConfig')({
         "@mapstore/patcher": path.resolve(__dirname, "node_modules", "@mapstore", "patcher"),
         "@mapstore": path.resolve(__dirname, "MapStore2", "web", "client"),
         "@js": path.resolve(__dirname, "js")
+    },
+    devServer: {
+        devMiddleware: { publicPath: '/dist/' },
+        ...devServer,
+        // serve the project root as static content, excluding backend build
+        // and log files whose changes would trigger a full page reload
+        static: [{
+            directory: __dirname,
+            watch: {
+                ignored: [
+                    '**/web/target/**',
+                    '**/logs/**',
+                    '**/*.log',
+                    '**/node_modules/**',
+                    '**/.git/**'
+                ]
+            }
+        }]
     }
 });

--- a/project/standard/templates/webpack.config.js
+++ b/project/standard/templates/webpack.config.js
@@ -3,6 +3,7 @@ const path = require("path");
 const themeEntries = require('./MapStore2/build/themes.js').themeEntries;
 const extractThemesPlugin = require('./MapStore2/build/themes.js').extractThemesPlugin;
 const ModuleFederationPlugin = require('./MapStore2/build/moduleFederation').plugin;
+const { devServer } = require('./MapStore2/build/devServer');
 
 
 module.exports = require('./MapStore2/build/buildConfig')({
@@ -25,6 +26,24 @@ module.exports = require('./MapStore2/build/buildConfig')({
     publicPath: undefined,
     cssPrefix: '.__PROJECTNAME__',
     prodPlugins: [],
+    devServer: {
+        devMiddleware: { publicPath: '/dist/' },
+        ...devServer,
+        // serve the project root as static content, excluding backend build
+        // and log files whose changes would trigger a full page reload
+        static: [{
+            directory: __dirname,
+            watch: {
+                ignored: [
+                    '**/web/target/**',
+                    '**/logs/**',
+                    '**/*.log',
+                    '**/node_modules/**',
+                    '**/.git/**'
+                ]
+            }
+        }]
+    },
     alias: {
         "@mapstore/patcher": path.resolve(__dirname, "node_modules", "@mapstore", "patcher"),
         "@mapstore": path.resolve(__dirname, "MapStore2", "web", "client"),

--- a/utility/projects/projectScripts.json
+++ b/utility/projects/projectScripts.json
@@ -2,8 +2,8 @@
   "start": "npm run app:start",
   "app:start": "concurrently -n frontend,backend -c green,blue \"npm:fe:start\" \"npm:be:start\"",
 
-  "fe:start": "webpack serve --progress --color --port 8081 --hot --config webpack.config.js --static .",
-  "fe:start-prod": "webpack serve --progress --color --port 8081 --hot --config prod.webpack.config.js --static .",
+  "fe:start": "webpack serve --progress --color --port 8081 --hot --config webpack.config.js",
+  "fe:start-prod": "webpack serve --progress --color --port 8081 --hot --config prod-webpack.config.js",
   "fe:build": "npm run clean && mkdirp ./dist && webpack build --progress --color --config prod-webpack.config.js",
   "compile": "npm run fe:build",
 


### PR DESCRIPTION
## Description

Fixes #12665

In new projects, `npm start` became unusable after the webpack-dev-server 3 → 5 upgrade (#12409): the dev server now watches its static directories by default and triggers a full page reload on every file change. Project scripts passed `--static .`, so the whole project root was watched, including the backend outputs (`web/target`, tomcat logs). Every backend log write triggered a page reload, causing continuous reloads / infinite boot loops, most visibly when clicking "Print".

The main product is not affected because it serves `--static web/client`, which does not contain backend outputs.

### Changes

- `project/standard/templates/webpack.config.js` / `prod-webpack.config.js`: the dev server configuration now defines the static directory explicitly (project root, as before) with `watch.ignored` patterns excluding backend build outputs, logs and other churn sources (`web/target`, `logs`, `*.log`, `node_modules`, `.git`).
- `utility/projects/projectScripts.json`: removed `--static .` from `fe:start`/`fe:start-prod` (the static configuration now lives in the webpack config, where watch options can be applied — the CLI flag would override them). Also fixed the `fe:start-prod` config file name (`prod.webpack.config.js` → `prod-webpack.config.js`).
- migration guide: added instructions for existing projects.

Putting the `watch.ignored` options in the shared `MapStore2/build/devServer.js` was evaluated and discarded: the `--static` CLI flag overrides the whole `static` object from the configuration, so the ignore patterns would be lost (verified empirically).

### Verification

Tested on a project generated from the template with local backend (cargo) running:

- backend log writes (`mapstore.log`, access logs) no longer trigger page reloads
- live reload still works for legitimate static files in the project root
- Print produces the PDF correctly with no page reload

## Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

- Bug fix

## Does this PR introduce a breaking change?

- No