### PR TITLE
Template resolution and link handling

### DIFF
--- a/web/client/components/catalog/resources/ALink.jsx
+++ b/web/client/components/catalog/resources/ALink.jsx
@@ -9,15 +9,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { getSafeHref } from '../../../utils/URLUtils';
+
 function ALink({ href, readOnly, children, fallbackComponent, ...props }) {
-    if (readOnly || !href) {
+    const linkHref = getSafeHref(href);
+    if (readOnly || !linkHref) {
         if (fallbackComponent) {
             const FallbackComponent = fallbackComponent;
             return <FallbackComponent {...props}>{children}</FallbackComponent>;
         }
         return <>{children}</>;
     }
-    return <a href={href} {...props}>{children}</a>;
+    return <a href={linkHref} {...props}>{children}</a>;
 }
 
 ALink.propTypes = {

--- a/web/client/components/catalog/resources/FilterItems.jsx
+++ b/web/client/components/catalog/resources/FilterItems.jsx
@@ -25,6 +25,7 @@ import SelectInfiniteScroll from './SelectInfiniteScroll';
 import FilterGroup from './FilterGroup';
 
 import { getFilterByField as defaultGetFilterByField, getTagColorVariables } from '../../../utils/ResourcesFiltersUtils';
+import { getSafeHref } from '../../../utils/URLUtils';
 import InputControl from './InputControl';
 import FlexBox from '../../../components/layout/FlexBox';
 import Text from '../../../components/layout/Text';
@@ -273,7 +274,7 @@ function FilterItem({
         return <div className="_row" />;
     }
     if (field.type === 'link') {
-        return <a href={field.href}>{field.labelId && getMessageById(messages, field.labelId) || field.label}</a>;
+        return <a href={getSafeHref(field.href)}>{field.labelId && getMessageById(messages, field.labelId) || field.label}</a>;
     }
     if (field.type === 'filter') {
         const filterKey = field.filterKey || "f";

--- a/web/client/components/catalog/resources/__tests__/ALink-test.jsx
+++ b/web/client/components/catalog/resources/__tests__/ALink-test.jsx
@@ -42,4 +42,20 @@ describe('ALink component', () => {
         const container = document.getElementById('container');
         expect(container.children[0].getAttribute('class')).toBe('child');
     });
+
+    describe('href validation', () => {
+        it('should not apply the link (a) tag if href can not be used as a link target', () => {
+            // eslint-disable-next-line no-script-url
+            ReactDOM.render(<ALink href="javascript:void(0)" className="link"><span className="child"></span></ALink>, document.getElementById('container'));
+            const container = document.getElementById('container');
+            expect(container.querySelector('a')).toBe(null);
+            expect(container.children[0].getAttribute('class')).toBe('child');
+        });
+        it('should apply the link (a) tag with an in app reference', () => {
+            ReactDOM.render(<ALink href="#/viewer/42" className="link"><span className="child"></span></ALink>, document.getElementById('container'));
+            const container = document.getElementById('container');
+            expect(container.children[0].getAttribute('class')).toBe('link');
+            expect(container.querySelector('a').getAttribute('href')).toBe('#/viewer/42');
+        });
+    });
 });

--- a/web/client/components/data/identify/viewers/TemplateViewer.jsx
+++ b/web/client/components/data/identify/viewers/TemplateViewer.jsx
@@ -7,10 +7,10 @@
  */
 
 import React from 'react';
-import { template } from 'lodash';
+import escape from 'lodash/escape';
 import PropTypes from 'prop-types';
 
-import { getCleanTemplate } from '../../../../utils/TemplateUtils';
+import { getCleanTemplate, generateTemplateString } from '../../../../utils/TemplateUtils';
 import HtmlRenderer from '../../../misc/HtmlRenderer';
 import Message from '../../../I18N/Message';
 
@@ -21,7 +21,11 @@ const TemplateViewer = ({layer = {}, response}) => (
             const cleanTemplate = getCleanTemplate(layer.featureInfo && layer.featureInfo.template || '', feature, /\$\{.*?\}/g, 2, 1);
             let html = "";
             try {
-                html = template(cleanTemplate)(feature);
+                // values are escaped, the markup of the template is kept
+                html = generateTemplateString(
+                    cleanTemplate,
+                    (value) => escape(String(value ?? ''))
+                )(feature);
             } catch (e) {
                 console.error(e);
                 return (<div key={i}>

--- a/web/client/components/data/identify/viewers/__tests__/viewers-test.jsx
+++ b/web/client/components/data/identify/viewers/__tests__/viewers-test.jsx
@@ -12,6 +12,7 @@ import ReactDOM from 'react-dom';
 
 import HTMLViewer from '../HTMLViewer';
 import JSONViewer from '../JSONViewer';
+import TemplateViewer from '../TemplateViewer';
 import TextViewer from '../TextViewer';
 
 import configureStore from 'redux-mock-store';
@@ -320,4 +321,37 @@ describe('Identity Viewers', () => {
         expect(propertiesViewer.length).toBe(1);
     });
 
+
+    describe('TemplateViewer', () => {
+        it('TemplateViewer resolves placeholders without compiling them', () => {
+            window.__viewerEvaluated = undefined;
+            const layer = {
+                featureInfo: {
+                    format: 'TEMPLATE',
+                    template: '<b>${(window.__viewerEvaluated = true)}</b>'
+                }
+            };
+            const response = { features: [{ id: 1, properties: { name: 'name' } }] };
+            ReactDOM.render(<TemplateViewer layer={layer} response={response} />, document.getElementById("container"));
+            expect(window.__viewerEvaluated).toBe(undefined);
+        });
+        it('TemplateViewer escapes the html of the feature values', () => {
+            const layer = {
+                featureInfo: { format: 'TEMPLATE', template: '<div>${properties.description}</div>' }
+            };
+            const response = { features: [{ id: 1, properties: { description: '<script>window.__viewerScript = true</script>' } }] };
+            window.__viewerScript = undefined;
+            ReactDOM.render(<TemplateViewer layer={layer} response={response} />, document.getElementById("container"));
+            expect(window.__viewerScript).toBe(undefined);
+            expect(document.getElementById("container").innerHTML.indexOf('<script')).toBe(-1);
+        });
+        it('TemplateViewer keeps the markup of the template', () => {
+            const layer = {
+                featureInfo: { format: 'TEMPLATE', template: '<b>Name: ${properties.name}</b>' }
+            };
+            const response = { features: [{ id: 1, properties: { name: 'Rome' } }] };
+            ReactDOM.render(<TemplateViewer layer={layer} response={response} />, document.getElementById("container"));
+            expect(document.getElementById("container").innerHTML.indexOf('<b>Name: Rome</b>')).toBeGreaterThan(-1);
+        });
+    });
 });

--- a/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
+++ b/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
@@ -118,4 +118,19 @@ describe('PropertiesViewer', () => {
             expect(value).toBe(testVal);
         });
     });
+
+    describe('sanitization', () => {
+        it('removes script tags from a property value', () => {
+            window.__propertiesViewerScript = undefined;
+            const feature = { id: 'f1', properties: { info: '<p>content</p><script>window.__propertiesViewerScript = true</script>' } };
+            ReactDOM.render(<PropertiesViewer feature={feature} />, document.getElementById("container"));
+            expect(window.__propertiesViewerScript).toBe(undefined);
+            expect(document.getElementById("container").innerHTML.indexOf('<script')).toBe(-1);
+        });
+        it('keeps the formatting tags of a property value', () => {
+            const feature = { id: 'f1', properties: { info: '<p><b>bold</b></p>' } };
+            ReactDOM.render(<PropertiesViewer feature={feature} />, document.getElementById("container"));
+            expect(document.querySelector('.ms-properties-viewer-value b')).toBeTruthy();
+        });
+    });
 });

