### PR TITLE
Publish Docker image from Create Release workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -12,6 +12,11 @@ on:
       previousVersion:
         description: 'Previous version to release, for full changelog link generation (format: `YYYY.MM.mm`)'
         required: true
+      dockerTagLatest:
+        description: 'Also tag the Docker image as `latest` and push it. Disable for patch releases of older branches.'
+        required: false
+        type: boolean
+        default: true
 jobs:
   ################
   # Build
@@ -121,7 +126,7 @@ jobs:
             - **[Fixed bugs](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%22${{ github.event.inputs.version }}%22+is%3Aclosed+label%3Abug)**
             - **[Closed issues](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%22${{ github.event.inputs.version }}%22+is%3Aclosed)**
             - **[MapStore Extension release v${{ github.event.inputs.version }}](https://github.com/geosolutions-it/MapStoreExtension/releases/tag/v${{ github.event.inputs.version }})**
-            - **[Docker image v${{ github.event.inputs.version }}](xxx)** `< TODO: add this link manually`
+            - **Docker image v${{ github.event.inputs.version }}**: `docker pull geosolutionsit/mapstore2:${{ github.event.inputs.version }}`
             - **[MapStore documentation v${{ github.event.inputs.version }}](https://docs.mapstore.geosolutionsgroup.com/en/v${{ github.event.inputs.version }}/)**
           draft: true
           prerelease: false
@@ -155,3 +160,47 @@ jobs:
           asset_path: artifacts/mapstore-printing.zip
           asset_name: mapstore-printing.zip
           asset_content_type: application/zip
+  ################
+  # Docker image build & push
+  ################
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: "checking out"
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      - name: "Download war"
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: release-war
+          path: product/target/
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Compute image tags
+        id: tags
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "geosolutionsit/mapstore2:${{ github.event.inputs.version }}"
+            if [ "${{ github.event.inputs.dockerTagLatest }}" = "true" ]; then
+              echo "geosolutionsit/mapstore2:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          no-cache: true
+          build-args: |
+            MAPSTORE_WEBAPP_SRC=./product/target/mapstore.war
+          tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
## Description

Ports the Jenkins **MapStore2 Stable Releaser** Docker job into the `Create Release` GitHub Action (`.github/workflows/create_release.yml`), so the release Docker image is built and pushed to Docker Hub (`geosolutionsit/mapstore2`) directly from the release workflow instead of a separate Jenkins pipeline.

The new `docker` job reuses the `mapstore.war` already produced by the existing `build` job (no second build), then builds and pushes the image, replicating the Jenkins step:

- `Dockerfile` at repo root, context `.`, `--no-cache`
- build arg `MAPSTORE_WEBAPP_SRC=./product/target/mapstore.war`
- tags `geosolutionsit/mapstore2:<version>` and (optionally) `:latest`

An input `dockerTagLatest` (default `true`) controls whether `latest` is also pushed — the Jenkins job always pushed `latest`; this lets us disable it for patch releases of older stable branches so they don't overwrite `latest`.

The `Docker image` entry in the generated release notes now shows the `docker pull geosolutionsit/mapstore2:<version>` command instead of the manual `TODO` (a tags/search URL is avoided on purpose: its prefix match would expose the internal `-stable` tag).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] CI related changes

## Issue

**What is the current behavior?**

The release Docker image (`geosolutionsit/mapstore2`) is built and published by a separate Jenkins job (*MapStore2 Stable Releaser*), decoupled from the GitHub `Create Release` workflow. The release notes contain a manual `TODO` placeholder for the Docker image link.

**What is the new behavior?**

`Create Release` builds and pushes the Docker image itself, in a `docker` job that runs after `build` and reuses the built war. The release notes link directly to the Docker Hub tag.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

## Other useful information

### One-time configuration required before the next release

Add two repository secrets (**Settings → Secrets and variables → Actions**):

| Secret | Value |
| ------ | ----- |
| `DOCKERHUB_USERNAME` | Docker Hub user with push rights on `geosolutionsit/mapstore2` |
| `DOCKERHUB_TOKEN` | Docker Hub access token (scope: read/write on that repo) |

These replace the Jenkins `config.json` file credential (`d12a6af3-…`).

### Running the release with Docker publish

1. Run the `Create Release` workflow (as today) from the stable branch.
2. `version` / `previousVersion` as usual.
3. `dockerTagLatest`:
   - **`true`** (default) for the newest release → also updates `:latest`.
   - **`false`** for a patch on an older branch → publishes only `:<version>`, leaves `:latest` untouched.

### Not ported from Jenkins (intentional)

- Final `docker rmi` / `docker image prune` cleanup — GitHub runners are ephemeral.
- Downstream `MapStore2-Stable-Releaser-EndPointTests` trigger — out of scope of image publishing.
- The war is reused from the `build` job artifact instead of being rebuilt inside the docker step.
