### PR TITLE
Fix 12840 search plugin freezes if some wfs request fails

### DIFF
--- a/web/client/configs/new.json
+++ b/web/client/configs/new.json
@@ -135,6 +135,46 @@
         "type": "empty",
         "visibility": false
       }
-    ]
+    ],
+    "text_search_config": {
+            "services": [
+                {
+                    "type": "wfs",
+                    "name": "sss",
+                    "displayName": "{bla}",
+                    "subTitle": "",
+                    "priority": 1,
+                    "options": {
+                        "url": "/geoservers/wfs",
+                        "typeName": "bla",
+                        "queriableAttributes": [
+                            "name"
+                        ],
+                        "sortBy": "",
+                        "maxFeatures": 5,
+                        "srsName": "EPSG:4326"
+                    }
+                },
+                {
+                    "type": "wfs",
+                    "name": "BROKEN",
+                    "displayName": "broken",
+                    "subTitle": "broken wfs",
+                    "priority": 1,
+                    "options": {
+                        "url": "/geoservers/broken",
+                        "typeName": "bla",
+                        "queriableAttributes": [
+                            "broken"
+                        ],
+                        "sortBy": "",
+                        "maxFeatures": 5,
+                        "srsName": "EPSG:4326"
+                    }
+                }
+            ],
+            "override": false
+        },
+        "bookmark_search_config": {}
   }
 }

--- a/web/client/configs/new.json
+++ b/web/client/configs/new.json
@@ -135,46 +135,6 @@
         "type": "empty",
         "visibility": false
       }
-    ],
-    "text_search_config": {
-            "services": [
-                {
-                    "type": "wfs",
-                    "name": "sss",
-                    "displayName": "{bla}",
-                    "subTitle": "",
-                    "priority": 1,
-                    "options": {
-                        "url": "/geoservers/wfs",
-                        "typeName": "bla",
-                        "queriableAttributes": [
-                            "name"
-                        ],
-                        "sortBy": "",
-                        "maxFeatures": 5,
-                        "srsName": "EPSG:4326"
-                    }
-                },
-                {
-                    "type": "wfs",
-                    "name": "BROKEN",
-                    "displayName": "broken",
-                    "subTitle": "broken wfs",
-                    "priority": 1,
-                    "options": {
-                        "url": "/geoservers/broken",
-                        "typeName": "bla",
-                        "queriableAttributes": [
-                            "broken"
-                        ],
-                        "sortBy": "",
-                        "maxFeatures": 5,
-                        "srsName": "EPSG:4326"
-                    }
-                }
-            ],
-            "override": false
-        },
-        "bookmark_search_config": {}
+    ]
   }
 }

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -548,7 +548,7 @@ describe('search Epics', () => {
             expect(actions.length).toBe(4);
             expect(actions[0].type).toBe(TEXT_SEARCH_LOADING);
             expect(actions[0].loading).toBe(true);
-            expect(actions[1].type).toBe('wfs');
+            expect(actions[1].type).toBe(TEXT_SEARCH_RESULTS_LOADED);
             expect(actions[1].results.length).toBe(1);
             expect(actions[2].type).toBe(TEXT_SEARCH_ERROR);
             expect(actions[2].error).toExist();

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -520,6 +520,41 @@ describe('search Epics', () => {
 
         });
     });
