### PR TITLE
Group user info still available in "Account info" even if disabled in plugin config  #12789

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -179,6 +179,24 @@ Copy the `logging.properties` file from the MapStore repository (`product/cargo/
 
 **CI/CD**: update your build infrastructure to use JDK 17 as the build JDK.
 
+## Migration from 2026.02.00 to 2026.02.01
+
+### Login `hideGroupUserInfo` configuration
+
+The `hideGroupUserInfo` option is now a direct configuration property of the `Login` plugin. Update all `Login` plugin configurations in `localConfig.json` as follows:
+
+```diff
+{
+    "name": "Login",
+    "cfg": {
+-        "toolsCfg": [{"hideGroupUserInfo": true}]
++        "hideGroupUserInfo": true
+    }
+}
+```
+
+The previous `toolsCfg` configuration is still supported as a fallback for backward compatibility, but the direct `hideGroupUserInfo` property should be used for all new configurations.
+
 ## Migration from 2026.01.02 to 2026.02.00
 
 ### Dev server static configuration moved to the webpack configuration files
@@ -503,22 +521,6 @@ Several monitored state entries have been added to the default configuration of 
 The entries you have configured will still work by overriding the default ones, anyway, in order to reduce the configuration, you should remove the entries if they are already available by default.
 
 The entries that you can remove because are available by default are documented in the [State Access and monitorState](./expressions.md#state-access-and-monitorstate) guide.
-
-### Login `hideGroupUserInfo` configuration
-
-The `hideGroupUserInfo` option is now a direct configuration property of the `Login` plugin. Update all `Login` plugin configurations in `localConfig.json` as follows:
-
-```diff
-{
-    "name": "Login",
-    "cfg": {
--        "toolsCfg": [{"hideGroupUserInfo": true}]
-+        "hideGroupUserInfo": true
-    }
-}
-```
-
-The previous `toolsCfg` configuration is still supported as a fallback for backward compatibility, but the direct `hideGroupUserInfo` property should be used for all new configurations.
 
 ## Migration from 2025.02.02 to 2026.01.00
 

--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -504,6 +504,22 @@ The entries you have configured will still work by overriding the default ones, 
 
 The entries that you can remove because are available by default are documented in the [State Access and monitorState](./expressions.md#state-access-and-monitorstate) guide.
 
+### Login `hideGroupUserInfo` configuration
+
+The `hideGroupUserInfo` option is now a direct configuration property of the `Login` plugin. Update all `Login` plugin configurations in `localConfig.json` as follows:
+
+```diff
+{
+    "name": "Login",
+    "cfg": {
+-        "toolsCfg": [{"hideGroupUserInfo": true}]
++        "hideGroupUserInfo": true
+    }
+}
+```
+
+The previous `toolsCfg` configuration is still supported as a fallback for backward compatibility, but the direct `hideGroupUserInfo` property should be used for all new configurations.
+
 ## Migration from 2025.02.02 to 2026.01.00
 
 ### Database update

--- a/web/client/components/security/modals/UserDetailsModal.jsx
+++ b/web/client/components/security/modals/UserDetailsModal.jsx
@@ -17,8 +17,8 @@ import Message from '../../../components/I18N/Message';
 import { isArray, isObject, isString } from 'lodash';
 
 /**
- * A Modal window to show password reset form
-  * @prop {bool} hideGroupUserInfo It is a flag from Login plugin (cfg.toolsCfg[0].hideGroupUserInfo): to show/hide user group in user details info, by default `false`
+ * A Modal window to show user details
+  * @prop {bool} hideGroupUserInfo if true, hides the user group information, by default `false`
  */
 class UserDetails extends React.Component {
     static propTypes = {

--- a/web/client/plugins/Login.jsx
+++ b/web/client/plugins/Login.jsx
@@ -106,7 +106,8 @@ function LoginPlugin({
     displayName,
     showAccountInfo,
     bsStyle,
-    className
+    className,
+    toolsCfg
 }, context) {
 
     const { loadedPlugins } = context;
@@ -152,6 +153,7 @@ function LoginPlugin({
                 showPasswordChange={showPasswordChange}
                 showAccountInfo={showAccountInfo}
                 isUsingLDAP={isUsingLDAP}
+                hideGroupUserInfo={toolsCfg?.[0]?.hideGroupUserInfo}
             />
             <Login/>
         </>
@@ -186,7 +188,8 @@ LoginPlugin.propTypes = {
     isAdmin: PropTypes.bool,
     isUsingLDAP: PropTypes.bool,
     displayName: PropTypes.string,
-    className: PropTypes.string
+    className: PropTypes.string,
+    toolsCfg: PropTypes.array
 };
 
 LoginPlugin.defaultProps = {

--- a/web/client/plugins/Login.jsx
+++ b/web/client/plugins/Login.jsx
@@ -62,6 +62,7 @@ const RULE_MANAGER_ID = 'rulesmanager';
   *
   * @prop {string} cfg.id identifier of the Plugin, by default `"mapstore-login-menu"`
   * @prop {boolean} cfg.isUsingLDAP flag refers to if the user with type LDAP or not to manage show/hide change psasword, by default: false
+  * @prop {boolean} cfg.hideGroupUserInfo if true, hides the user group information in the user details modal, by default: false
   * @prop {object[]} items this property contains the items injected from the other plugins
   *  * using the `containers` option in the plugin that want to inject the new menu items.
   * ```javascript
@@ -107,12 +108,15 @@ function LoginPlugin({
     showAccountInfo,
     bsStyle,
     className,
+    hideGroupUserInfo,
     toolsCfg
 }, context) {
 
     const { loadedPlugins } = context;
     const configuredItems = usePluginItems({ items, loadedPlugins });
     const showPasswordChange = !(!isAdmin && isUsingLDAP);
+    // Keep toolsCfg[0] as a fallback for backward compatibility.
+    const resolvedHideGroupUserInfo = hideGroupUserInfo ?? toolsCfg?.[0]?.hideGroupUserInfo ?? false;
     const authenticated = user?.[displayName];
     const userItems = authenticated ? [
         { name: 'UserDetails', Component: UserDetailsMenuItem, position: 1},
@@ -153,7 +157,7 @@ function LoginPlugin({
                 showPasswordChange={showPasswordChange}
                 showAccountInfo={showAccountInfo}
                 isUsingLDAP={isUsingLDAP}
-                hideGroupUserInfo={toolsCfg?.[0]?.hideGroupUserInfo}
+                hideGroupUserInfo={resolvedHideGroupUserInfo}
             />
             <Login/>
         </>
@@ -189,6 +193,7 @@ LoginPlugin.propTypes = {
     isUsingLDAP: PropTypes.bool,
     displayName: PropTypes.string,
     className: PropTypes.string,
+    hideGroupUserInfo: PropTypes.bool,
     toolsCfg: PropTypes.array
 };
 

--- a/web/client/plugins/__tests__/Login-test.js
+++ b/web/client/plugins/__tests__/Login-test.js
@@ -67,6 +67,28 @@ describe('Login Plugin', () => {
             // permission table present by default
             expect(document.querySelector('.modal-dialog')).toBeTruthy();
         });
+        it('hides user groups when configured through toolsCfg', () => {
+            const storeState = stateMocker(loginSuccess({
+                User: {
+                    name: "Test",
+                    role: "USER",
+                    groups: {
+                        group: [
+                            { groupName: "test-group" },
+                            { groupName: "another-group" }
+                        ]
+                    }
+                }
+            }), setControlProperty('AccountInfo', 'enabled', true));
+            const { Plugin } = getPluginForTest(Login, storeState);
+            ReactDOM.render(
+                <Plugin toolsCfg={[{ hideGroupUserInfo: true }]} />,
+                document.getElementById("container")
+            );
+
+            expect(document.querySelector('.ms-resizable-modal')).toExist();
+            expect(document.querySelector('.user-group-info')).toNotExist();
+        });
 
         it('render in OmniBar', () => {
             const storeState = stateMocker();

--- a/web/client/plugins/__tests__/Login-test.js
+++ b/web/client/plugins/__tests__/Login-test.js
@@ -67,7 +67,7 @@ describe('Login Plugin', () => {
             // permission table present by default
             expect(document.querySelector('.modal-dialog')).toBeTruthy();
         });
-        it('hides user groups when configured through toolsCfg', () => {
+        it('hides user groups when configured through hideGroupUserInfo', () => {
             const storeState = stateMocker(loginSuccess({
                 User: {
                     name: "Test",
@@ -82,7 +82,7 @@ describe('Login Plugin', () => {
             }), setControlProperty('AccountInfo', 'enabled', true));
             const { Plugin } = getPluginForTest(Login, storeState);
             ReactDOM.render(
-                <Plugin toolsCfg={[{ hideGroupUserInfo: true }]} />,
+                <Plugin hideGroupUserInfo />,
                 document.getElementById("container")
             );
 

--- a/web/client/plugins/login/index.js
+++ b/web/client/plugins/login/index.js
@@ -74,10 +74,10 @@ export const UserDetails = connect((state) => ({
     onClose: setControlProperty.bind(null, "AccountInfo", "enabled", false, false)
 })(UserDetailsModalComp);
 
-export const  UserDetailsMenuItem = userMenuConnect(({itemComponent, showAccountInfo = true, onShowAccountInfo}) => {
+export const  UserDetailsMenuItem = userMenuConnect(({itemComponent, showAccountInfo = true, onShowAccountInfo, hideGroupUserInfo}) => {
     const Menuitem = itemComponent;
     if (Menuitem && showAccountInfo) {
-        return (<><Menuitem glyph="user" msgId= "user.info" onClick={onShowAccountInfo}/><UserDetails/></>);
+        return (<><Menuitem glyph="user" msgId= "user.info" onClick={onShowAccountInfo}/><UserDetails hideGroupUserInfo={hideGroupUserInfo}/></>);
     }
     return null;
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The "hideGroupUserInfo" option configured through:

```json
{
  "name": "Login",
  "cfg": {
    "toolsCfg": [
      {
        "hideGroupUserInfo": true
      }
    ]
  }
}
```
was no longer propagated to the User Details modal. The regression was introduced on PR [#10963](https://github.com/geosolutions-it/MapStore2/pull/10963). 
This PR fixes the propagation of login toolsCgf to UserModal.
Now, if hideGroupUserInfo is true, then Groups can not be seen on the User Info modal.
<img width="523" height="351" alt="image" src="https://github.com/user-attachments/assets/77dabb0d-da12-43ec-8487-ef237b454f7b" />




**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12789

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
when configured from toolsCfg of Login plugin, groups information of user can be hidden

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