--- a/web/client/components/geostory/contents/__tests__/Text-test.jsx
+++ b/web/client/components/geostory/contents/__tests__/Text-test.jsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { Modes } from '../../../../utils/GeoStoryUtils';
+import Text from '../Text';
+
+describe('GeoStory Text content', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    describe('sanitization', () => {
+        it('removes script tags from the html content', () => {
+            window.__textContentScript = undefined;
+            ReactDOM.render(
+                <Text mode={Modes.VIEW} html={'<p>content</p><script>window.__textContentScript = true</script>'} />,
+                document.getElementById('container')
+            );
+            expect(window.__textContentScript).toBe(undefined);
+            expect(document.getElementById('container').innerHTML.indexOf('<script')).toBe(-1);
+        });
+        it('keeps the formatting tags of the html content', () => {
+            ReactDOM.render(
+                <Text mode={Modes.VIEW} html={'<p><b>bold</b></p>'} />,
+                document.getElementById('container')
+            );
+            expect(document.querySelector('.ms-text-wrapper b')).toBeTruthy();
+        });
+        it('renders an empty html content without throwing', () => {
+            expect(() => ReactDOM.render(
+                <Text mode={Modes.VIEW} html={null} />, document.getElementById('container')
+            )).toNotThrow();
+        });
+    });
+});

--- a/web/client/components/geostory/contents/texteditor/__tests__/getLinkDecorator-test.jsx
+++ b/web/client/components/geostory/contents/texteditor/__tests__/getLinkDecorator-test.jsx
@@ -53,6 +53,23 @@ describe('getLinkDecorator', () => {
         expect(m[0].state.showPopOver).toBe(false);
     });
 