+    it('returns the results of the services that succeed and the error when one service fails', (done) => {
+        let action = {
+            ...textSearch("TEST"),
+            services: [{
+                type: 'wfs',
+                options: {
+                    url: 'base/web/client/test-resources/wfs/Wyoming.json',
+                    typeName: 'topp:states',
+                    queriableAttributes: [STATE_NAME],
+                    returnFullData: false
+                }
+            }, {
+                type: 'wfs',
+                options: {
+                    url: 'base/web/client/test-resources/wfs/notExisting.json',
+                    typeName: 'topp:states',
+                    queriableAttributes: [STATE_NAME],
+                    returnFullData: false
+                }
+            }]
+        };
+        testEpic(searchEpic, 4, action, (actions) => {
+            expect(actions.length).toBe(4);
+            expect(actions[0].type).toBe(TEXT_SEARCH_LOADING);
+            expect(actions[0].loading).toBe(true);
+            expect(actions[1].type).toBe(TEXT_SEARCH_RESULTS_LOADED);
+            expect(actions[1].results.length).toBe(1);
+            expect(actions[2].type).toBe(TEXT_SEARCH_ERROR);
+            expect(actions[2].error).toExist();
+            expect(actions[2].error.msgId).toBe('search.services_error');
+            expect(actions[3].type).toBe(TEXT_SEARCH_LOADING);
+            expect(actions[3].loading).toBe(false);
+            done();
+        });
+    });
     it('check the search result resorting is conservative and the number of results limited to maxResults', (done) => {
         const maxResults = 5;
         let action = {

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -510,12 +510,15 @@ describe('search Epics', () => {
         };
         testEpic(searchEpic, 3, action, (actions) => {
             expect(actions).toExist();
-            expect(actions[0].type).toBe(TEXT_SEARCH_LOADING);
             expect(actions.length).toBe(3);
+            expect(actions[0].type).toBe(TEXT_SEARCH_LOADING);
+            expect(actions[0].loading).toBe(true);
             expect(actions[1].type).toBe(TEXT_SEARCH_ERROR);
             expect(actions[1].error).toExist();
-            expect(actions[1].error.serviceType).toBe('nom');
+            expect(actions[1].error.msgId).toBe('search.services_error');
+            expect(actions[1].error.message).toBe('nom');
             expect(actions[2].type).toBe(TEXT_SEARCH_LOADING);
+            expect(actions[2].loading).toBe(false);
             done();
 
         });
@@ -545,7 +548,7 @@ describe('search Epics', () => {
             expect(actions.length).toBe(4);
             expect(actions[0].type).toBe(TEXT_SEARCH_LOADING);
             expect(actions[0].loading).toBe(true);
-            expect(actions[1].type).toBe(TEXT_SEARCH_RESULTS_LOADED);
+            expect(actions[1].type).toBe('wfs');
             expect(actions[1].results.length).toBe(1);
             expect(actions[2].type).toBe(TEXT_SEARCH_ERROR);
             expect(actions[2].error).toExist();

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -71,29 +71,37 @@ const getInfoFormat = (layerObj, state) => getDefaultInfoFormatValueFromLayer(la
 export const searchEpic = action$ =>
     action$.ofType(TEXT_SEARCH_STARTED)
         .debounceTime(250)
-        .switchMap( action =>
-        // create a stream of streams from array
-            Rx.Observable.from(
-                (action.services || [ {type: "nominatim", priority: 5} ])
+        .switchMap( action => {
+            const services = action.services || [ {type: "nominatim", priority: 5} ];
+            const serviceErrors = [];
+            // create a stream of streams from array
+            return Rx.Observable.from(
+                services
                 // Create an stream for each Service
                     .map((service) => {
                         const serviceInstance = API.Utils.getService(service.type);
+                        let stream$;
                         if (!serviceInstance) {
                             const err = new Error("Service Missing");
                             err.msgId = "search.service_missing";
                             err.serviceType = service.type;
-                            return Rx.Observable.of(err).do((e) => {throw e; });
+                            stream$ = Rx.Observable.of(err).do((e) => {throw e; });
+                        } else {
+                            stream$ = Rx.Observable.defer(() =>
+                                serviceInstance(action.searchText, service.options)
+                                    .then( (response = []) => response.map(result => ({...result, __SERVICE__: service, __PRIORITY__: service.priority || 0}))
+                                    ))
+                                .retryWhen(errors => errors.delay(200).scan((count, err) => {
+                                    if ( count >= 2) {
+                                        throw err;
+                                    }
+                                    return count + 1;
+                                }, 0));
                         }
-                        return Rx.Observable.defer(() =>
-                            serviceInstance(action.searchText, service.options)
-                                .then( (response = []) => response.map(result => ({...result, __SERVICE__: service, __PRIORITY__: service.priority || 0}))
-                                ))
-                            .retryWhen(errors => errors.delay(200).scan((count, err) => {
-                                if ( count >= 2) {
-                                    throw err;
-                                }
-                                return count + 1;
-                            }, 0));
+                        return stream$.catch(e => {
+                            serviceErrors.push(e);
+                            return Rx.Observable.empty();
+                        });
                     }) // map
             )// from
             // merge all results from the streams
@@ -101,14 +109,21 @@ export const searchEpic = action$ =>
                 .scan((oldRes, newRes) => sortBy([...oldRes, ...newRes], ["__PRIORITY__"]))
             // limit the number of results returned from all services to maxResults
                 .map((results) => searchResultLoaded(results.slice(0, action.maxResults || 15), false))
+                .concat(Rx.Observable.defer(() => {
+                    if (serviceErrors.length > 0) {
+                        const e = serviceErrors[0];
+                        return Rx.Observable.of(searchResultError({msgId: "search.generic_error", ...e, message: e.message, stack: e.stack}));
+                    }
+                    return Rx.Observable.empty();
+                }))
                 .startWith(searchTextLoading(true))
                 .takeUntil(action$.ofType( TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_RESET, TEXT_SEARCH_ITEM_SELECTED))
                 .concat([searchTextLoading(false)])
                 .catch(e => {
                     const err = {msgId: "search.generic_error", ...e, message: e.message, stack: e.stack};
                     return Rx.Observable.from([searchResultError(err), searchTextLoading(false)]);
-                })
-        );
+                });
+        });
 
 /**
  * Gets every `TEXT_SEARCH_ITEM_SELECTED` event.

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -104,17 +104,15 @@ export const searchEpic = action$ =>
                         });
                     }) // map
             )// from
-            // merge all results from the streams
                 .mergeAll()
                 .scan((oldRes, newRes) => sortBy([...oldRes, ...newRes], ["__PRIORITY__"]))
-            // limit the number of results returned from all services to maxResults
                 .map((results) => searchResultLoaded(results.slice(0, action.maxResults || 15), false))
                 .concat(Rx.Observable.defer(() => {
                     if (serviceErrors.length > 0) {
                         const e = serviceErrors[0].error;
                         const failedServices = serviceErrors.map(({service}) => service.name || service.type).join(', ');
                         return Rx.Observable.of(searchResultError({
-                            msgId: "search.generic_error",
+                            msgId: "search.services_error",
                             message: failedServices,
                             stack: e.stack
                         }));
@@ -125,7 +123,7 @@ export const searchEpic = action$ =>
                 .takeUntil(action$.ofType( TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_RESET, TEXT_SEARCH_ITEM_SELECTED))
                 .concat([searchTextLoading(false)])
                 .catch(e => {
-                    const err = {msgId: "search.generic_error", ...e, message: e.message, stack: e.stack};
+                    const err = {msgId: "search.services_error", ...e, message: e.message, stack: e.stack};
                     return Rx.Observable.from([searchResultError(err), searchTextLoading(false)]);
                 });
         });

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -99,7 +99,7 @@ export const searchEpic = action$ =>
                                 }, 0));
                         }
                         return stream$.catch(e => {
-                            serviceErrors.push(e);
+                            serviceErrors.push({service, error: e});
                             return Rx.Observable.empty();
                         });
                     }) // map
@@ -111,8 +111,13 @@ export const searchEpic = action$ =>
                 .map((results) => searchResultLoaded(results.slice(0, action.maxResults || 15), false))
                 .concat(Rx.Observable.defer(() => {
                     if (serviceErrors.length > 0) {
-                        const e = serviceErrors[0];
-                        return Rx.Observable.of(searchResultError({msgId: "search.generic_error", ...e, message: e.message, stack: e.stack}));
+                        const e = serviceErrors[0].error;
+                        const failedServices = serviceErrors.map(({service}) => service.name || service.type).join(', ');
+                        return Rx.Observable.of(searchResultError({
+                            msgId: "search.generic_error",
+                            message: failedServices,
+                            stack: e.stack
+                        }));
                     }
                     return Rx.Observable.empty();
                 }))

--- a/web/client/translations/data.ca-ES.json
+++ b/web/client/translations/data.ca-ES.json
@@ -963,6 +963,7 @@
       "serviceslistempty": "No es defineixen serveis personalitzats",
       "service_missing": "{serviceType} El servei no est\u00e0 configurat",
       "generic_error": "S'ha produ\u00eft un error durant la cerca. Detalls de l'error: {message}",
+      "services_error": "S'han produït alguns errors durant la cerca en els serveis: {message}",
       "showGFI": "Mostra GFI",
       "errors": {
         "nonQueriableLayers": "La capa proporcionada a l'URL no \u00e9s consultable o no \u00e9s visible al mapa.",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1106,6 +1106,7 @@
       "serviceslistempty": "Keine benutzerdefinierten Services definiert",
       "service_missing": "{serviceType} dienst ist nicht konfiguriert",
       "generic_error": "Bei der Suche ist ein Fehler aufgetreten. Fehlerdetails: {message}",
+      "services_error": "Bei der Suche in den Diensten sind einige Fehler aufgetreten: {message}",
       "showGFI": "GFI anzeigen",
       "errors": {
         "nonQueriableLayers": "Der in der URL angegebene Layer ist nicht abfragbar oder in der Karte nicht sichtbar.",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1067,6 +1067,7 @@
       "serviceslistempty": "No custom services defined",
       "service_missing": "{serviceType} service is not configured",
       "generic_error": "An error occurred during search. Error details: {message}",
+      "services_error": "Some errors occurred during search in services: {message}",
       "showGFI": "Show GFI",
       "errors": {
         "nonQueriableLayers": "The layer provided in the URL is not queriable or not visible in map.",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1067,6 +1067,7 @@
       "serviceslistempty": "No se ha definido ningún servicio personalizado",
       "service_missing": "el servicio {serviceType} no está configurado",
       "generic_error": "Se ha producido un error durante la búsqueda. Error de detalles: {message}",
+      "services_error": "Se han producido algunos errores durante la búsqueda en los servicios: {message}",
       "showGFI": "Mostrar GFI",
       "errors": {
         "nonQueriableLayers": "La capa proporcionada en la url no es intercambiable o no es visible en el mapa",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1067,6 +1067,7 @@
       "serviceslistempty": "Aucun service personnalisé n'a été défini",
       "service_missing": "Le service {serviceType} n'est pas configuré",
       "generic_error": "Une erreur s'est produite lors de la recherche. Détails de l'erreur : {message}",
+      "services_error": "Certains erreurs se sont produites lors de la recherche dans les services : {message}",
       "showGFI": "Afficher GFI",
       "errors": {
         "nonQueriableLayers": "La couche fournie dans l'URL n'est pas interrogeable ou invisible sur la carte.",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1066,7 +1066,8 @@
       "s_tooltip": "Descrizione comando del menu di servizio",
       "serviceslistempty": "Nessun servizio definito",
       "service_missing": "Il servizio {serviceType} non è configurato",
-      "generic_error": "Un errore e' occorso durante la ricerca: Dettagli errore: {message}",
+      "generic_error": "Un errore e' occorso durante la ricerca. Dettagli errore: {message}",
+      "services_error": "Si sono verificati alcuni errori durante la ricerca nei servizi: {message}",
       "showGFI": "Mostra GFI",
       "errors": {
         "nonQueriableLayers": "Il layer indicato nell'url non è queriable o non è visibile in mappa",


### PR DESCRIPTION
## Description
Fix issue #12840

<img width="614" height="432" alt="services" src="https://github.com/user-attachments/assets/f8c08681-76c3-4db0-bd97-b2ea82e40cf7" />

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12840

**What is the new behavior?**
Show some results and if some search services fail show to user what services name is failed in tooltip error