### PR TITLE
[Backport 2026.02.xx] Fix #12627 CRS change crashes with grid-based projections when layer resolution limits are configured

### DIFF
--- a/web/client/actions/__tests__/map-test.js
+++ b/web/client/actions/__tests__/map-test.js
@@ -7,6 +7,8 @@
  */
 
 import expect from 'expect';
+import proj4 from 'proj4';
+import { register } from 'ol/proj/proj4';
 
 import {
     CHANGE_MAP_VIEW,
@@ -56,6 +58,7 @@ import {
     UPDATE_MAP_OPTIONS
 } from '../map';
 import {updateNode} from '../layers';
+import { METERS_PER_UNIT } from '../../utils/MapUtils';
 
 describe('Test correctness of the map actions', () => {
 
@@ -155,9 +158,12 @@ describe('Test correctness of the map actions', () => {
                 }],
                 map: {present: {projection: "EPSG:3857"}}
             }));
+        // metres are converted to degrees through the meters-per-unit of the units, the same ratio
+        // the map view uses to keep the scale when the projection changes
+        const metersPerDegree = METERS_PER_UNIT.degrees;
         const expectedActions = [
-            updateNode('layer1', 'layer', { minResolution: 0.02197265625, maxResolution: 0.0439453125 }),
-            updateNode('layer2', 'layer', { minResolution: 0.0439453125 }),
+            updateNode('layer1', 'layer', { minResolution: 2000 / metersPerDegree, maxResolution: 4000 / metersPerDegree }),
+            updateNode('layer2', 'layer', { minResolution: 5000 / metersPerDegree }),
             changeCRS(crs)
         ];
         for (let i = 0; i < expectedActions.length; i++) {
@@ -171,6 +177,59 @@ describe('Test correctness of the map actions', () => {
                 );
             }
         }
