### PR TITLE
Remove react-contenteditable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,6 @@
     "react-codemirror2": "4.0.0",
     "react-color": "2.17.0",
     "react-container-dimensions": "1.4.1",
-    "react-contenteditable": "3.3.2",
     "react-copy-to-clipboard": "5.0.0",
     "react-data-grid": "5.0.4",
     "react-data-grid-addons": "5.0.4",

--- a/web/client/components/geostory/builder/TitleEditable.jsx
+++ b/web/client/components/geostory/builder/TitleEditable.jsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
-import ContentEditable from 'react-contenteditable';
 import {withState, compose} from 'recompose';
 
 const manageUpdates = compose(
@@ -21,24 +20,21 @@ const manageUpdates = compose(
 const TitleEditable = manageUpdates(({
     text,
     className = "ms-story-title-editable",
-    onUpdate = () =>  {},
-    setText = () => {}} = {}
-) => {
-    return (<ContentEditable
+    onUpdate = () =>  {}
+} = {}) => {
+    return (<div
         className={className}
-        html={text}
         onClick={evt => {
             // avoid trigger select state
             evt.stopPropagation();
-        }}
-        onChange={evt => {
-            setText(evt.target.value);
         }}
         onBlur={(evt) => {
             // this event has no value property
             onUpdate(evt.target.innerText);
         }}
-    />);
+        contentEditable
+        suppressContentEditableWarning
+    >{text}</div>);
 });
 
 


### PR DESCRIPTION
## Description
This PR removes the react-contenteditable dependency and replaces the functionality with standard html.

- I removed the setText prop because it was not being used anywhere.
- I removed the onChange handler from the element, because div doesn't support it, while the ContentEditable element did. This is not a problem because it was not being used, and even if it did, the onBlur handler would end up catching the change anyways.
- I added `suppressContentEditableWarning` to avoid errors in the browser devtool

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12760

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
We will no longer download the react-contentable npm package and the <ContentEditable> component is replaced with a <div contenteditable></div>

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
