### PR TITLE
I18n danish 2026.02.01

### DIFF
--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -116,7 +116,7 @@
       "heightOffset": "Højdeoffset (m)",
       "wmsLayerTileSize": "Tile størrelse (WMS)",
       "maxFeaturesInView": "Maksimale antal features i udsnit",
-      "maxFeaturesInViewPlaceholder": "Når værdien ikke er udfyldt virker funktionaliteten som hidtil (dvs. henter alle features)",
+      "maxFeaturesInViewTooltip": "Når værdien ikke er udfyldt virker funktionaliteten som hidtil (dvs. henter alle features)",
       "serverType": "Servertype",
       "serverTypeOption": {
         "noVendor": "Ingen leverandør",

--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -4487,6 +4487,10 @@
       "loadingAPI": "Indlæser API...",
       "cyclomedia": {
         "initializing": "Initialiserer Street Smart API...",
+        "logout": "Street Smart Logud",
+        "tryForceLogout": "Tving Street Smart Logud",
+        "confirmLogout": "Er du sikker på at du vil logge ud fra Street Smart?",
+        "loggingOut": "Logger ud fra Street Smart...",
         "loadingAPI": "Indlæser Street Smart API...",
         "changeCredentials": "Skift Street Smart-legitimationsoplysninger",
         "insertCredentials": "Indtast dine Street Smart-legitimationsoplysninger",
@@ -4497,8 +4501,10 @@
         "zoomIn": "Zoom ind på kortet for at se gadevisningsdækning",
         "errorOccurred": "Der opstod en fejl: ",
         "errors": {
+          "notLoggedIn": "Du er ikke logget ind",
           "invalidCredentials": "Ugyldige legitimationsoplysninger",
-          "projectionNotAvailable": "Projektionen {srs} er ikke tilgængelig. Kontakt administratoren."
+          "projectionNotAvailable": "Projektionen {srs} er ikke tilgængelig. Kontakt administratoren.",
+          "apiLoadFailed": "Load af Street Smart API mislykkedes. Venligst kontroller netværksforbindelse eller kontakt administratoren."
         },
         "reloadAPI": "Genindlæs API"
       },

--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -4772,6 +4772,7 @@
         "errorDefault": "Netværksfejl"
       },
       "myResources": "Mine ressourcer",
+      "select": "Vælg",
       "creationFilter": {
         "from": "Oprettelsesdato fra",
         "to": "Oprettelsesdato til"

--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -3693,8 +3693,8 @@
         "title": "Login"
       },
       "LongitudinalProfileTool": {
-        "description": "Tillader brugeren at generere en længdeprofil ud fra en linje og et lag med højdeattribut. Kræver konfiguration",
-        "title": "Længdeprofilværktøj"
+        "description": "Tillader brugeren at generere en højdeprofil ud fra en linje og et lag med højdeattribut. Kræver konfiguration",
+        "title": "Højdeprofilværktøj"
       },
       "MapCatalog": {
         "description": "Tillader gennemse, redigere, slette og indlæse kort, der er tilgængelige på serveren",
@@ -4510,9 +4510,9 @@
       "showMoreItems": "Vis flere elementer"
     },
     "longitudinalProfile": {
-      "open": "Åbn Længdeprofil",
-      "close": "Luk Længdeprofil",
-      "title": "Længdeprofil",
+      "open": "Åbn Højdeprofil",
+      "close": "Luk Højdeprofil",
+      "title": "Højdeprofil",
       "draw": "Tegn linje",
       "import": "Indlæs fil",
       "select": "Vælg til profil",
@@ -4555,8 +4555,8 @@
       },
       "errors": {
         "outsideCoverage": "Den angivne linje er uden for profilens dækning",
-        "loadingError": "Fejl ved indlæsning af data til længdeprofil",
-        "unableToSetupPlugin": "Kunne ikke konfigurere længdeprofiludvidelsen",
+        "loadingError": "Fejl ved indlæsning af data til højdeprofil",
+        "unableToSetupPlugin": "Kunne ikke konfigurere højdeprofiludvidelsen",
         "defaultReferentialNotFound": "Standardreferencen er konfigureret, men kan ikke findes i reference listen. Opdater venligst konfigurationen for udvidelsen.",
         "projectionNotSupported": "Referentiel med kort understøttet af kortet kan ikke findes. Opdater venligst konfigurationen for udvidelsen eller tilføj den ønskede projektion til app-konfigurationen.",
         "cannotDownloadPDF": "Det er ikke muligt at udskrive det aktuelle kort, da det indeholder henvisninger til eksternt domæne. Fjern dem, gem kortet, genindlæs siden og prøv igen.",


### PR DESCRIPTION
## Description
Get the danish translations up to date with 2026.02.xx
the goal is to get this merged and backported so it can be a part of the 2026.02.01 release

I will make a separate pull request for the missing danish translations newer than 2026.02.xx

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:
Danish i18n

## Issue

**What is the current behavior?**
missing translations

**What is the new behavior?**
no missing translations for 2026.02.xx

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
