### PR TITLE
#12752 Global Identify configuration with HTML format throws an error with WFS layer

### DIFF
--- a/web/client/api/WFS.js
+++ b/web/client/api/WFS.js
@@ -160,7 +160,7 @@ export const describeFeatureType = function(url, typeName) {
 /**
  * Fetch the supported formats of the WFS service
  * @param url
- * @return {object} { infoFormats }
+ * @return {Promise} resolves with { infoFormats }
  */
 export const getSupportedFormat = (url) => {
     return getCapabilities(url)
@@ -168,12 +168,11 @@ export const getSupportedFormat = (url) => {
             const operations = castArray(response?.['wfs:WFS_Capabilities']?.['ows:OperationsMetadata']?.['ows:Operation'] || []);
             const getFeatureOperation = operations.find(operation => operation?.$?.name === 'GetFeature');
             const parameters = castArray(getFeatureOperation?.['ows:Parameter'] || []);
-            const outputFormats = parameters.find((parameter) => parameter?.$?.name === 'outputFormat')?.['ows:Value'] || [];
+            const outputFormats = castArray(parameters.find((parameter) => parameter?.$?.name === 'outputFormat')?.['ows:Value'] || []);
             const infoFormats = outputFormats.filter(isValidGetFeatureInfoFormat);
             return {
                 infoFormats: infoFormats?.length ? infoFormats : ['application/json']
             };
-        })
-        .catch(() => ({ infoFormats: ['application/json'] }));
+        });
 };
 

--- a/web/client/components/common/enhancers/withIdentifyPopup.jsx
+++ b/web/client/components/common/enhancers/withIdentifyPopup.jsx
@@ -19,7 +19,8 @@ import {
     defaultQueryableFilter,
     buildIdentifyRequest,
     filterRequestParams,
-    getValidator
+    getValidator,
+    resolveIdentifyLayer
 } from '../../../utils/MapInfoUtils';
 
 import { isInsideResolutionsLimits } from '../../../utils/LayersUtils';
@@ -58,50 +59,55 @@ export const withIdentifyRequest  = mapPropsStream(props$ => {
                 });
             }
 
+            const identifyOptions = {
+                format: mapInfoFormat,
+                map,
+                point,
+                currentLocale: "en-US"
+            };
             return Observable.from(queryableLayers)