+    it('should keep the href of the link', () => {
+        const entityK = contentState
+            .createEntity('LINK', 'MUTABLE', { url: 'https://my-host.com/page', targetOption: '_blank' })
+            .getLastCreatedEntityKey();
+        ReactDOM.render(<Link entityKey={entityK} contentState={contentState}>Link</Link>, document.getElementById("container"));
+        expect(document.querySelector('#container a').getAttribute('href')).toBe('https://my-host.com/page');
+    });
+
+    it('should not render an href that can not be used as a link target', () => {
+        const entityK = contentState
+            // eslint-disable-next-line no-script-url
+            .createEntity('LINK', 'MUTABLE', { url: 'javascript:void(0)', targetOption: '_blank' })
+            .getLastCreatedEntityKey();
+        ReactDOM.render(<Link entityKey={entityK} contentState={contentState}>Link</Link>, document.getElementById("container"));
+        expect(document.querySelector('#container a').getAttribute('href')).toBe('');
+    });
+
     it('should not render external popover img when geostory internal links', () => {
         const entityK = contentState
             .createEntity('LINK', 'MUTABLE', {

--- a/web/client/components/geostory/contents/texteditor/getLinkDecorator.jsx
+++ b/web/client/components/geostory/contents/texteditor/getLinkDecorator.jsx
@@ -10,6 +10,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { openlink } from 'react-draft-wysiwyg';
 
+import { getSafeHref } from '../../../../utils/URLUtils';
+
 function findLinkEntities(contentBlock, callback, contentState) {
     contentBlock.findEntityRanges(
         (character) => {
@@ -39,7 +41,11 @@ function getLinkComponent(config) {
     openLink = () => {
         const { entityKey, contentState } = this.props;
         const { url } = contentState.getEntity(entityKey).getData();
-        const linkTab = window.open(url, 'blank'); // eslint-disable-line no-undef
+        const href = getSafeHref(url);
+        if (!href) {
+            return;
+        }
+        const linkTab = window.open(href, 'blank'); // eslint-disable-line no-undef
         // linkTab can be null when the window failed to open.
         if (linkTab) {
             linkTab.focus();
@@ -78,7 +84,7 @@ function getLinkComponent(config) {
                 onMouseEnter={this.toggleShowPopOver}
                 onMouseLeave={this.toggleShowPopOver}
             >
-                <a href={url} target={targetOption}>{children}</a>
+                <a href={getSafeHref(url)} target={targetOption}>{children}</a>
                 {showPopOver && showOpenOptionOnHover ?
                     <img
                         src={openlink}

--- a/web/client/components/map/openlayers/__tests__/PopupSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/PopupSupport-test.jsx
@@ -149,5 +149,20 @@ describe('Openlayers PopupSupport', () => {
         expect(document.querySelector('#test-component-map-popup')).toExist();
     });
 
+
+    describe('sanitization', () => {
+        it('removes script tags from the popup content', () => {
+            window.__popupScript = undefined;
+            const popups = [{
+                id: 'popup',
+                content: '<div id="innerHtml">content</div><script>window.__popupScript = true</script>',
+                position: { coordinates: [0, 0] },
+                autoPan: false
+            }];
+            renderPopups({ popups });
+            expect(window.__popupScript).toBe(undefined);
+            expect(document.body.innerHTML.indexOf('<script')).toBe(-1);
+        });
+    });
 });
 

--- a/web/client/components/mapviews/__tests__/MapViewsSupport-test.jsx
+++ b/web/client/components/mapviews/__tests__/MapViewsSupport-test.jsx
@@ -195,4 +195,19 @@ describe('MapViewsSupport component', () => {
             })
             .catch(done);
     });
+
+    describe('sanitization', () => {
+        it('removes script tags from the description of the selected view', () => {
+            window.__mapViewsScript = undefined;
+            ReactDOM.render(<MapViewsSupport
+                mapType="cesium"
+                showDescription
+                map={{ camera: { position: {}, setView: () => {}, cancelFlight: () => {} } }}
+                views={[{ id: 'view-01', title: 'Title', description: '<p>content</p><script>window.__mapViewsScript = true</script>' }]}
+                selectedId="view-01"
+            />, document.getElementById("container"));
+            expect(window.__mapViewsScript).toBe(undefined);
+            expect(document.body.innerHTML.indexOf('<script')).toBe(-1);
+        });
+    });
 });

--- a/web/client/components/misc/__tests__/HtmlRenderer-test.jsx
+++ b/web/client/components/misc/__tests__/HtmlRenderer-test.jsx
@@ -62,4 +62,29 @@ describe("This test for HtmlRenderer component", () => {
         expect(node.id).toBeFalsy();
         expect(node.style.color).toBe('rgb(255, 255, 255)');
     });
+
+    describe('sanitization', () => {
+        it('removes script tags from the html prop', () => {
+            window.__htmlRendererScript = undefined;
+            ReactDOM.render(<HtmlRenderer html={'<p>content</p><script>window.__htmlRendererScript = true</script>'} />, document.getElementById("container"));
+            expect(window.__htmlRendererScript).toBe(undefined);
+            expect(document.getElementById("container").innerHTML.indexOf('<script')).toBe(-1);
+        });
+        it('removes inline event handlers from the html prop', () => {
+            window.__htmlRendererHandler = undefined;
+            ReactDOM.render(<HtmlRenderer html={'<img src="missing-image" onerror="window.__htmlRendererHandler = true">'} />, document.getElementById("container"));
+            expect(window.__htmlRendererHandler).toBe(undefined);
+            expect(document.getElementById("container").innerHTML.toLowerCase().indexOf('onerror')).toBe(-1);
+        });
+        it('keeps the formatting tags of the html prop', () => {
+            ReactDOM.render(<HtmlRenderer html={'<p><b>bold</b> and <i>italic</i></p>'} />, document.getElementById("container"));
+            const inner = document.getElementById("container").innerHTML;
+            expect(inner.indexOf('<b>bold</b>')).toBeGreaterThan(-1);
+            expect(inner.indexOf('<i>italic</i>')).toBeGreaterThan(-1);
+        });
+        it('renders an empty html prop without throwing', () => {
+            expect(() => ReactDOM.render(<HtmlRenderer html={null} />, document.getElementById("container"))).toNotThrow();
+            expect(() => ReactDOM.render(<HtmlRenderer html={undefined} />, document.getElementById("container"))).toNotThrow();
+        });
+    });
 });

--- a/web/client/components/resources/modals/fragments/__tests__/DetailsRow-test.jsx
+++ b/web/client/components/resources/modals/fragments/__tests__/DetailsRow-test.jsx
@@ -37,4 +37,13 @@ describe('DetailsRow component', () => {
         const btnGroup = details.getElementsByTagName('button');
         expect(btnGroup.length).toBe(0);
     });
+
+    describe('sanitization', () => {
+        it('removes script tags from the details preview', () => {
+            window.__detailsRowScript = undefined;
+            ReactDOM.render(<DetailsRow detailsText={'<p>content</p><script>window.__detailsRowScript = true</script>'} showPreview />, document.getElementById('container'));
+            expect(window.__detailsRowScript).toBe(undefined);
+            expect(document.getElementById('container').innerHTML.indexOf('<script')).toBe(-1);
+        });
+    });
 });

--- a/web/client/components/resources/modals/fragments/__tests__/DetailsViewer-test.jsx
+++ b/web/client/components/resources/modals/fragments/__tests__/DetailsViewer-test.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import DetailsViewer from '../DetailsViewer';
+
+describe('DetailsViewer component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    describe('sanitization', () => {
+        it('removes script tags from the details text', () => {
+            window.__detailsViewerScript = undefined;
+            ReactDOM.render(
+                <DetailsViewer detailsText={'<p>content</p><script>window.__detailsViewerScript = true</script>'} />,
+                document.getElementById('container')
+            );
+            expect(window.__detailsViewerScript).toBe(undefined);
+            expect(document.getElementById('container').innerHTML.indexOf('<script')).toBe(-1);
+        });
+        it('keeps the formatting tags of the details text', () => {
+            ReactDOM.render(
+                <DetailsViewer detailsText={'<p><b>bold</b></p>'} />,
+                document.getElementById('container')
+            );
+            expect(document.querySelector('b')).toBeTruthy();
+        });
+        it('renders a nil details text without throwing', () => {
+            expect(() => ReactDOM.render(
+                <DetailsViewer detailsText={null} />, document.getElementById('container')
+            )).toNotThrow();
+        });
+    });
+});

--- a/web/client/components/widgets/widget/__tests__/TextWidget-test.jsx
+++ b/web/client/components/widgets/widget/__tests__/TextWidget-test.jsx
@@ -61,4 +61,13 @@ describe('TextWidget component', () => {
         const container = document.getElementById('container');
         expect(container.querySelector('#TEST_TEXT')).toExist();
     });
+
+    describe('sanitization', () => {
+        it('removes script tags from the widget text', () => {
+            window.__textWidgetScript = undefined;
+            ReactDOM.render(<TextWidget text={'<p>content</p><script>window.__textWidgetScript = true</script>'} />, document.getElementById("container"));
+            expect(window.__textWidgetScript).toBe(undefined);
+            expect(document.getElementById("container").innerHTML.indexOf('<script')).toBe(-1);
+        });
+    });
 });

--- a/web/client/epics/__tests__/permalink-test.js
+++ b/web/client/epics/__tests__/permalink-test.js
@@ -529,4 +529,24 @@ describe('Permalink Epics', () => {
                 }
             });
     });
