### PR TITLE
Bump react-dom from 16.10.1 to 16.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "react-dnd-html5-backend": "2.6.0",
     "react-dnd-test-backend": "2.6.0",
     "react-dock": "0.2.4",
-    "react-dom": "16.10.1",
+    "react-dom": "16.14.0",
     "react-draft-wysiwyg": "npm:@geosolutions/react-draft-wysiwyg@1.14.8",
     "react-draggable": "2.2.6",
     "react-dropzone": "3.13.1",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR bumps the react-dom dependency to version 16.14.0, so its in sync with the react dependency.

All tests are passing, I have read through the changelogs and I have done some manual testing, everything seems to be working.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12764

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Bumps react-dom to version 16.14.0

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
