### PR TITLE
#12809 Attempt fix for failing backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,6 +24,12 @@ jobs:
         with:
             # Token for git actions, e.g. git push see https://github.com/korthout/backport-action/issues/379
             token: ${{ secrets.BACKPORT_ACTION_PAT }}
+            # backport-action runs several `git fetch --depth=N` on its own. On a shallow clone these
+            # rewrite .git/shallow and make the last fetch fail with
+            # "fatal: shallow file has changed since we read it", which the action reports as a
+            # missing target branch. Fetch the full history (blobs on demand) to avoid the shallow file.
+            fetch-depth: 0
+            filter: blob:none
       - name: Get issues
         id: get-issues
         uses: mondeja/pr-linked-issues-action@v2


### PR DESCRIPTION
# Description

The backport action reports `couldn't find remote ref <branch>` on branches that do exist. The real error in the logs is `fatal: shallow file has changed since we read it`: the action runs its own shallow fetches on top of the shallow clone we check out, and they clash.

Checking out the full history removes the shallow file. `filter: blob:none` keeps the checkout fast.

Fixes #12809

# Test

Cannot be tested before merge: `pull_request_target` runs the workflow from the base branch. Once merged, re-apply the `backport 2026.02.xx` label on #12557, which fails reproducibly today.