### PR TITLE
#12837: Identify - Use media rendering for GeoNode documents layer

### DIFF
--- a/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
+++ b/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
@@ -40,7 +40,10 @@ class PropertiesViewer extends React.Component {
     };
 
     getBodyItems = () => {
-        return Object.keys(this.props?.feature?.properties || {})
+        const propertyKeys = this.props.fields?.length
+            ? this.props.fields.map(({ name }) => name).filter(key => Object.hasOwn(this.props?.feature?.properties || {}, key))
+            : Object.keys(this.props?.feature?.properties || {});
+        return propertyKeys
             .filter(this.props?.include?.length > 0 ? this.toInclude : this.toExclude)
             .map((key) => {
                 const attribute = this.props.fields?.find(field => field.name === key) || { name: key };

--- a/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
+++ b/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
@@ -40,9 +40,14 @@ class PropertiesViewer extends React.Component {
     };
 
     getBodyItems = () => {
-        const propertyKeys = this.props.fields?.length
-            ? this.props.fields.map(({ name }) => name).filter(key => Object.hasOwn(this.props?.feature?.properties || {}, key))
-            : Object.keys(this.props?.feature?.properties || {});
+        const properties = this.props?.feature?.properties || {};
+        const orderedKeys = (this.props.fields || [])
+            .map(({ name }) => name)
+            .filter((key) => Object.hasOwn(properties, key));
+        const propertyKeys = [
+            ...orderedKeys,
+            ...Object.keys(properties).filter((key) => !orderedKeys.includes(key))
+        ];
         return propertyKeys
             .filter(this.props?.include?.length > 0 ? this.toInclude : this.toExclude)
             .map((key) => {

--- a/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
+++ b/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
@@ -119,6 +119,37 @@ describe('PropertiesViewer', () => {
         });
     });
 
+    it('test rendering properties ordered by fields and filtered by feature properties presence', () => {
+        const testProps = {
+            k0: "v0",
+            k1: "v1",
+            k2: "v2"
+        };
+        const fields = [
+            { name: "k2", alias: "alias2" },
+            { name: "nonExistingKey", alias: "nonExisting" },
+            { name: "k0", alias: "alias0" }
+        ];
+
+        const cmp = ReactDOM.render(<PropertiesViewer
+            feature={{ properties: testProps }}
+            fields={fields}
+        />, document.getElementById("container"));
+        expect(cmp).toBeTruthy();
+
+        const cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom).toBeTruthy();
+
+        const body = cmpDom.childNodes.item(0);
+        expect(body.childNodes.length).toBe(2);
+        const row0 = body.childNodes[0].querySelectorAll('div');
+        expect(row0[0].innerHTML).toBe("alias2");
+        expect(row0[1].innerHTML).toBe("v2");
+        const row1 = body.childNodes[1].querySelectorAll('div');
+        expect(row1[0].innerHTML).toBe("alias0");
+        expect(row1[1].innerHTML).toBe("v0");
+    });
+
     describe('sanitization', () => {
         it('removes script tags from a property value', () => {
             window.__propertiesViewerScript = undefined;

--- a/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
+++ b/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
@@ -119,7 +119,7 @@ describe('PropertiesViewer', () => {
         });
     });
 
-    it('test rendering properties ordered by fields and filtered by feature properties presence', () => {
+    it('test rendering properties ordered by fields, appending the ones not listed in fields', () => {
         const testProps = {
             k0: "v0",
             k1: "v1",
@@ -141,13 +141,16 @@ describe('PropertiesViewer', () => {
         expect(cmpDom).toBeTruthy();
 
         const body = cmpDom.childNodes.item(0);
-        expect(body.childNodes.length).toBe(2);
-        const row0 = body.childNodes[0].querySelectorAll('div');
-        expect(row0[0].innerHTML).toBe("alias2");
-        expect(row0[1].innerHTML).toBe("v2");
-        const row1 = body.childNodes[1].querySelectorAll('div');
-        expect(row1[0].innerHTML).toBe("alias0");
-        expect(row1[1].innerHTML).toBe("v0");
+        expect(body.childNodes.length).toBe(3);
+        const rows = [...body.childNodes].map((node) => {
+            const [key, value] = node.querySelectorAll('div');
+            return [key.innerHTML, value.innerHTML];
+        });
+        expect(rows).toEqual([
+            ["alias2", "v2"],
+            ["alias0", "v0"],
+            ["k1", "v1"]
+        ]);
     });
 
     describe('sanitization', () => {

--- a/web/client/utils/FeatureInfoAttributeUtils.js
+++ b/web/client/utils/FeatureInfoAttributeUtils.js
@@ -39,7 +39,9 @@ export const getDisplayTypeFromMediaType = (mediaType) => {
     }
     const normalizedMediaType = mediaType.toLowerCase().trim();
     if (!normalizedMediaType.includes('/')) {
-        return DISPLAY_TYPES.includes(normalizedMediaType) ? normalizedMediaType : null;
+        return DISPLAY_TYPES.includes(normalizedMediaType)
+            ? normalizedMediaType
+            : EXTENSION_TO_TYPE[normalizedMediaType] || null;
     }
     const [prefix] = normalizedMediaType.split('/');
     return MEDIA_TYPE_PREFIXES.includes(prefix) ? prefix : MEDIA_TYPES[normalizedMediaType] || null;
@@ -60,5 +62,16 @@ export const resolveAttributeDisplayType = ({ value, attribute = {}, mediaTypeVa
     const configuredType = attribute.displayType === 'media'
         ? getDisplayTypeFromMediaType(mediaTypeValue)
         : getDisplayTypeFromMediaType(attribute.displayType);
-    return configuredType || getDisplayTypeFromExtension(value) || 'string';
+    return configuredType || getDisplayTypeFromExtension(value) || (attribute.displayType === 'media' ? 'url' : 'string');
+};
+
+export const DEFAULT_DOCUMENTS_FEATURE_INFO = {
+    views: [{
+        id: 'documents',
+        type: 'PROPERTIES',
+        attributes: [
+            { name: 'title', visible: true },
+            { name: 'href', visible: true, displayType: 'media', mediaTypeAttribute: 'extension' }
+        ]
+    }]
 };

--- a/web/client/utils/GeoNodeUtils.js
+++ b/web/client/utils/GeoNodeUtils.js
@@ -18,6 +18,7 @@ import { getConfigProp } from './ConfigUtils';
 import { getSupportedLocales, shortLocale, getMessageById } from './LocaleUtils';
 import { ServerTypes } from './LayersUtils';
 import { getPolygonFromExtent } from './CoordinatesUtils';
+import { DEFAULT_DOCUMENTS_FEATURE_INFO } from './FeatureInfoAttributeUtils';
 
 export const SOURCE_TYPES = {
     LOCAL: 'LOCAL',
@@ -49,7 +50,6 @@ export const ResourceTypes = {
 
 export const GEONODE_KEYWORDS_FILTER = 'filter{keywords.slug.in}';
 export const GEONODE_CATEGORY_FILTER = 'filter{category.identifier.in}';
-export const GEONODE_DOCUMENTS_ROW_VIEWER = 'GEONODE_DOCUMENTS_ROW_VIEWER';
 
 const DEFAULT_PRESET_KEYS = {
     CATALOGS: 'catalog_list',
@@ -560,7 +560,7 @@ export const documentsToLayerConfig = (documents = [], locales) => {
         ...(bbox && { bbox }),
         features,
         style: getDocumentsStyle(locales),
-        rowViewer: GEONODE_DOCUMENTS_ROW_VIEWER
+        featureInfo: DEFAULT_DOCUMENTS_FEATURE_INFO
     };
 };
 

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -24,6 +24,7 @@ import { getEPSGCode } from './CoordinatesUtils';
 import { ANNOTATIONS, updateAnnotationsLayer, isAnnotationLayer } from '../plugins/Annotations/utils/AnnotationsUtils';
 import { getLocale } from './LocaleUtils';
 import { has, includes, indexOf } from 'lodash';
+import { DEFAULT_DOCUMENTS_FEATURE_INFO } from './FeatureInfoAttributeUtils';
 
 let LayersUtils;
 
@@ -451,6 +452,14 @@ export const normalizeLayer = (layer) => {
     // regenerate geodesic lines as property since that info has not been saved
     if (_layer.id === ANNOTATIONS) {
         _layer = updateAnnotationsLayer(_layer)[0];
+    }
+    // migrate legacy GeoNode document layers, preserving an existing featureInfo configuration
+    if (_layer.rowViewer === 'GEONODE_DOCUMENTS_ROW_VIEWER') {
+        const { rowViewer, ...rest } = _layer;
+        _layer = {
+            ...rest,
+            ...(!rest.featureInfo && { featureInfo: DEFAULT_DOCUMENTS_FEATURE_INFO })
+        };
     }
 
     return {

--- a/web/client/utils/__tests__/FeatureInfoAttributeUtils-test.js
+++ b/web/client/utils/__tests__/FeatureInfoAttributeUtils-test.js
@@ -10,6 +10,15 @@ describe('FeatureInfoAttributeUtils', () => {
         expect(getDisplayTypeFromMediaType(' VIDEO ')).toBe('video');
         expect(getDisplayTypeFromMediaType('image/jpeg')).toBe('image');
         expect(getDisplayTypeFromMediaType('application/pdf')).toBe('pdf');
+        expect(getDisplayTypeFromMediaType('text/html')).toBe('iframe');
+        expect(getDisplayTypeFromMediaType('panorama')).toBe('panorama');
+        expect(getDisplayTypeFromMediaType('png')).toBe('image');
+        expect(getDisplayTypeFromMediaType('mp4')).toBe('video');
+        expect(getDisplayTypeFromMediaType('mp3')).toBe('audio');
+        expect(getDisplayTypeFromMediaType(null)).toBe(null);
+        expect(getDisplayTypeFromMediaType(undefined)).toBe(null);
+        expect(getDisplayTypeFromMediaType(123)).toBe(null);
+        expect(getDisplayTypeFromMediaType('')).toBe(null);
         expect(getDisplayTypeFromMediaType('application/octet-stream')).toBe(null);
     });
 

--- a/web/client/utils/__tests__/GeoNodeUtils-test.js
+++ b/web/client/utils/__tests__/GeoNodeUtils-test.js
@@ -10,6 +10,7 @@ import expect from 'expect';
 
 import { setSupportedLocales, getSupportedLocales } from '../LocaleUtils';
 import { resourceToLayerConfig, getDimensions, resolveApiPresetParams, mergePresetParams, documentsToLayerConfig } from '../GeoNodeUtils';
+import { DEFAULT_DOCUMENTS_FEATURE_INFO } from '../FeatureInfoAttributeUtils';
 
 describe('GeoNodeUtils', () => {
     describe('resourceToLayerConfig', () => {
@@ -287,7 +288,8 @@ describe('GeoNodeUtils', () => {
             ]);
             expect(layer.type).toBe('vector');
             expect(layer.name).toBe('Documents');
-            expect(layer.rowViewer).toBe('GEONODE_DOCUMENTS_ROW_VIEWER');
+            expect(layer.rowViewer).toNotExist();
+            expect(layer.featureInfo).toEqual(DEFAULT_DOCUMENTS_FEATURE_INFO);
             // doc 11 has no extent -> skipped
             expect(layer.features.length).toBe(1);
             expect(layer.features[0].id).toBe(10);

--- a/web/client/utils/__tests__/IdentifyUtils-test.js
+++ b/web/client/utils/__tests__/IdentifyUtils-test.js
@@ -25,7 +25,7 @@ describe('IdentifyUtils', () => {
         expect(objectRow.mediaTypeValues).toEqual({});
         expect(objectRow.fields).toBe(objectFields);
 
-        // vector, model, cog and flatgeobuf layers expose fields as plain names
+        // the helper is shape agnostic, an unrecognized fields entry is passed through untouched
         const nameFields = ['a', 'b'];
         const nameRow = getVisibleFeatureRow(feature, nameFields);
         expect(nameRow.feature.properties).toBe(feature.properties);

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -10,8 +10,9 @@ import { v1 as uuidv1 } from 'uuid';
 import * as LayersUtils from '../LayersUtils';
 import { readZip, shpToGeoJSON } from '../FileUtils';
 import axios from '../../libs/ajax';
+import { DEFAULT_DOCUMENTS_FEATURE_INFO } from '../FeatureInfoAttributeUtils';
 
-const { extractTileMatrixSetFromLayers, splitMapAndLayers, flattenGroups, getTitle, isBackgroundCompatibleWithProjection} = LayersUtils;
+const { extractTileMatrixSetFromLayers, splitMapAndLayers, flattenGroups, getTitle, isBackgroundCompatibleWithProjection, normalizeLayer } = LayersUtils;
 const typeV1 = "empty";
 const emptyBackground = {
     type: typeV1
@@ -1983,5 +1984,22 @@ describe('LayersUtils', () => {
         const background = {type: "wmts", allowedSRS: ["EPSG:4326"]};
         const projection = "EPSG:4326";
         expect(isBackgroundCompatibleWithProjection(background, projection)).toEqual(true);
+    });
+    describe('normalizeLayer with GEONODE_DOCUMENTS_ROW_VIEWER', () => {
+        it('removes rowViewer and adds default featureInfo if missing', () => {
+            const layer = { id: 'doc-1', rowViewer: 'GEONODE_DOCUMENTS_ROW_VIEWER', name: 'documents' };
+            const normalized = normalizeLayer(layer);
+            expect(normalized.rowViewer).toBe(undefined);
+            expect(normalized.featureInfo).toEqual(DEFAULT_DOCUMENTS_FEATURE_INFO);
+            expect(normalized.id).toBe('doc-1');
+        });
+        it('removes rowViewer and keeps existing featureInfo', () => {
+            const customFeatureInfo = { views: [{ id: 'custom' }] };
+            const layer = { id: 'doc-2', rowViewer: 'GEONODE_DOCUMENTS_ROW_VIEWER', featureInfo: customFeatureInfo };
+            const normalized = normalizeLayer(layer);
+            expect(normalized.rowViewer).toBe(undefined);
+            expect(normalized.featureInfo).toEqual(customFeatureInfo);
+            expect(normalized.id).toBe('doc-2');
+        });
     });
 });

--- a/web/client/utils/mapinfo/__tests__/flatgeobuf-test.js
+++ b/web/client/utils/mapinfo/__tests__/flatgeobuf-test.js
@@ -107,7 +107,6 @@ describe("mapinfo flatgeobuf utils", () => {
                     "outputFormat": "application/json"
                 },
                 "metadata": {
-                    "fields": ["id", "name"],
                     "title": "countries"
                 },
                 "url": "client"

--- a/web/client/utils/mapinfo/__tests__/model-test.js
+++ b/web/client/utils/mapinfo/__tests__/model-test.js
@@ -23,7 +23,7 @@ describe('mapinfo 3D tiles utils', () => {
                 lng: undefined
             },
             metadata: {
-                title: layer.title, fields: [], resolution: undefined, buffer: 2, units: undefined, rowViewer: undefined, viewer: undefined, layerId: undefined
+                title: layer.title, resolution: undefined, buffer: 2, units: undefined, rowViewer: undefined, viewer: undefined, layerId: undefined
             },
             url: 'client'
         });
@@ -45,7 +45,7 @@ describe('mapinfo 3D tiles utils', () => {
                 lng: 1
             },
             metadata: {
-                title: layer.title, fields: [], resolution: undefined, buffer: 2, units: undefined, rowViewer: undefined, viewer: undefined, layerId: 'layer-id'
+                title: layer.title, resolution: undefined, buffer: 2, units: undefined, rowViewer: undefined, viewer: undefined, layerId: 'layer-id'
             },
             url: 'client'
         });

--- a/web/client/utils/mapinfo/__tests__/vector-test.js
+++ b/web/client/utils/mapinfo/__tests__/vector-test.js
@@ -47,7 +47,6 @@ describe("mapinfo vector utils", () => {
                 lng: 10
             },
             metadata: {
-                fields: ["prop1", "embedUrl"],
                 title: "My Layer",
                 resolution: 10,
                 buffer: 2,

--- a/web/client/utils/mapinfo/flatgeobuf.js
+++ b/web/client/utils/mapinfo/flatgeobuf.js
@@ -18,7 +18,6 @@ export default {
                 outputFormat: 'application/json'
             },
             metadata: {
-                fields: layer?.metadata?.columns?.map(({ name }) => name) || [],
                 title: isObject(layer.title)
                     ? layer.title[currentLocale] || layer.title.default
                     : layer.title

--- a/web/client/utils/mapinfo/model.js
+++ b/web/client/utils/mapinfo/model.js
@@ -26,7 +26,6 @@ export default {
                 lng: props?.point?.latlng?.lng
             },
             metadata: {
-                fields: layer.features?.[0]?.properties && Object.keys(layer.features[0].properties) || [],
                 title,
                 resolution: isNil(props?.map?.resolution)
                     ? props?.map?.zoom && getCurrentResolution(props?.map?.zoom, 0, 21, 96)

--- a/web/client/utils/mapinfo/vector.js
+++ b/web/client/utils/mapinfo/vector.js
@@ -35,7 +35,6 @@ export default {
                 lng: props.point.latlng.lng
             },
             metadata: {
-                fields: layer.features?.[0]?.properties && Object.keys(layer.features[0].properties) || [],
                 title,
                 resolution: isNil(props?.map?.resolution)
                     ? props?.map?.zoom && getCurrentResolution(props.map.zoom, 0, 21, 96)


### PR DESCRIPTION
## Description
This PR updates GeoNode document layer's featureInfo to use media rendering

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
- #12837 

**What is the new behavior?**
Document layer's feature info uses media rendering
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/82b5ef42-ddeb-4ff0-8ac7-151235659332" />

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
