### PR TITLE
Align standard pom template mapstore-services.version to 1.13-SNAPSHOT

### DIFF
--- a/project/standard/templates/pom.xml
+++ b/project/standard/templates/pom.xml
@@ -30,7 +30,7 @@
         <cargo.version>1.10.27</cargo.version>
 
         <!-- MapStore‑specific -->
-        <mapstore-services.version>1.12-SNAPSHOT</mapstore-services.version>
+        <mapstore-services.version>1.13-SNAPSHOT</mapstore-services.version>
         <geostore-webapp.version>2.7-SNAPSHOT</geostore-webapp.version>
         <http_proxy.version>1.7-SNAPSHOT</http_proxy.version>
         <print-lib.version>2.5-SNAPSHOT</print-lib.version>


### PR DESCRIPTION
## Description

Realigns the standard project pom template to the current master snapshot version.

`project/standard/templates/pom.xml` had `mapstore-services.version` set to `1.12-SNAPSHOT`. This was regressed by the Spring 7 merge (#12428), which was branched from a long-lived branch and overwrote the alignment previously done in #12708. Master builds and deploys `1.13-SNAPSHOT`, so a project generated from the master template pulled the wrong (older) `mapstore-services` artifact.

All other template properties (spring, spring-security, jackson, jakarta servlet-api, tomcat, geostore-webapp, http_proxy, print-lib) were verified aligned with the root pom; only `mapstore-services.version` was off.

## Issue
#12025

## What kind of change does this PR introduce?
- [x] Bugfix
- [x] Build related changes

## Follow-up
No automated guard currently catches template/root version drift (this is how it regressed). A CI check comparing `mapstore-services.version` in the template against the root pom version is recommended as a follow-up.
