### PR TITLE
make mapContainerId a configurable prop

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -194,6 +194,7 @@ class MapPlugin extends React.Component {
     static propTypes = {
         mapType: PropTypes.string,
         map: PropTypes.object,
+        mapContainerId: PropTypes.string,
         layers: PropTypes.array,
         additionalLayers: PropTypes.array,
         zoomControl: PropTypes.bool,
@@ -225,6 +226,7 @@ class MapPlugin extends React.Component {
 
     static defaultProps = {
         mapType: MapLibraries.OPENLAYERS,
+        mapContainerId: MAIN_MAP_CONTAINER_ID,
         actions: {},
         zoomControl: false,
         mapLoadingMessage: "map.loading",
@@ -438,7 +440,7 @@ class MapPlugin extends React.Component {
             const {mapOptions = {}} = this.props.map;
 
             return (
-                <this.state.plugins.Map id={MAIN_MAP_CONTAINER_ID}
+                <this.state.plugins.Map id={this.props.mapContainerId}
                     {...this.props.options}
                     projectionDefs={this.props.projectionDefs}
                     {...this.props.map}

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -158,6 +158,7 @@ import { MAIN_MAP_CONTAINER_ID } from '../utils/MapUtils';
  * @prop {array} additionalLayers static layers available in addition to those loaded from the configuration
  * @prop {boolean} coalesceWMSLayers when true, adjacent WMS layers from the same source with compatible options are combined into a single GetMap request to reduce the number of requests sent to the server (default false); if not set, falls back to the current map's `mapOptions.coalesceWMSLayers` (set from Map Settings) and then to `miscSettings.coalesceWMSLayers` in localConfig.json; a layer can opt out with `coalesce: false` in its own options; not supported on leaflet, where it is always disabled
  * @prop {number} coalesceWMSLayersMaxGroupSize maximum number of WMS layers that can be combined into a single coalesced GetMap request (default 10)
+ * @prop {string} mapContainerId the id of the html div that the map lives in. The default value is "map"
  * @prop {object} mapOptions map options grouped by map type
  * @prop {boolean} mapOptions.cesium.navigationTools enable cesium navigation tool (default false)
  * @prop {boolean} mapOptions.cesium.showSkyAtmosphere enable sky atmosphere of the globe (default true)


### PR DESCRIPTION
## Description
the map container id is hardcoded as "map". this prevents having two separate maps embedded in a single webpage.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#12872

**What is the current behavior?**
the div container always has "map" as id

**What is the new behavior?**
you can now supply a mapContainerId prop to the map to get a different id.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

the change is backwards compatible.

## Other useful information