+
+    it('test loadPermalinkEpic resolves pathTemplate placeholders without compiling them', (done) => {
+        window.__permalinkResolved = undefined;
+        setApiGetResource(api, {
+            getResource: () => Rx.Observable.of({
+                name: "test",
+                attributes: { type: "map", pathTemplate: "/viewer/${(window.__permalinkResolved = true)}" }
+            })
+        });
+        const NUMBER_OF_ACTIONS = 2;
+        testEpic(
+            loadPermalinkEpic,
+            NUMBER_OF_ACTIONS, [
+                loadPermalink(10)
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                expect(window.__permalinkResolved).toBe(undefined);
+                done();
+            }, state);
+    });
 });

--- a/web/client/epics/__tests__/permalink-test.js
+++ b/web/client/epics/__tests__/permalink-test.js
@@ -549,4 +549,44 @@ describe('Permalink Epics', () => {
                 done();
             }, state);
     });
+    describe('permalink target', () => {
+        const testInvalidTarget = (pathTemplate, done) => {
+            setApiGetResource(api, {
+                getResource: () => Rx.Observable.of({ name: "test", attributes: { type: "map", pathTemplate } })
+            });
+            const NUMBER_OF_ACTIONS = 2;
+            const invalidTarget = "permalink.errors.loading.invalidTarget";
+            testEpic(
+                loadPermalinkEpic,
+                NUMBER_OF_ACTIONS, [
+                    loadPermalink(10)
+                ], actions => {
+                    expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                    actions.forEach((action) => {
+                        switch (action.type) {
+                        case LOAD_PERMALINK_ERROR:
+                            expect(action.error).toBeTruthy();
+                            expect(action.error.messageId).toBe(invalidTarget);
+                            break;
+                        case SHOW_NOTIFICATION:
+                            expect(action.title).toBe("permalink.errors.loading.title");
+                            expect(action.message).toBe(invalidTarget);
+                            break;
+                        default:
+                            expect(true).toBe(false);
+                        }
+                    });
+                    done();
+                }, state);
+        };
+        it('test loadPermalinkEpic with a target resolved on another host', (done) => {
+            testInvalidTarget("//other-host.com/${id}", done);
+        });
+        it('test loadPermalinkEpic with an absolute url as target', (done) => {
+            testInvalidTarget("http://other-host.com/${id}", done);
+        });
+        it('test loadPermalinkEpic with an empty target', (done) => {
+            testInvalidTarget("", done);
+        });
+    });
 });

--- a/web/client/epics/permalink.js
+++ b/web/client/epics/permalink.js
@@ -34,6 +34,10 @@ import { pathnameSelector } from "../selectors/router";
 import { wrapStartStop } from "../observables/epics";
 import SecurityUtils from "../utils/SecurityUtils";
 import { generateTemplateString } from "../utils/TemplateUtils";
+import { isValidURL } from "../utils/URLUtils";
+
+// the router only handles paths of the application
+const isApplicationPath = (path) => path.indexOf("/") === 0 && isValidURL(path);
 
 const PERMALINK = "PERMALINK";
 const PERMALINK_RESOURCES = {
@@ -206,6 +210,15 @@ export const loadPermalinkEpic = (action$, { getState = () => {} } = {}) =>
                             pathTemplate || '',
                             (value) => encodeURIComponent(String(value ?? ''))
                         )(type === "context" ? { name } : { id });
