### PR TITLE
Support enable/disable rules on request configuration rules

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -208,6 +208,20 @@ For configuring plugins, see the [Configuring Plugins Section](plugins-documenta
     }
     ```
 
+  - `enabled` - Optional, a plain boolean or a plugin expression string (same syntax as a plugin's `disablePluginIf`) to
+    conditionally apply the rule, e.g. based on the current user's groups. Rules without `enabled` are always applied.
+    Example:
+
+    ```json
+    {
+      "urlPattern": ".*geoserver.*",
+      "params": {
+        "authkey": "${securityToken}"
+      },
+      "enabled": "{includes(state('usergroups'), 'editor')}"
+    }
+    ```
+
 !!! note "Backward Compatibility"
     The old `useAuthenticationRules` and `authenticationRules` configuration still works and will be automatically converted to the new format. However, the new format is recommended for better flexibility and features like expiration support.
 

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -20,6 +20,7 @@ import castArray from "lodash/castArray";
 
 import {setStore as stateSetStore, getState} from "./StateUtils";
 import { parseUrl, WMS_GET_CAPABILITIES_VERSION } from '../api/WMS';
+import { getMonitoredState, handleExpression } from './PluginsUtils';
 
 export const USER_GROUP_ALL = 'everyone';
 
@@ -249,6 +250,20 @@ export const convertAuthenticationRulesToRequestConfiguration = (authRules = [])
 };
 
 /**
+ * Checks a request configuration rule's `enabled` property.
+ * `enabled` can be a plain boolean or a plugin expression string (e.g. `"{state('usergroups').includes('editor')}"`),
+ * evaluated with the same syntax used for `cfg.disablePluginIf` (see `PluginsUtils.handleExpression`).
+ * Rules without an `enabled` property are always applied.
+ * @param {object} rule the request configuration rule
+ * @returns {boolean} true if the rule's `enabled` resolves to a truthy value
+ */
+const isRuleEnabled = (rule) => {
+    const enabled = rule?.enabled ?? true;
+    const monitoredState = getMonitoredState(getState());
+    return !!handleExpression((path) => get(monitoredState, path), undefined, enabled);
+};
+
+/**
  * Gets all request configuration rules from Redux state or config
  * Automatically converts authenticationRules to new format if requestsConfigurationRules is missing
  * @returns {Array} Array of request configuration rules
@@ -257,19 +272,19 @@ export const getRequestConfigurationRules = () => {
     // First try to get from Redux state (if available)
     const stateRules = get(getState(), 'security.rules', []);
     if (!isEmpty(stateRules)) {
-        return stateRules;
+        return stateRules.filter(isRuleEnabled);
     }
 
     // Try to get new format from config
     const configRules = ConfigUtils.getConfigProp('requestsConfigurationRules');
     if (!isEmpty(configRules)) {
-        return configRules;
+        return configRules.filter(isRuleEnabled);
     }
 
     // If new format is missing, convert old authenticationRules format
     const authRules = ConfigUtils.getConfigProp('authenticationRules');
     if (!isEmpty(authRules)) {
-        return convertAuthenticationRulesToRequestConfiguration(authRules);
+        return convertAuthenticationRulesToRequestConfiguration(authRules).filter(isRuleEnabled);
     }
 
     // No rules found

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -14,6 +14,7 @@ import head from "lodash/head";
 import isNil from "lodash/isNil";
 import isArray from "lodash/isArray";
 import isEmpty from "lodash/isEmpty";
+import isString from "lodash/isString";
 import template from "lodash/template";
 import get from "lodash/get";
 import castArray from "lodash/castArray";
@@ -250,17 +251,20 @@ export const convertAuthenticationRulesToRequestConfiguration = (authRules = [])
 };
 
 /**
- * Checks a request configuration rule's `enabled` property.
- * `enabled` can be a plain boolean or a plugin expression string (e.g. `"{state('usergroups').includes('editor')}"`),
+ * Filters out the request configuration rules whose `enabled` property resolves to a falsy value.
+ * `enabled` can be a plain boolean or a plugin expression string (e.g. `"{includes(state('usergroups'), 'editor')}"`),
  * evaluated with the same syntax used for `cfg.disablePluginIf` (see `PluginsUtils.handleExpression`).
  * Rules without an `enabled` property are always applied.
- * @param {object} rule the request configuration rule
- * @returns {boolean} true if the rule's `enabled` resolves to a truthy value
+ * The monitored state is resolved only when at least one rule needs it, because building it requires
+ * serializing every monitored entry.
+ * @param {object[]} rules the request configuration rules
+ * @returns {object[]} the enabled rules
  */
-const isRuleEnabled = (rule) => {
-    const enabled = rule?.enabled ?? true;
-    const monitoredState = getMonitoredState(getState());
-    return !!handleExpression((path) => get(monitoredState, path), undefined, enabled);
+const filterEnabledRules = (rules = []) => {
+    const needsMonitoredState = rules.some(rule => isString(rule?.enabled));
+    const monitoredState = needsMonitoredState ? getMonitoredState(getState(), ConfigUtils.getConfigProp('monitorState')) : {};
+    const getMonitored = (path) => get(monitoredState, path);
+    return rules.filter(rule => !!handleExpression(getMonitored, undefined, rule?.enabled ?? true));
 };
 
 /**
@@ -272,19 +276,19 @@ export const getRequestConfigurationRules = () => {
     // First try to get from Redux state (if available)
     const stateRules = get(getState(), 'security.rules', []);
     if (!isEmpty(stateRules)) {
-        return stateRules.filter(isRuleEnabled);
+        return filterEnabledRules(stateRules);
     }
 
     // Try to get new format from config
     const configRules = ConfigUtils.getConfigProp('requestsConfigurationRules');
     if (!isEmpty(configRules)) {
-        return configRules.filter(isRuleEnabled);
+        return filterEnabledRules(configRules);
     }
 
     // If new format is missing, convert old authenticationRules format
     const authRules = ConfigUtils.getConfigProp('authenticationRules');
     if (!isEmpty(authRules)) {
-        return convertAuthenticationRulesToRequestConfiguration(authRules).filter(isRuleEnabled);
+        return filterEnabledRules(convertAuthenticationRulesToRequestConfiguration(authRules));
     }
 
     // No rules found

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -509,6 +509,51 @@ describe('Test security utils methods', () => {
             expect(result.length).toBe(2);
             expect(result[0].urlPattern).toBe('.*geoserver.*');
         });
+
+        it('should keep rules without an enabled property', () => {
+            const rulesInConfig = [
+                { urlPattern: '.*api.*', headers: { 'Authorization': 'Bearer ${securityToken}' } }
+            ];
+            setSecurityInfo({});
+            ConfigUtils.setConfigProp('requestsConfigurationRules', rulesInConfig);
+
+            const result = SecurityUtils.getRequestConfigurationRules();
+            expect(result).toEqual(rulesInConfig);
+        });
+
+        it('should filter out rules with enabled: false', () => {
+            const rulesInConfig = [
+                { urlPattern: '.*api.*', enabled: false, headers: { 'Authorization': 'Bearer ${securityToken}' } }
+            ];
+            setSecurityInfo({});
+            ConfigUtils.setConfigProp('requestsConfigurationRules', rulesInConfig);
+
+            const result = SecurityUtils.getRequestConfigurationRules();
+            expect(result.length).toBe(0);
+        });
+
+        it('should filter out rules whose enabled expression resolves to false', () => {
+            const rulesInConfig = [
+                { urlPattern: '.*api.*', enabled: "{includes(state('usergroups'), 'editor')}" }
+            ];
+            setSecurityInfo({ user: { groups: { group: [] } } });
+            ConfigUtils.setConfigProp('requestsConfigurationRules', rulesInConfig);
+
+            const result = SecurityUtils.getRequestConfigurationRules();
+            expect(result.length).toBe(0);
+        });
+
+        it('should keep rules whose enabled expression resolves to true against usergroups state', () => {
+            const rulesInConfig = [
+                { urlPattern: '.*api.*', enabled: "{includes(state('usergroups'), 'editor')}" }
+            ];
+            setSecurityInfo({ user: { groups: { group: [{ groupName: 'editor', enabled: true }] } } });
+            ConfigUtils.setConfigProp('requestsConfigurationRules', rulesInConfig);
+
+            const result = SecurityUtils.getRequestConfigurationRules();
+            expect(result.length).toBe(1);
+            expect(result[0].urlPattern).toBe('.*api.*');
+        });
     });
 
     describe('getAuthKeyParameter', () => {

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -480,6 +480,10 @@ describe('Test security utils methods', () => {
     });
 
     describe('getRequestConfigurationRules', () => {
+        afterEach(() => {
+            ConfigUtils.removeConfigProp('monitorState');
+        });
+
         it('should return rules from Redux state first', () => {
             const rulesInState = [
                 { urlPattern: '.*api.*', headers: { 'Authorization': 'Bearer ${securityToken}' } }
@@ -548,6 +552,33 @@ describe('Test security utils methods', () => {
                 { urlPattern: '.*api.*', enabled: "{includes(state('usergroups'), 'editor')}" }
             ];
             setSecurityInfo({ user: { groups: { group: [{ groupName: 'editor', enabled: true }] } } });
+            ConfigUtils.setConfigProp('requestsConfigurationRules', rulesInConfig);
+
+            const result = SecurityUtils.getRequestConfigurationRules();
+            expect(result.length).toBe(1);
+            expect(result[0].urlPattern).toBe('.*api.*');
+        });
+
+        it('should evaluate enabled expressions on rules mixed with rules without enabled', () => {
+            const rulesInConfig = [
+                { urlPattern: '.*always.*' },
+                { urlPattern: '.*editor.*', enabled: "{includes(state('usergroups'), 'editor')}" },
+                { urlPattern: '.*admin.*', enabled: "{includes(state('usergroups'), 'admin')}" }
+            ];
+            setSecurityInfo({ user: { groups: { group: [{ groupName: 'editor', enabled: true }] } } });
+            ConfigUtils.setConfigProp('requestsConfigurationRules', rulesInConfig);
+
+            const result = SecurityUtils.getRequestConfigurationRules();
+            expect(result.length).toBe(2);
+            expect(result.map(rule => rule.urlPattern)).toEqual(['.*always.*', '.*editor.*']);
+        });
+
+        it('should evaluate enabled expressions against monitorState entries from configuration', () => {
+            const rulesInConfig = [
+                { urlPattern: '.*api.*', enabled: "{includes(state('customrole'), 'ADMIN')}" }
+            ];
+            ConfigUtils.setConfigProp('monitorState', [{ name: 'customrole', path: 'security.user.role' }]);
+            setSecurityInfo({ user: { role: 'ADMIN' } });
             ConfigUtils.setConfigProp('requestsConfigurationRules', rulesInConfig);
 
             const result = SecurityUtils.getRequestConfigurationRules();


### PR DESCRIPTION
Fixes #12704

## Summary
- Entries in `requestsConfigurationRules` (and legacy `authenticationRules`) can now declare an `enabled` property: a plain boolean or a plugin expression string (same syntax as `cfg.disablePluginIf`), e.g. `"{includes(state('usergroups'), 'editor')}"`.
- Rules without `enabled` keep the current behaviour (always applied).
- Reuses the existing `PluginsUtils.handleExpression`/`getMonitoredState` machinery, no new expression syntax introduced.
- Docs updated in `local-config.md`.

## Test plan
- [x] Added tests in `SecurityUtils-test.js`: no `enabled` property, `enabled: false`, expression resolving false, expression resolving true against `state('usergroups')`.
- [x] Ran the full `SecurityUtils-test.js` suite locally via karma (chrome headless) — 59/59 passing, no regressions.