### PR TITLE
Fix #12728: add missing entityManager bean to LDAP security config

### DIFF
--- a/product/config/ldap/geostore-spring-security-ldap.xml
+++ b/product/config/ldap/geostore-spring-security-ldap.xml
@@ -29,6 +29,13 @@
 		<security:anonymous />
         <security:intercept-url pattern="/**" access="permitAll" />
 	</security:http>
+
+    <bean id="entityManager"
+          class="org.springframework.orm.jpa.support.SharedEntityManagerBean">
+        <property name="entityManagerFactory" ref="geostoreEntityManagerFactory"/>
+        <property name="persistenceUnitName" value="geostore"/>
+    </bean>
+
 	<!-- Entry point -->
 	<bean id="restAuthenticationEntryPoint" class="it.geosolutions.geostore.services.rest.security.RestAuthenticationEntryPoint" >
 		<property name="realmName" value="GeoStore"></property>

--- a/web/src/config/ldap/geostore-spring-security-ldap.xml
+++ b/web/src/config/ldap/geostore-spring-security-ldap.xml
@@ -29,6 +29,13 @@
 		<security:anonymous />
         <security:intercept-url pattern="/**" access="permitAll" />
 	</security:http>
+
+    <bean id="entityManager"
+          class="org.springframework.orm.jpa.support.SharedEntityManagerBean">
+        <property name="entityManagerFactory" ref="geostoreEntityManagerFactory"/>
+        <property name="persistenceUnitName" value="geostore"/>
+    </bean>
+
 	<!-- Entry point -->
 	<bean id="restAuthenticationEntryPoint" class="it.geosolutions.geostore.services.rest.security.RestAuthenticationEntryPoint" >
 		<property name="realmName" value="GeoStore"></property>


### PR DESCRIPTION
## Description

The Spring 7 upgrade (#12428) added `depends-on="entityManager"` to the GeoStore token filters in both the db and ldap security configurations. It also added the `entityManager` bean definition, but only to the db configurations. The ldap configurations reference the bean without defining it, so building with the `ldap` profile fails during context initialization:

```
'authenticationTokenProcessingFilter' depends on missing bean 'entityManager'
Caused by: NoSuchBeanDefinitionException: No bean named 'entityManager' available
Context [/mapstore] startup failed
```

The web context never loads, and the application returns 404.

## Fix

Add the `entityManager` bean (the same one already present in the db configurations) to both ldap security configuration files:

- `product/config/ldap/geostore-spring-security-ldap.xml` (used by the product WAR)
- `web/src/config/ldap/geostore-spring-security-ldap.xml`

## Testing

Built the product with the `ldap` profile and ran it against the acme-ldap test server from the LDAP documentation.

- Before the fix: context initialization fails, application returns 404.
- After the fix: Tomcat starts cleanly, the app loads, and login with an LDAP account works (bill/hello authenticates with the ADMIN role).

Closes #12728