+                        if (!isApplicationPath(pathTemplate)) {
+                            return Observable.of(
+                                error({
+                                    title: "permalink.errors.loading.title",
+                                    message: "permalink.errors.loading.invalidTarget"
+                                }),
+                                loadPermalinkError({ messageId: "permalink.errors.loading.invalidTarget" })
+                            );
+                        }
                         return Observable.of(push(pathTemplate), permalinkLoaded());
                     })
                 ).catch((e) => {

--- a/web/client/epics/permalink.js
+++ b/web/client/epics/permalink.js
@@ -10,7 +10,6 @@ import { Observable } from "rxjs";
 import { push } from "connected-react-router";
 import pick from "lodash/pick";
 import get from "lodash/get";
-import template from "lodash/template";
 
 import API from "../api/GeoStoreDAO";
 import { error, show } from "../actions/notifications";
@@ -34,6 +33,7 @@ import { widgetsConfig } from "../selectors/widgets";
 import { pathnameSelector } from "../selectors/router";
 import { wrapStartStop } from "../observables/epics";
 import SecurityUtils from "../utils/SecurityUtils";
+import { generateTemplateString } from "../utils/TemplateUtils";
 
 const PERMALINK = "PERMALINK";
 const PERMALINK_RESOURCES = {
@@ -201,7 +201,11 @@ export const loadPermalinkEpic = (action$, { getState = () => {} } = {}) =>
                     getResource(id).switchMap((resource) => {
                         const { name, attributes } = resource ?? {};
                         let { type, pathTemplate } = attributes ?? {};
-                        pathTemplate = template(pathTemplate)(type === "context" ? {name} : { id });
+                        // the value ends up in the path, so it is URI-encoded
+                        pathTemplate = generateTemplateString(
+                            pathTemplate || '',
+                            (value) => encodeURIComponent(String(value ?? ''))
+                        )(type === "context" ? { name } : { id });
                         return Observable.of(push(pathTemplate), permalinkLoaded());
                     })
                 ).catch((e) => {

--- a/web/client/plugins/Annotations/components/__tests__/AnnotationsFields-test.jsx
+++ b/web/client/plugins/Annotations/components/__tests__/AnnotationsFields-test.jsx
@@ -82,4 +82,26 @@ describe('AnnotationsFields component', () => {
         expect(fieldsNode.querySelector('.help-block').innerText).toBe('annotations.error.fake');
         Simulate.change(input[0], { target: { value: 'Ok' } });
     });
+
+    describe('sanitization', () => {
+        it('removes script tags from the description in preview', () => {
+            window.__annotationsPreviewScript = undefined;
+            ReactDOM.render(<AnnotationsFields
+                preview
+                properties={{ description: '<p>content</p><script>window.__annotationsPreviewScript = true</script>' }}
+                fields={[{ name: 'description', type: 'html', showLabel: false }]}
+            />, document.getElementById("container"));
+            expect(window.__annotationsPreviewScript).toBe(undefined);
+            expect(document.body.innerHTML.indexOf('<script')).toBe(-1);
+        });
+        it('removes script tags from the description of a read only field', () => {
+            window.__annotationsFieldScript = undefined;
+            ReactDOM.render(<AnnotationsFields
+                properties={{ description: '<p>content</p><script>window.__annotationsFieldScript = true</script>' }}
+                fields={[{ name: 'description', type: 'html', showLabel: false, editable: false }]}
+            />, document.getElementById("container"));
+            expect(window.__annotationsFieldScript).toBe(undefined);
+            expect(document.body.innerHTML.indexOf('<script')).toBe(-1);
+        });
+    });
 });

--- a/web/client/plugins/ResourcesCatalog/components/DetailsInfo.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/DetailsInfo.jsx
@@ -22,6 +22,7 @@ import FlexBox from '../../../components/layout/FlexBox';
 import Text from '../../../components/layout/Text';
 import InputControl from '../../../components/catalog/resources/InputControl';
 import { getTagColorVariables } from '../../../utils/ResourcesFiltersUtils';
+import { getSafeHref } from '../../../utils/URLUtils';
 
 const replaceTemplateString = (properties, str) => {
     return Object.keys(properties).reduce((updatedStr, key) => {
@@ -50,8 +51,9 @@ const isFieldLabelOnly = ({style, value}) => isEmptyValue(value) && isStyleLabel
 
 const DetailInfoFieldLabel = ({ field }) => {
     const label = field.labelId ? <Message msgId={field.labelId} /> : field.label;
-    return isStyleLabel(field.style) && field.href
-        ? (<a href={field.href} target={field.target}>{label}</a>)
+    const href = getSafeHref(field.href);
+    return isStyleLabel(field.style) && href
+        ? (<a href={href} target={field.target}>{label}</a>)
         : label;
 };
 
@@ -182,8 +184,8 @@ function DetailsInfoFields({ fields, formatHref, editing, onChange, query = {}, 
                     <DetailsInfoField key={filedIndex} field={field}>
                         {(values) => values.map((value, idx) => {
                             return field.href
-                                ? <a key={idx} href={field.href}>{value}</a>
-                                : <a key={idx} href={value.href}>{value.value}</a>;
+                                ? <a key={idx} href={getSafeHref(field.href)}>{value}</a>
+                                : <a key={idx} href={getSafeHref(value?.href)}>{value?.value}</a>;
                         })}
                     </DetailsInfoField>
                 );

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/DetailsInfo-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/DetailsInfo-test.jsx
@@ -179,5 +179,16 @@ describe('DetailsInfo component', () => {
         const tabLink = document.querySelector('.ms-details-info li a');
         Simulate.click(tabLink);
     });
+
+    it('should not render an href that can not be used as a link target', () => {
+        ReactDOM.render(<DetailsInfo
+            tabs={[{ type: 'tab', id: 'info', labelId: 'Info', items: [
+                // eslint-disable-next-line no-script-url
+                { type: 'link', label: 'Label', href: 'javascript:void(0)', value: 'value' }
+            ] }]}
+            selectedTab="info"
+        />, document.getElementById('container'));
+        expect(document.querySelectorAll('a[href^="javascript:"]').length).toBe(0);
+    });
 });
 

--- a/web/client/plugins/ResourcesCatalog/components/__tests__/DetailsInfo-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/components/__tests__/DetailsInfo-test.jsx
@@ -190,5 +190,18 @@ describe('DetailsInfo component', () => {
         />, document.getElementById('container'));
         expect(document.querySelectorAll('a[href^="javascript:"]').length).toBe(0);
     });
+    describe('sanitization', () => {
+        it('removes script tags from an html field value', () => {
+            window.__detailsInfoScript = undefined;
+            ReactDOM.render(<DetailsInfo
+                tabs={[{ type: 'tab', id: 'info', labelId: 'Info', items: [
+                    { type: 'html', value: '<p>content</p><script>window.__detailsInfoScript = true</script>' }
+                ] }]}
+                selectedTab="info"
+            />, document.getElementById('container'));
+            expect(window.__detailsInfoScript).toBe(undefined);
+            expect(document.body.innerHTML.indexOf('<script')).toBe(-1);
+        });
+    });
 });
 

--- a/web/client/plugins/ResourcesCatalog/containers/__tests__/ResourceAbout-test.jsx
+++ b/web/client/plugins/ResourcesCatalog/containers/__tests__/ResourceAbout-test.jsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { waitFor } from '@testing-library/react';
+import { createStore, combineReducers } from 'redux';
+
+import ResourceAbout from '../ResourceAbout';
+import { DETAILS_DATA_KEY } from '../../../../utils/GeostoreUtils';
+
+const getStore = (resource) => createStore(combineReducers({
+    resourcesselected: () => ({ initialSelectedResource: resource })
+}));
+
+const renderResourceAbout = (resource) => ReactDOM.render(
+    <Provider store={getStore(resource)}>
+        <ResourceAbout resource={resource} />
+    </Provider>,
+    document.getElementById('container')
+);
+
+describe('ResourceAbout container', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    describe('sanitization', () => {
+        it('removes script tags from the about content', () => {
+            window.__resourceAboutScript = undefined;
+            renderResourceAbout({ attributes: { [DETAILS_DATA_KEY]: '<p>content</p><script>window.__resourceAboutScript = true</script>' } });
+            expect(window.__resourceAboutScript).toBe(undefined);
+            expect(document.getElementById('container').innerHTML.indexOf('<script')).toBe(-1);
+        });
+        it('keeps the formatting tags of the about content', (done) => {
+            renderResourceAbout({ attributes: { [DETAILS_DATA_KEY]: '<p><b>bold</b></p>' } });
+            waitFor(() => expect(document.querySelector('b')).toBeTruthy())
+                .then(() => done())
+                .catch(done);
+        });
+    });
+});

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1675,7 +1675,8 @@
           "title": "Fehler beim Laden des Peramlinks",
           "pleaseLogin": "Dieser Permalink ist nicht öffentlich. Bitte versuchen Sie sich anzumelden",
           "notFound": "Permalink nicht gefunden",
