### PR TITLE
[Backport geonode-5.1.x] Enhancement to OL WMS layer plugin

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -33,6 +33,8 @@ import { ServerTypes } from '../../../../utils/LayersUtils';
 
 
 import { Map, View } from 'ol';
+import ImageState from 'ol/ImageState';
+import TileState from 'ol/TileState';
 import { defaults as defaultControls } from 'ol/control';
 
 import axios from "../../../../libs/ajax";
@@ -347,6 +349,111 @@ describe('Openlayers layer', () => {
                 expect(e).toBeTruthy();
                 done();
             }, 200);
+        });
+    });
+    it('render wms singleTile layer with error does not request a spurious "null" url', (done) => {
+        ConfigUtils.setConfigProp('requestsConfigurationRules', [{
+            urlPattern: '.*\\/geoserver.*',
+            headers: {
+                Authorization: 'Bearer ${securityToken}'
+            }
+        }]);
+        setStore({
+            getState: () => ({
+                security: {
+                    token: "########-####-####-####-###########"
+                }
+            })
+        });
+        let request;
+        mockAxios.onGet().reply((r) => {
+            request = r;
+            return [200, new Blob(["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<ows:ExceptionReport xmlns:ows=\"http://www.opengis.net/ows\">\n" +
+            "  <ows:Exception exceptionCode=\"InvalidParameterValue\" locator=\"srsname\">\n" +
+            "    <ows:ExceptionText>WMS server error. Invalid GetMap Request</ows:ExceptionText>\n" +
+            "  </ows:Exception>\n" +
+            "</ows:ExceptionReport>"], {type: 'text/xml'})];
+        });
+        const options = {
+            type: 'wms',
+            visibility: true,
+            singleTile: true,
+            url: '/geoserver/wms',
+            name: 'ws:layer'
+        };
+        const layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={{
+                ...options
+            }}
+            map={map}
+            securityToken="########-####-####-####-###########" />, document.getElementById("container"));
+        ConfigUtils.setConfigProp('requestsConfigurationRules', undefined);
+        expect(layer.layer.getSource()).toBeTruthy();
+        layer.layer.getSource().once('imageloaderror', (e) => {
+            // the custom load function must have been used, so the exception comes from the OGC response
+            expect(request).toBeTruthy();
+            expect(request.headers.Authorization).toBe('Bearer ########-####-####-####-###########');
+            // ol/Image has no setState, the error state must be notified anyway
+            expect(e.image.getState()).toBe(ImageState.ERROR);
+            // the error handler must not set img.src = null, which the DOM coerces
+            // to the literal string "null" and resolves into a spurious request
+            const img = e.image.getImage();
+            expect(img.getAttribute('src') === 'null' || (img.src || '').endsWith('/null')).toBe(false);
+            done();
+        });
+    });
+    it('render wms tiled layer with error does not request a spurious "null" url', (done) => {
+        ConfigUtils.setConfigProp('requestsConfigurationRules', [{
+            urlPattern: '.*\\/geoserver.*',
+            headers: {
+                Authorization: 'Bearer ${securityToken}'
+            }
+        }]);
+        setStore({
+            getState: () => ({
+                security: {
+                    token: "########-####-####-####-###########"
+                }
+            })
+        });
+        let request;
+        mockAxios.onGet().reply((r) => {
+            request = r;
+            return [200, new Blob(["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<ows:ExceptionReport xmlns:ows=\"http://www.opengis.net/ows\">\n" +
+            "  <ows:Exception exceptionCode=\"InvalidParameterValue\" locator=\"srsname\">\n" +
+            "    <ows:ExceptionText>WMS server error. Invalid GetMap Request</ows:ExceptionText>\n" +
+            "  </ows:Exception>\n" +
+            "</ows:ExceptionReport>"], {type: 'text/xml'})];
+        });
+        const options = {
+            type: 'wms',
+            visibility: true,
+            singleTile: false,
+            url: '/geoserver/wms',
+            name: 'ws:tiled_layer'
+        };
+        const layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={{
+                ...options
+            }}
+            map={map}
+            securityToken="########-####-####-####-###########" />, document.getElementById("container"));
+        ConfigUtils.setConfigProp('requestsConfigurationRules', undefined);
+        expect(layer.layer.getSource()).toBeTruthy();
+        layer.layer.getSource().once('tileloaderror', (e) => {
+            // the custom load function must have been used, so the exception comes from the OGC response
+            expect(request).toBeTruthy();
+            expect(request.headers.Authorization).toBe('Bearer ########-####-####-####-###########');
+            expect(e.tile.getState()).toBe(TileState.ERROR);
+            // the error handler must not set img.src = null, which the DOM coerces
+            // to the literal string "null" and resolves into a spurious request
+            const img = e.tile.getImage();
+            expect(img.getAttribute('src') === 'null' || (img.src || '').endsWith('/null')).toBe(false);
+            done();
         });
     });
     it('creates a tiled wms layer for openlayers map with long url', (done) => {

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -3618,6 +3618,47 @@ describe('Openlayers layer', () => {
         // restore original method
         wmsSource.refresh = originalRefresh;
     });
+    it('wms layer should stop auto-refreshing after repeated loadingError within the cooldown window', () => {
+        var refreshCallCount = 0;
+        const options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms",
+            "id": "wms-loading-error-refresh-cap-test"
+        };
+
+        // create layer
+        ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+
+        const wmsSource = map.getLayers().item(0).getSource();
+        const originalRefresh = wmsSource.refresh;
+        wmsSource.refresh = function() {
+            refreshCallCount++;
+            originalRefresh.call(this);
+        };
+
+        // simulate the error state oscillating (fail, recover, fail, recover, ...) 5 times in a row,
+        // as happens when the underlying tile failure is intermittent rather than a one-off config mistake
+        for (let i = 0; i < 5; i++) {
+            ReactDOM.render(
+                <OpenlayersLayer type="wms"
+                    options={{...options, loadingError: "Error"}} map={map} />, document.getElementById("container"));
+            ReactDOM.render(
+                <OpenlayersLayer type="wms"
+                    options={{...options, loadingError: false}} map={map} />, document.getElementById("container"));
+        }
+
+        // refresh should be capped (MAX_LOADING_ERROR_REFRESH_ATTEMPTS = 3), not called once per oscillation (5)
+        expect(refreshCallCount).toBe(3);
+
+        // restore original method
+        wmsSource.refresh = originalRefresh;
+    });
     it('creates a arcgis layer (MapServer)', () => {
         const options = {
             type: 'arcgis',

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -34,7 +34,15 @@ import { OL_VECTOR_FORMATS, applyStyle } from '../../../../utils/openlayers/Vect
 
 import { proxySource, getWMSURLs, wmsToOpenlayersOptions, toOLAttributions, generateTileGrid } from '../../../../utils/openlayers/WMSUtils';
 
+const failTiles = new Set(); // registry of fail tile urls to prevent reloading loops
+
 const loadFunction = (options, headers) => function(image, src) {
+
+    if (failTiles.has(src)) {  // avoids custom reload in cases of tiles that have already returned exceptions
+        image.setState(3);
+        return;
+    }
+
     // fixes #3916, see https://gis.stackexchange.com/questions/175057/openlayers-3-wms-styling-using-sld-body-and-post-request
     let img = image.getImage();
     let newSrc = proxySource(options.forceProxy, src);
@@ -67,6 +75,7 @@ const loadFunction = (options, headers) => function(image, src) {
             }
         }).catch(e => {
             image.setState(3);
+            failTiles.add(src);
             console.error(e);
         });
     } else {
@@ -89,6 +98,7 @@ const loadFunction = (options, headers) => function(image, src) {
                 }).catch(errorMessage => {
                     image.getImage().src = null;   // needed to trigger the MS imageloaderror event in Map.onLayerError
                     image.setState(3);            // set error state for tile and removed from the queue to prevent reloading loops
+                    failTiles.add(src);           // indexing fail url tile to prevent reloading loops
                     console.error(errorMessage);  // show ogc exception in console for debugging
                 });
         } else {

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -66,27 +66,31 @@ const loadFunction = (options, headers) => function(image, src) {
                 }
             }
         }).catch(e => {
+            image.setState(3);
             console.error(e);
         });
     } else {
-        if (headers) {
+        if (headers) { // case of custom headers is setted in localConfig, example requestsConfigurationRules
             axios.get(newSrc, {
                 headers,
                 responseType: 'blob'
-            }).then(response => {
-                if (isValidResponse(response)) {
-                    image.getImage().src = URL.createObjectURL(response.data);
-                } else {
-                    // #10701 this is needed to trigger the imageloaderror event
-                    // in ol otherwise this event is not triggered if you assign
-                    // the xml content of the exception to the src attribute
-                    image.getImage().src = null;
-                    console.error("error: " + response.data);
-                }
-            }).catch(e => {
-                image.getImage().src = null;
-                console.error(e);
-            });
+            })
+                .then((response) => {
+                    return response.data.type === "text/xml"
+                        ? response.data.text().then(dataText => ({...response, dataText}))
+                        : response;
+                })
+                .then(response => {
+                    if (isValidResponse(response)) { // not contains OGC exception
+                        image.getImage().src = URL.createObjectURL(response.data);
+                    } else {
+                        throw new Error(response.dataText);
+                    }
+                }).catch(errorMessage => {
+                    image.getImage().src = null;   // needed to trigger the MS imageloaderror event in Map.onLayerError
+                    image.setState(3);            // set error state for tile and removed from the queue to prevent reloading loops
+                    console.error(errorMessage);  // show ogc exception in console for debugging
+                });
         } else {
             img.src = newSrc;
         }

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -36,6 +36,9 @@ import { OL_VECTOR_FORMATS, applyStyle } from '../../../../utils/openlayers/Vect
 import { proxySource, getWMSURLs, wmsToOpenlayersOptions, toOLAttributions, generateTileGrid } from '../../../../utils/openlayers/WMSUtils';
 
 const failTiles = new Set(); // registry of fail tile urls to prevent reloading loops
