### PR TITLE
#12666 Identify: It sometimes select an empty option in the layer selector 

### DIFF
--- a/web/client/components/data/identify/LayerSelector.jsx
+++ b/web/client/components/data/identify/LayerSelector.jsx
@@ -6,39 +6,33 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useState, useEffect} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
-import {isEmpty} from 'lodash';
 import localizedProps from '../../misc/enhancers/localizedProps';
 const SelectLocalized = localizedProps(['placeholder', 'clearValueText', 'noResultsText'])(Select);
 
 const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, emptyResponses, validator, format, showAllResponses = false}) => {
     const selectProps = {clearable: false, isSearchable: true};
-    const [options, setOptions] = useState([]);
-    const [title, setTitle] = useState("");
-
-    useEffect(()=>{
-        if (!isEmpty(responses)) {
-            setOptions(responses.map((opt, idx)=> {
-                const value = opt?.layerMetadata?.title || opt?.layer?.name;
-                // Display only valid responses in the drop down if showAllResponses is false,
-                // otherwise all response are visible and the first layer in toc is present in here
-                const valid = !!validator(format)?.getValidResponses([opt]).length;
-                return {
-                    label: value,
-                    value,
-                    idx,
-                    style: {
-                        display: showAllResponses ? 'block' : (valid ? 'block' : 'none')
-                    }};
-            }));
+    const responseValidator = validator(format);
+    const options = responses.reduce((validOptions, response, idx) => {
+        const value = response?.layerMetadata?.title || response?.layer?.name;
+        const valid = !responseValidator
+            || !!responseValidator.getValidResponses([response]).length;
+        // Keep the original response index while excluding invalid responses
+        // from the select instead of rendering hidden options.
+        if (showAllResponses || valid) {
+            validOptions.push({
+                label: value,
+                value,
+                idx
+            });
         }
-    }, [responses]);
-
-    useEffect(()=>{
-        loaded && setTitle(responses[index]?.layerMetadata?.title || responses[index]?.layer?.name || "");
-    }, [responses, index, loaded]);
+        return validOptions;
+    }, []);
+    const selectedValue = loaded
+        ? options.find(option => option.idx === index)?.value || ""
+        : "";
 
     const onChange = (event) => {
         const idx = event?.idx || 0;
@@ -49,7 +43,7 @@ const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, e
             <SelectLocalized
                 {...selectProps}
                 onChange={onChange}
-                value={title || ""}
+                value={selectedValue}
                 options={options}
                 disabled={missingResponses !== 0 || responses.length === 0 || emptyResponses}
                 noResultsText="identifyLayerSelectNoResult"

--- a/web/client/components/data/identify/__tests__/LayerSelector-test.jsx
+++ b/web/client/components/data/identify/__tests__/LayerSelector-test.jsx
@@ -37,11 +37,13 @@ describe("LayerSelector component", () => {
     });
     it('test LayerSelector display only valid responses', () => {
         const responses = [{layerMetadata: {title: "Test1"}, response: "no features were found"}, {layerMetadata: {title: "Test2"}, response: "GetFeatureInfo results"}];
-        ReactDOM.render(<LayerSelector loaded responses={responses} validator={getValidator} format={"text/plain"}/>, document.getElementById("container"));
+        ReactDOM.render(<LayerSelector loaded index={1} responses={responses} validator={getValidator} format={"text/plain"}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container).toExist();
         const select = container.querySelector("#identify-layer-select");
         expect(select).toExist();
+        const labelValue = container.querySelector(".Select-value-label");
+        expect(labelValue.innerText).toBe("Test2");
         const input = container.querySelector('input');
         expect(input).toBeTruthy();
 
@@ -50,11 +52,8 @@ describe("LayerSelector component", () => {
             TestUtils.Simulate.keyDown(input, { key: 'ArrowDown', keyCode: 40 });
         });
         const options = select.querySelectorAll(".Select-option");
-        // Invalid response - first option is hidden
-        expect(options[0].style.display).toBe('none');
-
-        // Valid response - second option is displayed
-        expect(options[1].style.display).toBe('block');
+        expect(options.length).toBe(1);
+        expect(options[0].innerText).toBe("Test2");
     });
     it('test LayerSelector with value and setIndex', (done) => {
 

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -25,6 +25,12 @@ import { MAP_CONFIG_LOADED } from '../../actions/config';
 import { VisualizationModes } from '../../utils/MapTypeUtils';
 
 describe('Test the mapInfo reducer', () => {
+    const createViewResponses = (response) => ({
+        "default": {
+            response,
+            queryParams: {info_format: 'text/plain'}
+        }
+    });
     const appState = {
         configuration: {
             infoFormat: 'text/plain'
@@ -534,15 +540,14 @@ describe('Test the mapInfo reducer', () => {
                 { reqId: 11, request: 'test1' }
             ],
             responses: [
-                { response: 'data0', queryParams: 'params0', layerMetadata: 'meta0', layer: { type: 'wms' } },
-                { response: 'data1', queryParams: 'params1', layerMetadata: 'meta1', layer: { type: 'wms' } }
+                { viewResponses: createViewResponses('data0'), layerMetadata: 'meta0', layer: { type: 'wms' } },
+                { viewResponses: createViewResponses('data1'), layerMetadata: 'meta1', layer: { type: 'wms' } }
             ]
         };
         // Action simulating a successful feature info load for reqId 11
         const action = {
             type: 'LOAD_FEATURE_INFO',
-            data: 'data1',
-            requestParams: 'params1',
+            viewResponses: createViewResponses('data1'),
             layerMetadata: 'meta1',
             layer: { type: 'wms' },
             reqId: 11
@@ -567,15 +572,14 @@ describe('Test the mapInfo reducer', () => {
                 { reqId: 11, request: 'test1' }
             ],
             responses: [
-                { response: 'data0', queryParams: 'params0', layerMetadata: 'meta0', layer: { type: 'wms' } },
-                { response: 'data1', queryParams: 'params1', layerMetadata: 'meta1', layer: { type: 'wms' } }
+                { viewResponses: createViewResponses('data0'), layerMetadata: 'meta0', layer: { type: 'wms' } },
+                { viewResponses: createViewResponses('data1'), layerMetadata: 'meta1', layer: { type: 'wms' } }
             ]
         };
         // Action simulating a successful feature info load for reqId 11
         const action = {
             type: 'LOAD_FEATURE_INFO',
-            data: null,
-            requestParams: 'params0',
+            viewResponses: createViewResponses(null),
             layerMetadata: 'meta0',
             layer: { type: 'wms' },
             reqId: 10
@@ -599,13 +603,13 @@ describe('Test the mapInfo reducer', () => {
                 { reqId: 12, request: 'test2' }
             ],
             responses: [
-                { response: null, layerMetadata: {title: 'empty'} },
-                { response: 'data1', layerMetadata: {title: 'valid1'} }
+                { viewResponses: createViewResponses(null), layerMetadata: {title: 'empty'} },
+                { viewResponses: createViewResponses('data1'), layerMetadata: {title: 'valid1'} }
             ]
         };
         const action = {
             type: 'LOAD_FEATURE_INFO',
-            data: 'data2',
+            viewResponses: createViewResponses('data2'),
             layerMetadata: {title: 'valid2'},
             reqId: 12
         };
@@ -628,7 +632,7 @@ describe('Test the mapInfo reducer', () => {
         };
         const lastRequestAction = {
             type: 'LOAD_FEATURE_INFO',
-            data: 'data2',
+            viewResponses: createViewResponses('data2'),
             layerMetadata: {title: 'valid2'},
             reqId: 12
         };
@@ -641,7 +645,7 @@ describe('Test the mapInfo reducer', () => {
 
         const retainedResponseAction = {
             type: 'LOAD_FEATURE_INFO',
-            data: null,
+            viewResponses: createViewResponses(null),
             layerMetadata: {title: 'empty0'},
             reqId: 10
         };
@@ -659,12 +663,12 @@ describe('Test the mapInfo reducer', () => {
                 { reqId: 11, request: 'test1' }
             ],
             responses: [
-                { response: 'data0', layerMetadata: {title: 'valid0'} }
+                { viewResponses: createViewResponses('data0'), layerMetadata: {title: 'valid0'} }
             ]
         };
         const action = {
             type: 'LOAD_FEATURE_INFO',
-            data: 'data1',
+            viewResponses: createViewResponses('data1'),
             layerMetadata: {title: 'valid1'},
             reqId: 11
         };
@@ -685,7 +689,7 @@ describe('Test the mapInfo reducer', () => {
         };
         const action = {
             type: 'LOAD_FEATURE_INFO',
-            data: 'data0',
+            viewResponses: createViewResponses('data0'),
             layerMetadata: {title: 'valid0'},
             reqId: 10
         };
@@ -705,12 +709,12 @@ describe('Test the mapInfo reducer', () => {
                 { reqId: 11, request: 'test1' }
             ],
             responses: [
-                { response: null, layerMetadata: {title: 'empty0'} }
+                { viewResponses: createViewResponses(null), layerMetadata: {title: 'empty0'} }
             ]
         };
         const action = {
             type: 'LOAD_FEATURE_INFO',
-            data: null,
+            viewResponses: createViewResponses(null),
             layerMetadata: {title: 'empty1'},
             reqId: 11
         };

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -654,30 +654,6 @@ describe('Test the mapInfo reducer', () => {
         expect(fallbackState.loaded).toBe(true);
         expect(fallbackState.index).toBe(2);
     });
-    it('receiveResponse preserves a retained response when it is still valid', () => {
-        const state = {
-            index: 1,
-            configuration: { infoFormat: 'text/plain' },
-            requests: [
-                { reqId: 10, request: 'test0' },
-                { reqId: 11, request: 'test1' }
-            ],
-            responses: [
-                { viewResponses: createViewResponses('data0'), layerMetadata: {title: 'valid0'} }
-            ]
-        };
-        const action = {
-            type: 'LOAD_FEATURE_INFO',
-            viewResponses: createViewResponses('data1'),
-            layerMetadata: {title: 'valid1'},
-            reqId: 11
-        };
-
-        const newState = mapInfo(state, action);
-
-        expect(newState.loaded).toBe(true);
-        expect(newState.index).toBe(1);
-    });
     it('receiveResponse recovers from a negative retained index', () => {
         const state = {
             index: -1,

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -589,4 +589,135 @@ describe('Test the mapInfo reducer', () => {
         // Should keep responses array
         expect(newState.responses.length).toBeGreaterThan(0);
     });
+    it('receiveResponse selects the first valid response when the retained response finishes empty', () => {
+        const state = {
+            index: 0,
+            configuration: { infoFormat: 'text/plain' },
+            requests: [
+                { reqId: 10, request: 'test0' },
+                { reqId: 11, request: 'test1' },
+                { reqId: 12, request: 'test2' }
+            ],
+            responses: [
+                { response: null, layerMetadata: {title: 'empty'} },
+                { response: 'data1', layerMetadata: {title: 'valid1'} }
+            ]
+        };
+        const action = {
+            type: 'LOAD_FEATURE_INFO',
+            data: 'data2',
+            layerMetadata: {title: 'valid2'},
+            reqId: 12
+        };
+
+        const newState = mapInfo(state, action);
+
+        expect(newState.loaded).toBe(true);
+        expect(newState.index).toBe(1);
+    });
+    it('receiveResponse does not treat a sparse response array as fully loaded', () => {
+        const state = {
+            index: 0,
+            configuration: { infoFormat: 'text/plain' },
+            requests: [
+                { reqId: 10, request: 'test0' },
+                { reqId: 11, request: 'test1' },
+                { reqId: 12, request: 'test2' }
+            ],
+            responses: []
+        };
+        const lastRequestAction = {
+            type: 'LOAD_FEATURE_INFO',
+            data: 'data2',
+            layerMetadata: {title: 'valid2'},
+            reqId: 12
+        };
+
+        const sparseState = mapInfo(state, lastRequestAction);
+
+        expect(sparseState.responses.length).toBe(3);
+        expect(sparseState.loaded).toBe(undefined);
+        expect(sparseState.index).toBe(0);
+
+        const retainedResponseAction = {
+            type: 'LOAD_FEATURE_INFO',
+            data: null,
+            layerMetadata: {title: 'empty0'},
+            reqId: 10
+        };
+        const fallbackState = mapInfo(sparseState, retainedResponseAction);
+
+        expect(fallbackState.loaded).toBe(true);
+        expect(fallbackState.index).toBe(2);
+    });
+    it('receiveResponse preserves a retained response when it is still valid', () => {
+        const state = {
+            index: 1,
+            configuration: { infoFormat: 'text/plain' },
+            requests: [
+                { reqId: 10, request: 'test0' },
+                { reqId: 11, request: 'test1' }
+            ],
+            responses: [
+                { response: 'data0', layerMetadata: {title: 'valid0'} }
+            ]
+        };
+        const action = {
+            type: 'LOAD_FEATURE_INFO',
+            data: 'data1',
+            layerMetadata: {title: 'valid1'},
+            reqId: 11
+        };
+
+        const newState = mapInfo(state, action);
+
+        expect(newState.loaded).toBe(true);
+        expect(newState.index).toBe(1);
+    });
+    it('receiveResponse recovers from a negative retained index', () => {
+        const state = {
+            index: -1,
+            configuration: { infoFormat: 'text/plain' },
+            requests: [
+                { reqId: 10, request: 'test0' }
+            ],
+            responses: []
+        };
+        const action = {
+            type: 'LOAD_FEATURE_INFO',
+            data: 'data0',
+            layerMetadata: {title: 'valid0'},
+            reqId: 10
+        };
+
+        const newState = mapInfo(state, action);
+
+        expect(newState.loaded).toBe(true);
+        expect(newState.index).toBe(0);
+    });
+    it('receiveResponse clears the index when all responses are empty', () => {
+        const state = {
+            loaded: true,
+            index: 0,
+            configuration: { infoFormat: 'text/plain' },
+            requests: [
+                { reqId: 10, request: 'test0' },
+                { reqId: 11, request: 'test1' }
+            ],
+            responses: [
+                { response: null, layerMetadata: {title: 'empty0'} }
+            ]
+        };
+        const action = {
+            type: 'LOAD_FEATURE_INFO',
+            data: null,
+            layerMetadata: {title: 'empty1'},
+            reqId: 11
+        };
+
+        const newState = mapInfo(state, action);
+
+        expect(newState.loaded).toBe(true);
+        expect(newState.index).toBe(undefined);
+    });
 });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -104,6 +104,8 @@ function receiveResponse(state, action, type) {
             }
         }
 
+        const allResponsesReceived = requests.length === responses
+            .filter(response => !isUndefined(response)).length;
         let indexObj;
         if (isHover || state.showAllResponses) {
             indexObj = {loaded: true, index: state.index || 0};
@@ -113,20 +115,48 @@ function receiveResponse(state, action, type) {
             } else {
                 indexObj = {loaded: true, index: requestIndex};
             }
-        } else if (responses.length === requests.length && !indexObj?.loaded) {
+        } else if (allResponsesReceived && !indexObj?.loaded) {
             // if all responses are empty hence valid but with no valid index
             // then set loaded to true
             indexObj = {loaded: true};
         }
 
-        if (state.loaded) {
-            if (state.index !== null) {
-                const validator = getValidator(config.infoFormat);
-                const checkIfStateIndexValid = validator?.getValidResponses([responses[state.index]]);
-                if (!checkIfStateIndexValid || checkIfStateIndexValid?.length === 0) {
-                    // If state.index is not valid, find the first valid response
-                    indexObj = {...indexObj, index: findIndex((responses || []), res => validator?.getValidResponses([res]).length > 0)};
-                }
+        if (!isHover && !state.showAllResponses) {
+            const validator = getValidator(config.infoFormat);
+            const firstValidResponseIndex = findIndex(
+                responses,
+                response => validator?.getValidResponses([response]).length > 0
+            );
+            const candidateIndex = !isUndefined(indexObj?.index)
+                ? indexObj.index
+                : state.index;
+            const hasCandidateValue = !isUndefined(candidateIndex) && candidateIndex !== null;
+            const hasCandidateIndex = Number.isInteger(candidateIndex) && candidateIndex >= 0;
+            const candidateResponse = hasCandidateIndex
+                ? responses[candidateIndex]
+                : undefined;
+            const candidateResponseIsValid = !isUndefined(candidateResponse)
+                && validator?.getValidResponses([candidateResponse]).length > 0;
+
+            if (candidateResponseIsValid) {
+                indexObj = {...indexObj, loaded: true, index: candidateIndex};
+            } else if (
+                firstValidResponseIndex >= 0
+                && (
+                    (hasCandidateValue && !hasCandidateIndex)
+                    || (hasCandidateIndex && (
+                        !isUndefined(candidateResponse)
+                        || allResponsesReceived
+                    ))
+                )
+            ) {
+                // The selected response is invalid or cannot arrive for the
+                // current request set. Select the first valid response.
+                indexObj = {...indexObj, loaded: true, index: firstValidResponseIndex};
+            } else if (allResponsesReceived && firstValidResponseIndex < 0) {
+                // All responses are empty. Clear a retained or provisional
+                // index instead of exposing an invalid or negative selection.
+                indexObj = {...indexObj, loaded: true, index: undefined};
             }
         }
 


### PR DESCRIPTION
## Description
The Identify panel could display an empty layer selection sometimes but layers had valid featureInfo results. The problem was caused by a race in the `mapInfo` reducer: it retained the selected response index from the previous

The issue appeared only occasionally because its outcome depended on the order
in which the layer requests completed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#12666 

**What is the new behavior?**
Harden the data replacement in reducer in order to make behaviour of identify feature consistent.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
