### PR TITLE
run handleLoad for containers requiring the same theme

### DIFF
--- a/web/client/components/theme/Theme.jsx
+++ b/web/client/components/theme/Theme.jsx
@@ -102,6 +102,14 @@ const Theme = memo(({
                 link.current.setAttribute('data-ms-state', 'mounted');
             } else {
                 link.current = linkNode;
+
+                // run handleLoad for secondary containers which require same theme
+                const alreadyLoaded = !!linkNode.sheet;
+                if (alreadyLoaded) {
+                    handleLoad();
+                } else {
+                    linkNode.addEventListener('load', handleLoad, { once: true });
+                }
             }
 
             // compare previous and current href to change the theme


### PR DESCRIPTION
## Description
For secondary maps handleLoad is never run, therefore the loadAfterTheme option does not work.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#12872

**What is the current behavior?**
when multiple maps are embedded loadAfterTheme only works for whichever map is first in installing its theme.

**What is the new behavior?**
all maps work with loadAfterTheme

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
