### PR TITLE
[Backport 2026.02.xx] #12670 Share plugin not showing in case of context resources 

### DIFF
--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -156,10 +156,11 @@ const ActionCardShareButton = connect(
 const shareButtonSelector = createSelector([
     mapIdSelector,
     dashboardResource,
-    geostoryResourceSelector
-], (mapId, dashboard, geostory) => {
+    geostoryResourceSelector,
+    currentContextSelector
+], (mapId, dashboard, geostory, context) => {
     return {
-        style: mapId || dashboard?.id || geostory?.id ? { } : { display: 'none' }
+        style: mapId || dashboard?.id || geostory?.id || context ? { } : { display: 'none' }
     };
 });
 

--- a/web/client/plugins/__tests__/Share-test.jsx
+++ b/web/client/plugins/__tests__/Share-test.jsx
@@ -66,6 +66,45 @@ describe('Share Plugin', () => {
         expect(containers.SidebarMenu).toContain({position: 1000, priority: 1, doNotHide: true});
     });
 
+    it('shows Share menu entries in a context with or without Permalink', () => {
+        const { containers } = getPluginForTest(SharePlugin, {}, {
+            ToolbarPlugin: {},
+            BurgerMenuPlugin: {},
+            SidebarMenuPlugin: {}
+        });
+
+        [
+            [{ name: 'Share' }],
+            [{ name: 'Share' }, { name: 'Permalink' }]
+        ].forEach((desktop) => {
+            const state = {
+                context: {
+                    currentContext: {
+                        plugins: { desktop }
+                    }
+                }
+            };
+
+            ['Toolbar', 'BurgerMenu', 'SidebarMenu'].forEach((container) => {
+                expect(containers[container].selector(state)).toEqual({ style: {} });
+            });
+        });
+    });
+
+    it('hides Share menu entries when there is no shareable resource or context', () => {
+        const { containers } = getPluginForTest(SharePlugin, {}, {
+            ToolbarPlugin: {},
+            BurgerMenuPlugin: {},
+            SidebarMenuPlugin: {}
+        });
+
+        ['Toolbar', 'BurgerMenu', 'SidebarMenu'].forEach((container) => {
+            expect(containers[container].selector({})).toEqual({
+                style: { display: 'none' }
+            });
+        });
+    });
+
     it('test Share plugin on close', (done) => {
         const controls = {
             share: {


### PR DESCRIPTION
# Description
Backport of #12671 to `2026.02.xx`.

Fixes #12670