### PR TITLE
#12738: Highlight active filter widget in the widget tray

### DIFF
--- a/web/client/components/widgets/view/WidgetsBar.jsx
+++ b/web/client/components/widgets/view/WidgetsBar.jsx
@@ -44,6 +44,10 @@ const getWidgetIcon = ({widgetType, charts = []} = {}) => {
     }
 };
 
+const isFilterActive = (widget) =>
+    widget.filters?.some(
+        ({ id, disabled }) => !disabled && widget.selections?.[id]?.length > 0
+    ) ?? false;
 /**
  * Bar that can be used to display the list of widgets
  */
@@ -61,7 +65,7 @@ export default compose(
             buttons: widgets.map(w => ({
                 glyph: getWidgetIcon(w),
                 tooltip: w.title,
-                className: `square-button ${w.collapsed ? "btn-tray" : "btn-tray active"}`,
+                className: `square-button ${w.collapsed ? "btn-tray" : `btn-tray active ${isFilterActive(w) ? "ms-notification-circle success" : ""}`}`,
                 onClick: () => onClick(w)
             }))
         })

--- a/web/client/components/widgets/view/__tests__/WidgetsBar-test.jsx
+++ b/web/client/components/widgets/view/__tests__/WidgetsBar-test.jsx
@@ -69,5 +69,38 @@ describe('WidgetsBar component', () => {
         ReactTestUtils.Simulate.click(el); // <-- trigger event callback
         expect(spyonClick).toHaveBeenCalled();
     });
+    it('Test WidgetsBar rendering with active filter style', () => {
+        const widget = {
+            widgetType: "filter",
+            filters: [{ id: 'f1', disabled: false }],
+            selections: { f1: ['value1'] }
+        };
+        ReactDOM.render(<WidgetsBar widgets={[widget]} />, document.getElementById("container"));
+        const el = document.getElementById('container').querySelector('.btn-group button');
+        expect(el.className).toInclude('ms-notification-circle');
+        expect(el.className).toInclude('success');
+    });
+    it('Test WidgetsBar rendering without active filter style if filter is disabled', () => {
+        const widgetDisabled = {
+            widgetType: "filter",
+            filters: [{ id: 'f1', disabled: true }],
+            selections: { f1: ['value1'] }
+        };
+        ReactDOM.render(<WidgetsBar widgets={[widgetDisabled]} />, document.getElementById("container"));
+        const el = document.getElementById('container').querySelector('.btn-group button');
+        expect(el.className).toNotInclude('ms-notification-circle');
+        expect(el.className).toNotInclude('success');
+    });
 
+    it('Test WidgetsBar rendering without active filter style if no selections', () => {
+        const widgetNoSelection = {
+            widgetType: "filter",
+            filters: [{ id: 'f1', disabled: false }],
+            selections: { f1: [] }
+        };
+        ReactDOM.render(<WidgetsBar widgets={[widgetNoSelection]} />, document.getElementById("container"));
+        const el = document.getElementById('container').querySelector('.btn-group button');
+        expect(el.className).toNotInclude('ms-notification-circle');
+        expect(el.className).toNotInclude('success');
+    });
 });


### PR DESCRIPTION
## Description
This PR adds a highlight indicator to the filter widget in the widget bar when the filter is active

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #12738 

**What is the new behavior?**
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/adce88cb-38c9-4479-b1e0-311831951d4d" />


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