-          "notAccessible": "Permalink nicht zugänglich"
+          "notAccessible": "Permalink nicht zugänglich",
+          "invalidTarget": "Das Ziel des Permalinks ist ungültig und kann nicht geöffnet werden"
         },
         "save": {
           "title": "Die Permalink-Generierung ist fehlgeschlagen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1636,7 +1636,8 @@
           "title": "Error loading peramlink",
           "pleaseLogin": "This permalink is not public. Please try to login",
           "notFound": "Permalink not found",
-          "notAccessible": "Permalink not accessible"
+          "notAccessible": "Permalink not accessible",
+          "invalidTarget": "The permalink target is not valid and can not be opened"
         },
         "save": {
           "title": "Permalink generation failed",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1636,7 +1636,8 @@
           "title": "Error al cargar el enlace permanente",
           "pleaseLogin": "Este enlace permanente no es público. Intente iniciar sesión",
           "notFound": "Enlace permanente no encontrado",
-          "notAccessible": "Enlace permanente no accesible"
+          "notAccessible": "Enlace permanente no accesible",
+          "invalidTarget": "El destino del enlace permanente no es válido y no se puede abrir"
         },
         "save": {
           "title": "La generación del enlace permanente falló",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1636,7 +1636,8 @@
           "title": "Erreur lors du chargement du lien permanent",
           "pleaseLogin": "Ce permalien n'est pas public. Veuillez essayer de vous connecter",
           "notFound": "Permalien introuvable",
-          "notAccessible": "Permalien inaccessible"
+          "notAccessible": "Permalien inaccessible",
+          "invalidTarget": "La destination du permalien n'est pas valide et ne peut pas être ouverte"
         },
         "save": {
           "title": "La génération du permalien a échoué",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1636,7 +1636,8 @@
           "title": "Errore durante il caricamento di peramlink",
           "pleaseLogin": "Questo permalink non è pubblico. Si prega di provare ad accedere",
           "notFound": "Permalink non trovato",
-          "notAccessible": "Permalink non accessibile"
+          "notAccessible": "Permalink non accessibile",
+          "invalidTarget": "La destinazione del permalink non è valida e non può essere aperta"
         },
         "save": {
           "title": "Generazione del permalink non riuscita",

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -15,7 +15,6 @@ import isNil from "lodash/isNil";
 import isArray from "lodash/isArray";
 import isEmpty from "lodash/isEmpty";
 import isString from "lodash/isString";
-import template from "lodash/template";
 import get from "lodash/get";
 import castArray from "lodash/castArray";
 
@@ -175,7 +174,20 @@ export function findUserAttributeValue(attributeName) {
 }
 
 /**
- * Parses request configuration by replacing variables with actual values using lodash template
+ * Replaces `${...}` placeholders with the matching value of securityProperties.
+ * Unresolved placeholders are left in place, filterUnresolvedTemplates drops them later.
+ * @param {string} value - configuration value containing placeholders
+ * @param {Object} securityProperties - properties used to resolve the placeholders
+ * @returns {string} the value with the resolved placeholders
+ */
+const substitutePlaceholders = (value, securityProperties) =>
+    value.replace(/\$\{([^{}]+)\}/g, (placeholder, path) => {
+        const resolved = get(securityProperties, path.trim());
+        return isNil(resolved) ? placeholder : String(resolved);
+    });
+
+/**
+ * Parses request configuration by replacing variables with actual values
  * @param {Object} config - Configuration object with headers/params
  * @param {Object} securityProperties - Security properties to replace variables
  * @returns {Object} Parsed configuration with replaced variables
@@ -187,9 +199,7 @@ const parseRequestConfiguration = (config = {}, securityProperties) => {
                 const [name, value] = entry;
                 if (typeof value === 'string' && value.includes('${')) {
                     try {
-                        // Use lodash template for variable substitution
-                        const compiled = template(value);
-                        let result = compiled(securityProperties);
+                        let result = substitutePlaceholders(value, securityProperties);
                         result = result === "" ? undefined : result;
                         return [name, result];
                     } catch (error) {

--- a/web/client/utils/TemplateUtils.js
+++ b/web/client/utils/TemplateUtils.js
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {isString, has, trim, template} from 'lodash';
+import {isString, has, isNil, trim} from 'lodash';
+import escape from 'lodash/escape';
 
 /**
  * check if a string attribute is inside of a given object
@@ -42,17 +43,6 @@ export const getCleanTemplate = (chosenTemplate, feature, regex, start = 0, end 
     return replacedTag && replacedTag.reduce((temp, variable) => temp.replace(variable.previous, variable.next), chosenTemplate) || chosenTemplate || '';
 };
 
-/**
- * parses a template with attributes defined in ${ ... } and applied to the metadata object
- * @param metadataTemplate {string} text with attribute to validate
- * @param getDefaultMissingProperty {function} if defined it returns a default value for undefined attributes
- * @param metadata {object} metadata object to match attributes
- * @return {string} template without invalid attribute and html tag inside attribute, e.g. ${ <p>properties.id</p> } -> ${ properties.id } and a default value for undefined attributes
- */
-export const parseCustomTemplate = (metadataTemplate = "", metadata = {}, getDefaultMissingProperty = (attribute) => `${trim(attribute.substring(2, attribute.length - 1))} Not Available`) => {
-    return template(getCleanTemplate(metadataTemplate || '', metadata, /\$\{.*?\}/g, 2, 1, getDefaultMissingProperty))(metadata);
-};
-
 export const generateTemplateString = (function() {
     var cache = {};
 
@@ -66,9 +56,9 @@ export const generateTemplateString = (function() {
                 let sanitized = chosenTemplate
                     .replace(/\$\{([\s]*[^;\s\{]+[\s]*)\}/g, (_, match) => {
                         const escapeFunction = escapeFn || (a => a);
-                        return escapeFunction(match.trim().split(".").reduce((a, b) => {
-                            return a && a[b] || '';
-                        }, map));
+                        // only a missing value falls back to '', 0 and false are kept
+                        const value = match.trim().split(".").reduce((a, b) => isNil(a) ? undefined : a[b], map);
+                        return escapeFunction(isNil(value) ? '' : value);
                     });
 
                 return isString(sanitized) && sanitized || '';
@@ -84,6 +74,21 @@ export const generateTemplateString = (function() {
     return generateTemplate;
 })();
 
+
+/**
+ * parses a template with attributes defined in ${ ... } and applied to the metadata object
+ * @param metadataTemplate {string} text with attribute to validate
+ * @param getDefaultMissingProperty {function} if defined it returns a default value for undefined attributes
+ * @param metadata {object} metadata object to match attributes
+ * @return {string} template without invalid attribute and html tag inside attribute, e.g. ${ <p>properties.id</p> } -> ${ properties.id } and a default value for undefined attributes
+ */
+export const parseCustomTemplate = (metadataTemplate = "", metadata = {}, getDefaultMissingProperty = (attribute) => `${trim(attribute.substring(2, attribute.length - 1))} Not Available`) => {
+    // values are escaped because the result is rendered as HTML
+    return generateTemplateString(
+        getCleanTemplate(metadataTemplate || '', metadata, /\$\{.*?\}/g, 2, 1, getDefaultMissingProperty),
+        (value) => escape(String(value ?? ''))
+    )(metadata);
+};
 
 const TemplateUtils = {
     /**

--- a/web/client/utils/URLUtils.js
+++ b/web/client/utils/URLUtils.js
@@ -90,17 +90,27 @@ export const getQueryParams = (url) => {
  * @param {string[]} [options.allowedProtocols] by default only http and https are allowed
  * @param {string[]} [options.forbiddenMimes] if `data` is one of the protcol allowed, here a list of forbidden mime types that can be risky.
  * by default `'text/html'`, `'text/javascript'`, `'application/javascript'`, `'image/svg+xml'` are forbidden.
+ * @param {boolean} [options.allowProtocolRelative=false] when true, relative urls starting with `//` or `/\` are accepted, even if they are resolved on another host.
  */
 export const isValidURL = (url, regexp,
     {
         allowedProtocols = ['http', 'https'],
-        forbiddenMimes = ['text/html', 'text/javascript', 'application/javascript', 'image/svg+xml']
+        forbiddenMimes = ['text/html', 'text/javascript', 'application/javascript', 'image/svg+xml'],
+        allowProtocolRelative = false
     } = {}) => {
     if (regexp) {
         const regex = new RegExp(regexp);
         return regex.test(url);
     }
-    const base = url.indexOf('/') === 0 ? window?.location?.origin : undefined;
+    if (!isString(url)) {
+        return false;
+    }
+    const isRelative = url.indexOf('/') === 0;
+    // "//host" and "/\host" are resolved by the browser on another host
+    if (isRelative && !allowProtocolRelative && /^\/[/\\]/.test(url)) {
+        return false;
+    }
+    const base = isRelative ? window?.location?.origin : undefined;
     if (!URL.canParse(url, base)) {
         return false;
     }
@@ -168,3 +178,32 @@ export function updateUrlParams(url, params) {
     const query = queryString.stringify(updatedQuery);
     return query ? `${parsedUrl?.url}?${query}` : parsedUrl?.url;
 }
+
+// "//host" and "/\host" look relative, the browser resolves them on another host
+const otherHostReference = /^[/\\]{2}/;
+// control characters are ignored by browsers when resolving a scheme, so reject them
+const controlCharacters = /[\u0000-\u001F\u007F-\u009F]/;
+const protocolPrefix = /^[a-z][a-z0-9+.-]*:/i;
+
+/**
+ * Returns the given href when the application can link to it, an empty string otherwise.
+ * References without protocol (`#...`, `?...`, `/path`, `path`) stay inside the application,
+ * urls with a protocol are accepted only for the allowed protocols.
+ * @param {string} href - href to check
+ * @param {object} [options] optional configurations
+ * @param {string[]} [options.allowedProtocols] protocols allowed for urls with a protocol
+ * @return {string} the href, or an empty string when it can not be used as a link target
+ */
+export const getSafeHref = (href, { allowedProtocols = ['http', 'https', 'mailto', 'tel'] } = {}) => {
+    if (!isString(href) || !href.trim()) {
+        return '';
+    }
+    const value = href.trim();
+    if (controlCharacters.test(value)) {
+        return '';
+    }
+    if (!protocolPrefix.test(value)) {
+        return otherHostReference.test(value) ? '' : value;
+    }
+    return isValidURL(value, undefined, { allowedProtocols }) ? value : '';
+};

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -911,4 +911,38 @@ describe('Test security utils methods', () => {
             });
         });
     });
+
+    describe('request configuration placeholders', () => {
+        it('substitutes request configuration placeholders without compiling them', () => {
+            window.__ruleEvaluated = undefined;
+            const rules = [
+                {
+                    urlPattern: '.*api.*',
+                    headers: { 'Authorization': 'Bearer ${(window.__ruleEvaluated = true)}' }
+                }
+            ];
+            ConfigUtils.setConfigProp('requestsConfigurationRules', rules);
+            ConfigUtils.setConfigProp('useAuthenticationRules', true);
+            setSecurityInfo(securityInfoToken);
+
+            const { headers } = SecurityUtils.getRequestConfigurationByUrl('https://api.example.com');
+            expect(window.__ruleEvaluated).toBe(undefined);
+            // the placeholder can not be resolved, so it is kept as it is
+            expect(headers.Authorization).toBe('Bearer ${(window.__ruleEvaluated = true)}');
+        });
+        it('should keep the placeholders that can not be resolved', () => {
+            const rules = [
+                {
+                    urlPattern: '.*api.*',
+                    headers: { 'Authorization': 'Bearer ${notAvailableProperty}' }
+                }
+            ];
+            ConfigUtils.setConfigProp('requestsConfigurationRules', rules);
+            ConfigUtils.setConfigProp('useAuthenticationRules', true);
+            setSecurityInfo(securityInfoToken);
+
+            const { headers } = SecurityUtils.getRequestConfigurationByUrl('https://api.example.com');
+            expect(headers.Authorization).toBe('Bearer ${notAvailableProperty}');
+        });
+    });
 });

--- a/web/client/utils/__tests__/TemplateUtils-test.js
+++ b/web/client/utils/__tests__/TemplateUtils-test.js
@@ -108,4 +108,31 @@ describe('TemplateUtils', () => {
         const retVal = parseCustomTemplate("${<p>desc </p>}, ${desc2}", {desc: "desc value"});
         expect(retVal).toEqual("desc value, desc2 Not Available");
     });
+
+    it('generateTemplateString keeps defined falsy values', () => {
+        const feature = { properties: { count: 0, flag: false, empty: '', name: 'Rome' } };
+        expect(generateTemplateString('${properties.count}')(feature)).toBe('0');
+        expect(generateTemplateString('${properties.flag}')(feature)).toBe('false');
+        expect(generateTemplateString('${properties.name}')(feature)).toBe('Rome');
+        expect(generateTemplateString('${properties.empty}')(feature)).toBe('');
+        expect(generateTemplateString('${properties.missing}')(feature)).toBe('');
+        expect(generateTemplateString('${properties.missing.nested}')(feature)).toBe('');
+    });
+    it('parseCustomTemplate keeps defined falsy values', () => {
+        expect(parseCustomTemplate('${count}', { count: 0 }, () => '')).toBe('0');
+        expect(parseCustomTemplate('${flag}', { flag: false }, () => '')).toBe('false');
+    });
+    it('parseCustomTemplate substitutes placeholders by value', () => {
+        window.__templateEvaluated = undefined;
+        parseCustomTemplate('${(window.__templateEvaluated = true)}', {}, () => '');
+        expect(window.__templateEvaluated).toBe(undefined);
+    });
+    it('parseCustomTemplate resolves only property references', () => {
+        const retVal = parseCustomTemplate('${1 + 1}', {}, () => '');
+        expect(retVal.indexOf('2')).toBe(-1);
+    });
+    it('parseCustomTemplate escapes the html of the resolved values', () => {
+        const retVal = parseCustomTemplate('${desc}', { desc: '<b>value</b>' }, () => '');
+        expect(retVal).toBe('&lt;b&gt;value&lt;/b&gt;');
+    });
 });

