### PR TITLE
Add ins and del tags to HtmlSanitizer.js allowed tags

### DIFF
--- a/web/client/utils/HtmlSanitizer.js
+++ b/web/client/utils/HtmlSanitizer.js
@@ -73,7 +73,7 @@ const HTML_CONFIG = {
         'blockquote', 'pre', 'code',
         'figure', 'figcaption', 'hr', 'details', 'summary',
         // Inline formatting — current HTML5
-        'b', 'i', 'u', 's', 'strong', 'em', 'small', 'mark', 'abbr', 'sup', 'sub',
+        'b', 'i', 'u', 'ins', 's', 'del', 'strong', 'em', 'small', 'mark', 'abbr', 'sup', 'sub',
         // Inline formatting — deprecated but common in stored content
         'font', 'center', 'strike',
         // Media and links

--- a/web/client/utils/__tests__/HtmlSanitizer-test.js
+++ b/web/client/utils/__tests__/HtmlSanitizer-test.js
@@ -18,6 +18,12 @@ describe('HtmlSanitizer', () => {
             expect(result).toContain('<p>paragraph</p>');
         });
 
+        it('preserves ins/del tags', () => {
+            const result = sanitizeHtml('<ins>inserted</ins> <del>deleted</del>');
+            expect(result).toContain('<ins>inserted</ins>');
+            expect(result).toContain('<del>deleted</del>');
+        });
+
         it('preserves safe links', () => {
             const result = sanitizeHtml('<a href="https://example.com" target="_blank">link</a>');
             expect(result).toContain('<a');


### PR DESCRIPTION
## Description

HtmlSanitizer.js's allowed tags list is missing `<del>` and `<ins>`. These tags are used by the rich text / WYSIWYG editor, but they disappear from the html.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
 
## What is the current behavior?

`<ins>`/`<del>` are removed by sanitizeHtml/SafeHtml.

## What is the new behavior?

`<ins>`/`<del>` are allowed and preserved.