+const loadingErrorRefreshState = new Map(); // layer id -> { attempts, windowStart }
+const MAX_LOADING_ERROR_REFRESH_ATTEMPTS = 3; // caps refresh() retries within the cooldown window
+const LOADING_ERROR_REFRESH_COOLDOWN_MS = 30000; // window resets only after this much quiet time, NOT on every transient recovery (error/success can oscillate every render during a real loop, which would otherwise reset the counter before it ever caps)
 
 /**
  * Flags a tile/image as failed, so the source emits tileloaderror/imageloaderror
@@ -290,9 +293,19 @@ Layers.registerType('wms', {
         }
         // refresh/update wms layer if there is error in loading tiles like: incorrect time dimension date filter, ..etc
         if (oldOptions.loadingError !== "Error" && newOptions.loadingError === "Error") {
-            // Clear tile cache before refresh to avoid showing old broken tiles
-            wmsSource?.tileCache?.pruneExceptNewestZ?.();
-            wmsSource?.refresh();
+            const now = Date.now();
+            const prev = loadingErrorRefreshState.get(newOptions.id);
+            // only start a new cooldown window if the previous one has fully expired;
+            // do NOT reset on every transient recovery, or a fast error/success oscillation
+            // (a real reload loop) would clear the counter before it ever caps
+            const windowExpired = !prev || (now - prev.windowStart) > LOADING_ERROR_REFRESH_COOLDOWN_MS;
+            const attempts = windowExpired ? 1 : prev.attempts + 1;
+            loadingErrorRefreshState.set(newOptions.id, { attempts, windowStart: windowExpired ? now : prev.windowStart });
+            if (attempts <= MAX_LOADING_ERROR_REFRESH_ATTEMPTS) {
+                // Clear tile cache before refresh to avoid showing old broken tiles
+                wmsSource?.tileCache?.pruneExceptNewestZ?.();
+                wmsSource?.refresh();
+            }
         }
         if (oldOptions.minResolution !== newOptions.minResolution) {
             layer.setMinResolution(newOptions.minResolution === undefined ? 0 : newOptions.minResolution);

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -20,6 +20,7 @@ import {optionsToVendorParams} from '../../../../utils/VendorParamsUtils';
 import {addAuthenticationToSLD, addAuthenticationParameter, getAuthenticationHeaders} from '../../../../utils/SecurityUtils';
 
 import ImageLayer from 'ol/layer/Image';
+import ImageState from 'ol/ImageState';
 import ImageWMS from 'ol/source/ImageWMS';
 import {get} from 'ol/proj';
 import TileLayer from 'ol/layer/Tile';
@@ -36,10 +37,26 @@ import { proxySource, getWMSURLs, wmsToOpenlayersOptions, toOLAttributions, gene
 
 const failTiles = new Set(); // registry of fail tile urls to prevent reloading loops
 
+/**
+ * Flags a tile/image as failed, so the source emits tileloaderror/imageloaderror
+ * and stops re-requesting it.
+ * Tiled layers get an `ol/ImageTile` (has `setState`), single tile layers get an
+ * `ol/Image`, that exposes no setter and needs the state change to be notified manually.
+ * @param {object} image the `ol/ImageTile` or `ol/Image` passed to the load function
+ */
+const setErrorState = (image) => {
+    if (image.setState) {
+        image.setState(ImageState.ERROR);
+        return;
+    }
+    image.state = ImageState.ERROR;
+    image.changed();
+};
+
 const loadFunction = (options, headers) => function(image, src) {
 
     if (failTiles.has(src)) {  // avoids custom reload in cases of tiles that have already returned exceptions
-        image.setState(3);
+        setErrorState(image);
         return;
     }
 
@@ -74,7 +91,7 @@ const loadFunction = (options, headers) => function(image, src) {
                 }
             }
         }).catch(e => {
-            image.setState(3);
+            setErrorState(image);
             failTiles.add(src);
             console.error(e);
         });
@@ -96,8 +113,7 @@ const loadFunction = (options, headers) => function(image, src) {
                         throw new Error(response.dataText);
                     }
                 }).catch(errorMessage => {
-                    image.getImage().src = null;   // needed to trigger the MS imageloaderror event in Map.onLayerError
-                    image.setState(3);            // set error state for tile and removed from the queue to prevent reloading loops
+                    setErrorState(image);         // set error state for tile and removed from the queue to prevent reloading loops
                     failTiles.add(src);           // indexing fail url tile to prevent reloading loops
                     console.error(errorMessage);  // show ogc exception in console for debugging
                 });


### PR DESCRIPTION
## Description
- Fix (#12371) WMS GetMap unhandled error for custom requestsConfigurationRules (#12372)
- Fix (#12371) additional condition to prevent tile exception reloding (#12397)
- Fix (#12689) Remove unnecessary src=null on WMS tile load error (#12691)
- Fix (#12688) Cap auto-refresh on recurring WMS tile load errors (#12690)