--- a/web/client/utils/__tests__/URLUtils-test.js
+++ b/web/client/utils/__tests__/URLUtils-test.js
@@ -7,7 +7,7 @@
  */
 import expect from 'expect';
 
-import { urlParts, isSameUrl, sameQueryParams, isValidURL, isValidURLTemplate, getDefaultUrl, updateUrlParams } from '../URLUtils';
+import { urlParts, isSameUrl, sameQueryParams, isValidURL, isValidURLTemplate, getDefaultUrl, updateUrlParams, getSafeHref } from '../URLUtils';
 
 const url1 = "https://demo.geo-solutions.it:443/geoserver/wfs";
 const url2 = "https://demo.geo-solutions.it/geoserver/wfs";
@@ -200,6 +200,71 @@ describe('URLUtils', () => {
         const url = 'https://my-site.com/some/path/to/resouce';
         const updatedUrl = updateUrlParams(url, {});
         expect(updatedUrl).toBe('https://my-site.com/some/path/to/resouce');
+    });
+
+    describe('link targets', () => {
+        it('isValidURL rejects urls resolved on another host', () => {
+            expect(isValidURL('//other-host.com/x')).toBe(false);
+            expect(isValidURL('/\\other-host.com/x')).toBe(false);
+        });
+        it('isValidURL accepts urls resolved on another host with allowProtocolRelative', () => {
+            expect(isValidURL('//other-host.com/x', undefined, { allowProtocolRelative: true })).toBe(true);
+        });
+        it('isValidURL rejects values that are not strings', () => {
+            expect(isValidURL(undefined)).toBe(false);
+            expect(isValidURL(null)).toBe(false);
+            expect(isValidURL(42)).toBe(false);
+            expect(isValidURL({})).toBe(false);
+        });
+        it('isValidURL rejects protocols that are not allowed', () => {
+            // eslint-disable-next-line no-script-url
+            expect(isValidURL('javascript:void(0)')).toBe(false);
+            expect(isValidURL('vbscript:void(0)')).toBe(false);
+            expect(isValidURL('file:///tmp/file.txt')).toBe(false);
+            expect(isValidURL('data:text/html,<p>content</p>')).toBe(false);
+        });
+        it('isValidURL accepts application paths and http urls', () => {
+            expect(isValidURL('/viewer/42')).toBe(true);
+            expect(isValidURL('/context/name?category=PERMALINK')).toBe(true);
+            expect(isValidURL('http://my-host.com/x')).toBe(true);
+            expect(isValidURL('https://my-host.com/x')).toBe(true);
+        });
+        it('getSafeHref returns in app references and linkable urls', () => {
+            expect(getSafeHref('#/viewer/42')).toBe('#/viewer/42');
+            expect(getSafeHref('?f=map')).toBe('?f=map');
+            expect(getSafeHref('/viewer/42')).toBe('/viewer/42');
+            expect(getSafeHref('https://my-host.com/x')).toBe('https://my-host.com/x');
+            expect(getSafeHref('mailto:info@my-host.com')).toBe('mailto:info@my-host.com');
+            expect(getSafeHref('tel:+123456')).toBe('tel:+123456');
+        });
+        it('getSafeHref returns references without protocol', () => {
+            expect(getSafeHref('viewer/42')).toBe('viewer/42');
+            expect(getSafeHref('./viewer/42')).toBe('./viewer/42');
+            expect(getSafeHref('../viewer/42')).toBe('../viewer/42');
+        });
+        it('getSafeHref returns an empty string for references resolved on another host', () => {
+            expect(getSafeHref('//other-host.com')).toBe('');
+            expect(getSafeHref('/\\other-host.com')).toBe('');
+            expect(getSafeHref('\\\\other-host.com')).toBe('');
+            expect(getSafeHref('\\/other-host.com')).toBe('');
+        });
+        it('getSafeHref returns an empty string for hrefs with control characters', () => {
+            // the browser removes the control characters, resolving the href to a protocol
+            expect(getSafeHref('java\nscript:void(0)')).toBe('');
+            expect(getSafeHref('java\tscript:void(0)')).toBe('');
+        });
+        it('getSafeHref returns an empty string for hrefs that can not be used', () => {
+            // eslint-disable-next-line no-script-url
+            expect(getSafeHref('javascript:void(0)')).toBe('');
+            // eslint-disable-next-line no-script-url
+            expect(getSafeHref('JAVASCRIPT:void(0)')).toBe('');
+            expect(getSafeHref('data:text/html,<p>content</p>')).toBe('');
+            expect(getSafeHref(undefined)).toBe('');
+            expect(getSafeHref(null)).toBe('');
+            expect(getSafeHref('')).toBe('');
+            expect(getSafeHref('   ')).toBe('');
+            expect(getSafeHref(42)).toBe('');
+        });
     });
 });
 


### PR DESCRIPTION
## Description
Refactor of how templates and link targets are handled, plus test coverage.

- Template placeholders are resolved without compiling them: only property  references (`${properties.NAME}`) are substituted, expressions are not; `0` and    `false` are preserved instead of being replaced. Interpolated values are HTML-escaped. 
- Link target checks are centralized in `URLUtils` (`getSafeHref`, hardened  `isValidURL`); `ALink`, `DetailsInfo`,  `FilterItems`, geostory and catalog links route through it, so references without a protocol stay in-app and absolute URLs are limited to the allowed protocols.
- Permalink loading resolves `pathTemplate` to an application path and reports an   invalid target instead of navigating to it. 
- Added coverage for the HTML rendering components.
 
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12823

**What is the new behavior?**

Closes #12823


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
