### PR TITLE
Align standard pom template to 1.11-SNAPSHOT

### DIFF
--- a/project/standard/templates/pom.xml
+++ b/project/standard/templates/pom.xml
@@ -29,7 +29,7 @@
         <mockito-core.version>4.0.0</mockito-core.version>
         <cargo.version>1.10.2</cargo.version>
         <!-- MapStore‑specific -->
-        <mapstore-services.version>1.10-SNAPSHOT</mapstore-services.version>
+        <mapstore-services.version>1.11-SNAPSHOT</mapstore-services.version>
         <geostore-webapp.version>2.5-SNAPSHOT</geostore-webapp.version>
         <http_proxy.version>1.5.0</http_proxy.version>
         <print-lib.version>2.3.4</print-lib.version>


### PR DESCRIPTION
## Description
Aligns the stale `mapstore-services.version` in the standard pom template on 2026.01.xx.

The branch's own version is already `1.11-SNAPSHOT` (root pom / java modules) but the standard project template still points to `1.10-SNAPSHOT`. Same root cause as #12705: `cut_major_branch` never updates `project/standard/templates/pom.xml`.

## Issue
#12705

## Breaking change
- [x] No