### PR TITLE
Width of slider tick dashes not consistent  #12783

### DIFF
--- a/web/client/components/widgets/builder/wizard/filter/FilterSlider.jsx
+++ b/web/client/components/widgets/builder/wizard/filter/FilterSlider.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup } from 'react-bootstrap';
 import Slider from '../../../../misc/Slider';
@@ -35,6 +35,68 @@ const getTickAngle = (value) => {
         return -90;
     }
     return Math.max(-90, Math.min(90, angle));
+};
+
+const ORIGINAL_LEFT_KEY = 'msOriginalLeft';
+const ORIGINAL_WIDTH_KEY = 'msOriginalWidth';
+
+/**
+ * Align noUiSlider tick markers to the physical pixel grid so fractional display
+ * scaling does not make individual dashes render with different widths.
+ */
+const snapMarkersToPixelGrid = (container) => {
+    const pips = container.querySelector('.noUi-pips');
+    if (!pips) {
+        return;
+    }
+    const scale = pips.getBoundingClientRect().width / pips.offsetWidth;
+    if (!(scale > 0)) {
+        return;
+    }
+    const pixelRatio = window.devicePixelRatio || 1;
+    const deviceScale = scale * pixelRatio;
+    const markers = Array.from(container.querySelectorAll('.noUi-marker'));
+    markers.forEach((marker) => {
+        if (marker.dataset[ORIGINAL_LEFT_KEY] === undefined) {
+            marker.dataset[ORIGINAL_LEFT_KEY] = marker.style.left;
+        }
+        if (marker.dataset[ORIGINAL_WIDTH_KEY] === undefined) {
+            marker.dataset[ORIGINAL_WIDTH_KEY] = marker.style.width;
+        }
+        marker.style.left = marker.dataset[ORIGINAL_LEFT_KEY];
+        marker.style.width = marker.dataset[ORIGINAL_WIDTH_KEY];
+    });
+    const resolved = markers.map((marker) => {
+        const style = window.getComputedStyle(marker);
+        return { left: parseFloat(style.left), width: parseFloat(style.width) };
+    });
+    markers.forEach((marker, index) => {
+        const { left, width } = resolved[index];
+        if (Number.isFinite(left)) {
+            marker.style.left = `${left}px`;
+        }
+        if (Number.isFinite(width) && width > 0) {
+            marker.style.width = `${Math.max(1, Math.round(width * deviceScale)) / deviceScale}px`;
+        }
+    });
+    for (let pass = 0; pass < 3; pass++) {
+        const errors = markers.map((marker) => {
+            const { left } = marker.getBoundingClientRect();
+            return Math.round(left * pixelRatio) / pixelRatio - left;
+        });
+        let corrected = false;
+        markers.forEach((marker, index) => {
+            const current = parseFloat(marker.style.left);
+            if (!Number.isFinite(current) || Math.abs(errors[index]) <= 0.01) {
+                return;
+            }
+            marker.style.left = `${current + errors[index] / scale}px`;
+            corrected = true;
+        });
+        if (!corrected) {
+            break;
+        }
+    }
 };
 
 const FilterSlider = ({
@@ -98,6 +160,23 @@ const FilterSlider = ({
         showTicks
     }), [normalizedItems, requestedTickValues, tickLabels, showTicks]);
 
+    const sliderRef = useRef();
+
+    useEffect(() => {
+        const container = sliderRef.current;
+        if (!showTicks || !container) {
+            return () => {};
+        }
+        const snap = () => snapMarkersToPixelGrid(container);
+        snap();
+        if (typeof ResizeObserver === 'undefined') {
+            return () => {};
+        }
+        const observer = new ResizeObserver(snap);
+        observer.observe(container);
+        return () => observer.disconnect();
+    }, [showTicks, sliderKey]);
+
     if (normalizedItems.length === 0) {
         return null;
     }
@@ -141,7 +220,7 @@ const FilterSlider = ({
                             : <Message msgId="widgets.filterWidget.sliderNotSelected" />}
                     </div>
                 )}
-                <div className="mapstore-slider ms-filter-slider-control" style={sliderStyle}>
+                <div className="mapstore-slider ms-filter-slider-control" style={sliderStyle} ref={sliderRef}>
                     <Slider
                         key={sliderKey}
                         start={[sliderStartIndex]}

