### PR TITLE
Fix #12688 - Cap auto-refresh on recurring WMS tile load errors

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -3608,6 +3608,47 @@ describe('Openlayers layer', () => {
         // restore original method
         wmsSource.refresh = originalRefresh;
     });
+    it('wms layer should stop auto-refreshing after repeated loadingError within the cooldown window', () => {
+        var refreshCallCount = 0;
+        const options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms",
+            "id": "wms-loading-error-refresh-cap-test"
+        };
+
+        // create layer
+        ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+
+        const wmsSource = map.getLayers().item(0).getSource();
+        const originalRefresh = wmsSource.refresh;
+        wmsSource.refresh = function() {
+            refreshCallCount++;
+            originalRefresh.call(this);
+        };
+
+        // simulate the error state oscillating (fail, recover, fail, recover, ...) 5 times in a row,
+        // as happens when the underlying tile failure is intermittent rather than a one-off config mistake
+        for (let i = 0; i < 5; i++) {
+            ReactDOM.render(
+                <OpenlayersLayer type="wms"
+                    options={{...options, loadingError: "Error"}} map={map} />, document.getElementById("container"));
+            ReactDOM.render(
+                <OpenlayersLayer type="wms"
+                    options={{...options, loadingError: false}} map={map} />, document.getElementById("container"));
+        }
+
+        // refresh should be capped (MAX_LOADING_ERROR_REFRESH_ATTEMPTS = 3), not called once per oscillation (5)
+        expect(refreshCallCount).toBe(3);
+
+        // restore original method
+        wmsSource.refresh = originalRefresh;
+    });
     it('creates a arcgis layer (MapServer)', () => {
         const options = {
             type: 'arcgis',

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -35,6 +35,9 @@ import { OL_VECTOR_FORMATS, applyStyle } from '../../../../utils/openlayers/Vect
 import { proxySource, getWMSURLs, wmsToOpenlayersOptions, toOLAttributions, generateTileGrid } from '../../../../utils/openlayers/WMSUtils';
 
 const failTiles = new Set(); // registry of fail tile urls to prevent reloading loops
+const loadingErrorRefreshState = new Map(); // layer id -> { attempts, windowStart }
+const MAX_LOADING_ERROR_REFRESH_ATTEMPTS = 3; // caps refresh() retries within the cooldown window
+const LOADING_ERROR_REFRESH_COOLDOWN_MS = 30000; // window resets only after this much quiet time, NOT on every transient recovery (error/success can oscillate every render during a real loop, which would otherwise reset the counter before it ever caps)
 
 const loadFunction = (options, headers) => function(image, src) {
 
@@ -274,9 +277,19 @@ Layers.registerType('wms', {
         }
         // refresh/update wms layer if there is error in loading tiles like: incorrect time dimension date filter, ..etc
         if (oldOptions.loadingError !== "Error" && newOptions.loadingError === "Error") {
-            // Clear tile cache before refresh to avoid showing old broken tiles
-            wmsSource?.tileCache?.pruneExceptNewestZ?.();
-            wmsSource?.refresh();
+            const now = Date.now();
+            const prev = loadingErrorRefreshState.get(newOptions.id);
+            // only start a new cooldown window if the previous one has fully expired;
+            // do NOT reset on every transient recovery, or a fast error/success oscillation
+            // (a real reload loop) would clear the counter before it ever caps
+            const windowExpired = !prev || (now - prev.windowStart) > LOADING_ERROR_REFRESH_COOLDOWN_MS;
+            const attempts = windowExpired ? 1 : prev.attempts + 1;
+            loadingErrorRefreshState.set(newOptions.id, { attempts, windowStart: windowExpired ? now : prev.windowStart });
+            if (attempts <= MAX_LOADING_ERROR_REFRESH_ATTEMPTS) {
+                // Clear tile cache before refresh to avoid showing old broken tiles
+                wmsSource?.tileCache?.pruneExceptNewestZ?.();
+                wmsSource?.refresh();
+            }
         }
         if (oldOptions.minResolution !== newOptions.minResolution) {
             layer.setMinResolution(newOptions.minResolution === undefined ? 0 : newOptions.minResolution);


### PR DESCRIPTION
Closes #12688

Adds a per-layer attempt counter within a 30s cooldown window (`loadingErrorRefreshState`, `MAX_LOADING_ERROR_REFRESH_ATTEMPTS = 3`) capping how many times `wmsSource.refresh()` fires in response to a `loadingError` transition.

Why a cooldown window and not a reset-on-recovery counter: the error state genuinely oscillates during a real loop (fail, briefly recover, fail again), so resetting the counter on every recovery would defeat the cap before it ever engages — verified this empirically while testing the fix.

Verified locally against a real intermittently-failing backend: before the fix, the same tiles were re-requested 170+ times in 20s with 56 consecutive `refresh()` calls observed via instrumentation; after the fix, capped at 4 requests/tile (1 initial + 3 refreshes) and stable over 60+ seconds.