### PR TITLE
Align LDAP security config with db (Spring 7 follow-up)

### DIFF
--- a/product/config/ldap/geostore-spring-security-ldap.xml
+++ b/product/config/ldap/geostore-spring-security-ldap.xml
@@ -20,7 +20,7 @@
 	<!-- ==================================================================== -->
 	<security:method-security secured-enabled="true"/>
 
-	<security:http auto-config="true" create-session="never" >
+	<security:http auto-config="true" create-session="never" authentication-manager-ref="authenticationManager">
 		<security:http-basic entry-point-ref="restAuthenticationEntryPoint"/>
         <security:csrf disabled="true"/>
 		<security:custom-filter ref="authenticationTokenProcessingFilter" before="FORM_LOGIN_FILTER"/>
@@ -42,7 +42,9 @@
 	</bean>
 	<!-- GeoStore Auth Provider -->
 	<bean id="geoStoreUserServiceAuthenticationProvider"
-		class="it.geosolutions.geostore.services.rest.security.UserServiceAuthenticationProvider">
+		class="it.geosolutions.geostore.services.rest.security.UserServiceAuthenticationProvider"
+		lazy-init="true"
+		depends-on="entityManager">
 	</bean>
 
     <bean id="authenticationTokenProcessingFilter"
@@ -57,7 +59,7 @@
           depends-on="entityManager">
     </bean>
 
-	<security:authentication-manager>
+	<security:authentication-manager alias="authenticationManager">
         <security:authentication-provider ref='geoStoreUserServiceAuthenticationProvider' />
         <security:authentication-provider ref='geostoreLdapProvider' />
     </security:authentication-manager>

--- a/web/src/config/ldap/geostore-spring-security-ldap.xml
+++ b/web/src/config/ldap/geostore-spring-security-ldap.xml
@@ -20,7 +20,7 @@
 	<!-- ==================================================================== -->
     <security:method-security secured-enabled="true"/>
 
-	<security:http auto-config="true" create-session="never" >
+	<security:http auto-config="true" create-session="never" authentication-manager-ref="authenticationManager">
 		<security:http-basic entry-point-ref="restAuthenticationEntryPoint"/>
         <security:csrf disabled="true"/>
 		<security:custom-filter ref="authenticationTokenProcessingFilter" before="FORM_LOGIN_FILTER"/>
@@ -42,7 +42,9 @@
 	</bean>
 	<!-- GeoStore Auth Provider -->
 	<bean id="geoStoreUserServiceAuthenticationProvider"
-		class="it.geosolutions.geostore.services.rest.security.UserServiceAuthenticationProvider">
+		class="it.geosolutions.geostore.services.rest.security.UserServiceAuthenticationProvider"
+		lazy-init="true"
+		depends-on="entityManager">
 	</bean>
 
     <bean id="authenticationTokenProcessingFilter"
@@ -57,7 +59,7 @@
           depends-on="entityManager">
     </bean>
 
-	<security:authentication-manager>
+	<security:authentication-manager alias="authenticationManager">
         <security:authentication-provider ref='geoStoreUserServiceAuthenticationProvider' />
         <security:authentication-provider ref='geostoreLdapProvider' />
     </security:authentication-manager>


### PR DESCRIPTION
## Description

Follow-up to #12729. The Spring 7 upgrade (#12428) reworked both the db and ldap security configurations, but some of the wiring it added to the db configs was not mirrored on the ldap ones. This aligns the ldap security configuration with the db version.

Two changes, both already present in `geostore-spring-security-db.xml`:

- Name the authentication manager: `alias="authenticationManager"` on `<security:authentication-manager>` and `authentication-manager-ref="authenticationManager"` on `<security:http>`.
- Mark `geoStoreUserServiceAuthenticationProvider` with `lazy-init="true"` and `depends-on="entityManager"`, so it follows the same init order as in the db config.

Applied to both ldap config copies:

- `product/config/ldap/geostore-spring-security-ldap.xml` (used by the product WAR)
- `web/src/config/ldap/geostore-spring-security-ldap.xml`

## Testing

Built the product with the `ldap` profile and ran it against the acme-ldap test server from the LDAP documentation.

- Tomcat starts cleanly, the web context loads.
- Login as `bill`/`hello` returns the ADMIN role, `bob`/`secret` returns USER, and a wrong password returns 401.

Related to #12025.