+    });
+
+    it('changes map crs without crashing when the target CRS relies on an unavailable datum grid', () => {
+        // simulates a datum grid (e.g. NTv2/gsb) that can't be resolved for the map's current location
+        const crs = 'TEST:6265-GRID-CRS';
+        proj4.defs(crs, '+proj=utm +zone=30 +ellps=GRS80 +units=m +no_defs +nadgrids=unavailable-grid-6265-actions');
+        register(proj4);
+
+        const thunk = changeMapCrs(crs);
+        expect(thunk).toExist();
+        const dispatchedActions = [];
+        const dispatch = (action) => {
+            dispatchedActions.push(action);
+        };
+        expect(() => thunk(dispatch,
+            () => ({
+                layers: [{
+                    id: 'layer1',
+                    minResolution: 2000,
+                    maxResolution: 4000
+                }],
+                map: {present: {
+                    projection: "EPSG:3857",
+                    center: {x: -1.13, y: 38.0, crs: 'EPSG:4326'}
+                }}
+            }))).toNotThrow();
+
+        const updateNodeActions = dispatchedActions.filter(a => a.type === updateNode('layer1', 'layer', {}).type);
+        expect(updateNodeActions.length).toBe(1);
+        const { minResolution, maxResolution } = updateNodeActions[0].options;
+        expect(isNaN(minResolution)).toBe(false);
+        expect(isNaN(maxResolution)).toBe(false);
+        expect(dispatchedActions[dispatchedActions.length - 1]).toEqual(changeCRS(crs));
+    });
+
+    it('changes map crs back and forth without altering the layer resolution limits', () => {
+        proj4.defs('TEST:UTM30N', '+proj=utm +zone=30 +ellps=GRS80 +units=m +no_defs');
+        register(proj4);
+        const limitsAfter = (sourceCRS, targetCRS, layer) => {
+            const dispatched = [];
+            changeMapCrs(targetCRS)((action) => dispatched.push(action), () => ({
+                layers: [layer],
+                map: { present: { projection: sourceCRS } }
+            }));
+            return dispatched[0].options;
+        };
+
+        const inGeographic = limitsAfter('TEST:UTM30N', 'EPSG:4326', { id: 'layer1', minResolution: 0.5, maxResolution: 100 });
+        const backInMetric = limitsAfter('EPSG:4326', 'TEST:UTM30N', { id: 'layer1', ...inGeographic });
+
+        // the ratio is applied in both directions, so the round trip is stable down to float rounding
+        expect(Math.abs(backInMetric.minResolution / 0.5 - 1)).toBeLessThan(1e-12);
+        expect(Math.abs(backInMetric.maxResolution / 100 - 1)).toBeLessThan(1e-12);
     });
 
     it('changeMapScales', () => {

--- a/web/client/actions/map.js
+++ b/web/client/actions/map.js
@@ -6,11 +6,10 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-import { getResolutions, convertResolution } from '../utils/MapUtils';
+import { convertResolutionByUnits } from '../utils/MapUtils';
 import { layersSelector } from '../selectors/layers';
 import { projectionSelector } from '../selectors/map';
 import { updateNode } from '../actions/layers';
-import minBy from 'lodash/minBy';
 
 export const CHANGE_MAP_VIEW = 'CHANGE_MAP_VIEW';
 export const CLICK_ON_MAP = 'CLICK_ON_MAP';
@@ -95,38 +94,18 @@ export function changeMapCrs(crs) {
     return (dispatch, getState = () => {}) => {
         const state =  getState();
         const sourceCRS = projectionSelector(state);
-        const layersWithLimits = layersSelector(state).filter(l => l.minResolution || l.maxResolution);
-        layersWithLimits.forEach(layer => {
-            const options = {};
-            const newResolutions = getResolutions(crs);
-            if (layer.minResolution) {
-                options.minResolution = convertResolution(sourceCRS, crs, layer.minResolution).transformedResolution;
-                const diffs = newResolutions.map((resolution, zoom) => ({ diff: Math.abs(resolution - options.minResolution), zoom }));
-                const { zoom } = minBy(diffs, 'diff');
-                options.minResolution = newResolutions[zoom];
-            }
-            if (layer.maxResolution) {
-                options.maxResolution = convertResolution(sourceCRS, crs, layer.maxResolution).transformedResolution;
-                const diffs = newResolutions.map((resolution, zoom) => ({ diff: Math.abs(resolution - options.maxResolution), zoom }));
-                const { zoom } = minBy(diffs, 'diff');
-                // check if min and max resolutions are not the same
-                options.maxResolution = newResolutions[zoom];
-                if (options.minResolution === options.maxResolution) {
-                    if ((zoom - 1) >= 0) {
-                        // increase max res if possible
-                        options.maxResolution = newResolutions[zoom - 1];
-                    } else if (zoom + 1 < newResolutions.length) {
-                        // decrease max res if possible
-                        options.minResolution = newResolutions[zoom + 1];
-                    } else {
-                        // keep only min res if none of the previous is happening
-                        options.maxResolution = undefined;
-                    }
+        layersSelector(state)
+            .filter(l => l.minResolution || l.maxResolution)
+            .forEach(layer => {
+                const options = {};
+                if (layer.minResolution) {
+                    options.minResolution = convertResolutionByUnits(sourceCRS, crs, layer.minResolution);
                 }
-            }
-            // the minimum difference represents the nearest zoom to the target resolution
-            dispatch(updateNode(layer.id, "layer", options));
-        });
+                if (layer.maxResolution) {
+                    options.maxResolution = convertResolutionByUnits(sourceCRS, crs, layer.maxResolution);
+                }
+                dispatch(updateNode(layer.id, "layer", options));
+            });
         dispatch(changeCRS(crs));
     };
 }

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -532,9 +532,11 @@ export function getRandomPointInCRS(crs) {
  * @param {string} sourceCRS the code of a projection
  * @param {string} targetCRS the code of a projection
  * @param {number} sourceResolution the resolution to convert
+ * @param {number[]} [anchorPoint] point in sourceCRS to anchor the conversion to. Falls back to a random point
+ *  in the source extent when omitted, for backwards compatibility.
  * @returns the converted resolution
  */
-export function convertResolution(sourceCRS, targetCRS, sourceResolution) {
+export function convertResolution(sourceCRS, targetCRS, sourceResolution, anchorPoint) {
     const sourceProjection = getProjectionOL(sourceCRS);
     const targetProjection = getProjectionOL(targetCRS);
 
@@ -542,18 +544,49 @@ export function convertResolution(sourceCRS, targetCRS, sourceResolution) {
         throw new Error(`Invalid CRS: ${sourceCRS} or ${targetCRS}`);
     }
 
-    // Get a random point in the extent of the source CRS
-    const randomPoint = getRandomPointInCRS(sourceCRS);
+    const point = anchorPoint || getRandomPointInCRS(sourceCRS);
 
-    // Transform the resolution
-    const transformedResolution = getPointResolution(
-        sourceProjection,
-        sourceResolution,
-        transform(randomPoint, sourceCRS, targetCRS),
-        targetProjection.getUnits()
-    );
+    // getPointResolution expects the point in the space of the projection passed as first argument,
+    // so `point` stays in sourceCRS: measuring the source resolution needs no target transform
+    const groundResolution = getPointResolution(sourceProjection, sourceResolution, point, 'm');
 
-    return { randomPoint, transformedResolution };
+    // ground meters covered by one targetCRS unit at the same location
+    let metersPerTargetUnit;
+    try {
+        const targetPoint = transform(point, sourceCRS, targetCRS);
+        if (targetPoint.every((value) => Number.isFinite(value))) {
+            metersPerTargetUnit = getPointResolution(targetProjection, 1, targetPoint, 'm');
+        }
+    } catch (e) {
+        metersPerTargetUnit = undefined;
+    }
+
+    const transformedResolution = metersPerTargetUnit > 0
+        ? groundResolution / metersPerTargetUnit
+        // targetCRS not reachable from this point: convert by units only, ignoring its local distortion
+        : getPointResolution(sourceProjection, sourceResolution, point, targetProjection.getUnits());
+
+    return { randomPoint: point, transformedResolution };
+}
+
+/**
+ * Convert a resolution between two CRSs through the meters-per-unit ratio of their units.
+ *
+ * This is the ratio the map view uses as well when it looks for the zoom level that keeps the
+ * current scale on a projection change: resolutions converted this way keep the same relation
+ * with the view resolution, which is what preserves layer visibility across a CRS switch.
+ * Converting through the local point resolution instead would be closer to the real size on the
+ * ground, but it would drift from the view by the local scale factor of the projection
+ * (1 / cos(lat) for Mercator, one full zoom level around 45 degrees of latitude).
+ *
+ * @param {string} sourceCRS the code of the source projection
+ * @param {string} targetCRS the code of the target projection
+ * @param {number} sourceResolution the resolution to convert, in sourceCRS units
+ * @returns {number} the resolution in targetCRS units
+ */
+export function convertResolutionByUnits(sourceCRS, targetCRS, sourceResolution) {
+    const metersPerCRSUnit = (code) => getMetersPerUnit(getUnits(code), 1);
+    return sourceResolution * metersPerCRSUnit(sourceCRS) / metersPerCRSUnit(targetCRS);
 }
 
 /**
@@ -564,10 +597,11 @@ export function convertResolution(sourceCRS, targetCRS, sourceResolution) {
 export function getZoomFromResolution(targetResolution, resolutions = getResolutions()) {
     // compute the absolute difference for all resolutions
     // and store the idx as zoom
-    const diffs = resolutions.map((resolution, zoom) => ({ diff: Math.abs(resolution - targetResolution), zoom }));
+    const diffs = resolutions
+        .map((resolution, zoom) => ({ diff: Math.abs(resolution - targetResolution), zoom }))
+        .filter(({ diff }) => Number.isFinite(diff));
     // the minimum difference represents the nearest zoom to the target resolution
-    const { zoom } = minBy(diffs, 'diff');
-    return zoom;
+    return minBy(diffs, 'diff')?.zoom;
 }
 
 /**

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -7,6 +7,8 @@
  */
 import expect from 'expect';
 import * as Cesium from 'cesium';
+import proj4 from 'proj4';
+import { register } from 'ol/proj/proj4';
 
 import { keys, sortBy } from 'lodash';
 
@@ -44,6 +46,8 @@ import {
     reprojectZoom,
     getRandomPointInCRS,
     convertResolution,
+    convertResolutionByUnits,
+    METERS_PER_UNIT,
     getExactZoomFromResolution,
     recursiveIsChangedWithRules,
     filterFieldByRules,
@@ -2435,7 +2439,50 @@ describe('Test the MapUtils', () => {
         expect(getRandomPointInCRS('EPSG:4326').length).toBe(2);
     });
     it('convertResolution', () => {
-        expect(convertResolution('EPSG:3857', 'EPSG:4326', 2000).transformedResolution).toBe(0.017986440587896155);
+        expect(convertResolution('EPSG:3857', 'EPSG:4326', 2000).transformedResolution).toBe(0.01798640727449076);
+    });
+    it('convertResolution keeps the same size on the ground when converting to a Mercator CRS', () => {
+        proj4.defs('TEST:UTM30N', '+proj=utm +zone=30 +ellps=GRS80 +units=m +no_defs');
+        register(proj4);
+        const lat = 45;
+        const utmPoint = proj4('EPSG:4326', 'TEST:UTM30N', [-1.13, lat]);
+        const mercatorPoint = proj4('EPSG:4326', 'EPSG:3857', [-1.13, lat]);
+        // one UTM metre is a real metre, one EPSG:3857 metre is cos(lat) real metres,
+        // so the same pixel size on the ground needs a 1 / cos(lat) larger resolution in EPSG:3857
+        const expected = 2000 / Math.cos(lat * Math.PI / 180);
+
+        const mercatorResolution = convertResolution('TEST:UTM30N', 'EPSG:3857', 2000, utmPoint).transformedResolution;
+        expect(Math.abs(mercatorResolution / expected - 1)).toBeLessThan(0.01);
+
+        const back = convertResolution('EPSG:3857', 'TEST:UTM30N', mercatorResolution, mercatorPoint).transformedResolution;
+        expect(Math.abs(back / 2000 - 1)).toBeLessThan(0.01);
+    });
+    it('convertResolution returns degrees when the target CRS is geographic', () => {
+        proj4.defs('TEST:UTM30N', '+proj=utm +zone=30 +ellps=GRS80 +units=m +no_defs');
+        register(proj4);
+        const utmPoint = proj4('EPSG:4326', 'TEST:UTM30N', [-1.13, 45]);
+        // 2000 metres is roughly 0.02 degrees at this latitude
+        const result = convertResolution('TEST:UTM30N', 'EPSG:4326', 2000, utmPoint).transformedResolution;
+        expect(result).toBeGreaterThan(0.01);
+        expect(result).toBeLessThan(0.03);
+    });
+    it('convertResolutionByUnits converts through the meters-per-unit ratio of the units', () => {
+        proj4.defs('TEST:UTM30N', '+proj=utm +zone=30 +ellps=GRS80 +units=m +no_defs');
+        register(proj4);
+        expect(convertResolutionByUnits('TEST:UTM30N', 'EPSG:4326', 2000)).toBe(2000 / METERS_PER_UNIT.degrees);
+        expect(convertResolutionByUnits('EPSG:4326', 'TEST:UTM30N', 1)).toBe(METERS_PER_UNIT.degrees);
+        // both CRS in metres: nothing to convert
+        expect(convertResolutionByUnits('TEST:UTM30N', 'EPSG:3857', 2000)).toBe(2000);
+    });
+    it('convertResolution does not fail when the target CRS relies on an unavailable datum grid', () => {
+        // simulates a datum grid (e.g. NTv2/gsb) that can't be resolved for the given point
+        proj4.defs('TEST:6265-GRID-CRS', '+proj=utm +zone=30 +ellps=GRS80 +units=m +no_defs +nadgrids=unavailable-grid-6265');
+        register(proj4);
+
+        const result = convertResolution('EPSG:3857', 'TEST:6265-GRID-CRS', 2000);
+        expect(result).toExist();
+        expect(isNaN(result.transformedResolution)).toBe(false);
+        expect(isFinite(result.transformedResolution)).toBe(true);
     });
     it('test get exact zoom level from resolution using getExactZoomFromResolution', () => {
         const resolutions =  [156543, 78271, 39135, 19567, 9783, 4891, 2445, 1222];


### PR DESCRIPTION
Backport of [https://github.com/geosolutions-it/MapStore2/pull/12691 ](https://github.com/geosolutions-it/MapStore2/pull/12669) to 2026.02.xx.

Fixes #12627