### PR TITLE
Fix #12689 - Remove unnecessary src=null on WMS tile load error

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -357,6 +357,40 @@ describe('Openlayers layer', () => {
             }, 200);
         });
     });
+    it('render wms singleTile layer with error does not request a spurious "null" url', (done) => {
+        mockAxios.onGet().reply(r => {
+            expect(r.url.indexOf('SAMPLE_URL') >= 0 ).toBeTruthy();
+            return [200, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<ows:ExceptionReport xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+            "  <ows:Exception exceptionCode=\"InvalidParameterValue\" locator=\"srsname\">\n" +
+            "    <ows:ExceptionText>msWFSGetFeature(): WFS server error. Invalid GetFeature Request</ows:ExceptionText>\n" +
+            "  </ows:Exception>\n" +
+            "</ows:ExceptionReport>"];
+        });
+        const options = {
+            type: 'wms',
+            visibility: true,
+            singleTile: true,
+            url: 'SAMPLE_URL',
+            name: 'osm:vector_tile'
+        };
+        const layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={{
+                ...options
+            }}
+            map={map} />, document.getElementById("container"));
+        expect(layer.layer.getSource()).toBeTruthy();
+        layer.layer.getSource().on('imageloaderror', (e) => {
+            setTimeout(() => {
+                // the error handler must not set img.src = null, which the DOM coerces
+                // to the literal string "null" and resolves into a spurious request
+                const img = e.image.getImage();
+                expect(img.getAttribute('src') === 'null' || (img.src || '').endsWith('/null')).toBe(false);
+                done();
+            }, 200);
+        });
+    });
     it('creates a tiled wms layer for openlayers map with long url', (done) => {
         let options = {
             "type": "wms",

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -40,6 +40,8 @@ import { addElevationTile, getElevationKey } from '../../../../utils/ElevationUt
 
 
 import { Map, View } from 'ol';
+import ImageState from 'ol/ImageState';
+import TileState from 'ol/TileState';
 import VectorSource from 'ol/source/Vector';
 import { defaults as defaultControls } from 'ol/control';
 
@@ -358,37 +360,108 @@ describe('Openlayers layer', () => {
         });
     });
     it('render wms singleTile layer with error does not request a spurious "null" url', (done) => {
-        mockAxios.onGet().reply(r => {
-            expect(r.url.indexOf('SAMPLE_URL') >= 0 ).toBeTruthy();
-            return [200, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-            "<ows:ExceptionReport xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+        ConfigUtils.setConfigProp('requestsConfigurationRules', [{
+            urlPattern: '.*\\/geoserver.*',
+            headers: {
+                Authorization: 'Bearer ${securityToken}'
+            }
+        }]);
+        setStore({
+            getState: () => ({
+                security: {
+                    token: "########-####-####-####-###########"
+                }
+            })
+        });
+        let request;
+        mockAxios.onGet().reply((r) => {
+            request = r;
+            return [200, new Blob(["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<ows:ExceptionReport xmlns:ows=\"http://www.opengis.net/ows\">\n" +
             "  <ows:Exception exceptionCode=\"InvalidParameterValue\" locator=\"srsname\">\n" +
-            "    <ows:ExceptionText>msWFSGetFeature(): WFS server error. Invalid GetFeature Request</ows:ExceptionText>\n" +
+            "    <ows:ExceptionText>WMS server error. Invalid GetMap Request</ows:ExceptionText>\n" +
             "  </ows:Exception>\n" +
-            "</ows:ExceptionReport>"];
+            "</ows:ExceptionReport>"], {type: 'text/xml'})];
         });
         const options = {
             type: 'wms',
             visibility: true,
             singleTile: true,
-            url: 'SAMPLE_URL',
-            name: 'osm:vector_tile'
+            url: '/geoserver/wms',
+            name: 'ws:layer'
         };
         const layer = ReactDOM.render(<OpenlayersLayer
             type="wms"
             options={{
                 ...options
             }}
-            map={map} />, document.getElementById("container"));
+            map={map}
+            securityToken="########-####-####-####-###########" />, document.getElementById("container"));
+        ConfigUtils.setConfigProp('requestsConfigurationRules', undefined);
         expect(layer.layer.getSource()).toBeTruthy();
-        layer.layer.getSource().on('imageloaderror', (e) => {
-            setTimeout(() => {
-                // the error handler must not set img.src = null, which the DOM coerces
-                // to the literal string "null" and resolves into a spurious request
-                const img = e.image.getImage();
-                expect(img.getAttribute('src') === 'null' || (img.src || '').endsWith('/null')).toBe(false);
-                done();
-            }, 200);
+        layer.layer.getSource().once('imageloaderror', (e) => {
+            // the custom load function must have been used, so the exception comes from the OGC response
+            expect(request).toBeTruthy();
+            expect(request.headers.Authorization).toBe('Bearer ########-####-####-####-###########');
+            // ol/Image has no setState, the error state must be notified anyway
+            expect(e.image.getState()).toBe(ImageState.ERROR);
+            // the error handler must not set img.src = null, which the DOM coerces
+            // to the literal string "null" and resolves into a spurious request
+            const img = e.image.getImage();
+            expect(img.getAttribute('src') === 'null' || (img.src || '').endsWith('/null')).toBe(false);
+            done();
+        });
+    });
+    it('render wms tiled layer with error does not request a spurious "null" url', (done) => {
+        ConfigUtils.setConfigProp('requestsConfigurationRules', [{
+            urlPattern: '.*\\/geoserver.*',
+            headers: {
+                Authorization: 'Bearer ${securityToken}'
+            }
+        }]);
+        setStore({
+            getState: () => ({
+                security: {
+                    token: "########-####-####-####-###########"
+                }
+            })
+        });
+        let request;
+        mockAxios.onGet().reply((r) => {
+            request = r;
+            return [200, new Blob(["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<ows:ExceptionReport xmlns:ows=\"http://www.opengis.net/ows\">\n" +
+            "  <ows:Exception exceptionCode=\"InvalidParameterValue\" locator=\"srsname\">\n" +
+            "    <ows:ExceptionText>WMS server error. Invalid GetMap Request</ows:ExceptionText>\n" +
+            "  </ows:Exception>\n" +
+            "</ows:ExceptionReport>"], {type: 'text/xml'})];
+        });
+        const options = {
+            type: 'wms',
+            visibility: true,
+            singleTile: false,
+            url: '/geoserver/wms',
+            name: 'ws:tiled_layer'
+        };
+        const layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={{
+                ...options
+            }}
+            map={map}
+            securityToken="########-####-####-####-###########" />, document.getElementById("container"));
+        ConfigUtils.setConfigProp('requestsConfigurationRules', undefined);
+        expect(layer.layer.getSource()).toBeTruthy();
+        layer.layer.getSource().once('tileloaderror', (e) => {
+            // the custom load function must have been used, so the exception comes from the OGC response
+            expect(request).toBeTruthy();
+            expect(request.headers.Authorization).toBe('Bearer ########-####-####-####-###########');
+            expect(e.tile.getState()).toBe(TileState.ERROR);
+            // the error handler must not set img.src = null, which the DOM coerces
+            // to the literal string "null" and resolves into a spurious request
+            const img = e.tile.getImage();
+            expect(img.getAttribute('src') === 'null' || (img.src || '').endsWith('/null')).toBe(false);
+            done();
         });
     });
     it('creates a tiled wms layer for openlayers map with long url', (done) => {

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -96,8 +96,7 @@ const loadFunction = (options, headers) => function(image, src) {
                         throw new Error(response.dataText);
                     }
                 }).catch(errorMessage => {
-                    image.getImage().src = null;   // needed to trigger the MS imageloaderror event in Map.onLayerError
-                    image.setState(3);            // set error state for tile and removed from the queue to prevent reloading loops
+                    image.setState(3);            // set error state for tile; this alone fires the source's tileloaderror/imageloaderror (state-based, no DOM event needed) and removes it from the queue to prevent reloading loops
                     failTiles.add(src);           // indexing fail url tile to prevent reloading loops
                     console.error(errorMessage);  // show ogc exception in console for debugging
                 });

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -20,6 +20,7 @@ import {optionsToVendorParams} from '../../../../utils/VendorParamsUtils';
 import {addAuthenticationToSLD, addAuthenticationParameter, getAuthenticationHeaders} from '../../../../utils/SecurityUtils';
 
 import ImageLayer from 'ol/layer/Image';
