### PR TITLE
Fix #12739: keep the restored current time on map load, snap only when no time is set

### DIFF
--- a/web/client/epics/__tests__/timeline-test.js
+++ b/web/client/epics/__tests__/timeline-test.js
@@ -861,10 +861,29 @@ describe('timeline Epics', () => {
         testEpic(updateTimelineDataOnMapLoad, 3, configureMap(config), ([action1, action2, action3]) => {
             expect(action1.type).toBe(INIT_SELECT_LAYER);
             expect(action1.layerId).toBe("TEST_LAYER");
+            // a current time is restored from config, so the guide layer must not snap over it
+            expect(action1.snap).toBe(false);
             expect(action2.type).toBe(SET_END_VALUES_SUPPORT);
             expect(action2.endValuesSupport).toBe(true);
             expect(action3.type).toBe(SET_SNAP_RADIO_BUTTON_ENABLED);
             expect(action3.snapRadioButtonEnabled).toBe(false);
+            done();
+        }, {});
+    });
+    it("updateTimelineDataOnMapLoad snaps the guide layer when no current time is restored", (done) =>{
+        const config = {
+            timelineData: {
+                selectedLayer: "TEST_LAYER",
+                endValuesSupport: true,
+                snapRadioButtonEnabled: false
+            },
+            dimensionData: {}
+        };
+        testEpic(updateTimelineDataOnMapLoad, 4, configureMap(config), ([action1, , , action4]) => {
+            expect(action1.type).toBe(INIT_SELECT_LAYER);
+            expect(action1.layerId).toBe("TEST_LAYER");
+            expect(action1.snap).toBe(true);
+            expect(action4.type).toBe(AUTOSELECT);
             done();
         }, {});
     });
@@ -972,6 +991,29 @@ describe('timeline Epics', () => {
             }, {...STATE_TIMELINE, layers: { ...STATE_TIMELINE.layers,
                 flat: [{...STATE_TIMELINE.layers.flat[0], visibility: true}]
             }});
+        });
+        it('syncTimelineGuideLayer snaps when no current time is set', done => {
+            testEpic(syncTimelineGuideLayer, NUM_ACTIONS, [autoselect()], ([action]) => {
+                expect(action.type).toBe(SELECT_LAYER);
+                expect(action.layerId).toBe('TEST_LAYER');
+                expect(action.snap).toBe(true);
+                done();
+            }, {...STATE_TIMELINE, layers: { ...STATE_TIMELINE.layers,
+                flat: [{...STATE_TIMELINE.layers.flat[0], visibility: true}]
+            }});
+        });
+        it('syncTimelineGuideLayer does not snap when a current time is already set', done => {
+            testEpic(syncTimelineGuideLayer, NUM_ACTIONS, [autoselect()], ([action]) => {
+                expect(action.type).toBe(SELECT_LAYER);
+                expect(action.layerId).toBe('TEST_LAYER');
+                expect(action.snap).toBe(false);
+                done();
+            }, {...STATE_TIMELINE,
+                layers: { ...STATE_TIMELINE.layers,
+                    flat: [{...STATE_TIMELINE.layers.flat[0], visibility: true}]
+                },
+                dimension: { currentTime: '2005-03-04T00:00:00.000Z' }
+            });
         });
         it('syncTimelineGuideLayer on showHiddenLayers', done => {
             testEpic(syncTimelineGuideLayer, NUM_ACTIONS, [selectLayer('TEST_LAYER2'), removeNode('TEST_LAYER1', 'layers') ], (actions) => {

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -277,7 +277,7 @@ export const updateTimelineDataOnMapLoad = (action$) =>
             const snapRadioButtonEnabled = config?.timelineData?.snapRadioButtonEnabled;
             const layers = config?.timelineData?.layers;
             return Rx.Observable.of(
-                ...(!isEmpty(selectedLayer) ? [initializeSelectLayer(selectedLayer)] : []),
+                ...(!isEmpty(selectedLayer) ? [initializeSelectLayer(selectedLayer, isEmpty(currentTime))] : []),
                 ...(!isNil(endValuesSupport) ? [setEndValuesSupport(endValuesSupport)] : []),
                 ...(!isNil(snapRadioButtonEnabled) ? [setSnapRadioButtonEnabled(snapRadioButtonEnabled)] : []),
                 ...(!isEmpty(layers) ? [setTimeLayers(layers)] : [])
@@ -356,7 +356,8 @@ export const syncTimelineGuideLayer = (action$, { getState = () => { } } = {}) =
             const state = getState();
             const firstTimeLayer = get(timelineLayersSelector(state), "[0].id");
             if (isAutoSelectEnabled(state) && firstTimeLayer) {
-                return Rx.Observable.of(selectLayer(firstTimeLayer)); // Select the first guide layer from the list and snap time
+                // select the first guide layer; snap the time only when no current time is set, so a restored/saved time is preserved
+                return Rx.Observable.of(selectLayer(firstTimeLayer, isEmpty(currentTimeSelector(state))));
             }
             return Rx.Observable.empty();
         });


### PR DESCRIPTION
## Description

On map load the Timeline re-snaps the guide layer time and can overwrite a current time restored from the saved config. This change keeps the restored value and snaps only when there is no current time to preserve.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**

#12739

When a map with a time layer is reloaded with a saved current time, the Timeline snaps that time to the nearest layer domain value on load. If the saved instant is not exactly a domain value, the current time (and the WMS `TIME` sent to the layer) changes to a different date. The result also depends on the timing of the asynchronous multidimensional `describeDomains` request, so it is not deterministic.

Root cause: on `MAP_CONFIG_LOADED`, `epics/dimension.js` `updateLayerDimensionDataOnMapLoad` restores the current time and then asynchronously loads the domains. Meanwhile `epics/timeline.js` selects the guide layer (`updateTimelineDataOnMapLoad`, or `onUpdateLayerDimensionData` when none is selected). Selecting the guide layer snaps the time: both `initializeSelectLayer` and `selectLayer` default to `snap = true`, so `snapTimeGuideLayer` runs `setCurrentTime(nearestDomainValue)` over the restored value.

**What is the new behavior?**

The saved value wins when it exists; snapping happens only when there is no restored current time. On load the guide layer is still selected, but without snapping when a current time was restored from the config. User-driven layer selection keeps snapping as before.

Proposed fix, in `web/client/epics/timeline.js`:
- `updateTimelineDataOnMapLoad`: `initializeSelectLayer(selectedLayer, isEmpty(currentTime))`.
- `syncTimelineGuideLayer`: `selectLayer(firstTimeLayer, isEmpty(currentTimeSelector(state)))`.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

## Other useful information

Regression tests added in `web/client/epics/__tests__/timeline-test.js`:
- `syncTimelineGuideLayer` selects with `snap = true` when no current time is set, and with `snap = false` when a current time is already set.
- `updateTimelineDataOnMapLoad` selects with `snap = false` when a current time is restored, and with `snap = true` (plus `AUTOSELECT`) when none is.

How to reproduce: load a saved map with a WMS time layer (WMTS multidimensional extension) whose stored `dimensionData.currentTime` is not one of the layer domain values and whose `timelineData.selectedLayer` points to that layer. Before the fix the time snaps to a different value on load; after the fix the saved time is kept.
