### PR TITLE
Support WMTS services that omit the optional ows:OperationsMetadata

### DIFF
--- a/web/client/api/__tests__/WMTS-test.js
+++ b/web/client/api/__tests__/WMTS-test.js
@@ -10,6 +10,7 @@ import expect from 'expect';
 
 import API, { getLayerTileMatrixSetsInfo, parseUrl } from '../WMTS';
 import { getGetTileURL } from '../../utils/WMTSUtils';
+import { castArray } from 'lodash';
 import MockAdapter from 'axios-mock-adapter';
 import axios from '../../libs/ajax';
 let mockAxios;
@@ -57,6 +58,26 @@ describe('Test correctness of the WMTS APIs', () => {
                 done(ex);
             }
         });
+    });
+    it('GetRecords RESTful without OperationsMetadata', (done) => {
+        API.getRecords('base/web/client/test-resources/wmts/GetCapabilities-rest-no-operations-metadata.xml', 0, 2, '').then((result) => {
+            try {
+                expect(result).toExist();
+                expect(result.numberOfRecordsMatched).toBe(2);
+                result.records.map(record => {
+                    expect(record.requestEncoding).toBe('RESTful');
+                    expect(record.queryable).toBe(false);
+                    expect(record.GetTileURL).toNotExist();
+                    expect(getGetTileURL(record)).toEqual(castArray(record.ResourceURL).map(({ $: v }) => v.template));
+                });
+                expect(result.records[0].style).toBe("default");
+                expect(result.records[0].format).toBe("image/png");
+                expect(getGetTileURL(result.records[0])).toEqual(["https://maps.sampleServer.org/basemap/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"]);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        }).catch(done);
     });
     it('GetRecords KVP for GeoServer 2.15', (done) => {
         // GS 2.15 has ResourceURLs together with KVP. This checks that the proper URL is returned by getTileURL, used to generate the layer. See #3796

--- a/web/client/api/catalog/__tests__/WMTS-test.js
+++ b/web/client/api/catalog/__tests__/WMTS-test.js
@@ -8,7 +8,7 @@
 
 import expect from 'expect';
 
-import { getCatalogRecords } from '../WMTS';
+import { getCatalogRecords, getLayerFromRecord, textSearch } from '../WMTS';
 
 describe('Test correctness of the WMTS APIs', () => {
     it('wmts', () => {
@@ -141,6 +141,23 @@ describe('Test correctness of the WMTS APIs', () => {
         const records = getCatalogRecords({ records: wmtsRecords });
         expect(records.length).toBe(1);
         expect(records[0].references[0].url).toBe(undefined);
+    });
+    it('wmts layer from a RESTful service without OperationsMetadata', (done) => {
+        textSearch('base/web/client/test-resources/wmts/GetCapabilities-rest-no-operations-metadata.xml', 1, 2, '').then((result) => {
+            try {
+                const records = getCatalogRecords(result, {});
+                expect(records.length).toBe(2);
+                expect(records[0].requestEncoding).toBe('RESTful');
+                const layer = getLayerFromRecord(records[0]);
+                expect(layer.type).toBe('wmts');
+                expect(layer.name).toBe('baselayer');
+                expect(layer.requestEncoding).toBe('RESTful');
+                expect(layer.url).toBe('https://maps.sampleServer.org/basemap/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png');
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        }).catch(done);
     });
     it('wmts capabilities url', () => {
         const wmtsRecords = [{ GetTileURL: "tileURL" }];

--- a/web/client/test-resources/wmts/GetCapabilities-rest-no-operations-metadata.xml
+++ b/web/client/test-resources/wmts/GetCapabilities-rest-no-operations-metadata.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd" version="1.0.0">
+  <ows:ServiceIdentification>
+    <ows:Title>sample server without operations metadata</ows:Title>
+    <ows:Abstract>RESTful WMTS that omits the optional ows:OperationsMetadata section</ows:Abstract>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+    <ows:Fees>none</ows:Fees>
+    <ows:AccessConstraints>none</ows:AccessConstraints>
+  </ows:ServiceIdentification>
+  <ows:ServiceProvider>
+    <ows:ProviderName>City of Nowhere</ows:ProviderName>
+    <ows:ProviderSite xlink:href="https://www.sampleServer.org"/>
+  </ows:ServiceProvider>
+  <Contents>
+    <Layer>
+      <ows:Title>Base Layer</ows:Title>
+      <ows:Abstract>Base layer of the sample server</ows:Abstract>
+      <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+        <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>
+        <ows:UpperCorner>180.0 90.0</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>baselayer</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>google3857</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" template="https://maps.sampleServer.org/basemap/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png" resourceType="tile"/>
+    </Layer>
+    <Layer>
+      <ows:Title>Overlay Layer</ows:Title>
+      <ows:Abstract>Overlay layer of the sample server</ows:Abstract>
+      <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+        <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>
+        <ows:UpperCorner>180.0 90.0</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>overlaylayer</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>google3857</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" template="https://maps.sampleServer.org/basemap/overlaylayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png" resourceType="tile"/>
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>google3857</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.18.3:3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.029</ScaleDenominator>
+        <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>279541132.014</ScaleDenominator>
+        <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2</MatrixWidth>
+        <MatrixHeight>2</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>2</ows:Identifier>
+        <ScaleDenominator>139770566.007</ScaleDenominator>
+        <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4</MatrixWidth>
+        <MatrixHeight>4</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+  <ServiceMetadataURL xlink:href="https://maps.sampleServer.org/basemap/1.0.0/WMTSCapabilities.xml"/>
+</Capabilities>

--- a/web/client/utils/WMTSUtils.js
+++ b/web/client/utils/WMTSUtils.js
@@ -56,9 +56,26 @@ export const getTileMatrixSet = (tileMatrixSet, srs, allowedSRS, matrixIds = {},
  */
 export const getRequestEncoding = json => {
     const operations = WMTSUtils.getOperations(json);
+    if (operations.length === 0) {
+        // ows:OperationsMetadata is optional, so the encoding can only be deduced
+        // from the layers: a tile ResourceURL is what a RESTful service advertises
+        return WMTSUtils.hasTileResourceURL(json) ? "RESTful" : "KVP";
+    }
     return WMTSUtils.getOperation(operations, "GetTile", "KVP") ? "KVP" : WMTSUtils.getOperation(operations, "GetTile", "RESTful") && "RESTful";
 };
-export const getOperations = (json = {}) => castArray(json.Capabilities["ows:OperationsMetadata"]["ows:Operation"]);
+/**
+ * Gets the 'Operations' array from the WMTS Capabilities json parsed object.
+ * Returns an empty array when the optional 'ows:OperationsMetadata' section is missing
+ */
+export const getOperations = (json = {}) => {
+    const operations = json?.Capabilities?.["ows:OperationsMetadata"]?.["ows:Operation"];
+    return operations ? castArray(operations) : [];
+};
+/**
+ * Checks if at least one layer of the WMTS Capabilities json parsed object declares a tile ResourceURL
+ */
+export const hasTileResourceURL = (json = {}) => castArray(json?.Capabilities?.Contents?.Layer || [])
+    .some((layer) => castArray(layer.ResourceURL || []).some((resource) => resource?.$?.resourceType === "tile"));
 /**
  * gets the first operation of the type and with the name provided from the 'Operations' array of the WMTS Capabilities json parsed object
  */
@@ -213,5 +230,6 @@ export const generateGeoServerWMTSUrl = (options) => {
 
 WMTSUtils = {
     getOperations,
-    getOperation
+    getOperation,
+    hasTileResourceURL
 };

--- a/web/client/utils/__tests__/WMTSUtils-test.js
+++ b/web/client/utils/__tests__/WMTSUtils-test.js
@@ -11,6 +11,7 @@ import xml2js from 'xml2js';
 import * as WMTSUtils from '../WMTSUtils';
 import restCapabilities from 'raw-loader!../../test-resources/wmts/GetCapabilities-rest.xml';
 import kvpCapabilities from 'raw-loader!../../test-resources/wmts/GetCapabilities-1.0.0.xml';
+import restCapabilitiesNoOperationsMetadata from 'raw-loader!../../test-resources/wmts/GetCapabilities-rest-no-operations-metadata.xml';
 
 describe('Test the WMTSUtils', () => {
     it('get matrix ids with object', () => {
@@ -53,6 +54,27 @@ describe('Test the WMTSUtils', () => {
             expect(tileURLs[0]).toBe("https://maps1.sampleServer.org/basemap/geolandbasemap/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png");
             done();
         });
+    });
+    it('wmts rest without OperationsMetadata', (done) => {
+        xml2js.parseString(restCapabilitiesNoOperationsMetadata, { explicitArray: false }, (ignore, json) => {
+            const operations = WMTSUtils.getOperations(json);
+            expect(operations).toEqual([]);
+            expect(WMTSUtils.getOperation(operations, "GetTile", "KVP")).toNotExist();
+            expect(WMTSUtils.getOperation(operations, "GetTile", "RESTful")).toNotExist();
+            // OperationsMetadata is optional, the RESTful encoding is advertised by the tile ResourceURL
+            expect(WMTSUtils.getRequestEncoding(json)).toBe("RESTful");
+            const tileURLs = WMTSUtils.getGetTileURL({ ...json.Capabilities.Contents.Layer[0], requestEncoding: "RESTful" });
+            expect(tileURLs).toEqual(["https://maps.sampleServer.org/basemap/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"]);
+            done();
+        });
+    });
+    it('getOperations with empty capabilities', () => {
+        expect(WMTSUtils.getOperations()).toEqual([]);
+        expect(WMTSUtils.getOperations({})).toEqual([]);
+        expect(WMTSUtils.getOperations({ Capabilities: {} })).toEqual([]);
+    });
+    it('getRequestEncoding without OperationsMetadata and without tile ResourceURL', () => {
+        expect(WMTSUtils.getRequestEncoding({ Capabilities: { Contents: { Layer: { "ows:Identifier": "layer" } } } })).toBe("KVP");
     });
     it('parseTileMatrixSetOption', () => {
         const layer = WMTSUtils.parseTileMatrixSetOption({


### PR DESCRIPTION
This PR proposes support for WMTS services that omit the optional `ows:OperationsMetadata` section, so their layers are listed and can be added from the Catalog instead of the search failing outright (Fixes #6763). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/511. You can sign in with your GitHub ID to claim ownership of the project.

## What is wrong

`getOperations` in `web/client/utils/WMTSUtils.js` dereferences the capabilities document unconditionally:

```js
export const getOperations = (json = {}) => castArray(json.Capabilities["ows:OperationsMetadata"]["ows:Operation"]);
```

`ows:OperationsMetadata` is optional in WMTS 1.0.0, and RESTful services routinely leave it out. When it is absent, `searchAndPaginate` in `web/client/api/WMTS.js` calls `getOperations` on its first line and throws, so the promise returned by `WMTS.getRecords` rejects and the Catalog lists nothing at all for the service.

Both public services named in the two open issues still omit the section today, so the failure is live on current master:

```
$ curl -s https://tiles.emodnet-bathymetry.eu/wmts/1.0.0/WMTSCapabilities.xml | grep -c OperationsMetadata
0
$ curl -s https://sgx.geodatenzentrum.de/wmts_topplus_open/1.0.0/WMTSCapabilities.xml | grep -c OperationsMetadata
0
```

Running the five new cases against master (this branch with `web/client/utils/WMTSUtils.js` reverted) reproduces it exactly at the line issue #6763 points to:

```
Test correctness of the WMTS APIs
  x GetRecords RESTful without OperationsMetadata
    TypeError: Cannot read properties of undefined (reading 'ows:Operation')
        at getOperations (web/client/utils/WMTSUtils.js)
        at searchAndPaginate (web/client/api/WMTS.js)
```

## What changed

`getOperations` now reads the optional section defensively and returns an empty array when it is missing, which is enough on its own to stop the throw — `getOperation` already handles an empty operations array and simply returns `undefined`, so `queryable` and `GetTileURL` come out false and undefined rather than crashing.

`getRequestEncoding` then has to answer a question the document no longer answers directly. When there are no operations it falls back to the layers, via a new `hasTileResourceURL` helper: a `ResourceURL` with `resourceType="tile"` is exactly what a RESTful service advertises in place of the operations section, so that means `RESTful`, and anything else keeps the previous KVP default that `recordToLayer` already documents. This is the first two items of the checklist in issue #4496; the third item there (an explicit KVP/RESTful selector in the catalog UI) is a separate change and is not included here.

Nothing changes for a service that does publish `ows:OperationsMetadata`: the fallback is only reached when the operations array is empty, so KVP services, RESTful services and the GeoServer 2.15 mixed case all take the same path as before. The existing `wmts kvp`, `wmts rest`, `GetRecords KVP`, `GetRecords RESTful` and `GetRecords KVP for GeoServer 2.15` cases were kept untouched and stay green.

## How it was verified

Five cases were added, covering the fix at three levels: `WMTSUtils` directly (operations parsing, encoding fallback, and a control asserting a document with neither operations nor a tile `ResourceURL` still resolves to KVP), `WMTS.getRecords` for the record shape, and `api/catalog/WMTS` end to end, asserting the layer built from the record carries `requestEncoding: 'RESTful'` and a usable tile template as its URL. All five fail on master with the `TypeError` quoted above and pass with the change. The new fixture `GetCapabilities-rest-no-operations-metadata.xml` follows the anonymised style of the existing WMTS fixtures.

The specs for these two modules and for every other file that imports them — `PrintUtils`, `WMSCacheOptions`, the `catalog`, `backgroundselector` and `layerinfo` epics, the leaflet and mapinfo WMTS utils and the OpenLayers `Layer` spec — were run with karma before and after: 276 passing before, 281 passing after, nothing newly red. `eslint` on the four touched JS files and `prettier --check` on the fixture are both clean.

As a last check the same catalog path was pointed at the two real capabilities documents linked above. On master both throw; with the change EMODnet Bathymetry resolves 20 layers and topplus_open resolves 6, each with `requestEncoding: 'RESTful'` and a tile template that survives into the layer:

```
[emodnet]  matched=20 encoding=RESTful name=baselayer url=https://tiles.emodnet-bathymetry.eu/2020/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png
[topplus]  matched=6  encoding=RESTful name=web       url=https://sgx.geodatenzentrum.de/wmts_topplus_open/tile/1.0.0/web/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png
```

## How this was managed

This work was tracked as a single story, [WMTS catalog fails if OperationMetadata is missing, but it is optional](https://eastagiletracker.com/projects/511/stories/472097), on a board imported from this repository's own issues, pull requests and milestones — the same board linked at the top: https://eastagiletracker.com/projects/511

![board](https://raw.githubusercontent.com/eastagiletracker/MapStore2/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