--- a/web/client/components/widgets/builder/wizard/filter/__tests__/FilterSlider-test.jsx
+++ b/web/client/components/widgets/builder/wizard/filter/__tests__/FilterSlider-test.jsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026, GeoSolutions
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import FilterSlider from '../FilterSlider';
+
+const ITEMS = Array.from({ length: 12 }, (unused, index) => ({
+    id: `${index}`,
+    label: `Item ${index}`
+}));
+
+const NOUISLIDER_LAYOUT_RULES = `
+    #container { width: 401px; }
+    .noUi-target { position: relative; display: block; }
+    .noUi-pips { position: absolute; top: 100%; left: 0; width: 100%; }
+    .noUi-marker { position: absolute; width: 2px; height: 8px; margin-left: -1px; }
+`;
+
+const renderSlider = (props = {}) => {
+    const container = document.getElementById("container");
+    ReactDOM.render(
+        <FilterSlider items={ITEMS} onSelectionChange={() => {}} {...props} />,
+        container
+    );
+    return container;
+};
+
+describe('FilterSlider', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<style id="rules"></style><div id="container"></div>';
+        document.getElementById("rules").textContent = NOUISLIDER_LAYOUT_RULES;
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render one tick marker for every item', () => {
+        const container = renderSlider({ showTicks: true });
+        expect(container.querySelectorAll('.noUi-marker').length).toBe(ITEMS.length);
+    });
+
+    it('should render no tick marker when ticks are disabled', () => {
+        const container = renderSlider();
+        expect(container.querySelectorAll('.noUi-marker').length).toBe(0);
+    });
+
+    it('should align the tick markers on the physical pixel grid', (done) => {
+        const container = renderSlider({ showTicks: true });
+        const pixelRatio = window.devicePixelRatio || 1;
+        setTimeout(() => {
+            const markers = Array.from(container.querySelectorAll('.noUi-marker'));
+            expect(markers.length).toBe(ITEMS.length);
+            markers.forEach((marker) => {
+                const position = marker.getBoundingClientRect().left * pixelRatio;
+                expect(Math.abs(Math.round(position) - position)).toBeLessThan(0.02);
+            });
+            done();
+        });
+    });
+
+    it('should give every tick marker a whole number of physical pixels', (done) => {
+        const container = renderSlider({ showTicks: true });
+        const pixelRatio = window.devicePixelRatio || 1;
+        setTimeout(() => {
+            const widths = Array.from(container.querySelectorAll('.noUi-marker'))
+                .map((marker) => marker.getBoundingClientRect().width * pixelRatio);
+            widths.forEach((width) => {
+                expect(Math.abs(Math.round(width) - width)).toBeLessThan(0.02);
+            });
+            expect(Math.max(...widths) - Math.min(...widths)).toBeLessThan(0.02);
+            done();
+        });
+    });
+
+    it('should keep the stylesheet width to realign the markers after a resize', (done) => {
+        const container = renderSlider({ showTicks: true });
+        setTimeout(() => {
+            Array.from(container.querySelectorAll('.noUi-marker')).forEach((marker) => {
+                expect(marker.dataset.msOriginalWidth).toNotBe(undefined);
+            });
+            done();
+        });
+    });
+
+    it('should keep the percentage offsets to realign the markers after a resize', (done) => {
+        const container = renderSlider({ showTicks: true });
+        setTimeout(() => {
+            const markers = Array.from(container.querySelectorAll('.noUi-marker'));
+            markers.forEach((marker) => {
+                expect(marker.dataset.msOriginalLeft.indexOf('%')).toBeGreaterThan(-1);
+            });
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes an issue with the filter slider to avoid differently rendered tick thickness. 

The slider package renders the tick positions using percentages. At different zoom levels, some positions become fractional pixels, and the browser renders the tick marks slightly differently.

This workaround overrides the rendered tick positions and widths with pixel values using JavaScript. It is applied only to FilterSlider component and does not change the slider package itself.

This is a self-contained workaround for a visual-only issue. It is somewhat coupled to the current noUiSlider DOM implementation, so it may need updates if the package structure changes in the future.


https://github.com/user-attachments/assets/53ca858e-24b8-4917-9463-cc25d50ea4e2



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12783

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now width of all ticks of the filter Slider component will be the same at all zoom levels.
<img width="935" height="230" alt="image" src="https://github.com/user-attachments/assets/bb4c09a2-e3a7-4969-bc96-9229e14122ce" />
 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
