### PR TITLE
Bump master to 1.13-SNAPSHOT and align standard pom template

### DIFF
--- a/binary/bin-war/pom.xml
+++ b/binary/bin-war/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>it.geosolutions.mapstore</groupId>
         <artifactId>mapstore-binary</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.13-SNAPSHOT</version>
     </parent>
     <groupId>it.geosolutions.mapstore</groupId>
     <artifactId>mapstore-bin-war</artifactId>
     <packaging>war</packaging>
-    <version>1.12-SNAPSHOT</version>
+    <version>1.13-SNAPSHOT</version>
     <name>MapStore 2 Release Module WAR</name>
     <description>Creates the war for the binary package, adding customization (e.g. h2 database)</description>
     <url>http://www.geo-solutions.it</url>

--- a/binary/pom.xml
+++ b/binary/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>it.geosolutions.mapstore</groupId>
         <artifactId>mapstore-root</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.13-SNAPSHOT</version>
     </parent>
     <groupId>it.geosolutions.mapstore</groupId>
     <artifactId>mapstore-binary</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>it.geosolutions.mapstore</groupId>
         <artifactId>mapstore-root</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.13-SNAPSHOT</version>
     </parent>
 
     <groupId>it.geosolutions.mapstore</groupId>

--- a/java/printing/pom.xml
+++ b/java/printing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>it.geosolutions.mapstore</groupId>
         <artifactId>mapstore-java</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.13-SNAPSHOT</version>
     </parent>
 
     <groupId>it.geosolutions.mapstore</groupId>

--- a/java/services/pom.xml
+++ b/java/services/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>it.geosolutions.mapstore</groupId>
         <artifactId>mapstore-java</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.13-SNAPSHOT</version>
     </parent>
 
     <groupId>it.geosolutions.mapstore</groupId>

--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>it.geosolutions.mapstore</groupId>
         <artifactId>mapstore-java</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.13-SNAPSHOT</version>
     </parent>
 
     <groupId>it.geosolutions.mapstore</groupId>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapstore2",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "MapStore 2",
   "repository": "https://github.com/geosolutions-it/MapStore2",
   "main": "index.js",

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>it.geosolutions.mapstore</groupId>
     <artifactId>mapstore-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.12-SNAPSHOT</version>
+    <version>1.13-SNAPSHOT</version>
     <name>MapStore Root</name>
 
     <properties>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>it.geosolutions.mapstore</groupId>
         <artifactId>mapstore-root</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.13-SNAPSHOT</version>
     </parent>
     <groupId>it.geosolutions.mapstore</groupId>
     <artifactId>mapstore-product</artifactId>

--- a/project/standard/templates/pom.xml
+++ b/project/standard/templates/pom.xml
@@ -30,7 +30,7 @@
         <mockito-core.version>4.0.0</mockito-core.version>
         <cargo.version>1.10.2</cargo.version>
         <!-- MapStore‑specific -->
-        <mapstore-services.version>1.10-SNAPSHOT</mapstore-services.version>
+        <mapstore-services.version>1.13-SNAPSHOT</mapstore-services.version>
         <geostore-webapp.version>2.6-SNAPSHOT</geostore-webapp.version>
         <http_proxy.version>1.6-SNAPSHOT</http_proxy.version>
         <print-lib.version>2.3.5</print-lib.version>


### PR DESCRIPTION


## Description
2026.02.xx was cut at 1.12-SNAPSHOT but master was never bumped. Also fixes the stale mapstore-services.version in the standard pom template (root cause of #12705, never updated by cut_major_branch).

Fix #12705
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**

Fix #12705

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
