### PR TITLE
Fix docma error crashing plugin documentation

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -383,10 +383,9 @@ class MapPlugin extends React.Component {
         }
         return this._coalesceUnits;
     };
-    /**
+    /*
      * Logic for coalescing priority is: map settings > plugin cfg > config miscSettings.
      * A single layer can always opt out with `coalesce: false` in its own options.
-     * @returns true if coalescing is enabled, false otherwise
      */
     isCoalesceEnabled = () => {
         if (this.props.mapType === MapLibraries.LEAFLET) {


### PR DESCRIPTION
## Description
This PR fixes a docma error that was crashing the plugin documentation. The error was caused by a missing **type** in the `Map` plugin component. The inline comment was also converted to a standard comment so that docma skips it, as it is only intended for inline use and is not needed in the generated documentation.

Caused by #12662

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
 [Plugins](https://dev-mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins) documentation crashes in DEV

**What is the new behavior?**
Plugin documentation page loads up correctly without crashing

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
