### PR TITLE
[Backport 2026.02.xx] Group user info still available in "Account info" even if disabled in plugin config  #12789

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -20,6 +20,24 @@ This is a list of things to check if you want to update from a previous version 
 - Optionally check also accessory files like `.eslinrc`, if you want to keep aligned with lint standards.
 - Follow the instructions below, in order, from your version to the one you want to update to.
 
+## Migration from 2026.02.00 to 2026.02.01
+
+### Login `hideGroupUserInfo` configuration
+
+The `hideGroupUserInfo` option is now a direct configuration property of the `Login` plugin. Update all `Login` plugin configurations in `localConfig.json` as follows:
+
+```diff
+{
+    "name": "Login",
+    "cfg": {
+-        "toolsCfg": [{"hideGroupUserInfo": true}]
++        "hideGroupUserInfo": true
+    }
+}
+```
+
+The previous `toolsCfg` configuration is still supported as a fallback for backward compatibility, but the direct `hideGroupUserInfo` property should be used for all new configurations.
+
 ## Migration from 2026.01.02 to 2026.02.00
 
 ### Dev server static configuration moved to the webpack configuration files

--- a/web/client/components/security/modals/UserDetailsModal.jsx
+++ b/web/client/components/security/modals/UserDetailsModal.jsx
@@ -17,8 +17,8 @@ import Message from '../../../components/I18N/Message';
 import { isArray, isObject, isString } from 'lodash';
 
 /**
- * A Modal window to show password reset form
-  * @prop {bool} hideGroupUserInfo It is a flag from Login plugin (cfg.toolsCfg[0].hideGroupUserInfo): to show/hide user group in user details info, by default `false`
+ * A Modal window to show user details
+  * @prop {bool} hideGroupUserInfo if true, hides the user group information, by default `false`
  */
 class UserDetails extends React.Component {
     static propTypes = {

--- a/web/client/plugins/Login.jsx
+++ b/web/client/plugins/Login.jsx
@@ -62,6 +62,7 @@ const RULE_MANAGER_ID = 'rulesmanager';
   *
   * @prop {string} cfg.id identifier of the Plugin, by default `"mapstore-login-menu"`
   * @prop {boolean} cfg.isUsingLDAP flag refers to if the user with type LDAP or not to manage show/hide change psasword, by default: false
+  * @prop {boolean} cfg.hideGroupUserInfo if true, hides the user group information in the user details modal, by default: false
   * @prop {object[]} items this property contains the items injected from the other plugins
   *  * using the `containers` option in the plugin that want to inject the new menu items.
   * ```javascript
@@ -106,12 +107,16 @@ function LoginPlugin({
     displayName,
     showAccountInfo,
     bsStyle,
-    className
+    className,
+    hideGroupUserInfo,
+    toolsCfg
 }, context) {
 
     const { loadedPlugins } = context;
     const configuredItems = usePluginItems({ items, loadedPlugins });
     const showPasswordChange = !(!isAdmin && isUsingLDAP);
+    // Keep toolsCfg[0] as a fallback for backward compatibility.
+    const resolvedHideGroupUserInfo = hideGroupUserInfo ?? toolsCfg?.[0]?.hideGroupUserInfo ?? false;
     const authenticated = user?.[displayName];
     const userItems = authenticated ? [
         { name: 'UserDetails', Component: UserDetailsMenuItem, position: 1},
@@ -152,6 +157,7 @@ function LoginPlugin({
                 showPasswordChange={showPasswordChange}
                 showAccountInfo={showAccountInfo}
                 isUsingLDAP={isUsingLDAP}
+                hideGroupUserInfo={resolvedHideGroupUserInfo}
             />
             <Login/>
         </>
@@ -186,7 +192,9 @@ LoginPlugin.propTypes = {
     isAdmin: PropTypes.bool,
     isUsingLDAP: PropTypes.bool,
     displayName: PropTypes.string,
-    className: PropTypes.string
+    className: PropTypes.string,
+    hideGroupUserInfo: PropTypes.bool,
+    toolsCfg: PropTypes.array
 };
 
 LoginPlugin.defaultProps = {

--- a/web/client/plugins/__tests__/Login-test.js
+++ b/web/client/plugins/__tests__/Login-test.js
@@ -67,6 +67,28 @@ describe('Login Plugin', () => {
             // permission table present by default
             expect(document.querySelector('.modal-dialog')).toBeTruthy();
         });
+        it('hides user groups when configured through hideGroupUserInfo', () => {
+            const storeState = stateMocker(loginSuccess({
+                User: {
+                    name: "Test",
+                    role: "USER",
+                    groups: {
+                        group: [
+                            { groupName: "test-group" },
+                            { groupName: "another-group" }
+                        ]
+                    }
+                }
+            }), setControlProperty('AccountInfo', 'enabled', true));
+            const { Plugin } = getPluginForTest(Login, storeState);
+            ReactDOM.render(
+                <Plugin hideGroupUserInfo />,
+                document.getElementById("container")
+            );
+
+            expect(document.querySelector('.ms-resizable-modal')).toExist();
+            expect(document.querySelector('.user-group-info')).toNotExist();
+        });
 
         it('render in OmniBar', () => {
             const storeState = stateMocker();

--- a/web/client/plugins/login/index.js
+++ b/web/client/plugins/login/index.js
@@ -74,10 +74,10 @@ export const UserDetails = connect((state) => ({
     onClose: setControlProperty.bind(null, "AccountInfo", "enabled", false, false)
 })(UserDetailsModalComp);
 
-export const  UserDetailsMenuItem = userMenuConnect(({itemComponent, showAccountInfo = true, onShowAccountInfo}) => {
+export const  UserDetailsMenuItem = userMenuConnect(({itemComponent, showAccountInfo = true, onShowAccountInfo, hideGroupUserInfo}) => {
     const Menuitem = itemComponent;
     if (Menuitem && showAccountInfo) {
-        return (<><Menuitem glyph="user" msgId= "user.info" onClick={onShowAccountInfo}/><UserDetails/></>);
+        return (<><Menuitem glyph="user" msgId= "user.info" onClick={onShowAccountInfo}/><UserDetails hideGroupUserInfo={hideGroupUserInfo}/></>);
     }
     return null;
 });


### PR DESCRIPTION
# Description
Backport of #12796 to `2026.02.xx`.

Fixes #12789