+import ImageState from 'ol/ImageState';
 import ImageWMS from 'ol/source/ImageWMS';
 import {get} from 'ol/proj';
 import TileLayer from 'ol/layer/Tile';
@@ -36,10 +37,26 @@ import { proxySource, getWMSURLs, wmsToOpenlayersOptions, toOLAttributions, gene
 
 const failTiles = new Set(); // registry of fail tile urls to prevent reloading loops
 
+/**
+ * Flags a tile/image as failed, so the source emits tileloaderror/imageloaderror
+ * and stops re-requesting it.
+ * Tiled layers get an `ol/ImageTile` (has `setState`), single tile layers get an
+ * `ol/Image`, that exposes no setter and needs the state change to be notified manually.
+ * @param {object} image the `ol/ImageTile` or `ol/Image` passed to the load function
+ */
+const setErrorState = (image) => {
+    if (image.setState) {
+        image.setState(ImageState.ERROR);
+        return;
+    }
+    image.state = ImageState.ERROR;
+    image.changed();
+};
+
 const loadFunction = (options, headers) => function(image, src) {
 
     if (failTiles.has(src)) {  // avoids custom reload in cases of tiles that have already returned exceptions
-        image.setState(3);
+        setErrorState(image);
         return;
     }
 
@@ -74,7 +91,7 @@ const loadFunction = (options, headers) => function(image, src) {
                 }
             }
         }).catch(e => {
-            image.setState(3);
+            setErrorState(image);
             failTiles.add(src);
             console.error(e);
         });
@@ -96,7 +113,7 @@ const loadFunction = (options, headers) => function(image, src) {
                         throw new Error(response.dataText);
                     }
                 }).catch(errorMessage => {
-                    image.setState(3);            // set error state for tile; this alone fires the source's tileloaderror/imageloaderror (state-based, no DOM event needed) and removes it from the queue to prevent reloading loops
+                    setErrorState(image);         // set error state for tile and removed from the queue to prevent reloading loops
                     failTiles.add(src);           // indexing fail url tile to prevent reloading loops
                     console.error(errorMessage);  // show ogc exception in console for debugging
                 });


### PR DESCRIPTION
Closes #12689

Removes `image.getImage().src = null;` from the tile load error handler in `WMSLayer.js`. Assigning `null` to an `<img>`'s `src` coerces to the literal string `"null"`, causing a real (always-404) request to a relative URL named `null`.

The line immediately after it, `image.setState(3)`, already sets OpenLayers' internal tile/image state to `ERROR`. Traced through `ol/source/UrlTile.js` (`handleTileChange`) and `ol/source/Image.js` (`handleImageChange`): both dispatch `tileloaderror`/`imageloaderror` purely based on that internal state, synchronously, with no dependency on the `<img>` element's native `error` DOM event. So the `src = null` line isn't needed for the error signal MapStore listens for (`Map.onLayerError`) — it's redundant, and its only effect is the spurious network request.

Verified locally: removing the line eliminates the `/null` requests while the layer's error state and `onLayerError` still propagate correctly.