### PR TITLE
Fixed extension delete endpoint configuration.

### DIFF
--- a/java/services/src/main/java/it/geosolutions/mapstore/controllers/rest/config/UploadPluginController.java
+++ b/java/services/src/main/java/it/geosolutions/mapstore/controllers/rest/config/UploadPluginController.java
@@ -226,7 +226,7 @@ public class UploadPluginController extends BaseMapStoreController {
      */
     @Secured({"ROLE_ADMIN"})
     @RequestMapping(value = "/uninstallPlugin/{pluginName}", method = RequestMethod.DELETE)
-    public @ResponseBody String uninstallPlugin(@PathVariable String pluginName) throws IOException {
+    public @ResponseBody String uninstallPlugin(@PathVariable("pluginName") String pluginName) throws IOException {
         validatePluginName(pluginName);
 
         ObjectNode configObj = getExtensionConfig();


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This change fixes the issue with extension delete endpoint described in #12791. The issue was caused by a misconfigured parameter definition, made compulsory after upgrading to spring7.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [X] Other... Please describe: Misconfiguration after Spring 7 upgrade.

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12791 
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Now the extensions can be deleted again.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