-                .mergeMap(layer => {
-                    let { url, request, metadata } = buildIdentifyRequest(layer, {
-                        format: mapInfoFormat,
-                        map,
-                        point,
-                        currentLocale: "en-US"});
-                    const basePath = url;
-                    const queryParams = request;
-                    const appParams = filterRequestParams(layer, includeOptions, excludeParams);
-                    const param = { ...appParams, ...queryParams };
-                    const reqId = uuidv1();
-                    return getFeatureInfo(basePath, param, layer)
-                        .map((response) =>
-                            response.data.exceptions
-                                ? ({
-                                    reqId,
-                                    exceptions: response.data.exceptions,
-                                    queryParams,
-                                    layerMetadata: metadata
-                                })
-                                : ({
-                                    data: response.data,
-                                    reqId: reqId,
-                                    queryParams,
-                                    layerMetadata: {
-                                        ...metadata,
-                                        features: response.features,
-                                        featuresCrs: response.featuresCrs
-                                    }
-                                })
-                        )
-                        .catch((e) => Observable.of({
-                            error: e.data || e.statusText || e.status,
-                            reqId,
-                            queryParams,
-                            layerMetadata: metadata
-                        }))
-                        .startWith(({
-                            start: true,
-                            reqId,
-                            request: param
-                        }));
-                }).scan(({requests, responses, validResponses}, action) => {
+                .mergeMap(identifyLayer => Observable
+                    .defer(() => resolveIdentifyLayer(identifyLayer, identifyOptions))
+                    .mergeMap(layer => {
+                        let { url, request, metadata } = buildIdentifyRequest(layer, identifyOptions);
+                        const basePath = url;
+                        const queryParams = request;
+                        const appParams = filterRequestParams(layer, includeOptions, excludeParams);
+                        const param = { ...appParams, ...queryParams };
+                        const reqId = uuidv1();
+                        return getFeatureInfo(basePath, param, layer)
+                            .map((response) =>
+                                response.data.exceptions
+                                    ? ({
+                                        reqId,
+                                        exceptions: response.data.exceptions,
+                                        queryParams,
+                                        layerMetadata: metadata
+                                    })
+                                    : ({
+                                        data: response.data,
+                                        reqId: reqId,
+                                        queryParams,
+                                        layerMetadata: {
+                                            ...metadata,
+                                            features: response.features,
+                                            featuresCrs: response.featuresCrs
+                                        }
+                                    })
+                            )
+                            .catch((e) => Observable.of({
+                                error: e.data || e.statusText || e.status,
+                                reqId,
+                                queryParams,
+                                layerMetadata: metadata
+                            }))
+                            .startWith(({
+                                start: true,
+                                reqId,
+                                request: param
+                            }));
+                    }))
+                .scan(({requests, responses, validResponses}, action) => {
                     if (action.start) {
                         const {reqId, request} = action;
                         return {requests: requests.concat({ reqId, request }), responses, validResponses};

--- a/web/client/components/geostory/common/enhancers/withPopupSupport.jsx
+++ b/web/client/components/geostory/common/enhancers/withPopupSupport.jsx
@@ -24,7 +24,8 @@ import {
     buildIdentifyRequest,
     defaultQueryableFilter,
     filterRequestParams,
-    getValidator
+    getValidator,
+    resolveIdentifyLayer
 } from "../../../../utils/MapInfoUtils";
 import {Observable} from "rxjs";
 import { getFeatureInfo } from "../../../../api/identify";
@@ -84,51 +85,56 @@ const withIdentifyRequest  = mapPropsStream(props$ => {
                 });
             }
 
+            const identifyOptions = {
+                format: mapInfoFormat,
+                map,
+                point,
+                currentLocale: "en-US"
+            };
             return Observable.from(queryableLayers)
-                .mergeMap(layer => {
-                    let { url, request, metadata } = buildIdentifyRequest(layer, {
-                        format: mapInfoFormat,
-                        map,
-                        point,
-                        currentLocale: "en-US"});
-                    const basePath = url;
-                    const queryParams = request;
-                    const appParams = filterRequestParams(layer, includeOptions, excludeParams);
-                    const param = { ...appParams, ...queryParams };
-                    const reqId = uuidv1();
-                    return (url ? getFeatureInfo(basePath, param, layer)
-                        .map((response) =>
-                            response.data.exceptions
-                                ? ({
-                                    reqId,
-                                    exceptions: response.data.exceptions,
-                                    queryParams,
-                                    layerMetadata: metadata
-                                })
-                                : ({
-                                    data: response.data,
-                                    reqId: reqId,
-                                    queryParams,
-                                    layerMetadata: {
-                                        ...metadata,
-                                        features: response.features,
-                                        featuresCrs: response.featuresCrs
-                                    }
-                                })
-                        ) : Observable.empty()
-                    )
-                        .catch((e) => Observable.of({
-                            error: e.data || e.statusText || e.status,
-                            reqId,
-                            queryParams,
-                            layerMetadata: metadata
-                        }))
-                        .startWith(({
-                            start: true,
-                            reqId,
-                            request: param
-                        }));
-                }).scan(({requests, responses, validResponses}, action) => {
+                .mergeMap(identifyLayer => Observable
+                    .defer(() => resolveIdentifyLayer(identifyLayer, identifyOptions))
+                    .mergeMap(layer => {
+                        let { url, request, metadata } = buildIdentifyRequest(layer, identifyOptions);
+                        const basePath = url;
+                        const queryParams = request;
+                        const appParams = filterRequestParams(layer, includeOptions, excludeParams);
+                        const param = { ...appParams, ...queryParams };
+                        const reqId = uuidv1();
+                        return (url ? getFeatureInfo(basePath, param, layer)
+                            .map((response) =>
+                                response.data.exceptions
+                                    ? ({
+                                        reqId,
+                                        exceptions: response.data.exceptions,
+                                        queryParams,
+                                        layerMetadata: metadata
+                                    })
+                                    : ({
+                                        data: response.data,
+                                        reqId: reqId,
+                                        queryParams,
+                                        layerMetadata: {
+                                            ...metadata,
+                                            features: response.features,
+                                            featuresCrs: response.featuresCrs
+                                        }
+                                    })
+                            ) : Observable.empty()
+                        )
+                            .catch((e) => Observable.of({
+                                error: e.data || e.statusText || e.status,
+                                reqId,
+                                queryParams,
+                                layerMetadata: metadata
+                            }))
+                            .startWith(({
+                                start: true,
+                                reqId,
+                                request: param
+                            }));
+                    }))
+                .scan(({requests, responses, validResponses}, action) => {
                     if (action.start) {
                         const {reqId, request} = action;
                         return {requests: requests.concat({ reqId, request }), responses, validResponses};

--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -9,8 +9,7 @@
 import expect from 'expect';
 import {head} from 'lodash';
 import {
-    loadMapConfigAndConfigureMap, loadMapInfoEpic, storeDetailsInfoDashboardEpic, storeDetailsInfoEpic, backgroundsListInitEpic,
-    getSupportedFormatsEpic, fetchWFSInfoFormatsEpic
+    loadMapConfigAndConfigureMap, loadMapInfoEpic, storeDetailsInfoDashboardEpic, storeDetailsInfoEpic, backgroundsListInitEpic, getSupportedFormatsEpic
 } from '../config';
 import {LOAD_USER_SESSION} from '../../actions/usersession';
 import {
@@ -41,7 +40,6 @@ import {
     SET_FORMAT_OPTIONS,
     SHOW_FORMAT_ERROR
 } from '../../actions/catalog';
-import { CHANGE_LAYER_PROPERTIES } from '../../actions/layers';
 const api = {
     getResource: (id, {includeAttributes = true, withData = true}) => {
         if (!includeAttributes && !withData) {
@@ -84,43 +82,6 @@ describe('config epics', () => {
             done();
         }, {
             catalog: {}
-        });
-    });
-
-    it('fetchWFSInfoFormatsEpic should populate formats for WFS layers loaded from a map', (done) => {
-        const wfsMockAxios = new MockAdapter(axios);
-        wfsMockAxios.onGet().reply(200, `
-            <wfs:WFS_Capabilities>
-                <ows:OperationsMetadata>
-                    <ows:Operation name="GetFeature">
-                        <ows:Parameter name="outputFormat">
-                            <ows:Value>application/json</ows:Value>
-                        </ows:Parameter>
-                    </ows:Operation>
-                </ows:OperationsMetadata>
-            </wfs:WFS_Capabilities>
-        `);
-        testEpic(fetchWFSInfoFormatsEpic, 1, configureMap({
-            map: {
-                layers: [{
-                    id: 'wfs-layer',
-                    type: 'wfs',
-                    url: '/geoserver/wfs'
-                }]
-            }
-        }), ([action]) => {
-            try {
-                expect(action.type).toBe(CHANGE_LAYER_PROPERTIES);
-                expect(action.layer).toBe('wfs-layer');
-                expect(action.newProperties).toEqual({
-                    infoFormats: ['application/json']
-                });
-                wfsMockAxios.restore();
-                done();
-            } catch (error) {
-                wfsMockAxios.restore();
-                done(error);
-            }
         });
     });
     describe('loadMapConfigAndConfigureMap', () => {

--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -9,7 +9,8 @@
 import expect from 'expect';
 import {head} from 'lodash';
 import {
-    loadMapConfigAndConfigureMap, loadMapInfoEpic, storeDetailsInfoDashboardEpic, storeDetailsInfoEpic, backgroundsListInitEpic,    getSupportedFormatsEpic
+    loadMapConfigAndConfigureMap, loadMapInfoEpic, storeDetailsInfoDashboardEpic, storeDetailsInfoEpic, backgroundsListInitEpic,
+    getSupportedFormatsEpic, fetchWFSInfoFormatsEpic
 } from '../config';
 import {LOAD_USER_SESSION} from '../../actions/usersession';
 import {
@@ -40,6 +41,7 @@ import {
     SET_FORMAT_OPTIONS,
     SHOW_FORMAT_ERROR
 } from '../../actions/catalog';
+import { CHANGE_LAYER_PROPERTIES } from '../../actions/layers';
 const api = {
     getResource: (id, {includeAttributes = true, withData = true}) => {
         if (!includeAttributes && !withData) {
@@ -82,6 +84,43 @@ describe('config epics', () => {
             done();
         }, {
             catalog: {}
+        });
+    });
+
+    it('fetchWFSInfoFormatsEpic should populate formats for WFS layers loaded from a map', (done) => {
+        const wfsMockAxios = new MockAdapter(axios);
+        wfsMockAxios.onGet().reply(200, `
+            <wfs:WFS_Capabilities>
+                <ows:OperationsMetadata>
+                    <ows:Operation name="GetFeature">
+                        <ows:Parameter name="outputFormat">
+                            <ows:Value>application/json</ows:Value>
+                        </ows:Parameter>
+                    </ows:Operation>
+                </ows:OperationsMetadata>
+            </wfs:WFS_Capabilities>
+        `);
+        testEpic(fetchWFSInfoFormatsEpic, 1, configureMap({
+            map: {
+                layers: [{
+                    id: 'wfs-layer',
+                    type: 'wfs',
+                    url: '/geoserver/wfs'
+                }]
+            }
+        }), ([action]) => {
+            try {
+                expect(action.type).toBe(CHANGE_LAYER_PROPERTIES);
+                expect(action.layer).toBe('wfs-layer');
+                expect(action.newProperties).toEqual({
+                    infoFormats: ['application/json']
+                });
+                wfsMockAxios.restore();
+                done();
+            } catch (error) {
+                wfsMockAxios.restore();
+                done(error);
+            }
         });
     });
     describe('loadMapConfigAndConfigureMap', () => {
@@ -578,4 +617,3 @@ describe('config epics', () => {
         });
     });
 });
-

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -7,7 +7,7 @@
  */
 import { Observable } from 'rxjs';
 import axios from '../libs/ajax';
-import { get, isNaN, find, groupBy } from 'lodash';
+import { get, isNaN, find } from 'lodash';
 import {
     LOAD_NEW_MAP,
     LOAD_MAP_CONFIG,
@@ -34,7 +34,7 @@ import { detailsLoaded } from '../actions/details';
 import {userSessionEnabledSelector, buildSessionName} from "../selectors/usersession";
 import {getRequestParameterValue} from "../utils/QueryParamsUtils";
 import { EMPTY_RESOURCE_VALUE } from '../utils/MapInfoUtils';
-import { ADD_LAYER, changeLayerProperties } from '../actions/layers';
+import { changeLayerProperties } from '../actions/layers';
 import { createBackgroundsList } from '../actions/backgroundselector';
 import {
     FORMAT_OPTIONS_FETCH,
@@ -46,7 +46,6 @@ import {
     getFormatUrlUsedSelector
 } from '../selectors/catalog';
 import { getSupportedFormat } from '../api/WMS';
-import { getSupportedFormat as getSupportedFormatWFS } from '../api/WFS';
 import { wrapStartStop } from '../observables/epics';
 import { error } from '../actions/notifications';
 import { applyOverrides } from '../utils/ConfigUtils';
@@ -330,35 +329,5 @@ export const getSupportedFormatsEpic = (action$, {getState = ()=> {}} = {}) =>
                             );
                         }
                     )
-                );
-        });
-
-/**
- * Fetch WFS GetFeature formats when layers are loaded so identify can
- * distinguish unsupported HTML from capability metadata that is still unknown.
- */
-export const fetchWFSInfoFormatsEpic = action$ =>
-    action$.ofType(MAP_CONFIG_LOADED, ADD_LAYER)
-        .mergeMap((action) => {
-            const layers = action.type === MAP_CONFIG_LOADED
-                ? action.config?.map?.layers || []
-                : [action.layer];
-            const layersByUrl = Object.values(groupBy(
-                layers.filter((layer) =>
-                    layer?.id
-                    && layer.type === 'wfs'
-                    && !layer.infoFormats?.length
-                    && layer.url
-                ),
-                (layer) => JSON.stringify(layer.url)
-            ));
-            return Observable.from(layersByUrl)
-                .mergeMap((layersWithSameUrl) =>
-                    Observable.defer(() => getSupportedFormatWFS(layersWithSameUrl[0].url))
-                        .mergeMap(({ infoFormats }) =>
-                            Observable.from(layersWithSameUrl.map((layer) =>
-                                changeLayerProperties(layer.id, { infoFormats })
-                            ))
-                        )
                 );
         });

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -7,7 +7,7 @@
  */
 import { Observable } from 'rxjs';
 import axios from '../libs/ajax';
-import { get, isNaN, find } from 'lodash';
+import { get, isNaN, find, groupBy } from 'lodash';
 import {
     LOAD_NEW_MAP,
     LOAD_MAP_CONFIG,
@@ -34,7 +34,7 @@ import { detailsLoaded } from '../actions/details';
 import {userSessionEnabledSelector, buildSessionName} from "../selectors/usersession";
 import {getRequestParameterValue} from "../utils/QueryParamsUtils";
 import { EMPTY_RESOURCE_VALUE } from '../utils/MapInfoUtils';
-import { changeLayerProperties } from '../actions/layers';
+import { ADD_LAYER, changeLayerProperties } from '../actions/layers';
 import { createBackgroundsList } from '../actions/backgroundselector';
 import {
     FORMAT_OPTIONS_FETCH,
@@ -46,6 +46,7 @@ import {
     getFormatUrlUsedSelector
 } from '../selectors/catalog';
 import { getSupportedFormat } from '../api/WMS';
+import { getSupportedFormat as getSupportedFormatWFS } from '../api/WFS';
 import { wrapStartStop } from '../observables/epics';
 import { error } from '../actions/notifications';
 import { applyOverrides } from '../utils/ConfigUtils';
@@ -329,5 +330,35 @@ export const getSupportedFormatsEpic = (action$, {getState = ()=> {}} = {}) =>
                             );
                         }
                     )
+                );
+        });
+
+/**
+ * Fetch WFS GetFeature formats when layers are loaded so identify can
+ * distinguish unsupported HTML from capability metadata that is still unknown.
+ */
+export const fetchWFSInfoFormatsEpic = action$ =>
+    action$.ofType(MAP_CONFIG_LOADED, ADD_LAYER)
+        .mergeMap((action) => {
+            const layers = action.type === MAP_CONFIG_LOADED
+                ? action.config?.map?.layers || []
+                : [action.layer];
+            const layersByUrl = Object.values(groupBy(
+                layers.filter((layer) =>
+                    layer?.id
+                    && layer.type === 'wfs'
+                    && !layer.infoFormats?.length
+                    && layer.url
+                ),
+                (layer) => JSON.stringify(layer.url)
+            ));
+            return Observable.from(layersByUrl)
+                .mergeMap((layersWithSameUrl) =>
+                    Observable.defer(() => getSupportedFormatWFS(layersWithSameUrl[0].url))
+                        .mergeMap(({ infoFormats }) =>
+                            Observable.from(layersWithSameUrl.map((layer) =>
+                                changeLayerProperties(layer.id, { infoFormats })
+                            ))
+                        )
                 );
         });

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -56,7 +56,7 @@ import { mouseOutSelector } from '../selectors/mousePosition';
 import { hideEmptyPopupSelector } from '../selectors/mapPopups';
 import {getBbox, getCurrentResolution} from '../utils/MapUtils';
 import { parseLayoutValue } from '../utils/LayoutUtils';
-import {buildIdentifyRequest, defaultQueryableFilter, filterRequestParams} from '../utils/MapInfoUtils';
+import {buildIdentifyRequest, defaultQueryableFilter, filterRequestParams, resolveIdentifyLayer} from '../utils/MapInfoUtils';
 import { IDENTIFY_POPUP } from '../components/map/popups';
 
 const gridEditingSelector = state => modeSelector(state) === 'EDIT';
@@ -117,46 +117,48 @@ export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { }
             // filtering a subset of layers
                 return filterNameList.length ? (filterNameList.filter(name => name.indexOf(l.name) !== -1).length > 0) : true;
             })))
-                .mergeMap(layer => {
-                    let env = localizedLayerStylesEnvSelector(getState());
-                    let { url, request, metadata } = buildIdentifyRequest(layer, {...identifyOptionsSelector(getState()), env});
-                    // request override
-                    if (itemIdSelector(getState()) && overrideParamsSelector(getState())) {
-                        request = {...request, ...overrideParamsSelector(getState())[layer.name]};
-                    }
-                    if (overrideParams[layer.name]) {
-                        request = {...request, ...overrideParams[layer.name]};
-                    }
-                    if (url) {
-                        const basePath = url;
-                        const requestParams = request;
-                        const lMetaData = metadata;
-                        const appParams = filterRequestParams(layer, includeOptions, excludeParams);
-                        const attachJSON = isHighlightEnabledSelector(getState());
-                        const itemId = itemIdSelector(getState());
-                        const reqId = uuidv1();
-                        const param = { ...appParams, ...requestParams };
-                        return getFeatureInfo(basePath, param, layer, {attachJSON, itemId})
-                            // this 0 delay is needed for vector/3dtiles layer because makes the response async and give time to the GUI to render
-                            // these type of layers don't perform requests to the server because the values are taken from the client map so the response were applied synchronously
-                            // this delay allows the panel to open and show the spinner for the first one
-                            // this delay mitigates the freezing of the app when there are a great amount of queried layers at the same time
-                            .delay(0)
-                            .map((response) =>loadFeatureInfo(reqId, response.data, requestParams, { ...lMetaData, features: response.features, featuresCrs: response.featuresCrs, isQueryJustOneLayer, sidebarIsOpened, featureBbox: (queryParamZoomOption?.overrideZoomLvl || queryParamZoomOption?.isCoordsProvided) ? null : bbox }, layer, queryParamZoomOption))
-                            .catch((e) => Rx.Observable.of(errorFeatureInfo(reqId, e, requestParams, lMetaData)))
-                            .concat(Rx.Observable.defer(() => {
-                                // update the layout only after the initial response
-                                // we don't need to trigger this for each query layer
-                                if (!firstResponseReturned) {
-                                    firstResponseReturned = true;
-                                    return Rx.Observable.of(forceUpdateMapLayout());
-                                }
-                                return Rx.Observable.empty();
-                            }))
-                            .startWith(newMapInfoRequest(reqId, param));
-                    }
-                    return Rx.Observable.of(forceUpdateMapLayout());
-                });
+                .mergeMap(identifyLayer => Rx.Observable
+                    .defer(() => resolveIdentifyLayer(identifyLayer, identifyOptionsSelector(getState())))
+                    .mergeMap(layer => {
+                        let env = localizedLayerStylesEnvSelector(getState());
+                        let { url, request, metadata } = buildIdentifyRequest(layer, {...identifyOptionsSelector(getState()), env});
+                        // request override
+                        if (itemIdSelector(getState()) && overrideParamsSelector(getState())) {
+                            request = {...request, ...overrideParamsSelector(getState())[layer.name]};
+                        }
+                        if (overrideParams[layer.name]) {
+                            request = {...request, ...overrideParams[layer.name]};
+                        }
+                        if (url) {
+                            const basePath = url;
+                            const requestParams = request;
+                            const lMetaData = metadata;
+                            const appParams = filterRequestParams(layer, includeOptions, excludeParams);
+                            const attachJSON = isHighlightEnabledSelector(getState());
+                            const itemId = itemIdSelector(getState());
+                            const reqId = uuidv1();
+                            const param = { ...appParams, ...requestParams };
+                            return getFeatureInfo(basePath, param, layer, {attachJSON, itemId})
+                                // this 0 delay is needed for vector/3dtiles layer because makes the response async and give time to the GUI to render
+                                // these type of layers don't perform requests to the server because the values are taken from the client map so the response were applied synchronously
+                                // this delay allows the panel to open and show the spinner for the first one
+                                // this delay mitigates the freezing of the app when there are a great amount of queried layers at the same time
+                                .delay(0)
+                                .map((response) =>loadFeatureInfo(reqId, response.data, requestParams, { ...lMetaData, features: response.features, featuresCrs: response.featuresCrs, isQueryJustOneLayer, sidebarIsOpened, featureBbox: (queryParamZoomOption?.overrideZoomLvl || queryParamZoomOption?.isCoordsProvided) ? null : bbox }, layer, queryParamZoomOption))
+                                .catch((e) => Rx.Observable.of(errorFeatureInfo(reqId, e, requestParams, lMetaData)))
+                                .concat(Rx.Observable.defer(() => {
+                                    // update the layout only after the initial response
+                                    // we don't need to trigger this for each query layer
+                                    if (!firstResponseReturned) {
+                                        firstResponseReturned = true;
+                                        return Rx.Observable.of(forceUpdateMapLayout());
+                                    }
+                                    return Rx.Observable.empty();
+                                }))
+                                .startWith(newMapInfoRequest(reqId, param));
+                        }
+                        return Rx.Observable.of(forceUpdateMapLayout());
+                    }));
             // NOTE: multiSelection is inside the event
             // TODO: move this flag in the application state
             if (point && point.modifiers && point.modifiers.ctrl === true && point.multiSelection) {

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -292,6 +292,20 @@ export const getIdentifyFlow = (layer, baseURL, params) => {
     }
     return null;
 };
+/**
+ * Resolves layer properties not persisted in the configuration, when the service supports it.
+ * It must be applied before `buildIdentifyRequest`.
+ * @param {object} layer the layer object
+ * @param {object} options the options for the request (see `buildIdentifyRequest`)
+ * @return {Promise} resolves with the layer to use for the identify request
+ */
+export const resolveIdentifyLayer = (layer, options = {}) => {
+    const service = MapInfoUtils.services[layer?.type];
+    if (!service?.resolveLayer) {
+        return Promise.resolve(layer);
+    }
+    return service.resolveLayer(layer, MapInfoUtils.getDefaultInfoFormatValueFromLayer(layer, options));
+};
 
 const deduceInfoFormat = (response) => {
     let infoFormat;

--- a/web/client/utils/mapinfo/__tests__/wfs-test.js
+++ b/web/client/utils/mapinfo/__tests__/wfs-test.js
@@ -123,6 +123,7 @@ describe("mapinfo wfs utils", () => {
             id: "layer-id",
             title: "Title",
             url: '/geoserver/wfs',
+            infoFormats: ['application/json', 'text/html'],
             fields: [{
                 name: "key",
                 type: "string",
@@ -159,6 +160,91 @@ describe("mapinfo wfs utils", () => {
                 featureInfo: undefined
             },
             url: '/geoserver/wfs'
+        });
+    });
+
+    it('should keep the remote workflow when supported formats are unknown', () => {
+        const layer = {
+            id: "layer-id",
+            title: "Title",
+            url: '/geoserver/wfs',
+            fields: [{
+                name: "key",
+                type: "string",
+                alias: "alias"
+            }]
+        };
+        const point = {
+            intersectedFeatures: [
+                {
+                    id: "layer-id",
+                    features: [
+                        {
+                            type: "Feature",
+                            id: 'feature.1',
+                            properties: { key: "value" },
+                            geometry: null
+                        }
+                    ]
+                }
+            ]
+        };
+        expect(wfs.buildRequest(layer, { point }, 'text/html')).toEqual({
+            request: {
+                features: [
+                    { type: 'Feature', id: 'feature.1', properties: { key: 'value' }, geometry: null }
+                ],
+                outputFormat: 'text/html'
+            },
+            metadata: {
+                title: 'Title',
+                regex: undefined,
+                fields: [ { name: 'key', type: 'string', alias: 'alias' } ],
+                viewer: undefined,
+                featureInfo: undefined
+            },
+            url: '/geoserver/wfs'
+        });
+    });
+
+    it('should use the client workflow when text/html is explicitly unsupported', () => {
+        const layer = {
+            id: "layer-id",
+            title: "Title",
+            url: '/geoserver/wfs',
+            infoFormats: ['application/json']
+        };
+        const point = {
+            intersectedFeatures: [
+                {
+                    id: "layer-id",
+                    features: [
+                        {
+                            type: "Feature",
+                            id: 'feature.1',
+                            properties: { key: "value" },
+                            geometry: null
+                        }
+                    ]
+                }
+            ]
+        };
+
+        expect(wfs.buildRequest(layer, { point }, 'text/html')).toEqual({
+            request: {
+                features: [
+                    { type: 'Feature', id: 'feature.1', properties: { key: 'value' }, geometry: null }
+                ],
+                outputFormat: 'application/json'
+            },
+            metadata: {
+                title: 'Title',
+                regex: undefined,
+                fields: undefined,
+                viewer: undefined,
+                featureInfo: undefined
+            },
+            url: 'client'
         });
     });
 

--- a/web/client/utils/mapinfo/wfs.js
+++ b/web/client/utils/mapinfo/wfs.js
@@ -33,7 +33,7 @@ const CLIENT_WORKFLOW = 'client';
 const buildRequest = (layer, { map = {}, point, currentLocale, params, maxItems = 10 } = {}, infoFormat, viewer, featureInfo) => {
     if (point?.intersectedFeatures) {
         const { features = [] } = point?.intersectedFeatures?.find(({ id }) => id === layer.id) || {};
-        const isRemote = infoFormat === 'text/html';
+        const isRemote = infoFormat === 'text/html' && layer.infoFormats.includes('text/html');
         return {
             request: {
                 features: [...features],

--- a/web/client/utils/mapinfo/wfs.js
+++ b/web/client/utils/mapinfo/wfs.js
@@ -9,11 +9,12 @@
 import {Observable} from 'rxjs';
 
 import {normalizeSRS} from '../CoordinatesUtils';
-import { getLayerUrl } from '../LayersUtils';
+import { getCapabilitiesUrl, getLayerUrl } from '../LayersUtils';
 import { isObject } from 'lodash';
 import { optionsToVendorParams } from '../VendorParamsUtils';
-import { describeFeatureType, getFeature } from '../../api/WFS';
+import { describeFeatureType, getFeature, getSupportedFormat } from '../../api/WFS';
 import { extractGeometryAttributeName } from '../WFSLayerUtils';
+import { INFO_FORMATS } from '../FeatureInfoUtils';
 
 
 import {addAuthenticationToSLD} from '../SecurityUtils';
@@ -33,11 +34,12 @@ const CLIENT_WORKFLOW = 'client';
 const buildRequest = (layer, { map = {}, point, currentLocale, params, maxItems = 10 } = {}, infoFormat, viewer, featureInfo) => {
     if (point?.intersectedFeatures) {
         const { features = [] } = point?.intersectedFeatures?.find(({ id }) => id === layer.id) || {};
-        const isRemote = infoFormat === 'text/html' && layer.infoFormats.includes('text/html');
+        // unknown supported formats keep the remote workflow
+        const isRemote = infoFormat === INFO_FORMATS.HTML && layer.infoFormats?.includes(INFO_FORMATS.HTML) !== false;
         return {
             request: {
                 features: [...features],
-                outputFormat: isRemote ? 'text/html' : 'application/json'
+                outputFormat: isRemote ? INFO_FORMATS.HTML : INFO_FORMATS.JSON
             },
             metadata: {
                 title: isObject(layer.title)
@@ -98,6 +100,24 @@ const getIdentifyGeometry = point => {
 
 export default {
     buildRequest,
+    /**
+     * Detects the supported info formats, text/html is the only one a WFS service could be missing.
+     * @param {object} layer
+     * @param {string} infoFormat the info format needed by the identify request
+     * @return {Promise} resolves with the layer, with `infoFormats` when they could be detected
+     */
+    resolveLayer: (layer, infoFormat) => {
+        if (infoFormat !== INFO_FORMATS.HTML || layer.infoFormats?.length || !layer.url) {
+            return Promise.resolve(layer);
+        }
+        // layer specific capabilities is a smaller document
+        const capabilitiesUrl = layer.name
+            ? getCapabilitiesUrl({ url: layer.url, name: layer.name })
+            : getLayerUrl(layer);
+        return getSupportedFormat(capabilitiesUrl)
+            .then(({ infoFormats }) => ({ ...layer, infoFormats }))
+            .catch(() => layer);
+    },
     getIdentifyFlow: (layer = {}, baseURL, defaultParams) => {
         const { point, features, ...baseParams } = defaultParams || {};
         if (features) {


### PR DESCRIPTION
## Description
Adds missing info formats for layer object and also explicitly checks for infoFormat Support. This preserves change from https://github.com/geosolutions-it/MapStore2/pull/10234 as the supported `text/html` value will be advertised(as mentioned in notes [here](https://docs.geoserver.org/main/en/user/services/wfs/outputformats/), it does not explicitly tell about `text/html` but do tell that plugins advertise supported formats) and included in `layer.infoFormats`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#12752 

**What is the new behavior?**
GetFeatureInfo works correctly based on supported infoFormats

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
