### PR TITLE
Identify: support custom vocabularies for the media type attribute  #12871

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -159,6 +159,17 @@ For configuring plugins, see the [Configuring Plugins Section](plugins-documenta
 - `initialState`: is an object that will initialize the state with some default values and this WILL OVERRIDE the initialState imposed by plugins & reducers.
 - `projectionDefs`: is an array of objects that contain definitions for Coordinate Reference Systems
 - `gridFiles`: is an object that contains definitions for grid files used in coordinate transformations
+- `featureInfoMediaTypeAliases`: is an object that maps display types to custom alias values used by media type attributes. Values are normalized trimming whitespace and converting to lowercase, so also numeric codes are supported. Only display types listed in `DISPLAY_TYPES` are accepted. For example:
+
+  ```json
+  "featureInfoMediaTypeAliases": {
+    "panorama": ["PAN", "PANO", "360"],
+    "image": ["IMG", "FOTO"],
+    "video": ["VID"]
+  }
+  ```
+
+  When a field uses `"displayType": "media"` and references a media type attribute, these aliases are resolved before the value's file extension is used for detection.
 - `useAuthenticationRules` (deprecated): if this flag is set to true, legacy `authenticationRules` will be used. The new `requestsConfigurationRules` system does not require this flag and is always active when rules are present.
 - `requestsConfigurationRules`: is an array of objects that contain rules to match for request configuration. Each rule has a `urlPattern` regex to match and either `headers`, `params`, or `withCredentials` configuration. If the URL of a request matches the `urlPattern` of a rule, the configuration will be applied to the request.
 

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -49,6 +49,7 @@
     },
     "floatingIdentifyDelay": 1000
   },
+  "featureInfoMediaTypeAliases": {},
   "localizedLayerStyles": {
     "name": "mapstore_language"
   },

--- a/web/client/utils/FeatureInfoAttributeUtils.js
+++ b/web/client/utils/FeatureInfoAttributeUtils.js
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import ConfigUtils from './ConfigUtils';
+
 export const DISPLAY_TYPES = [
     'image', 'video', 'audio', 'panorama', 'pdf', 'url', 'iframe', 'media'
 ];
@@ -55,12 +57,25 @@ export const getDisplayTypeFromExtension = (value) => {
     return extension ? EXTENSION_TO_TYPE[extension] || null : null;
 };
 
+const getDisplayTypeFromAlias = (value) => {
+    if (value === undefined || value === null) {
+        return null;
+    }
+    const normalizedValue = String(value).trim().toLowerCase();
+    const aliases = ConfigUtils.getConfigProp('featureInfoMediaTypeAliases') || {};
+    return Object.entries(aliases).find(([displayType, displayTypeAliases]) =>
+        DISPLAY_TYPES.includes(displayType)
+        && Array.isArray(displayTypeAliases)
+        && displayTypeAliases.some(alias => String(alias).trim().toLowerCase() === normalizedValue)
+    )?.[0] || null;
+};
+
 export const resolveAttributeDisplayType = ({ value, attribute = {}, mediaTypeValue } = {}) => {
     if (!attribute.displayType) {
         return 'string';
     }
     const configuredType = attribute.displayType === 'media'
-        ? getDisplayTypeFromMediaType(mediaTypeValue)
+        ? getDisplayTypeFromAlias(mediaTypeValue) || getDisplayTypeFromMediaType(mediaTypeValue)
         : getDisplayTypeFromMediaType(attribute.displayType);
     return configuredType || getDisplayTypeFromExtension(value) || (attribute.displayType === 'media' ? 'url' : 'string');
 };

--- a/web/client/utils/__tests__/FeatureInfoAttributeUtils-test.js
+++ b/web/client/utils/__tests__/FeatureInfoAttributeUtils-test.js
@@ -4,8 +4,11 @@ import {
     getDisplayTypeFromMediaType,
     resolveAttributeDisplayType
 } from '../FeatureInfoAttributeUtils';
+import ConfigUtils from '../ConfigUtils';
 
 describe('FeatureInfoAttributeUtils', () => {
+    afterEach(() => ConfigUtils.removeConfigProp('featureInfoMediaTypeAliases'));
+
     it('normalizes configured media types and MIME types', () => {
         expect(getDisplayTypeFromMediaType(' VIDEO ')).toBe('video');
         expect(getDisplayTypeFromMediaType('image/jpeg')).toBe('image');
@@ -33,5 +36,37 @@ describe('FeatureInfoAttributeUtils', () => {
             attribute: { displayType: 'media', mediaTypeAttribute: 'mimeType' },
             mediaTypeValue: 'audio/mpeg'
         })).toBe('audio');
+    });
+
+    it('resolves configured media type aliases', () => {
+        ConfigUtils.setConfigProp('featureInfoMediaTypeAliases', {
+            panorama: ['PAN', 'PANO', '360'],
+            image: ['IMG', 'FOTO'],
+            video: ['VID']
+        });
+
+        expect(resolveAttributeDisplayType({
+            value: 'https://example.com/resource.jpg',
+            attribute: { displayType: 'media', mediaTypeAttribute: 'mediaType' },
+            mediaTypeValue: ' pano '
+        })).toBe('panorama');
+        expect(resolveAttributeDisplayType({
+            value: 'https://example.com/resource.jpg',
+            attribute: { displayType: 'media', mediaTypeAttribute: 'mediaType' },
+            mediaTypeValue: 360
+        })).toBe('panorama');
+    });
+
+    it('ignores aliases with unsupported display types', () => {
+        ConfigUtils.setConfigProp('featureInfoMediaTypeAliases', {
+            unsupported: ['PAN'],
+            image: ['IMG']
+        });
+
+        expect(resolveAttributeDisplayType({
+            value: 'https://example.com/resource.jpg',
+            attribute: { displayType: 'media' },
+            mediaTypeValue: 'PAN'
+        })).toBe('image');
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR added configurable aliases for FeatureInfo media types. So now user can configure what type of media attribute is known from which vocabulary.
For example:
```
 "featureInfoMediaTypeAliases": {
    "panorama": ["PAN", "PANO", "360"],
    "image": ["IMG", "FOTO"],
    "video": ["VID"]
  }
```

https://github.com/user-attachments/assets/10e79cdf-da67-4d53-bc83-501485782915



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#12871

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Custom vocabularies for different media types can be configurable from localConfig.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
