### PR TITLE
Add information for Timeline plugin when no time dimension layer is selected in TOC  #11959

### DIFF
--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -39,12 +39,14 @@ import withResizeSpy from '../components/misc/enhancers/withResizeSpy';
 import Toolbar from '../components/misc/toolbar/Toolbar';
 import InlineDateTimeSelector from '../components/time/InlineDateTimeSelector';
 import { currentTimeSelector, offsetEnabledSelector } from '../selectors/dimension';
+import { getEffectivelyVisibleLayers } from '../selectors/layers';
 import { playbackRangeSelector, statusSelector } from '../selectors/playback';
 import {
     currentTimeRangeSelector,
     isMapSync,
     isVisible,
     rangeSelector,
+    selectedLayerData,
     selectedLayerSelector,
     timelineLayersSelector
 } from '../selectors/timeline';
@@ -103,7 +105,9 @@ const TimelinePlugin = compose(
             rangeSelector,
             (state) => state.timeline?.loader !== undefined,
             selectedLayerSelector,
-            (visible, layers, currentTime, currentTimeRange, offsetEnabled, playbackRange, status, viewRange, timelineIsReady, selectedLayer) => ({
+            selectedLayerData,
+            getEffectivelyVisibleLayers,
+            (visible, layers, currentTime, currentTimeRange, offsetEnabled, playbackRange, status, viewRange, timelineIsReady, selectedLayer, selectedLayerObject, effectivelyVisibleLayers) => ({
                 visible,
                 layers,
                 currentTime,
@@ -113,7 +117,9 @@ const TimelinePlugin = compose(
                 status,
                 viewRange,
                 timelineIsReady,
-                selectedLayer
+                selectedLayer,
+                selectedLayerIsHidden: !!selectedLayerObject
+                    && !effectivelyVisibleLayers.some(({ id }) => id === selectedLayer)
             })
         ), {
             setCurrentTime: selectTime,
@@ -200,7 +206,8 @@ const TimelinePlugin = compose(
         initialSnap = 'now',
         resetButton,
         reset = () => {},
-        selectedLayer
+        selectedLayer,
+        selectedLayerIsHidden
     }) => {
         useEffect(()=>{
             // update state with configs coming from configuration file like localConfig.json so that can be used as props initializer
@@ -328,6 +335,12 @@ const TimelinePlugin = compose(
                         tooltip={<Message msgId= {collapsed ? "timeline.expand" : "timeline.collapse"}/>}>
                         <Glyphicon glyph={collapsed ? 'resize-full' : 'resize-small'}/>
                     </Button>
+                    {selectedLayerIsHidden && <Button
+                        className="square-button ms-timeline-visibility-warning"
+                        bsStyle="warning"
+                        tooltip={<Message msgId="timeline.hiddenGuideLayerWarning"/>}>
+                        <Glyphicon glyph="warning-sign"/>
+                    </Button>}
                 </div>
             </div>
             {!timelineIsReady && <div className="timeline-loader">

--- a/web/client/plugins/__tests__/Timeline-test.jsx
+++ b/web/client/plugins/__tests__/Timeline-test.jsx
@@ -134,6 +134,22 @@ describe('Timeline Plugin', () => {
             ReactDOM.render(<Plugin />, document.getElementById("container"));
             expect(document.querySelector('.timeline-plugin.hidden')).toBeTruthy();
         });
+        it('shows the warning  when the hidden selected layer is not displayed in the timeline', () => {
+            const state = {
+                ...FALSY_STATE,
+                layers: {
+                    ...FALSY_STATE.layers,
+                    flat: FALSY_STATE.layers.flat.map(layer =>
+                        layer.id === 'TEST_LAYER_2' ? { ...layer, visibility: true } : layer
+                    )
+                }
+            };
+            const { Plugin } = getPluginForTest(TimelinePlugin, state);
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+
+            const warning = document.querySelector('.ms-timeline-visibility-warning');
+            expect(warning).toBeTruthy();
+        });
         it('Timeline plugin is not visible when there are no layers with dimension data', ()=>{
             const { Plugin } = getPluginForTest(TimelinePlugin, {});
             ReactDOM.render(<Plugin />, document.getElementById("container"));

--- a/web/client/themes/default/less/timeline.less
+++ b/web/client/themes/default/less/timeline.less
@@ -378,11 +378,13 @@
             font-weight: bold;
         }
     }
-    .ms-timeline-expand {
+    .ms-timeline-expand,
+    .ms-timeline-visibility-warning {
         flex-shrink: 0;
         border-radius: 4px;
         height: 30px;
         width: 30px;
+        margin-right: 4px;
     }
 
     /* local mixin to highlight handlers on timeline, used on active and over */

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -3294,7 +3294,7 @@
       "disableRange": "Zeitbereich deaktivieren",
       "enablePlayBack": "Aktivieren Sie die Wiedergabesteuerung",
       "disablePlayBack": "Deaktivieren Sie die Wiedergabesteuerung",
-      "hiddenGuideLayerWarning": "Dieser Führungslayer ist im Inhaltsverzeichnis und auf der Karte ausgeblendet, steuert aber weiterhin das Einrasten der Zeitleiste.",
+      "hiddenGuideLayerWarning": "Die Führungslayer ist im Inhaltsverzeichnis und auf der Karte ausgeblendet, steuert aber weiterhin das Einrasten der Zeitleiste.",
       "expand": "Erweitern Sie den Zeitschieberegler",
       "collapse": "Schieberegler für die Zeitspanne reduzieren",
       "reset": {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -3294,6 +3294,7 @@
       "disableRange": "Zeitbereich deaktivieren",
       "enablePlayBack": "Aktivieren Sie die Wiedergabesteuerung",
       "disablePlayBack": "Deaktivieren Sie die Wiedergabesteuerung",
+      "hiddenGuideLayerWarning": "Dieser Führungslayer ist im Inhaltsverzeichnis und auf der Karte ausgeblendet, steuert aber weiterhin das Einrasten der Zeitleiste.",
       "expand": "Erweitern Sie den Zeitschieberegler",
       "collapse": "Schieberegler für die Zeitspanne reduzieren",
       "reset": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -3263,6 +3263,7 @@
       "disableRange": "Disable time range",
       "enablePlayBack": "Enable playback controls",
       "disablePlayBack": "Disable playback controls",
+      "hiddenGuideLayerWarning": "This guide layer is hidden in the TOC and on the map, but continues to control timeline snapping.",
       "expand": "Expand time slider",
       "collapse": "Collapse time slider",
       "reset": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -3263,7 +3263,7 @@
       "disableRange": "Disable time range",
       "enablePlayBack": "Enable playback controls",
       "disablePlayBack": "Disable playback controls",
-      "hiddenGuideLayerWarning": "This guide layer is hidden in the TOC and on the map, but continues to control timeline snapping.",
+      "hiddenGuideLayerWarning": "The guide layer is hidden in the TOC and on the map, but continues to control timeline snapping.",
       "expand": "Expand time slider",
       "collapse": "Collapse time slider",
       "reset": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -3251,6 +3251,7 @@
       "disableRange": "Desactivar intervalo de tiempo",
       "enablePlayBack": "Habilitar controles de reproducción",
       "disablePlayBack": "Deshabilitar los controles de reproducción",
+      "hiddenGuideLayerWarning": "Esta capa guía está oculta en la TOC y en el mapa, pero sigue controlando el ajuste de la línea de tiempo.",
       "expand": "Expandir el control deslizante de tiempo",
       "collapse": "Minimizar el control deslizante de tiempo",
       "reset": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -3251,7 +3251,7 @@
       "disableRange": "Desactivar intervalo de tiempo",
       "enablePlayBack": "Habilitar controles de reproducción",
       "disablePlayBack": "Deshabilitar los controles de reproducción",
-      "hiddenGuideLayerWarning": "Esta capa guía está oculta en la TOC y en el mapa, pero sigue controlando el ajuste de la línea de tiempo.",
+      "hiddenGuideLayerWarning": "La capa guía está oculta en la TOC y en el mapa, pero sigue controlando el ajuste de la línea de tiempo.",
       "expand": "Expandir el control deslizante de tiempo",
       "collapse": "Minimizar el control deslizante de tiempo",
       "reset": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -3255,7 +3255,7 @@
       "disableRange": "Désactiver la plage de temps",
       "enablePlayBack": "Activer les contrôles de lecture",
       "disablePlayBack": "Désactiver les contrôles de lecture",
-      "hiddenGuideLayerWarning": "Cette couche de référence est masquée dans la TOC et sur la carte, mais continue de contrôler l'accrochage de la chronologie.",
+      "hiddenGuideLayerWarning": "Le couche de référence est masquée dans la TOC et sur la carte, mais continue de contrôler l'accrochage de la chronologie.",
       "expand": "Développer le curseur temporel",
       "collapse": "Réduire le curseur temporel",
       "reset": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -3255,6 +3255,7 @@
       "disableRange": "Désactiver la plage de temps",
       "enablePlayBack": "Activer les contrôles de lecture",
       "disablePlayBack": "Désactiver les contrôles de lecture",
+      "hiddenGuideLayerWarning": "Cette couche de référence est masquée dans la TOC et sur la carte, mais continue de contrôler l'accrochage de la chronologie.",
       "expand": "Développer le curseur temporel",
       "collapse": "Réduire le curseur temporel",
       "reset": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -3255,7 +3255,7 @@
       "disableRange": "Disabilita intervallo",
       "enablePlayBack": "Abilita i controlli di riproduzione",
       "disablePlayBack": "Disabilita i controlli di riproduzione",
-      "hiddenGuideLayerWarning": "Questo layer guida è nascosto nel TOC e sulla mappa, ma continua a controllare l'aggancio della timeline.",
+      "hiddenGuideLayerWarning": "Il layer guida è nascosto nel TOC e sulla mappa, ma continua a controllare l'aggancio della timeline.",
       "expand": "Espandi",
       "collapse": "Riduci",
       "reset": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -3255,6 +3255,7 @@
       "disableRange": "Disabilita intervallo",
       "enablePlayBack": "Abilita i controlli di riproduzione",
       "disablePlayBack": "Disabilita i controlli di riproduzione",
+      "hiddenGuideLayerWarning": "Questo layer guida è nascosto nel TOC e sulla mappa, ma continua a controllare l'aggancio della timeline.",
       "expand": "Espandi",
       "collapse": "Riduci",
       "reset": {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Currently, if none of the time-enabled layers are hidden in the TOC, the timeline is not shown. But when there are two time-enabled layers and the selected one is disabled from the TOC. The snapping layer is still the previously selected one and it seems confusing. So now a warning icon with a tooltip is shown in such a case.
<img width="699" height="694" alt="image" src="https://github.com/user-attachments/assets/9f927fba-b245-44cb-bc82-0e4d2a1b4d3b" />


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
fixes #11959(gitub is not letting me link issue using Developement, so using keyword "fixes" to link the issue)
**What is the current behavior?**
<!-- You can also link to an existing issue here -->
No warning when a hidden layer on the TOC is the selected layer in the timeline


**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Warning shown when a hidden layer is the selected layer in the timeline.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
